### PR TITLE
Connect Telegram Bot

### DIFF
--- a/config/SETUP.md
+++ b/config/SETUP.md
@@ -140,11 +140,11 @@ Verify with `openclaw models list` — should show Gemini as default, Groq as fa
 ### Connect to OpenClaw
 
 ```bash
-# Add Telegram channel with bot token
-openclaw channels add --channel telegram --token "$TELEGRAM_BOT_TOKEN"
+# Add Telegram channel with bot token (replace with your token from BotFather)
+openclaw channels add --channel telegram --token "123456:ABC-DEF..."
 
-# Restrict to your Telegram user ID only (get it from @userinfobot)
-openclaw config set channels.telegram.allowFrom "[$YOUR_TELEGRAM_ID]"
+# Restrict to your Telegram user ID only (get yours from @userinfobot)
+openclaw config set channels.telegram.allowFrom "[123456789]"
 
 # Restart gateway to apply
 openclaw gateway restart
@@ -160,9 +160,9 @@ Send any message to your bot in Telegram. It should reply and the conversation s
 |---|---|
 | `channels.telegram.enabled` | Enable/disable the channel |
 | `channels.telegram.botToken` | Bot token from BotFather |
-| `channels.telegram.allowFrom` | Array of allowed Telegram user IDs |
-| `channels.telegram.dmPolicy` | `pairing` (default) — reply to anyone who writes first |
-| `channels.telegram.groupPolicy` | `allowlist` (default) — block all groups unless allowed |
+| `channels.telegram.allowFrom` | Primary safety control: array of allowed Telegram user IDs. If unset, the bot may respond to anyone. |
+| `channels.telegram.dmPolicy` | `pairing` (default) — within `allowFrom` set, pair with whoever writes first. Without `allowFrom`, replies to anyone. |
+| `channels.telegram.groupPolicy` | `allowlist` (default) — only respond in explicitly allowed groups. Without allowlist, drops all group messages. |
 | `channels.telegram.streaming` | `partial` — stream responses as they generate |
 
 ## 7. Health Check

--- a/config/SETUP.md
+++ b/config/SETUP.md
@@ -131,13 +131,39 @@ Verify with `openclaw models list` — should show Gemini as default, Groq as fa
 
 ## 6. Telegram Bot
 
-See issue #32 for Telegram setup. After creating bot via BotFather:
+### Create the bot
+
+1. Open Telegram, find [@BotFather](https://t.me/BotFather)
+2. Send `/newbot`, choose a name and username
+3. Copy the bot token (format: `123456:ABC-DEF...`)
+
+### Connect to OpenClaw
 
 ```bash
-openclaw config set channels.telegram.enabled true
-openclaw config set channels.telegram.token "$TELEGRAM_BOT_TOKEN"
+# Add Telegram channel with bot token
+openclaw channels add --channel telegram --token "$TELEGRAM_BOT_TOKEN"
+
+# Restrict to your Telegram user ID only (get it from @userinfobot)
+openclaw config set channels.telegram.allowFrom "[$YOUR_TELEGRAM_ID]"
+
+# Restart gateway to apply
 openclaw gateway restart
 ```
+
+### Verify
+
+Send any message to your bot in Telegram. It should reply and the conversation should appear in the dashboard at `http://127.0.0.1:18789/`.
+
+### Settings reference
+
+| Setting | Description |
+|---|---|
+| `channels.telegram.enabled` | Enable/disable the channel |
+| `channels.telegram.botToken` | Bot token from BotFather |
+| `channels.telegram.allowFrom` | Array of allowed Telegram user IDs |
+| `channels.telegram.dmPolicy` | `pairing` (default) — reply to anyone who writes first |
+| `channels.telegram.groupPolicy` | `allowlist` (default) — block all groups unless allowed |
+| `channels.telegram.streaming` | `partial` — stream responses as they generate |
 
 ## 7. Health Check
 


### PR DESCRIPTION
## Summary
- Full Telegram bot setup instructions in SETUP.md: BotFather creation, `openclaw channels add`, `allowFrom` restriction, verification steps
- Settings reference table for all Telegram channel options
- Tested end-to-end: messages sent from phone reach Jarvis, responses appear in Telegram and dashboard

## Test plan
- [x] Created bot via BotFather
- [x] Connected via `openclaw channels add`
- [x] Set `allowFrom` to owner's Telegram ID
- [x] Verified two-way communication (phone → Jarvis → phone)
- [x] Verified dashboard mirrors Telegram conversations

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)