### PR TITLE
M1 hardening: runtime execution reliability and plain-text chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # Required for Claude runtime execution (`python src/main.py --execute ...`)
 ANTHROPIC_API_KEY=
 
+# Path to Claude CLI executable
+CLAUDE_CLI_PATH=
+
 # Optional Telegram integration
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_ALLOW_USER_ID=
@@ -12,6 +15,10 @@ TELEGRAM_ALLOW_USER_ID=
 JARVIS_MODEL_DEFAULT=claude-haiku-4.5
 JARVIS_MODEL_PLANNING=claude-sonnet-4.6
 JARVIS_MODEL_CRITICAL=claude-opus-4.6
+
+# Optional Claude CLI execution safety limits
+JARVIS_MAX_BUDGET_USD=0.30
+JARVIS_EXEC_TIMEOUT_SEC=600
 
 # Optional MCP GitHub token (if your MCP server setup reads this variable)
 GITHUB_TOKEN=

--- a/docs/MIGRATION_STATUS.md
+++ b/docs/MIGRATION_STATUS.md
@@ -8,7 +8,7 @@ Status date: 2026-03-24
 - [x] Add command routing for `/triage`, `/weekly-report`, `/issue-health`
 - [x] Add baseline environment and model configuration loader
 - [x] Add `.mcp.json` bootstrap for GitHub + filesystem MCP servers
-- [ ] Connect Telegram handler and validate end-to-end message flow
+- [x] Connect Telegram handler and validate end-to-end message flow
 - [ ] Configure Claude Agent SDK direct runtime integration (beyond CLI bridge)
 - [ ] Add scheduled runs (Task Scheduler or GitHub Actions trigger)
 

--- a/src/handlers/telegram.py
+++ b/src/handlers/telegram.py
@@ -10,7 +10,11 @@ import requests
 from agents.registry import command_to_agent
 from jarvis.costs import record_execution
 from jarvis.config import RuntimeConfig
-from jarvis.dispatcher import UnsupportedCommandError, build_prompt_for_command, get_skill_command_map
+from jarvis.dispatcher import (
+    UnsupportedCommandError,
+    build_prompt_for_user_input,
+    get_skill_command_map,
+)
 from jarvis.executor import execute_prompt_with_claude
 
 TELEGRAM_API = "https://api.telegram.org/bot{token}/{method}"
@@ -169,26 +173,19 @@ def run_telegram_loop(config: RuntimeConfig) -> int:
                 continue
 
             normalized_command = _normalize_command(parsed.text)
-            if normalized_command is None:
-                command_list = ", ".join(_supported_commands())
-                _send_message(
-                    token,
-                    parsed.chat_id,
-                    f"Unsupported input. Send one of: {command_list}, /research <topic>",
-                )
-                continue
+            user_input = normalized_command or parsed.text.strip()
 
-            if normalized_command == "/help":
+            if user_input == "/help":
                 help_lines = ["Available commands:", *(_supported_commands()), "/research <topic>"]
                 _send_message(
                     token,
                     parsed.chat_id,
-                    "\n".join(help_lines),
+                    "\n".join(help_lines) + "\n\nYou can also send plain text to chat with Jarvis.",
                 )
                 continue
 
             try:
-                prompt = build_prompt_for_command(normalized_command)
+                prompt = build_prompt_for_user_input(user_input)
             except (UnsupportedCommandError, FileNotFoundError) as exc:
                 _send_message(token, parsed.chat_id, f"[jarvis] {exc}")
                 continue
@@ -197,7 +194,7 @@ def run_telegram_loop(config: RuntimeConfig) -> int:
                 _send_message(token, parsed.chat_id, "[jarvis] ANTHROPIC_API_KEY is not set.")
                 continue
 
-            selected_agent = command_to_agent(normalized_command)
+            selected_agent = command_to_agent(user_input)
             result = execute_prompt_with_claude(prompt, model=selected_agent.model)
             if result.return_code != 0:
                 error = result.stderr.strip() or "unknown claude execution error"

--- a/src/jarvis/dispatcher.py
+++ b/src/jarvis/dispatcher.py
@@ -71,3 +71,18 @@ def build_prompt_for_command(command: str) -> str:
         f"{skill_instructions}\n"
         "=== SKILL INSTRUCTIONS END ===\n"
     )
+
+
+def build_prompt_for_user_input(user_input: str) -> str:
+    text = user_input.strip()
+    if not text:
+        raise UnsupportedCommandError("Input is empty.")
+
+    if text.startswith("/"):
+        return build_prompt_for_command(text)
+
+    return (
+        "You are Jarvis, a personal AI assistant for project and research workflows. "
+        "Respond clearly in the user's language, and ask brief clarifying questions only when needed.\n\n"
+        f"User message:\n{text}\n"
+    )

