### PR TITLE
docs: final architecture — Claude Code native, no custom Python services

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **Jarvis** — universal personal AI agent. See `docs/PROJECT_PLAN.md` for full scope.
 
-Architecture: Claude Code native (skills, hooks, MCP, subagents) + thin Python service for Telegram, scheduler, autonomous ops.
+Architecture: Claude Code native (skills, hooks, MCP, subagents) + Supabase memory layer + SOUL.md identity. Telegram via Channels, scheduling via /loop — no custom Python services.
 
 ## Memory — USE IT
 
@@ -43,7 +43,7 @@ Owner explicitly wants honest criticism. Challenge bad ideas. Don't build prompt
 After conversations with decisions: `memory_store(...)`. The #1 frustration is context loss between sessions.
 
 ### Check native capabilities
-Before writing Python: can Claude Code skills, MCP servers, hooks, or subagents handle this? Only write external Python for Telegram, scheduler, autonomous ops, budget tracking.
+Before writing Python: can Claude Code skills, MCP servers, hooks, or subagents handle this? The only justified Python is `mcp-memory/server.py`. Everything else (Telegram → Channels, scheduling → /loop, background tasks → Desktop agents) is handled natively.
 
 ### Data-first skills
 Don't pay LLM tokens to run shell commands. Fetch data in Python, send only data to cheap LLM for analysis.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,211 +1,138 @@
 # Jarvis Project Plan
 
-Version: 4.0
+Version: 5.0
 Date: 2026-03-28
 Status: Active
 
 ## 1. Purpose
 
-Strategic plan for Jarvis — a universal personal AI agent built on Claude Agent SDK + MCP.
+Strategic plan for Jarvis — a personal AI agent built on top of Claude Code (Anthropic).
 
-Use this document to:
-- understand the full vision and current priorities,
-- decide what to build next,
-- keep scope focused on capabilities that deliver real value,
-- track architecture evolution and key decisions.
+This document answers:
+- what Jarvis is and what it adds on top of Claude Code,
+- what to build next and what to skip,
+- architectural decisions and why they were made.
 
-## 2. Problem and Vision
+## 2. Vision
 
-### Problem
+Jarvis is a **thin, permanent layer on top of Claude Code** that provides:
+1. **Identity** — consistent personality and behavior across all sessions (SOUL.md)
+2. **Cross-device memory** — context that survives sessions and syncs across machines (Supabase MCP)
+3. **Custom skills** — task-specific automation tailored to the owner's workflow
 
-One person managing multiple software projects and learning across many domains cannot do everything alone. Development coordination, research, and routine tasks consume time that should go to creative and strategic work.
-
-### Vision
-
-Jarvis is a universal personal AI agent that:
-- manages development workflows across multiple GitHub projects,
-- helps research and learn new topics,
-- executes routine tasks autonomously (with human review for critical actions),
-- communicates via Telegram (mobile) and CLI (workstation),
-- delegates code changes to specialized coding agents with safeguards,
-- remembers conversations, decisions, and context across sessions,
-- grows its capabilities through self-review and self-improvement.
-
-The name "Jarvis" reflects the full ambition: a personal assistant that grows with its owner.
+Everything else — mobile access, scheduling, background tasks, Telegram — is handled by Anthropic's native stack (Pro subscription).
 
 ### Platform History
 
-1. **Custom Python MVP** (archived) — validated core ideas, but infrastructure burden too high for one person.
-2. **OpenClaw** (abandoned 2026-03-23) — promising platform, but critical security issues (512 vulnerabilities, ~20% malicious skills on ClawHub, creator departing for OpenAI) made it unsuitable as a foundation.
-3. **Claude Agent SDK + MCP** (current) — production-ready framework from Anthropic. Same engine as Claude Code, programmable in Python/TypeScript, with MCP for external integrations.
+1. **Custom Python MVP** (archived) — validated core ideas, too much infrastructure for one person.
+2. **OpenClaw** (abandoned 2026-03-23) — 512 security vulnerabilities, malicious skills, creator leaving.
+3. **Claude Agent SDK wrappers** (abandoned 2026-03-28) — 6 of 8 skills were unnecessary Python around what Claude Code does natively.
+4. **Claude Code native + Supabase memory** (current, final) — Claude Code handles orchestration, delegation, agents, scheduling, Telegram. Jarvis adds only what Claude Code genuinely can't do.
 
 ## 3. Architecture
 
