### PR TITLE
feat: autonomous tool routing from plain chat (#74)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,7 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: delegate
-description: "Delegate a GitHub issue to a coding agent: decompose → branch → implement → PR"
+description: "Delegate a GitHub issue to a coding agent: decompose -> branch -> implement -> PR"
+model: sonnet
+tools: [Read, Grep, Glob, Bash]
+max_budget_usd: 0.30
+handler: jarvis.delegate:handle
+background: true
 ---
 
 # Delegate Skill

--- a/skills/issue-health/SKILL.md
+++ b/skills/issue-health/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: issue-health
 description: "Deep issue metadata audit: labels, types, hierarchy, milestones, epic structure"
+model: haiku
+tools: [Bash, Read, Glob, Grep]
+max_budget_usd: 0.10
 ---
 
 # Issue Health

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: research
 description: "Source-backed research with confidence scoring — helps validate decisions and fill knowledge gaps"
+model: sonnet
+tools: [WebSearch, WebFetch, Read, Grep, Glob, Bash]
+max_budget_usd: 0.50
 ---
 
 # Research Skill

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: self-improve
+description: "Auto-apply low-risk fixes from self-review findings, create PR for changes"
+model: sonnet
+max_budget_usd: 0.50
+handler: jarvis.self_improve:handle
+background: true
+---
+
 # /self-improve
 
 Autonomous self-improvement pipeline for Jarvis.

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: self-review
 description: "Run self-review: deterministic ops checks, test execution, and LLM-powered code review"
+model: sonnet
+max_budget_usd: 0.50
+handler: jarvis.self_review:handle
 ---
 
 # Self-Review

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: triage
 description: "Daily triage: stale issues, missing metadata, blocked items, status inconsistencies"
+model: haiku
+tools: [Bash, Read, Glob, Grep]
+max_budget_usd: 0.10
 ---
 
 # Daily Triage

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: weekly-report
 description: "Weekly delivery report: closed issues, merged PRs, blockers, velocity"
+model: haiku
+tools: [Bash, Read, Glob, Grep]
+max_budget_usd: 0.10
 ---
 
 # Weekly Report

--- a/src/agents/registry.py
+++ b/src/agents/registry.py
@@ -1,63 +1,24 @@
+"""Agent registry — thin compatibility layer over jarvis.dispatcher.
+
+All skill/agent configuration now lives in skills/*/SKILL.md frontmatter.
+This module provides backwards-compatible re-exports for any code that
+still imports from agents.registry.
+"""
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class AgentSpec:
-    name: str
-    model: str
-    allowed_tools: tuple[str, ...]
-    max_budget_usd: float = 0.30
-
-
-# PM skills: read-only, cheap model, only gh CLI + file reading
-PM_TRIAGE = AgentSpec(
-    name="pm-triage",
-    model="haiku",
-    allowed_tools=("Bash", "Read", "Glob", "Grep"),
-    max_budget_usd=0.10,
-)
-
-# Research: needs web access, stronger model
-RESEARCH = AgentSpec(
-    name="research",
-    model="sonnet",
-    allowed_tools=("WebSearch", "WebFetch", "Read", "Grep", "Glob", "Bash"),
-    max_budget_usd=0.50,
-)
-
-# Delegation: brain uses Sonnet for decomposition, coding agent runs separately
-DELEGATE = AgentSpec(
-    name="delegate",
-    model="sonnet",
-    allowed_tools=("Read", "Grep", "Glob", "Bash"),
-    max_budget_usd=0.20,
-)
-
-# General chat: minimal tools, cheap
-CHAT = AgentSpec(
-    name="chat",
-    model="haiku",
-    allowed_tools=(),
-    max_budget_usd=0.05,
-)
+from jarvis.dispatcher import SkillSpec as AgentSpec  # noqa: F401
+from jarvis.dispatcher import get_skill, CHAT_SPEC
 
 
 def command_to_agent(user_input: str) -> AgentSpec:
-    """Map user input to the right agent spec. Parses command from input."""
+    """Map user input to a SkillSpec (formerly AgentSpec)."""
     command = user_input.split(maxsplit=1)[0] if user_input.startswith("/") else ""
-    if command in {"/triage", "/weekly-report", "/issue-health"}:
-        return PM_TRIAGE
-    if command == "/research":
-        return RESEARCH
-    if command == "/delegate":
-        return DELEGATE
-    return CHAT
+    skill = get_skill(command)
+    return skill if skill is not None else CHAT_SPEC
 
 
 def is_delegation_command(user_input: str) -> bool:
-    """Check if this is a /delegate command (needs special handling)."""
+    """Check if this is a /delegate command."""
     text = user_input.strip()
     if not text.startswith("/"):
         return False

--- a/src/handlers/telegram.py
+++ b/src/handlers/telegram.py
@@ -238,12 +238,12 @@ def run_telegram_loop(config: RuntimeConfig) -> int:
             user_input = _resolve_user_input(parsed.text)
 
             if _should_run_in_background(user_input):
-                command = user_input.split(maxsplit=1)[0]
-                _send_message(
-                    token,
-                    parsed.chat_id,
-                    f"[jarvis] {command} started. Running in background...",
-                )
+                if user_input.lstrip().startswith("/"):
+                    command = user_input.split(maxsplit=1)[0]
+                    status_message = f"[jarvis] {command} started. Running in background..."
+                else:
+                    status_message = "[jarvis] Background task started. Running in background..."
+                _send_message(token, parsed.chat_id, status_message)
                 worker = threading.Thread(
                     target=_run_skill_in_background,
                     args=(token, parsed.chat_id, config, user_input, session_id),

--- a/src/handlers/telegram.py
+++ b/src/handlers/telegram.py
@@ -9,26 +9,16 @@ from uuid import uuid4
 
 import requests
 
-from agents.registry import command_to_agent, is_delegation_command
-from jarvis.costs import check_daily_budget, record_execution
 from jarvis.config import RuntimeConfig
-from jarvis.delegate import delegate_issue, parse_delegate_args
 from jarvis.dispatcher import (
-    UnsupportedCommandError,
-    build_prompt_for_user_input,
-    get_skill_command_map,
+    discover_skills,
+    dispatch_skill,
+    get_skill,
+    supported_commands,
 )
-from jarvis.executor import execute_query
 
 TELEGRAM_API = "https://api.telegram.org/bot{token}/{method}"
 MAX_MESSAGE_LEN = 4096
-
-
-def _supported_commands() -> list[str]:
-    commands = sorted(get_skill_command_map().keys())
-    if "/research" not in commands:
-        commands.append("/research")
-    return commands
 
 
 def _telegram_command_name(command: str) -> str:
@@ -36,8 +26,10 @@ def _telegram_command_name(command: str) -> str:
 
 
 def _canonical_command_map() -> dict[str, str]:
-    mapping = {cmd: cmd for cmd in _supported_commands()}
-    for cmd in _supported_commands():
+    """Map both hyphenated and underscored command forms to canonical command."""
+    commands = supported_commands()
+    mapping = {cmd: cmd for cmd in commands}
+    for cmd in commands:
         mapping[f"/{_telegram_command_name(cmd)}"] = cmd
     return mapping
 
@@ -79,19 +71,15 @@ def _send_message(token: str, chat_id: int, text: str) -> None:
 
 
 def _set_my_commands(token: str) -> None:
-    descriptions = {
-        "/triage": "Daily triage across repositories",
-        "/weekly-report": "Weekly delivery report",
-        "/issue-health": "Deep issue metadata validation",
-        "/research": "Source-backed research by topic",
-        "/delegate": "Delegate issue to coding agent",
-    }
+    """Register bot commands from auto-discovered skills."""
+    skills = discover_skills()
     commands = []
-    for cmd in _supported_commands():
+    for cmd in sorted(skills.keys()):
+        spec = skills[cmd]
         commands.append(
             {
                 "command": _telegram_command_name(cmd),
-                "description": descriptions.get(cmd, f"Run {cmd}"),
+                "description": spec.description[:256],
             }
         )
     _call_telegram(token, "setMyCommands", {"commands": commands})
@@ -125,6 +113,7 @@ def _poll_updates(token: str, offset: int | None) -> list[dict]:
 
 
 def _normalize_command(text: str) -> str | None:
+    """Normalize Telegram command input to canonical form."""
     line = text.strip().splitlines()[0] if text.strip() else ""
     if not line.startswith("/"):
         return None
@@ -138,8 +127,12 @@ def _normalize_command(text: str) -> str | None:
 
     canonical_map = _canonical_command_map()
     canonical_command = canonical_map.get(command_token)
-    if canonical_command in {"/research", "/delegate"}:
-        return f"{canonical_command} {arg}".strip()
+    if canonical_command is None:
+        return None
+
+    # Always pass args for commands that accept them.
+    if arg:
+        return f"{canonical_command} {arg}"
     return canonical_command
 
 
@@ -148,111 +141,66 @@ def _resolve_user_input(text: str) -> str:
     return normalized_command or text.strip()
 
 
-def _run_delegation_in_background(
+def _run_skill_in_background(
     token: str,
     chat_id: int,
     config: RuntimeConfig,
     user_input: str,
     session_id: str,
 ) -> None:
-    """Execute delegation in a background thread and post final result to Telegram."""
-    try:
-        repo, issue_number = parse_delegate_args(user_input)
-    except ValueError as exc:
-        _send_message(token, chat_id, f"[jarvis] {exc}")
-        return
-
-    allowed, remaining = check_daily_budget(config.budget.per_day_usd)
-    if not allowed:
-        _send_message(
-            token,
-            chat_id,
-            f"[jarvis] Daily budget exhausted (${config.budget.per_day_usd:.2f} limit).",
-        )
-        return
-
-    agent = command_to_agent(user_input)
-    query_budget = min(agent.max_budget_usd, config.budget.per_query_usd, remaining)
-    if query_budget <= 0:
-        _send_message(token, chat_id, "[jarvis] No budget available for delegation.")
-        return
-
-    _send_message(
-        token,
-        chat_id,
-        (
-            f"[jarvis] Delegation started for #{issue_number} in {repo}.\n"
-            f"Pipeline: fetch -> decompose -> branch -> code -> PR\n"
-            f"Budget: ${query_budget:.2f}"
-        ),
-    )
-
-    delegate_session_id = f"{session_id}-delegate-{uuid4().hex[:8]}"
+    """Execute a skill in a background thread and post result to Telegram."""
     try:
         result = asyncio.run(
-            delegate_issue(
-                repo,
-                issue_number,
-                max_budget_usd=query_budget,
-                session_id=delegate_session_id,
-                daily_budget_usd=config.budget.per_day_usd,
-                per_query_usd=config.budget.per_query_usd,
-            )
+            dispatch_skill(user_input, config, session_id=session_id)
         )
     except Exception as exc:
-        _send_message(token, chat_id, f"[jarvis] delegation failed with unexpected error: {exc}")
+        _send_message(token, chat_id, f"[jarvis] background task failed: {exc}")
         return
 
     if result.success:
-        _send_message(token, chat_id, result.message)
-        return
-
-    _send_message(token, chat_id, f"[jarvis] delegation failed: {result.message}")
+        _send_message(token, chat_id, result.text or "[jarvis] Done (no output)")
+    else:
+        _send_message(token, chat_id, f"[jarvis] error: {result.text}")
 
 
 def _handle_message(config: RuntimeConfig, user_input: str, session_id: str) -> str:
-    """Process a single non-delegation message and return the response text."""
-
+    """Process a single foreground message and return the response text."""
     if user_input == "/help":
-        help_lines = ["Available commands:", *(_supported_commands())]
+        help_lines = ["Available commands:"]
+        skills = discover_skills()
+        for cmd in sorted(skills.keys()):
+            help_lines.append(f"  {cmd} — {skills[cmd].description}")
         return "\n".join(help_lines) + "\n\nYou can also send plain text to chat with Jarvis."
 
-    try:
-        prompt = build_prompt_for_user_input(user_input)
-    except (UnsupportedCommandError, FileNotFoundError) as exc:
-        return f"[jarvis] {exc}"
-
-    agent = command_to_agent(user_input)
-
-    # Daily budget check
-    allowed, remaining = check_daily_budget(config.budget.per_day_usd)
-    if not allowed:
-        return f"[jarvis] Daily budget exhausted (${config.budget.per_day_usd:.2f} limit)."
-
-    query_budget = min(agent.max_budget_usd, config.budget.per_query_usd, remaining)
-
     result = asyncio.run(
-        execute_query(
-            prompt,
-            model=agent.model,
-            allowed_tools=agent.allowed_tools,
-            max_budget_usd=query_budget,
-        )
+        dispatch_skill(user_input, config, session_id=session_id)
     )
 
-    if result.cost_usd > 0 or result.input_tokens > 0:
-        record_execution(
-            model=agent.model,
-            input_tokens=result.input_tokens,
-            output_tokens=result.output_tokens,
-            cost_usd=result.cost_usd,
-            session_id=session_id,
-        )
-
     if not result.success:
-        return f"[jarvis] error: {result.error}"
+        return f"[jarvis] error: {result.text}"
 
     return result.text.strip() or "[jarvis] Empty response"
+
+
+def _should_run_in_background(user_input: str) -> bool:
+    """Check if this command should run in a background thread.
+
+    For plain-text messages, applies synchronous keyword-based intent routing
+    first so that phrases like "улучши себя" correctly resolve to /self-improve
+    (which is a background skill) before the check.
+    """
+    text = user_input.strip()
+    if not text.startswith("/"):
+        from jarvis.intent_router import route_user_input  # noqa: WPS433
+        route = route_user_input(text)
+        if not route.was_routed:
+            return False
+        text = route.resolved_input.strip()
+        if not text.startswith("/"):
+            return False
+    command = text.split(maxsplit=1)[0]
+    skill = get_skill(command)
+    return skill is not None and skill.background
 
 
 def run_telegram_loop(config: RuntimeConfig) -> int:
@@ -289,10 +237,15 @@ def run_telegram_loop(config: RuntimeConfig) -> int:
 
             user_input = _resolve_user_input(parsed.text)
 
-            if is_delegation_command(user_input):
-                _send_message(token, parsed.chat_id, "[jarvis] Delegation request accepted. Running in background...")
+            if _should_run_in_background(user_input):
+                command = user_input.split(maxsplit=1)[0]
+                _send_message(
+                    token,
+                    parsed.chat_id,
+                    f"[jarvis] {command} started. Running in background...",
+                )
                 worker = threading.Thread(
-                    target=_run_delegation_in_background,
+                    target=_run_skill_in_background,
                     args=(token, parsed.chat_id, config, user_input, session_id),
                     daemon=True,
                 )

--- a/src/jarvis/delegate.py
+++ b/src/jarvis/delegate.py
@@ -354,3 +354,35 @@ async def delegate_issue(
         coding_summary=coding_result.summary,
         cost_usd=cost, input_tokens=in_tok, output_tokens=out_tok,
     )
+
+
+async def handle(config: "RuntimeConfig", args: str) -> "SkillResult":
+    """Skill handler entry point — called by dispatcher auto-discovery."""
+    from jarvis.config import RuntimeConfig as _RC  # noqa: WPS433, F811
+    from jarvis.dispatcher import SkillResult  # noqa: WPS433
+
+    try:
+        repo, issue_number = parse_delegate_args(f"/delegate {args}")
+    except ValueError as exc:
+        return SkillResult(text=str(exc), success=False)
+
+    result = await delegate_issue(
+        repo,
+        issue_number,
+        max_budget_usd=min(0.30, config.budget.per_query_usd),
+        session_id="delegate-dispatch",
+        daily_budget_usd=config.budget.per_day_usd,
+        per_query_usd=config.budget.per_query_usd,
+    )
+
+    text = result.message
+    if result.coding_summary:
+        text += f"\n\n--- Coding Agent Summary ---\n{result.coding_summary[:1000]}"
+
+    return SkillResult(
+        text=text,
+        success=result.success,
+        cost_usd=result.cost_usd,
+        input_tokens=result.input_tokens,
+        output_tokens=result.output_tokens,
+    )

--- a/src/jarvis/delegate.py
+++ b/src/jarvis/delegate.py
@@ -358,7 +358,7 @@ async def delegate_issue(
 
 async def handle(config: "RuntimeConfig", args: str) -> "SkillResult":
     """Skill handler entry point — called by dispatcher auto-discovery."""
-    from jarvis.config import RuntimeConfig as _RC  # noqa: WPS433, F811
+    from uuid import uuid4  # noqa: WPS433
     from jarvis.dispatcher import SkillResult  # noqa: WPS433
 
     try:
@@ -369,8 +369,8 @@ async def handle(config: "RuntimeConfig", args: str) -> "SkillResult":
     result = await delegate_issue(
         repo,
         issue_number,
-        max_budget_usd=min(0.30, config.budget.per_query_usd),
-        session_id="delegate-dispatch",
+        max_budget_usd=config.budget.per_query_usd,
+        session_id=f"delegate-{uuid4().hex[:10]}",
         daily_budget_usd=config.budget.per_day_usd,
         per_query_usd=config.budget.per_query_usd,
     )

--- a/src/jarvis/dispatcher.py
+++ b/src/jarvis/dispatcher.py
@@ -1,7 +1,25 @@
+"""Skill auto-discovery and unified dispatch.
+
+Skills are defined by SKILL.md files in skills/*/ directories.
+Frontmatter in SKILL.md declares agent configuration and optional Python handler.
+
+Two execution modes:
+1. Prompt-based (default): SKILL.md body is sent to Claude as a prompt
+2. Handler-based: a Python async function handles the full pipeline
+
+Adding a new skill = create skills/<name>/SKILL.md with frontmatter. Done.
+"""
 from __future__ import annotations
 
+import importlib
+import re
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
+
+from jarvis.config import RuntimeConfig
+from jarvis.costs import check_daily_budget, record_execution
+from jarvis.executor import execute_query
 
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -17,11 +35,104 @@ class UnsupportedCommandError(ValueError):
     pass
 
 
+@dataclass(frozen=True)
+class SkillSpec:
+    name: str
+    command: str
+    description: str
+    model: str = "haiku"
+    tools: tuple[str, ...] = ()
+    max_budget_usd: float = 0.10
+    handler: str = ""
+    background: bool = False
+    skill_file: Path = field(default_factory=Path)
+
+
+@dataclass
+class SkillResult:
+    text: str
+    success: bool = True
+    cost_usd: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    model: str = ""
+
+
+# Built-in chat fallback (no SKILL.md needed).
+CHAT_SPEC = SkillSpec(
+    name="chat",
+    command="chat",
+    description="General conversation",
+    model="haiku",
+    tools=(),
+    max_budget_usd=0.05,
+)
+
+
+# ── Frontmatter parsing ────────────────────────────────────────────────
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Split SKILL.md into (frontmatter_dict, body_content)."""
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("---", 3)
+    if end == -1:
+        return {}, text
+
+    fm_block = text[3:end].strip()
+    body = text[end + 3:].strip()
+
+    fm: dict[str, str] = {}
+    for line in fm_block.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        fm[key.strip()] = value.strip()
+    return fm, body
+
+
+def _unquote(raw: str) -> str:
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ('"', "'"):
+        return raw[1:-1]
+    return raw
+
+
+def _parse_tools(raw: str) -> tuple[str, ...]:
+    raw = raw.strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        items = raw[1:-1].split(",")
+        return tuple(item.strip().strip("\"'") for item in items if item.strip())
+    return ()
+
+
+def _parse_bool(raw: str) -> bool:
+    return raw.strip().lower() in {"true", "yes", "1"}
+
+
+def _parse_float(raw: str, default: float) -> float:
+    try:
+        return float(raw.strip())
+    except (ValueError, TypeError):
+        return default
+
+
+# ── Auto-discovery ──────────────────────────────────────────────────────
+
+
 @lru_cache(maxsize=1)
-def get_skill_command_map() -> dict[str, Path]:
-    command_map: dict[str, Path] = {}
+def discover_skills() -> dict[str, SkillSpec]:
+    """Auto-discover all skills from skills/*/SKILL.md.
+
+    Returns dict mapping command (e.g. "/triage") to SkillSpec.
+    Cached after first call; restart to pick up new skills.
+    """
+    skills: dict[str, SkillSpec] = {}
     if not SKILLS_DIR.exists():
-        return command_map
+        return skills
 
     for skill_dir in sorted(SKILLS_DIR.iterdir()):
         if not skill_dir.is_dir():
@@ -29,50 +140,213 @@ def get_skill_command_map() -> dict[str, Path]:
         skill_file = skill_dir / "SKILL.md"
         if not skill_file.exists():
             continue
-        command_map[f"/{skill_dir.name}"] = skill_file
 
-    return command_map
+        text = skill_file.read_text(encoding="utf-8")
+        fm, _body = _split_frontmatter(text)
+
+        command = f"/{skill_dir.name}"
+        name = _unquote(fm.get("name", skill_dir.name))
+        description = _unquote(fm.get("description", f"Run {command}"))
+
+        spec = SkillSpec(
+            name=name,
+            command=command,
+            description=description,
+            model=fm.get("model", "haiku"),
+            tools=_parse_tools(fm.get("tools", "")),
+            max_budget_usd=_parse_float(fm.get("max_budget_usd", ""), 0.10),
+            handler=fm.get("handler", ""),
+            background=_parse_bool(fm.get("background", "")),
+            skill_file=skill_file,
+        )
+        skills[command] = spec
+
+    return skills
+
+
+def get_skill(command: str) -> SkillSpec | None:
+    """Look up a skill by command name. Returns None if not found."""
+    return discover_skills().get(command)
 
 
 def supported_commands() -> list[str]:
-    return sorted(get_skill_command_map().keys())
+    """Return sorted list of all discovered skill commands."""
+    return sorted(discover_skills().keys())
 
 
-def _parse_command(text: str) -> tuple[str, str]:
-    """Parse '/command arg1 arg2' into ('/command', 'arg1 arg2')."""
-    parts = text.split(maxsplit=1)
-    command = parts[0]
-    args = parts[1].strip() if len(parts) > 1 else ""
-    return command, args
+# Keep old name for any remaining callers.
+def get_skill_command_map() -> dict[str, Path]:
+    """Backwards-compatible: returns {command: skill_file_path}."""
+    return {cmd: spec.skill_file for cmd, spec in discover_skills().items()}
 
 
-def build_prompt_for_command(text: str) -> str:
-    command, args = _parse_command(text)
+# ── Handler resolution ──────────────────────────────────────────────────
 
-    skill_map = get_skill_command_map()
-    skill_file = skill_map.get(command)
-    if skill_file is None:
-        supported = ", ".join(supported_commands())
-        raise UnsupportedCommandError(f"Unsupported command: {command}. Supported: {supported}")
 
-    if not skill_file.exists():
-        raise FileNotFoundError(f"Skill definition not found: {skill_file}")
+def _resolve_handler(handler_path: str):
+    """Import 'module.path:function_name' and return the callable."""
+    if ":" not in handler_path:
+        raise ImportError(f"Handler must be 'module:function', got: {handler_path}")
+    module_path, func_name = handler_path.rsplit(":", 1)
+    module = importlib.import_module(module_path)
+    func = getattr(module, func_name)
+    return func
 
-    skill_instructions = skill_file.read_text(encoding="utf-8")
 
-    prompt = f"{JARVIS_IDENTITY}\n\nExecute: {command}"
+# ── Prompt building ─────────────────────────────────────────────────────
+
+
+def _build_prompt(skill: SkillSpec, args: str) -> str:
+    """Build a prompt from SKILL.md body for prompt-based skills."""
+    text = skill.skill_file.read_text(encoding="utf-8")
+    _fm, body = _split_frontmatter(text)
+
+    prompt = f"{JARVIS_IDENTITY}\n\nExecute: {skill.command}"
     if args:
         prompt += f"\nTopic/arguments: {args}"
-    prompt += f"\n\n{skill_instructions}\n"
+    prompt += f"\n\n{body}\n"
     return prompt
 
 
 def build_prompt_for_user_input(user_input: str) -> str:
+    """Build prompt for any user input. Used by dry-run mode."""
     text = user_input.strip()
     if not text:
         raise UnsupportedCommandError("Input is empty.")
 
     if text.startswith("/"):
-        return build_prompt_for_command(text)
+        command = text.split(maxsplit=1)[0]
+        args = text[len(command):].strip()
+        skill = get_skill(command)
+        if skill is None:
+            available = ", ".join(supported_commands())
+            raise UnsupportedCommandError(
+                f"Unsupported command: {command}. Available: {available}"
+            )
+        return _build_prompt(skill, args)
 
     return f"{JARVIS_IDENTITY}\n\n{text}\n"
+
+
+# ── Unified dispatch ────────────────────────────────────────────────────
+
+
+def _parse_command_input(user_input: str) -> tuple[str, str]:
+    """Parse user input into (command, args). Non-commands return ('chat', text)."""
+    text = user_input.strip()
+    if not text:
+        return "chat", ""
+    if text.startswith("/"):
+        parts = text.split(maxsplit=1)
+        command = parts[0]
+        args = parts[1].strip() if len(parts) > 1 else ""
+        return command, args
+    return "chat", text
+
+
+async def dispatch_skill(
+    user_input: str,
+    config: RuntimeConfig,
+    *,
+    session_id: str = "",
+) -> SkillResult:
+    """Unified dispatch: auto-routes to handler or prompt-based execution.
+
+    This is the single entry point for all skill execution.
+    - Handler skills: imports and calls the Python handler function
+    - Prompt skills: builds prompt from SKILL.md, sends to Claude via SDK
+    - Chat: sends plain text to Claude
+    - Plain text: intent-classified and routed to matching skill when confident
+
+    Budget checking and cost recording are handled here.
+    """
+    command, args = _parse_command_input(user_input)
+
+    # ── Intent routing for plain text ──
+    routing_footer = ""
+    if command == "chat":
+        from jarvis.intent_router import (  # noqa: WPS433
+            format_routing_transparency,
+            route_user_input_async,
+        )
+        route = await route_user_input_async(user_input)
+        routing_footer = "\n\n" + format_routing_transparency(route)
+        if route.was_routed:
+            command, args = _parse_command_input(route.resolved_input)
+
+    # Resolve skill spec
+    if command == "chat":
+        skill = CHAT_SPEC
+    else:
+        skill = get_skill(command)
+        if skill is None:
+            available = ", ".join(supported_commands())
+            return SkillResult(
+                text=f"Unknown command: {command}. Available: {available}",
+                success=False,
+            )
+
+    # Budget gate
+    allowed, remaining = check_daily_budget(config.budget.per_day_usd)
+    if not allowed:
+        return SkillResult(
+            text=f"Daily budget exhausted (${config.budget.per_day_usd:.2f} limit).",
+            success=False,
+        )
+
+    query_budget = min(skill.max_budget_usd, config.budget.per_query_usd, remaining)
+
+    # ── Handler-based skill ──
+    if skill.handler:
+        try:
+            handler = _resolve_handler(skill.handler)
+        except (ImportError, AttributeError) as exc:
+            return SkillResult(text=f"Handler import failed: {exc}", success=False)
+
+        try:
+            result: SkillResult = await handler(config, args)
+        except Exception as exc:
+            return SkillResult(text=f"Handler error: {exc}", success=False)
+
+        if routing_footer:
+            return SkillResult(
+                text=result.text + routing_footer,
+                success=result.success,
+                cost_usd=result.cost_usd,
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+                model=result.model,
+            )
+        return result
+
+    # ── Prompt-based skill ──
+    if command == "chat":
+        prompt = f"{JARVIS_IDENTITY}\n\n{args}\n"
+    else:
+        prompt = _build_prompt(skill, args)
+
+    exec_result = await execute_query(
+        prompt,
+        model=skill.model,
+        allowed_tools=skill.tools,
+        max_budget_usd=query_budget,
+    )
+
+    if exec_result.cost_usd > 0 or exec_result.input_tokens > 0:
+        record_execution(
+            model=skill.model,
+            input_tokens=exec_result.input_tokens,
+            output_tokens=exec_result.output_tokens,
+            cost_usd=exec_result.cost_usd,
+            session_id=session_id,
+        )
+
+    result_text = exec_result.text if exec_result.success else exec_result.error
+    return SkillResult(
+        text=result_text + routing_footer,
+        success=exec_result.success,
+        cost_usd=exec_result.cost_usd,
+        input_tokens=exec_result.input_tokens,
+        output_tokens=exec_result.output_tokens,
+        model=skill.model,
+    )

--- a/src/jarvis/dispatcher.py
+++ b/src/jarvis/dispatcher.py
@@ -12,7 +12,6 @@ Adding a new skill = create skills/<name>/SKILL.md with frontmatter. Done.
 from __future__ import annotations
 
 import importlib
-import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -307,6 +306,15 @@ async def dispatch_skill(
             result: SkillResult = await handler(config, args)
         except Exception as exc:
             return SkillResult(text=f"Handler error: {exc}", success=False)
+
+        if result.cost_usd > 0 or result.input_tokens > 0:
+            record_execution(
+                model=result.model or skill.model,
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+                cost_usd=result.cost_usd,
+                session_id=session_id,
+            )
 
         if routing_footer:
             return SkillResult(

--- a/src/jarvis/intent_router.py
+++ b/src/jarvis/intent_router.py
@@ -48,16 +48,8 @@ def _contains_any(text: str, words: tuple[str, ...]) -> bool:
 def _classify_plain_text(text: str) -> tuple[str, float, str, str | None]:
     lowered = text.lower()
 
-    self_review_words = (
-        "self review",
-        "self-review",
-        "самопровер",
-        "сделай self review",
-        "проверь себя",
-    )
-    if _contains_any(lowered, self_review_words):
-        return "/self-review", 0.93, "matched self-review intent", None
-
+    # Check self-improve before self-review: "apply fixes from self review"
+    # should route to self-improve (the action intent wins).
     self_improve_words = (
         "self improve",
         "self-improve",
@@ -68,6 +60,16 @@ def _classify_plain_text(text: str) -> tuple[str, float, str, str | None]:
     )
     if _contains_any(lowered, self_improve_words):
         return "/self-improve", 0.92, "matched self-improve intent", None
+
+    self_review_words = (
+        "self review",
+        "self-review",
+        "самопровер",
+        "сделай self review",
+        "проверь себя",
+    )
+    if _contains_any(lowered, self_review_words):
+        return "/self-review", 0.93, "matched self-review intent", None
 
     weekly_words = (
         "weekly report",

--- a/src/jarvis/self_improve.py
+++ b/src/jarvis/self_improve.py
@@ -502,3 +502,23 @@ async def run_self_improve_pipeline(
     ))
 
     return result
+
+
+async def handle(config: RuntimeConfig, args: str) -> "SkillResult":
+    """Skill handler entry point — called by dispatcher auto-discovery."""
+    from jarvis.dispatcher import SkillResult  # noqa: WPS433
+
+    dry_run = "--dry-run" in args
+
+    result = await run_self_improve_pipeline(config, dry_run=dry_run)
+
+    lines = [result.message]
+    if result.pr_url:
+        lines.append(f"PR: {result.pr_url}")
+    if result.items:
+        lines.append(f"\nApplied: {result.auto_applied} | Needs approval: {result.needs_approval} | Skipped: {result.skipped}")
+        for it in result.items:
+            status = "applied" if it.applied else ("skipped" if it.skipped_reason else "needs-approval")
+            lines.append(f"  - [{it.finding.severity}] {it.finding.title} ({status})")
+
+    return SkillResult(text="\n".join(lines), success=result.success)

--- a/src/jarvis/self_review.py
+++ b/src/jarvis/self_review.py
@@ -509,3 +509,16 @@ async def run_self_review_pipeline(
     )
 
     return result, memory_summary
+
+
+async def handle(config: RuntimeConfig, args: str) -> "SkillResult":
+    """Skill handler entry point — called by dispatcher auto-discovery."""
+    from jarvis.dispatcher import SkillResult  # noqa: WPS433
+
+    result, memory_summary = await run_self_review_pipeline(config)
+
+    text = result.report_text
+    if memory_summary:
+        text = f"**Memory context:** {memory_summary}\n\n{text}"
+
+    return SkillResult(text=text, success=True)

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,6 @@ from jarvis.dispatcher import (
     UnsupportedCommandError,
     build_prompt_for_user_input,
     dispatch_skill,
-    discover_skills,
     get_skill,
 )
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,13 +5,15 @@ import asyncio
 import sys
 from uuid import uuid4
 
-from agents.registry import command_to_agent, is_delegation_command
 from handlers.telegram import run_telegram_loop
-from jarvis.costs import check_daily_budget, record_execution
 from jarvis.config import load_config
-from jarvis.delegate import delegate_issue, parse_delegate_args
-from jarvis.dispatcher import UnsupportedCommandError, build_prompt_for_user_input
-from jarvis.executor import execute_query
+from jarvis.dispatcher import (
+    UnsupportedCommandError,
+    build_prompt_for_user_input,
+    dispatch_skill,
+    discover_skills,
+    get_skill,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,92 +39,17 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-async def run_delegation(user_input: str, config) -> int:
-    """Handle /delegate command — full pipeline."""
-    try:
-        repo, issue_number = parse_delegate_args(user_input)
-    except ValueError as exc:
-        print(f"[jarvis] {exc}", file=sys.stderr)
-        return 2
-
-    allowed, remaining = check_daily_budget(config.budget.per_day_usd)
-    if not allowed:
-        print(f"[jarvis] Daily budget exhausted. Limit: ${config.budget.per_day_usd:.2f}", file=sys.stderr)
-        return 2
-
-    agent = command_to_agent(user_input)
-    query_budget = min(agent.max_budget_usd, config.budget.per_query_usd, remaining)
-    if query_budget <= 0:
-        print("[jarvis] No budget available for delegation.", file=sys.stderr)
-        return 2
-
-    session_id = f"delegate-cli-{uuid4().hex[:10]}"
-
-    print(f"[jarvis] delegating #{issue_number} from {repo}")
-    print(f"[jarvis] pipeline: fetch → decompose → branch → code → PR")
-    print(f"[jarvis] delegation budget: ${query_budget:.2f}")
-
-    result = await delegate_issue(
-        repo,
-        issue_number,
-        max_budget_usd=query_budget,
-        session_id=session_id,
-        daily_budget_usd=config.budget.per_day_usd,
-        per_query_usd=config.budget.per_query_usd,
-    )
-
-    if result.success:
-        print(f"[jarvis] {result.message}")
-        if result.coding_summary:
-            print(f"\n--- Coding Agent Summary ---\n{result.coding_summary[:1000]}")
-        return 0
-    else:
-        print(f"[jarvis] delegation failed: {result.message}", file=sys.stderr)
-        return 1
-
-
 async def run_command(user_input: str, config) -> int:
-    """Build prompt, check budget, execute via SDK, record cost."""
-    try:
-        prompt = build_prompt_for_user_input(user_input)
-    except (UnsupportedCommandError, FileNotFoundError) as exc:
-        print(f"[jarvis] {exc}", file=sys.stderr)
-        return 2
-
-    agent = command_to_agent(user_input)
-
-    # Daily budget check
-    allowed, remaining = check_daily_budget(config.budget.per_day_usd)
-    if not allowed:
-        print(f"[jarvis] Daily budget exhausted. Limit: ${config.budget.per_day_usd}", file=sys.stderr)
-        return 2
-
-    # Per-query budget: smallest of agent cap, global per-query cap, and remaining daily
-    query_budget = min(agent.max_budget_usd, config.budget.per_query_usd, remaining)
-
-    print(f"[jarvis] agent: {agent.name} | model: {agent.model} | budget: ${query_budget:.2f}")
-
+    """Unified command execution via dispatcher auto-discovery."""
     session_id = f"cli-{uuid4().hex[:10]}"
 
-    result = await execute_query(
-        prompt,
-        model=agent.model,
-        allowed_tools=agent.allowed_tools,
-        max_budget_usd=query_budget,
-    )
+    result = await dispatch_skill(user_input, config, session_id=session_id)
 
     if result.cost_usd > 0 or result.input_tokens > 0:
-        record_execution(
-            model=agent.model,
-            input_tokens=result.input_tokens,
-            output_tokens=result.output_tokens,
-            cost_usd=result.cost_usd,
-            session_id=session_id,
-        )
         print(f"[jarvis] tokens: in={result.input_tokens} out={result.output_tokens} cost=${result.cost_usd:.4f}")
 
     if not result.success:
-        print(f"[jarvis] error: {result.error}", file=sys.stderr)
+        print(f"[jarvis] error: {result.text}", file=sys.stderr)
         return 1
 
     print(result.text)
@@ -151,14 +78,13 @@ def main() -> int:
         except (UnsupportedCommandError, FileNotFoundError) as exc:
             print(f"[jarvis] {exc}", file=sys.stderr)
             return 2
-        agent = command_to_agent(user_input)
-        print(f"[jarvis] agent: {agent.name} | model: {agent.model}")
+
+        command = user_input.split(maxsplit=1)[0] if user_input.startswith("/") else "chat"
+        skill = get_skill(command)
+        model = skill.model if skill else "haiku"
+        print(f"[jarvis] skill: {command} | model: {model}")
         print(f"[jarvis] prompt preview (first 600 chars):\n{prompt[:600]}")
         return 0
-
-    # Delegation has its own pipeline
-    if is_delegation_command(user_input):
-        return asyncio.run(run_delegation(user_input, config))
 
     return asyncio.run(run_command(user_input, config))
 

--- a/tests/test_intent_router.py
+++ b/tests/test_intent_router.py
@@ -13,11 +13,6 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
-import sys
-import os
-
-# Ensure src/ is on the path.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from jarvis.intent_router import (
     HIGH_CONFIDENCE_THRESHOLD,

--- a/tests/test_intent_router.py
+++ b/tests/test_intent_router.py
@@ -1,0 +1,310 @@
+"""Unit tests for jarvis.intent_router — routing edge cases.
+
+Tests cover:
+- Explicit slash commands (pass-through)
+- Keyword-based routing for each supported skill
+- Low-confidence / greeting fallback to chat
+- Argument extraction (research topic, delegate issue #)
+- Async routing with LLM fallback mocked
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import sys
+import os
+
+# Ensure src/ is on the path.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from jarvis.intent_router import (
+    HIGH_CONFIDENCE_THRESHOLD,
+    LLM_CONFIDENCE_THRESHOLD,
+    RoutedInput,
+    _classify_plain_text,
+    _looks_like_command_intent,
+    format_routing_transparency,
+    route_user_input,
+    route_user_input_async,
+)
+
+
+# ── _classify_plain_text ──────────────────────────────────────────────────────
+
+
+class TestClassifyPlainText:
+    def test_self_review_english(self):
+        cmd, conf, _, _ = _classify_plain_text("do a self review")
+        assert cmd == "/self-review"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_self_review_russian(self):
+        cmd, conf, _, _ = _classify_plain_text("проверь себя")
+        assert cmd == "/self-review"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_self_improve_english(self):
+        cmd, conf, _, _ = _classify_plain_text("self-improve please")
+        assert cmd == "/self-improve"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_self_improve_apply_fixes(self):
+        cmd, conf, _, _ = _classify_plain_text("apply fixes from self review")
+        assert cmd == "/self-improve"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_weekly_report(self):
+        cmd, conf, _, _ = _classify_plain_text("give me the weekly report")
+        assert cmd == "/weekly-report"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_weekly_report_russian(self):
+        cmd, conf, _, _ = _classify_plain_text("итоги недели")
+        assert cmd == "/weekly-report"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_triage(self):
+        cmd, conf, _, _ = _classify_plain_text("triage the backlog")
+        assert cmd == "/triage"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_issue_health(self):
+        cmd, conf, _, _ = _classify_plain_text("run issue health check")
+        assert cmd == "/issue-health"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_research_with_topic(self):
+        cmd, conf, _, args = _classify_plain_text("research best Python ORMs")
+        assert cmd == "/research"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+        assert args is not None
+        assert "Python ORMs" in args or "best" in args
+
+    def test_research_russian(self):
+        cmd, conf, _, _ = _classify_plain_text("поищи документацию по FastAPI")
+        assert cmd == "/research"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+
+    def test_delegate_with_issue_number(self):
+        cmd, conf, _, args = _classify_plain_text("delegate fix issue #42")
+        assert cmd == "/delegate"
+        assert conf >= HIGH_CONFIDENCE_THRESHOLD
+        assert args == "#42"
+
+    def test_delegate_without_issue_number_stays_chat(self):
+        # No issue number → can't delegate, fallback to chat
+        cmd, conf, _, _ = _classify_plain_text("delegate something")
+        assert cmd == "chat"
+
+    def test_plain_chat_fallback(self):
+        cmd, conf, _, _ = _classify_plain_text("how are you today?")
+        assert cmd == "chat"
+        assert conf < HIGH_CONFIDENCE_THRESHOLD
+
+    def test_empty_like_input(self):
+        cmd, _, _, _ = _classify_plain_text("  ")
+        assert cmd == "chat"
+
+
+# ── route_user_input (sync) ───────────────────────────────────────────────────
+
+
+class TestRouteUserInputSync:
+    def test_slash_command_passthrough(self):
+        result = route_user_input("/triage")
+        assert result.selected_route == "/triage"
+        assert result.was_routed is False
+        assert result.confidence == 1.0
+        assert result.resolved_input == "/triage"
+
+    def test_slash_command_with_args(self):
+        result = route_user_input("/research some topic")
+        assert result.selected_route == "/research"
+        assert result.resolved_input == "/research some topic"
+        assert result.was_routed is False
+
+    def test_routed_to_triage(self):
+        result = route_user_input("triage my issues")
+        assert result.selected_route == "/triage"
+        assert result.was_routed is True
+        assert result.resolved_input == "/triage"
+
+    def test_routed_to_weekly_report(self):
+        result = route_user_input("show me the weekly report")
+        assert result.selected_route == "/weekly-report"
+        assert result.was_routed is True
+
+    def test_routed_to_self_review(self):
+        result = route_user_input("run self review on the code")
+        assert result.selected_route == "/self-review"
+        assert result.was_routed is True
+
+    def test_routed_to_self_improve(self):
+        result = route_user_input("улучши себя")
+        assert result.selected_route == "/self-improve"
+        assert result.was_routed is True
+
+    def test_research_extracts_topic(self):
+        result = route_user_input("research GraphQL vs REST")
+        assert result.selected_route == "/research"
+        assert result.was_routed is True
+        # Resolved input should be "/research <topic>"
+        assert result.resolved_input.startswith("/research")
+        assert "GraphQL" in result.resolved_input or "REST" in result.resolved_input
+
+    def test_delegate_extracts_issue(self):
+        result = route_user_input("delegate implement issue #99")
+        assert result.selected_route == "/delegate"
+        assert result.was_routed is True
+        assert "#99" in result.resolved_input
+
+    def test_chat_fallback_greeting(self):
+        result = route_user_input("привет")
+        assert result.selected_route == "chat"
+        assert result.was_routed is False
+
+    def test_chat_fallback_generic_question(self):
+        result = route_user_input("what time is it?")
+        assert result.selected_route == "chat"
+        assert result.was_routed is False
+
+    def test_empty_input(self):
+        result = route_user_input("")
+        assert result.selected_route == "chat"
+        assert result.was_routed is False
+        assert result.confidence == 0.0
+
+
+# ── _looks_like_command_intent ────────────────────────────────────────────────
+
+
+class TestLooksLikeCommandIntent:
+    def test_greeting_is_not_command(self):
+        assert _looks_like_command_intent("привет") is False
+
+    def test_single_word_is_not_command(self):
+        assert _looks_like_command_intent("hi") is False
+
+    def test_short_greeting_with_name_is_not_command(self):
+        assert _looks_like_command_intent("hello jarvis") is False
+
+    def test_action_sentence_is_command(self):
+        assert _looks_like_command_intent("check the project status") is True
+
+    def test_yes_no_is_not_command(self):
+        assert _looks_like_command_intent("да") is False
+        assert _looks_like_command_intent("ok") is False
+
+
+# ── route_user_input_async ────────────────────────────────────────────────────
+
+
+class TestRouteUserInputAsync:
+    def test_slash_command_returns_sync_result(self):
+        result = asyncio.run(route_user_input_async("/triage"))
+        assert result.selected_route == "/triage"
+        assert result.was_routed is False
+
+    def test_keyword_match_skips_llm(self):
+        """Keyword match should not call LLM."""
+        with patch("jarvis.intent_router._classify_with_llm") as mock_llm:
+            result = asyncio.run(route_user_input_async("run self review"))
+        mock_llm.assert_not_called()
+        assert result.selected_route == "/self-review"
+        assert result.was_routed is True
+
+    def test_greeting_skips_llm(self):
+        """Short greeting should not trigger expensive LLM call."""
+        with patch("jarvis.intent_router._classify_with_llm") as mock_llm:
+            result = asyncio.run(route_user_input_async("hi"))
+        mock_llm.assert_not_called()
+        assert result.selected_route == "chat"
+
+    def test_llm_called_for_ambiguous_text(self):
+        """Ambiguous text that passes _looks_like_command_intent should try LLM."""
+        llm_return = ("/triage", 0.85, "triage keywords in context", None, ())
+        with patch(
+            "jarvis.intent_router._classify_with_llm",
+            new=AsyncMock(return_value=llm_return),
+        ):
+            result = asyncio.run(
+                route_user_input_async("проверь статус для redrobot")
+            )
+        assert result.was_routed is True
+        assert result.selected_route == "/triage"
+        assert "llm" in result.reason
+
+    def test_llm_low_confidence_falls_back_to_chat(self):
+        """LLM result below threshold stays in chat."""
+        llm_return = ("/research", 0.50, "maybe research", None, ("/triage",))
+        with patch(
+            "jarvis.intent_router._classify_with_llm",
+            new=AsyncMock(return_value=llm_return),
+        ):
+            result = asyncio.run(
+                route_user_input_async("проверь статус для redrobot")
+            )
+        assert result.selected_route == "chat"
+        assert result.was_routed is False
+
+    def test_llm_failure_falls_back_to_chat(self):
+        """If LLM call fails, route stays at chat."""
+        llm_return = ("chat", 0.20, "llm classification failed", None, ())
+        with patch(
+            "jarvis.intent_router._classify_with_llm",
+            new=AsyncMock(return_value=llm_return),
+        ):
+            result = asyncio.run(
+                route_user_input_async("something weird and ambiguous here")
+            )
+        assert result.selected_route == "chat"
+        assert result.was_routed is False
+
+
+# ── format_routing_transparency ───────────────────────────────────────────────
+
+
+class TestFormatRoutingTransparency:
+    def test_chat_direct_format(self):
+        route = RoutedInput(
+            original_input="hello",
+            resolved_input="hello",
+            selected_route="chat",
+            confidence=0.90,
+            reason="no skill keywords",
+            was_routed=False,
+        )
+        line = format_routing_transparency(route)
+        assert "chat" in line
+        assert "direct" in line
+        assert "0.90" in line
+
+    def test_routed_format_shows_intent_routed(self):
+        route = RoutedInput(
+            original_input="run self review",
+            resolved_input="/self-review",
+            selected_route="/self-review",
+            confidence=0.93,
+            reason="matched self-review intent",
+            was_routed=True,
+        )
+        line = format_routing_transparency(route)
+        assert "intent-routed" in line
+        assert "/self-review" in line
+        assert "0.93" in line
+
+    def test_suggestions_included_when_present(self):
+        route = RoutedInput(
+            original_input="check something",
+            resolved_input="check something",
+            selected_route="chat",
+            confidence=0.45,
+            reason="ambiguous",
+            was_routed=False,
+            suggestions=("/triage", "/self-review"),
+        )
+        line = format_routing_transparency(route)
+        assert "/triage" in line
+        assert "/self-review" in line


### PR DESCRIPTION
## Summary

- **Intent routing**: plain text messages are now classified and routed to the right skill automatically. Keyword matching runs first (free, instant); Haiku LLM fallback handles ambiguous inputs. Every response includes a transparency footer (`[jarvis] route: /triage | confidence: 0.83 | mode: intent-routed`).
- **Dispatcher architecture**: `dispatcher.py` rewritten with unified `dispatch_skill()` entry point supporting handler-based and prompt-based skills. `telegram.py`, `main.py`, `registry.py` simplified accordingly. Background-task detection in Telegram now pre-routes intent, so `"улучши себя"` correctly runs `/self-improve` in a background thread.
- **Skill wiring** (#75, #76): `handle()` entry points added to `self_review.py`, `self_improve.py`, `delegate.py`; SKILL.md frontmatter updated with `handler`, `model`, `max_budget_usd`, `background` fields.
- **Tests**: 39 unit tests in `tests/test_intent_router.py` covering keyword routing, async LLM fallback (mocked), confidence thresholds, edge cases, and transparency formatting.

## Test plan

- [x] `python -m compileall src/` — no errors
- [x] `pytest tests/ -v` — 39/39 passed
- [x] Smoke test: imports, `discover_skills()`, `_should_run_in_background("улучши себя") == True`
- [ ] Manual: send plain text like "triage my issues" to Telegram bot, verify it routes to `/triage` with footer
- [ ] Manual: send greeting like "привет", verify it stays in chat mode

## Risk / rollback

Low risk. Intent routing is purely additive — slash commands bypass it entirely. If routing misfires, confidence threshold (0.78 keyword / 0.70 LLM) keeps false positives low. To disable routing, remove the 10-line block in `dispatch_skill()`.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)