--- a/src/jarvis/executor.py
+++ b/src/jarvis/executor.py
@@ -20,12 +20,31 @@ class ExecutionResult:
 def execute_prompt_with_claude(prompt: str, model: str) -> ExecutionResult:
     input_tokens = estimate_tokens(prompt)
     claude_cmd = os.getenv("CLAUDE_CLI_PATH", "claude")
+    max_budget_usd = os.getenv("JARVIS_MAX_BUDGET_USD")
+    timeout_sec = int(os.getenv("JARVIS_EXEC_TIMEOUT_SEC", "600"))
+    model_lower = model.lower()
+    if "haiku" in model_lower:
+        cli_model = "haiku"
+    elif "sonnet" in model_lower:
+        cli_model = "sonnet"
+    elif "opus" in model_lower:
+        cli_model = "opus"
+    else:
+        cli_model = model
+
+    command = [claude_cmd, "--model", cli_model, "-p", prompt, "--bare", "--output-format", "text"]
+    if max_budget_usd:
+        command.extend(["--max-budget-usd", max_budget_usd])
+
     try:
         completed = subprocess.run(
-            [claude_cmd, "-p", prompt, "--bare"],
+            command,
             check=False,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
+            timeout=timeout_sec,
         )
     except FileNotFoundError:
         return ExecutionResult(
@@ -38,15 +57,31 @@ def execute_prompt_with_claude(prompt: str, model: str) -> ExecutionResult:
             output_tokens=0,
             estimated_cost_usd=0.0,
         )
+    except subprocess.TimeoutExpired:
+        return ExecutionResult(
+            return_code=124,
+            stdout="",
+            stderr=(
+                f"Claude CLI timeout after {timeout_sec}s. "
+                "Increase JARVIS_EXEC_TIMEOUT_SEC or simplify the request."
+            ),
+            input_tokens=input_tokens,
+            output_tokens=0,
+            estimated_cost_usd=0.0,
+        )
 
     output_text = completed.stdout or ""
     output_tokens = estimate_tokens(output_text)
     estimated_cost_usd = estimate_cost_usd(model, input_tokens, output_tokens)
+    stderr_text = completed.stderr or ""
+
+    if completed.returncode == 0 and not output_text.strip() and not stderr_text.strip():
+        stderr_text = "Claude CLI returned an empty response."
 
     return ExecutionResult(
         return_code=completed.returncode,
         stdout=output_text,
-        stderr=completed.stderr or "",
+        stderr=stderr_text,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         estimated_cost_usd=estimated_cost_usd,

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from agents.registry import command_to_agent
 from handlers.telegram import run_telegram_loop
 from jarvis.costs import record_execution
 from jarvis.config import load_config
-from jarvis.dispatcher import UnsupportedCommandError, build_prompt_for_command
+from jarvis.dispatcher import UnsupportedCommandError, build_prompt_for_user_input
 from jarvis.executor import execute_prompt_with_claude
 
 
@@ -19,6 +19,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--command",
         help="Command to execute, e.g. /triage, /weekly-report, /issue-health",
+    )
+    parser.add_argument(
+        "--text",
+        help="Plain text message for normal Jarvis conversation mode",
     )
     parser.add_argument(
         "--telegram",
@@ -66,19 +70,20 @@ def main() -> int:
             print(f"[jarvis] telegram mode failed: {exc}", file=sys.stderr)
             return 2
 
-    if not args.command:
-        print("[jarvis] --command is required unless --telegram is provided.", file=sys.stderr)
+    user_input = args.command or args.text
+    if not user_input:
+        print("[jarvis] --command or --text is required unless --telegram is provided.", file=sys.stderr)
         return 2
 
     try:
-        prompt = build_prompt_for_command(args.command)
+        prompt = build_prompt_for_user_input(user_input)
     except (UnsupportedCommandError, FileNotFoundError) as exc:
         print(f"[jarvis] {exc}", file=sys.stderr)
         return 2
 
-    selected_agent = command_to_agent(args.command)
+    selected_agent = command_to_agent(user_input)
 
-    print(f"[jarvis] command: {args.command}")
+    print(f"[jarvis] input: {user_input}")
     print(f"[jarvis] default model: {config.models.default_model}")
     print(f"[jarvis] selected agent: {selected_agent.name} ({selected_agent.model})")
 


### PR DESCRIPTION
## Summary
- enforce explicit Claude model selection in CLI execution (--model)
- add execution guards: max budget and timeout
- fix Windows Unicode decode crashes in subprocess output handling
- support plain-text chat in both CLI and Telegram (not only slash commands)
- update migration status after Telegram E2E validation

## Validation
- python src/main.py --execute --text "������ ����� ������: OK"
- python src/main.py --text "������, ��� �� ������ ������?"
- python src/main.py --execute --command "/triage"

## Notes
- This PR intentionally excludes #55 scheduler draft files.

Closes #48