-### Agent Roles
+### What Claude Code handles natively (don't rebuild)
 
-- **Jarvis (brain)**: orchestrator. Receives user input, classifies intent, routes to skills or delegates to coding agents. Has identity (SOUL.md), memory, and conversation context. Runs on Haiku/Sonnet.
-- **Coding agent (executor)**: Claude Code CLI subprocess. Receives structured prompts from Jarvis, writes code, returns results. Has NO Jarvis identity — follows repo-specific CLAUDE.md instructions. Uses Pro subscription.
-- **Owner (human)**: strategic decisions, PR review, go/no-go on critical actions.
+| Need | Native solution |
+|------|----------------|
+| Mobile access (phone) | Dispatch (Claude mobile → Desktop, QR pairing) |
+| Telegram interface | Claude Code Channels (`--channels` flag, official plugin) |
+| Scheduling / cron | `/loop` + Desktop scheduled tasks (up to 50 concurrent) |
+| Background agents | Claude Code Desktop background agents |
+| Delegation (issue → PR) | Claude Code subagents with model routing |
+| GitHub/Slack connectors | Cowork connectors |
 
-### Key Principle
+### What Jarvis adds on top
 
-Jarvis is the brain, not a prompt router. It should:
-1. Understand context from memory and conversation history
-2. Decide whether to act itself or delegate
-3. Provide its identity (SOUL.md) to its own LLM calls, NOT to coding agents
-4. Receive structured summaries from every tool/agent it delegates to
-5. Write important decisions and context to memory
+| Gap | Solution |
+|-----|----------|
+| Cross-device memory | `mcp-memory/server.py` → Supabase (syncs all devices/projects) |
+| Identity continuity | `config/SOUL.md` loaded at session start via `CLAUDE.md` |
+| Custom workflow skills | `.claude/skills/` (triage, risk-radar, intel, delegate, etc.) |
 
-The coding agent is just an executor. It gets: Jarvis's structured prompt + the target repo's CLAUDE.md. It doesn't need Jarvis's memory or identity.
+### Memory architecture
 
-### Memory Architecture
+Single source of truth: **Supabase** via MCP.
 
-Three layers:
-1. **Conversation log** — full chat history per user session. New session daily or on demand. Compressed when context grows large. Enables continuity within a session.
-2. **Structured memory** — extracted knowledge: decisions, plans, user preferences, project context. Persists across sessions. Loaded into Jarvis prompts.
-3. **Execution log** — append-only JSONL of skill runs (work_memory.jsonl). Used by self-review/self-improve. Auto-cleanup after retention period.
+- `memory_recall` at session start → loads project context, owner preferences, past decisions
+- `memory_store` during work → saves decisions, findings, architectural notes
+- Cross-device: same Supabase URL on all machines, same memory everywhere
+- Cross-project: `project=null` for global memories, `project="jarvis"` for project-specific
 
-The coding agent does NOT receive Jarvis memory. It gets project context from the target repo's CLAUDE.md, plus a `[JARVIS-AUTOMATED]` tag to indicate it's running under automation.
+`~/.claude/` local files are supplementary only — not relied upon for persistence.
 
 ## 4. Scope
 
-### In Scope
+### In scope
 
