### PR TITLE
Install OpenClaw and document setup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,3 +29,4 @@ Do not confuse the two.
 - Test skills against real GitHub projects before PR.
 - Keep CI green.
 - Add concise risk/rollback notes for non-trivial changes.
+- Before merging PRs, check and respond to GitHub Copilot auto-review comments (see `.github/copilot-instructions.md` for details).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,3 +84,10 @@ For code/skill changes:
 For process changes:
 - ensure issue templates and workflows remain consistent,
 - preserve parent-child traceability.
+
+## PR Reviews
+
+GitHub Copilot automatically reviews every PR. Before merging:
+1. Check review comments: `gh api repos/Osasuwu/personal-AI-agent/pulls/NUMBER/comments`.
+2. Address valid feedback with code changes or explain why no change is needed.
+3. Post a summary reply: `gh pr review NUMBER --comment`.

--- a/config/SETUP.md
+++ b/config/SETUP.md
@@ -1,0 +1,87 @@
+# Jarvis / OpenClaw Setup Guide
+
+## Prerequisites
+
+- Node.js 22+ (tested with v24.14.0)
+- npm 11+
+- Windows 11 (primary), Linux (server)
+
+## 1. Install OpenClaw
+
+```bash
+npm install -g openclaw@latest
+openclaw --version  # verify: 2026.3.13+
+```
+
+## 2. Configure Gateway
+
+```bash
+# Local-only, not exposed to network
+openclaw config set gateway.mode local
+openclaw config set gateway.bind loopback
+openclaw config set gateway.port 18789
+
+# Auth token (generate once)
+GATEWAY_TOKEN=$(openssl rand -hex 32)
+openclaw config set gateway.auth.mode token
+openclaw config set gateway.auth.token "$GATEWAY_TOKEN"
+
+# Disable memory search (no embedding provider)
+openclaw config set agents.defaults.memorySearch.enabled false
+```
+
+Config is stored at `~/.openclaw/openclaw.json`.
+
+## 3. Start Gateway
+
+```bash
+# Foreground (for testing):
+openclaw gateway
+
+# Check status:
+openclaw gateway status
+
+# Dashboard:
+# http://127.0.0.1:18789/
+```
+
+Note: on Windows, `openclaw gateway install` may fail due to permissions. Run gateway manually or via startup script.
+
+## 4. LLM Provider (Ollama)
+
+See issue #30 for Ollama setup. After Ollama is running:
+
+```bash
+openclaw config set models.providers.ollama.api ollama
+openclaw config set models.providers.ollama.baseUrl "http://localhost:11434"
+openclaw config set models.providers.ollama.apiKey "ollama-local"
+openclaw config set models.default "ollama/<model-name>"
+```
+
+## 5. Telegram Bot
+
+See issue #32 for Telegram setup. After creating bot via BotFather:
+
+```bash
+openclaw config set channels.telegram.enabled true
+openclaw config set channels.telegram.token "$TELEGRAM_BOT_TOKEN"
+openclaw gateway restart
+```
+
+## 6. Health Check
+
+```bash
+openclaw doctor
+openclaw doctor --fix  # auto-fix common issues
+```
+
+## Key Paths
+
+| What | Path |
+|---|---|
+| Config | `~/.openclaw/openclaw.json` |
+| Workspace | `~/.openclaw/workspace/` |
+| SOUL.md | `~/.openclaw/workspace/SOUL.md` |
+| Custom skills | `~/.openclaw/workspace/skills/` |
+| Logs | `/tmp/openclaw/` |
+| Sessions | `~/.openclaw/agents/main/sessions/` |

--- a/config/SETUP.md
+++ b/config/SETUP.md
@@ -4,6 +4,7 @@
 
 - Node.js 22+ (tested with v24.14.0)
 - npm 11+
+- OpenSSL (for token generation) or PowerShell
 - Windows 11 (primary), Linux (server)
 
 ## 1. Install OpenClaw
@@ -22,7 +23,10 @@ openclaw config set gateway.bind loopback
 openclaw config set gateway.port 18789
 
 # Auth token (generate once)
+# Linux/macOS:
 GATEWAY_TOKEN=$(openssl rand -hex 32)
+# Windows PowerShell (if openssl not available):
+# $GATEWAY_TOKEN = -join ((1..32) | ForEach-Object { "{0:x2}" -f (Get-Random -Max 256) })
 openclaw config set gateway.auth.mode token
 openclaw config set gateway.auth.token "$GATEWAY_TOKEN"
 
@@ -83,5 +87,5 @@ openclaw doctor --fix  # auto-fix common issues
 | Workspace | `~/.openclaw/workspace/` |
 | SOUL.md | `~/.openclaw/workspace/SOUL.md` |
 | Custom skills | `~/.openclaw/workspace/skills/` |
-| Logs | `/tmp/openclaw/` |
+| Logs | Linux: `/tmp/openclaw/`, Windows: see gateway output for log path |
 | Sessions | `~/.openclaw/agents/main/sessions/` |


### PR DESCRIPTION
## Summary

- Install OpenClaw 2026.3.13 globally via npm
- Configure gateway: loopback-only, token auth, port 18789
- Disable memory search (no embedding provider yet)
- Verify gateway runs successfully (RPC probe OK, dashboard at localhost:18789)
- Add setup guide to `config/SETUP.md`

Closes #29

## Test plan

- [x] `openclaw --version` returns 2026.3.13
- [x] `openclaw gateway` starts and listens on 127.0.0.1:18789
- [x] `openclaw gateway status` shows RPC probe OK
- [x] `openclaw doctor --fix` resolves state integrity issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)