### PR TITLE
feat: Port weekly report as OpenClaw skill

### DIFF
--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: weekly_report
+description: "Weekly delivery report across configured GitHub repos: closed issues, merged PRs, blockers, velocity summary. Trigger: /weekly-report or on schedule."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📊",
+        "requires": { "bins": ["gh"] },
+      },
+  }
+---
+
+# Weekly Report Skill
+
+Generate a weekly delivery report across all configured GitHub repositories.
+
+## When to Use
+
+Use this skill when:
+- The user asks for a weekly report, weekly summary, or delivery update
+- Triggered by schedule (cron, typically Friday afternoon)
+- The user says `/weekly-report`
+
+## Configuration
+
+Repositories to report on are listed in `repos.conf` in the `triage` skill directory (shared config). If the file is missing, ask the user which repos to report on.
+
+## Execution Steps
+
+### Step 1 — Determine time window
+
+The report covers the last 7 days. Calculate the date 7 days ago from now in ISO format (YYYY-MM-DDTHH:MM:SSZ).
+
+### Step 2 — Collect data for each repo
+
+For each repo in the config, run these commands:
+
+#### Closed issues (last 7 days)
+
+```bash
+gh issue list --repo <owner/repo> --state closed --json number,title,labels,closedAt,milestone --limit 100
+```
+
+Filter results to only include issues where `closedAt` is within the last 7 days.
+
+#### Merged PRs (last 7 days)
+
+```bash
+gh pr list --repo <owner/repo> --state merged --json number,title,author,mergedAt --limit 100
+```
+
+Filter results to only include PRs where `mergedAt` is within the last 7 days.
+
+#### Current blockers
+
+```bash
+gh issue list --repo <owner/repo> --state open --label status:blocked --json number,title
+```
+
+#### Open issues count
+
+```bash
+gh issue list --repo <owner/repo> --state open --json number --jq 'length'
+```
+
+### Step 3 — Format report
+
+Produce a markdown report with this structure:
+
+```markdown
+# Weekly Report
+
+**Period:** YYYY-MM-DD — YYYY-MM-DD
+**Generated:** YYYY-MM-DD
+
+## Summary
+
+| Repo | Closed | Merged PRs | Blockers | Open |
+|------|--------|------------|----------|------|
+| repo1 | N | N | N | N |
+| repo2 | N | N | N | N |
+| **Total** | **N** | **N** | **N** | **N** |
+
+## repo1
+
+### Closed Issues (N)
+
+- [x] #42 Issue title
+- [x] #43 Issue title
+
+### Merged PRs (N)
+
+- #10 PR title (@author)
+- #11 PR title (@author)
+
+### Blockers (N)
+
+- :red_circle: #7 Blocked issue title
+
+## repo2
+
+### Closed Issues (N)
+
+...
+
+## Velocity Notes
+
+- Total throughput: N items closed, N PRs merged
+- Active blockers requiring attention: N
+```
+
+### Step 4 — Handle edge cases
+
+- If a repo has no activity in the period, include it with zeros in the summary table and note "No activity this week" in its section.
+- If `gh` fails for a repo, log the error and continue with other repos.
+- If no repos had any activity, report "Quiet week — no closed issues or merged PRs across all repos."
+
+### Step 5 — Deliver
+
+Return the full markdown report to the user. The report must be readable in both Telegram (plain text fallback) and web UI (rendered markdown).
+
+## Important Rules
+
+- Use `gh` CLI for all GitHub API calls.
+- Process repos sequentially to avoid rate limits.
+- This skill is read-only — no modifications to any repos.
+- Keep the report concise: skip empty subsections within repos that had some activity.
+- Use the shared `repos.conf` from the triage skill to stay consistent.


### PR DESCRIPTION
## Summary
- Add `skills/weekly-report/` with SKILL.md for generating weekly delivery reports
- Collects: closed issues, merged PRs, current blockers, open issue counts
- Groups data by repo with summary table and velocity notes
- Uses shared `repos.conf` from triage skill for consistency

Closes #35

## Test plan
- [x] `gh issue list --state closed` returns data for all repos
- [x] `gh pr list --state merged` returns data for all repos
- [x] `gh issue list --label status:blocked` works correctly
- [ ] End-to-end test via OpenClaw session (covered by #37)

## Risk / Rollback
- Read-only skill — no write operations
- Rollback: delete `skills/weekly-report/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)