-Milestone 1 — Architecture Migration (DONE):
-- Claude Agent SDK project setup
-- Telegram integration
-- Model tier configuration (Haiku/Sonnet/Opus)
-- Basic agent loop: receive command → execute → respond
+**M3: Intelligence Layer** (current milestone):
+- Identity: SOUL.md loaded every session *(PR #88)*
+- Telegram: Claude Code Channels setup *(PR #89)*
+- Custom skills: triage, issue-health, risk-radar, research, delegate, self-review, self-improve, intel
+- Memory: cross-device Supabase MCP *(done)*
+- Self-improvement loop: self-review → intel → self-improve cycle
 
-Milestone 2 — Core Features (DONE):
-- PM skills on demand: triage, weekly report, issue health
-- Research skill: source-backed research with confidence scoring
-- Delegation pipeline: Jarvis decomposes → coding agent executes → PR
-- Cost control: daily budget, per-query limits, model tier routing
+**M4: Depth** (next):
+- Memory upgrade: vector/semantic search (Hindsight migration from ILIKE)
+- Skills refinement based on real usage
+- Intel digest: automated weekly scan for Claude/MCP updates
 
-Milestone 3 — Intelligence Layer (IN PROGRESS):
-- Identity: SOUL.md loaded into every Jarvis LLM call
-- Conversation memory: session-based chat history with compression
-- Structured long-term memory: decisions, plans, preferences persisted
-- Intent routing: plain text → skill classification without slash commands
-- Self-improvement: self-review → opportunity scan → risk radar → self-improve loop
+### Out of scope (permanently, handled natively)
 
-Milestone 4 — Expansion (PLANNED):
-- Multi-repo delegation (coding agent CWD fix)
-- Long-term memory with semantic search (vector store)
-- Inbox aggregator (when solo dev gets inbound volume)
-- Scheduled execution (when regular cadence becomes useful)
-- Context-switch helper (may be obsoleted by memory)
+- Custom Telegram relay (→ use Channels)
+- Custom scheduler / cron service (→ use /loop)
+- Custom background task runner (→ use Desktop agents)
+- Budget tracking (→ Anthropic dashboard, Pro subscription)
+- Multi-user features (Jarvis serves one person)
+- Local LLM as primary (deferred; possible as MCP tool later)
 
-### Out of Scope (Current)
-
-- Multi-user / team features (Jarvis serves one person)
-- Cloud hosting (runs on owner's machine, API calls to Claude)
-- Plugin marketplace
-- Mobile app (Telegram is the mobile interface)
-- Local LLM as primary (deferred; possible as auxiliary MCP tool later)
-
-### Deferred (Build When Needed)
-
-- Scheduled cron execution — owner works irregular schedule, manual trigger preferred
-- Weekly report automation — rarely reviewed, on-demand is sufficient
-- Inbox aggregator — solo dev has minimal inbound; build when volume grows
-
-## 5. Delivery Milestones
+## 5. Milestones
 
 ### M1: Architecture Migration ✅
-
-Goal: Jarvis running on Claude Agent SDK with basic Telegram connectivity.
-
-Exit criteria (all met):
-- Agent SDK project created and runnable
-- Claude API key configured with billing
-- Telegram bot receives messages and responds via Agent SDK
-- Model tiers configured (Haiku default, Sonnet for complex tasks)
-- Basic command routing works (/triage, /weekly-report, /issue-health)
+Claude Agent SDK setup, Telegram bot, basic routing. *(Superseded by reboot)*
 
 ### M2: Core Features ✅
-
-Goal: PM capabilities functional + delegation pipeline working.
-
-Exit criteria (all met):
-- PM skills available on demand via Telegram and CLI
-- Research skill functional with source-backed findings
-- Delegation pipeline: Jarvis decomposes issue → coding agent implements → PR created
-- Cost control: daily budget tracking, per-query limits enforced
+PM skills, research, delegation pipeline, cost control. *(Redefined: skills now in .claude/skills/)*
 
 ### M3: Intelligence Layer 🔧
 
-Goal: Jarvis becomes a stateful assistant with identity and memory.
+Exit criteria:
+- [ ] SOUL.md loaded every session (PR #88)
+- [ ] Telegram via Channels working (PR #89, requires manual setup)
+- [ ] Cross-device memory working on all owner's devices
+- [ ] Self-improve cycle functional: `/self-review` → `/self-improve` → PR
+
+### M4: Depth 📋
 
 Exit criteria:
-- SOUL.md loaded into every Jarvis LLM call (identity)
-- Conversation history maintained per session (short-term memory)
-- Important context extracted and persisted across sessions (long-term memory)
-- Plain text messages routed to correct skills without slash commands
-- Self-improvement cycle functional: review → analyze → propose → apply
+- [ ] Memory semantic search (Hindsight or pgvector migration)
+- [ ] `/intel` producing useful weekly digests
+- [ ] All skills validated with real usage data
 
-### M4: Expansion 📋
+## 6. Decision rules
 
-Goal: Jarvis handles multiple repos and scales capabilities.
+**Default to native first.** Before writing any code:
+1. Can Claude Code do this natively? (skills, hooks, /loop, subagents, Channels, Desktop)
+2. Can an existing MCP server handle it?
+3. Only if both answers are no: write Python, but only for `mcp-memory/`-type gaps.
 
-Exit criteria:
-- Coding agent can work in any repo (not just Jarvis repo)
-- Long-term memory searchable via semantic similarity
-- Additional skills added as real needs emerge
+**Build for real problems.** Only build features needed in the last week. Park ideas in GitHub Discussions.
 
-## 6. Decision Rules
+**No duplicate abstractions.** Don't wrap what Claude Code already does. The 2x rebuild from Claude Agent SDK happened because of wrapping — don't repeat.
 
-When a new idea appears:
-1. Does it solve a real problem the owner has right now?
-2. Can it be implemented within Claude Agent SDK architecture?
-3. Is the cost acceptable within $10-30/month API budget?
-4. If yes to all — create a task. Otherwise, park in GitHub Discussions (Ideas category).
+## 7. Technical setup
 
-When uncertain what to do next:
-1. Finish in-progress work first.
-2. Prioritize capabilities that save the most time in daily work.
-3. Prefer simple implementations that can be tested immediately.
-4. Memory and identity features take priority over new skills.
+- **Subscription**: Anthropic Pro (covers Claude Code, Desktop, Channels, Dispatch)
+- **Memory**: Supabase free tier (PostgreSQL, REST API)
+- **Skills runtime**: Claude Code (Claude Code handles all skill execution)
+- **Python**: only `mcp-memory/server.py` (MCP stdio server)
+- **OS**: Windows 11, 3 devices
+- **Hardware**: Intel i5 9400f / RTX 3050 6GB / 32GB RAM (home)
 
-## 7. Risk Register
+## 8. Success metrics
 
-R1: Claude API cost overrun.
-- Mitigation: use Haiku for routine tasks, Sonnet only when needed, Opus rarely. Monitor spending weekly.
-- Budget ceiling: $30/month. Alert if approaching $25.
-
-R2: Vendor lock-in to Anthropic.
-- Mitigation: keep agent logic decoupled from SDK specifics where practical. MCP integrations are standard-based and portable.
-- Accepted trade-off: Claude quality justifies lock-in at this scale.
-
-R3: Scope creep into features nobody uses.
-- Mitigation: only build for problems experienced in the last week. Park ideas in GitHub Discussions.
-- New: defer inbox, scheduling, context-switch until real need emerges.
-
-R4: Coding agent produces bad code.
-- Mitigation: all code changes go through PR. Branch protection enforced. CLAUDE.md in each repo instructs conservative behavior for agent-generated tasks.
-
-R5: Bus factor = 1.
-- Mitigation: clear documentation, simple architecture, standard patterns.
-
-R6: Memory bloat / noise.
-- Mitigation: conversation logs compressed per session. Structured memory is selective — only decisions, plans, preferences. Execution logs auto-cleaned after retention period.
-
-## 8. Technical Constraints
-
-- Hardware (home): Intel i5 9400f, RTX 3050 6GB, 32GB RAM
-- LLM: Claude API (Haiku $1/1M input, Sonnet $3/1M input, Opus $5/1M input)
-- Budget: $10-30/month on API
-- Platform: Claude Agent SDK (Python or TypeScript)
-- Integrations: MCP servers (GitHub, Telegram, filesystem)
-- Communication: Telegram Bot API via MCP, Claude Code CLI for workstation
-- OS: Windows 11 (primary)
-
-## 9. Success Metrics
-
-- Jarvis used daily for real work (not just testing)
-- Jarvis remembers context from previous sessions without re-explanation
-- API cost stays within $30/month budget
-- Delegation pipeline produces usable PRs that need minimal human editing
-- Skills work reliably without constant debugging
-- Self-improvement cycle identifies real issues and proposes useful fixes
+- Jarvis used daily for real work, not just testing
+- Memory recall at session start requires zero re-explanation of context
+- Skills work without debugging across all 3 devices
+- `/intel` surfaces genuinely new information weekly
+- Self-improve cycle produces usable PRs


### PR DESCRIPTION
Closes #55
Closes #57
Closes #58

## Summary
Фиксирует финальное архитектурное решение: Pro подписка, всё нативное.

**CLAUDE.md**: убраны упоминания Python services, добавлено правило "единственный оправданный Python — mcp-memory/"

**PROJECT_PLAN.md v5.0**: полная перезапись
- Native features matrix (Dispatch, Channels, /loop, Desktop agents, Cowork)
- Jarvis добавляет только: memory + identity + custom skills
- Убраны все M1/M2 описания старой Agent SDK архитектуры
- Новые decision rules: native first, no wrapping

🤖 Generated with [Claude Code](https://claude.ai/claude-code)