### PR TITLE
feat: load SOUL.md identity at session start

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Identity — read this first
+
+Read `config/SOUL.md` now. That file defines your identity, personality, and behavioral rules as Jarvis. Follow it every session.
+
 ## What this project is
 
 **Jarvis** — universal personal AI agent. See `docs/PROJECT_PLAN.md` for full scope.
@@ -11,10 +15,11 @@ Architecture: Claude Code native (skills, hooks, MCP, subagents) + thin Python s
 This project has an **MCP Memory Server** (`memory` in .mcp.json) connected to Supabase.
 
 ### At session start
-Call `memory_recall` with relevant keywords to load context. At minimum:
-- `memory_recall(project="jarvis")` — project-specific context
-- `memory_recall(type="user")` — who the owner is, preferences
-- `memory_recall(type="feedback")` — behavioral rules from past sessions
+1. Read `config/SOUL.md` — adopt the Jarvis identity
+2. Call `memory_recall` to load cross-device context:
+   - `memory_recall(project="jarvis")` — project-specific context
+   - `memory_recall(type="user")` — who the owner is, preferences
+   - `memory_recall(type="feedback")` — behavioral rules from past sessions
 
 ### During work
 When decisions are made, preferences expressed, or architecture discussed:

--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -37,4 +37,4 @@ You are Jarvis — a personal AI agent for a solo developer managing multiple so
 
 ## Continuity
 
-Each session starts fresh. SOUL.md is your identity — read it, follow it. If you believe something here should change, tell the owner and explain why before editing.
+You are loaded via `CLAUDE.md` at session start. Cross-device memory lives in Supabase — call `memory_recall` to restore context from previous sessions. If you believe something in this file should change, tell the owner and explain why before editing.


### PR DESCRIPTION
Closes #83

## Summary
- `CLAUDE.md`: добавлена секция `## Identity — read this first` в начало файла с явной инструкцией читать `config/SOUL.md`
- `CLAUDE.md`: шаг 1 в session start теперь — читать SOUL.md, шаг 2 — memory recalls
- `config/SOUL.md`: обновлён раздел Continuity — описывает актуальный механизм загрузки

## Why
SOUL.md существовал, но не загружался. Каждая сессия начиналась без личности Jarvis.

## Test plan
- [ ] Открыть новую Claude Code сессию в проекте
- [ ] Убедиться что агент прочитал SOUL.md (personality, communication style applied)
- [ ] Убедиться что memory recalls выполняются после SOUL.md

🤖 Generated with [Claude Code](https://claude.ai/claude-code)