### PR TITLE
Configure Ollama and cloud fallback for OpenClaw

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Jarvis / OpenClaw environment variables
+# Copy to .env and fill in your values.
+# Load into shell: `source .env` (bash) or `Get-Content .env | ForEach-Object { if ($_ -match '^([^#]\S+?)=(.*)') { [Environment]::SetEnvironmentVariable($matches[1], $matches[2]) } }` (PowerShell)
+
+# Cloud LLM fallbacks (get free API keys):
+# Groq: https://console.groq.com
+GROQ_API_KEY=
+# Google Gemini: https://aistudio.google.com/apikey
+GEMINI_API_KEY=
+
+# Ollama is configured in ~/.openclaw/openclaw.json, no env var needed.
+# Gateway token is also in openclaw.json.

--- a/config/SETUP.md
+++ b/config/SETUP.md
@@ -59,36 +59,41 @@ Install Ollama from https://ollama.com, then pull the model:
 ollama pull qwen3:8b
 ```
 
-OpenClaw provider config must be set directly in `~/.openclaw/openclaw.json` (individual `config set` commands fail validation because `baseUrl` and `models` are both required). Add to the JSON:
+OpenClaw provider config must be set directly in `~/.openclaw/openclaw.json` (individual `config set` commands fail validation because `baseUrl` and `models` are both required). **Merge** these sections into the existing config — do not replace the whole file:
+
+Add a `"models"` top-level key:
 
 ```json
-{
-  "models": {
-    "providers": {
-      "ollama": {
-        "baseUrl": "http://localhost:11434",
-        "apiKey": "ollama-local",
-        "api": "ollama",
-        "models": [
-          {
-            "id": "qwen3:8b",
-            "name": "Qwen3 8B",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 32768,
-            "maxTokens": 4096
-          }
-        ]
-      }
+"models": {
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434",
+      "apiKey": "ollama-local",
+      "api": "ollama",
+      "models": [
+        {
+          "id": "qwen3:8b",
+          "name": "Qwen3 8B",
+          "reasoning": true,
+          "input": ["text"],
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+          "contextWindow": 32768,
+          "maxTokens": 4096
+        }
+      ]
     }
-  },
-  "agents": {
-    "defaults": {
-      "model": {
-        "primary": "ollama/qwen3:8b",
-        "fallbacks": ["groq/llama-4-scout-17b-16e-instruct", "google/gemini-2.5-flash"]
-      }
+  }
+}
+```
+
+Add `"model"` inside the existing `agents.defaults` section:
+
+```json
+"agents": {
+  "defaults": {
+    "model": {
+      "primary": "ollama/qwen3:8b",
+      "fallbacks": ["groq/llama-4-scout-17b-16e-instruct", "google/gemini-2.5-flash"]
     }
   }
 }

--- a/config/SETUP.md
+++ b/config/SETUP.md
@@ -53,16 +53,66 @@ Note: on Windows, `openclaw gateway install` may fail due to permissions. Run ga
 
 ## 4. LLM Provider (Ollama)
 
-See issue #30 for Ollama setup. After Ollama is running:
+Install Ollama from https://ollama.com, then pull the model:
 
 ```bash
-openclaw config set models.providers.ollama.api ollama
-openclaw config set models.providers.ollama.baseUrl "http://localhost:11434"
-openclaw config set models.providers.ollama.apiKey "ollama-local"
-openclaw config set models.default "ollama/<model-name>"
+ollama pull qwen3:8b
 ```
 
-## 5. Telegram Bot
+OpenClaw provider config must be set directly in `~/.openclaw/openclaw.json` (individual `config set` commands fail validation because `baseUrl` and `models` are both required). Add to the JSON:
+
+```json
+{
+  "models": {
+    "providers": {
+      "ollama": {
+        "baseUrl": "http://localhost:11434",
+        "apiKey": "ollama-local",
+        "api": "ollama",
+        "models": [
+          {
+            "id": "qwen3:8b",
+            "name": "Qwen3 8B",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 32768,
+            "maxTokens": 4096
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "ollama/qwen3:8b",
+        "fallbacks": ["groq/llama-4-scout-17b-16e-instruct", "google/gemini-2.5-flash"]
+      }
+    }
+  }
+}
+```
+
+Important: do NOT add `/v1` to Ollama baseUrl — it breaks tool calling.
+
+## 5. Cloud Fallback
+
+Cloud providers activate automatically when Ollama is unavailable. Set API keys as environment variables:
+
+```bash
+# Groq (https://console.groq.com — free tier)
+export GROQ_API_KEY="gsk_..."
+
+# Google Gemini (https://aistudio.google.com/apikey — free tier: 1000 req/day on Flash)
+export GEMINI_API_KEY="..."
+```
+
+Groq and Google are built-in providers — no `models.providers` config needed, just the env vars.
+
+Verify with `openclaw models` — fallbacks should show under "Fallbacks".
+
+## 6. Telegram Bot
 
 See issue #32 for Telegram setup. After creating bot via BotFather:
 
@@ -72,7 +122,7 @@ openclaw config set channels.telegram.token "$TELEGRAM_BOT_TOKEN"
 openclaw gateway restart
 ```
 
-## 6. Health Check
+## 7. Health Check
 
 ```bash
 openclaw doctor


### PR DESCRIPTION
## Summary
- Configured **qwen3:8b** (Q4_K_M, 5.2GB) as primary local model via Ollama for RTX 3050 6GB
- Added **Groq** (llama-4-scout) and **Google Gemini** (2.5-flash) as free cloud fallbacks
- Updated `config/SETUP.md` with full provider JSON config, cloud fallback setup, and Ollama install instructions

## Configuration applied to `~/.openclaw/openclaw.json`
- Primary: `ollama/qwen3:8b` (local, free)
- Fallback 1: `groq/llama-4-scout-17b-16e-instruct` (free tier, needs `GROQ_API_KEY`)
- Fallback 2: `google/gemini-2.5-flash` (free tier, needs `GEMINI_API_KEY`)

## Pending
- [x] Add real `GROQ_API_KEY` (https://console.groq.com)
- [x] Add real `GEMINI_API_KEY` (https://aistudio.google.com/apikey)

## Test plan
- [x] `ollama list` shows qwen3:8b (5.2GB)
- [x] `ollama run qwen3:8b` responds correctly
- [x] Ollama API at localhost:11434 returns model list
- [x] `openclaw models` shows correct default and fallbacks
- [ ] Cloud fallbacks work after API keys are set

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)