### PR TITLE
feat: memory server tests + graph tool + linked dedup fix

### DIFF
--- a/.claude/skills/memory-manager/SKILL.md
+++ b/.claude/skills/memory-manager/SKILL.md
@@ -16,6 +16,9 @@ Browse, audit, and maintain Jarvis's memory system. Adds structured retrieval ti
 - `/memory stale` — find memories older than 14 days that haven't been validated
 - `/memory cleanup` — interactive cleanup of stale/orphaned working states
 - `/memory stats` — count by type, project, tag distribution
+- `/memory graph` — link graph overview: stats, top connected, orphans
+- `/memory links <name>` — all connections for a specific memory
+- `/memory clusters` — tightly connected memory groups (consolidation candidates)
 
 ## Memory Tiers
 
@@ -115,6 +118,28 @@ memory_recall(type="decision", project="<current_project>", limit=5)
 # Get research pointers (reference tier)
 memory_recall(type="reference", limit=5)
 ```
+
+## Graph Exploration (Memory 2.0)
+
+Memory 2.0 auto-links memories on store via semantic similarity. Use the `memory_graph` MCP tool to explore the link graph.
+
+**`/memory graph`** — overview:
+```
+memory_graph(mode="overview")
+```
+Shows: link stats by type (related/supersedes/consolidates), top-10 most connected memories, orphans (embedded but unlinked).
+
+**`/memory links <name>`** — per-memory connections:
+```
+memory_graph(mode="links", name="<memory_name>")
+```
+Shows: all outgoing (→) and incoming (←) links with type and strength.
+
+**`/memory clusters`** — find consolidation candidates:
+```
+memory_graph(mode="clusters")
+```
+Shows: groups of tightly connected memories (strength >= 0.7). These are candidates for consolidation — merging related memories into one.
 
 ## Naming Conventions (enforced)
 

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -277,7 +277,7 @@ language sql stable as $$
               and not (l.source_id = any(memory_ids))
               and (link_types is null or l.link_type = any(link_types))
         ) sub
-        order by sub.id, sub.link_strength desc
+        order by sub.id, sub.link_strength desc, sub.link_type, sub.linked_from
     ) deduped
     order by deduped.link_strength desc
     limit 10;

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -253,23 +253,32 @@ returns table(
     link_type text, link_strength float, linked_from uuid
 )
 language sql stable as $$
+    -- Outer query re-orders deduped results by strength
     select * from (
-        select m.id, m.name, m.type, m.project, m.description, m.content, m.tags, m.updated_at,
-               l.link_type, l.strength as link_strength, l.source_id as linked_from
-        from memory_links l
-        join memories m on m.id = l.target_id
-        where l.source_id = any(memory_ids)
-          and not (l.target_id = any(memory_ids))
-          and (link_types is null or l.link_type = any(link_types))
-        union
-        select m.id, m.name, m.type, m.project, m.description, m.content, m.tags, m.updated_at,
-               l.link_type, l.strength as link_strength, l.target_id as linked_from
-        from memory_links l
-        join memories m on m.id = l.source_id
-        where l.target_id = any(memory_ids)
-          and not (l.source_id = any(memory_ids))
-          and (link_types is null or l.link_type = any(link_types))
-    ) sub
-    order by link_strength desc
+        -- DISTINCT ON keeps only the strongest link per target memory
+        select distinct on (sub.id)
+            sub.id, sub.name, sub.type, sub.project, sub.description,
+            sub.content, sub.tags, sub.updated_at,
+            sub.link_type, sub.link_strength, sub.linked_from
+        from (
+            select m.id, m.name, m.type, m.project, m.description, m.content, m.tags, m.updated_at,
+                   l.link_type, l.strength as link_strength, l.source_id as linked_from
+            from memory_links l
+            join memories m on m.id = l.target_id
+            where l.source_id = any(memory_ids)
+              and not (l.target_id = any(memory_ids))
+              and (link_types is null or l.link_type = any(link_types))
+            union all
+            select m.id, m.name, m.type, m.project, m.description, m.content, m.tags, m.updated_at,
+                   l.link_type, l.strength as link_strength, l.target_id as linked_from
+            from memory_links l
+            join memories m on m.id = l.source_id
+            where l.target_id = any(memory_ids)
+              and not (l.source_id = any(memory_ids))
+              and (link_types is null or l.link_type = any(link_types))
+        ) sub
+        order by sub.id, sub.link_strength desc
+    ) deduped
+    order by deduped.link_strength desc
     limit 10;
 $$;

--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -921,9 +921,15 @@ async def _hybrid_recall(
             if ids:
                 linked = await _expand_with_links(client, ids)
                 if linked:
-                    # Deduplicate against already-found IDs
+                    # Deduplicate against already-found IDs and within linked results
                     found_ids = set(ids)
-                    unique_linked = [r for r in linked if r.get("id") not in found_ids]
+                    seen_linked = set()
+                    unique_linked = []
+                    for r in linked:
+                        rid = r.get("id")
+                        if rid not in found_ids and rid not in seen_linked:
+                            seen_linked.add(rid)
+                            unique_linked.append(r)
                     if unique_linked:
                         link_formatted = _format_memories(unique_linked, link_info=True)
                         text += f"\n\n### Linked memories ({len(unique_linked)}):\n\n" + "\n---\n".join(link_formatted)

--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -526,6 +526,35 @@ async def list_tools() -> list[Tool]:
                 "required": ["event_ids", "processed_by"],
             },
         ),
+        # ---- Graph tools ----
+        Tool(
+            name="memory_graph",
+            description=(
+                "Explore the memory link graph. "
+                "Modes: 'overview' (stats, top connected, orphans), "
+                "'links' (all connections for a specific memory by name), "
+                "'clusters' (groups of tightly connected memories for consolidation)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "enum": ["overview", "links", "clusters"],
+                        "description": (
+                            "overview = link stats + top connected + orphans. "
+                            "links = all connections for a memory (requires 'name'). "
+                            "clusters = tightly connected groups."
+                        ),
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Memory name (required for 'links' mode).",
+                    },
+                },
+                "required": ["mode"],
+            },
+        ),
     ]
 
 
@@ -565,6 +594,9 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent] | CallToolR
             return _big_result(await _handle_list(arguments))
         elif name == "memory_delete":
             return await _handle_delete(arguments)
+        # Graph tools
+        elif name == "memory_graph":
+            return _big_result(await _handle_graph(arguments))
         # Event tools
         elif name == "events_list":
             return _big_result(await _handle_events_list(arguments))
@@ -1205,6 +1237,239 @@ async def _handle_delete(args: dict) -> list[TextContent]:
     if result.data:
         return [TextContent(type="text", text=f"Deleted memory '{mem_name}' (project={project or 'global'}).")]
     return [TextContent(type="text", text=f"Memory '{mem_name}' not found.")]
+
+
+# -- Graph handlers ---------------------------------------------------------
+
+
+async def _handle_graph(args: dict) -> list[TextContent]:
+    mode = args.get("mode", "overview")
+    client = _get_client()
+
+    if mode == "overview":
+        return await _graph_overview(client)
+    elif mode == "links":
+        name = args.get("name")
+        if not name:
+            return [TextContent(type="text", text="Error: 'name' is required for 'links' mode.")]
+        return await _graph_links(client, name)
+    elif mode == "clusters":
+        return await _graph_clusters(client)
+    else:
+        return [TextContent(type="text", text=f"Unknown graph mode: {mode}")]
+
+
+async def _graph_overview(client) -> list[TextContent]:
+    """Graph overview: link stats, top connected memories, orphans."""
+    lines = ["## Memory Graph Overview\n"]
+
+    # 1. Link stats by type
+    all_links = client.table("memory_links").select("link_type, strength").execute()
+    link_data = all_links.data or []
+    total = len(link_data)
+
+    if total == 0:
+        return [TextContent(type="text", text="No memory links found. Store more memories to build the graph.")]
+
+    type_stats: dict[str, list[float]] = {}
+    for row in link_data:
+        lt = row["link_type"]
+        type_stats.setdefault(lt, []).append(row["strength"])
+
+    lines.append(f"### Link Statistics ({total} total)\n")
+    lines.append("| Type | Count | Avg Strength | Min | Max |")
+    lines.append("|------|-------|-------------|-----|-----|")
+    for lt, strengths in sorted(type_stats.items()):
+        avg = sum(strengths) / len(strengths)
+        lines.append(f"| {lt} | {len(strengths)} | {avg:.3f} | {min(strengths):.3f} | {max(strengths):.3f} |")
+
+    # 2. Top connected memories
+    links_src = client.table("memory_links").select("source_id").execute()
+    links_tgt = client.table("memory_links").select("target_id").execute()
+    counts: dict[str, int] = {}
+    for row in links_src.data or []:
+        mid = row["source_id"]
+        counts[mid] = counts.get(mid, 0) + 1
+    for row in links_tgt.data or []:
+        mid = row["target_id"]
+        counts[mid] = counts.get(mid, 0) + 1
+
+    top_ids = sorted(counts.keys(), key=lambda k: counts[k], reverse=True)[:10]
+    if top_ids:
+        # Fetch names for top IDs
+        names_result = client.table("memories").select("id, name, type, project").in_("id", top_ids).execute()
+        id_to_mem = {r["id"]: r for r in (names_result.data or [])}
+
+        lines.append(f"\n### Top Connected ({len(top_ids)})\n")
+        lines.append("| Memory | Type | Project | Links |")
+        lines.append("|--------|------|---------|-------|")
+        for mid in top_ids:
+            mem = id_to_mem.get(mid, {})
+            name = mem.get("name", mid[:8])
+            mtype = mem.get("type", "?")
+            proj = mem.get("project") or "global"
+            lines.append(f"| {name} | {mtype} | {proj} | {counts[mid]} |")
+
+    # 3. Orphans (have embedding, no links)
+    total_with_emb = client.table("memories").select("id", count="exact").not_.is_("embedding", "null").execute()
+    total_emb_count = total_with_emb.count or 0
+    linked_ids = set(counts.keys())
+    all_emb = client.table("memories").select("id, name, type, project").not_.is_("embedding", "null").execute()
+    orphans = [r for r in (all_emb.data or []) if r["id"] not in linked_ids]
+
+    lines.append(f"\n### Orphans ({len(orphans)} of {total_emb_count} embedded memories have no links)\n")
+    if orphans:
+        for o in orphans[:15]:
+            proj = o.get("project") or "global"
+            lines.append(f"- **{o['name']}** ({o['type']}, {proj})")
+        if len(orphans) > 15:
+            lines.append(f"- ... and {len(orphans) - 15} more")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def _graph_links(client, name: str) -> list[TextContent]:
+    """All connections for a specific memory."""
+    # Find memory by name
+    mem_result = client.table("memories").select("id, name, type, project").eq("name", name).execute()
+    if not mem_result.data:
+        return [TextContent(type="text", text=f"Memory '{name}' not found.")]
+
+    mem = mem_result.data[0]
+    mem_id = mem["id"]
+    proj = mem.get("project") or "global"
+
+    lines = [f"## Links for: {name} ({mem['type']}, {proj})\n"]
+
+    # Outgoing links (this memory → others)
+    out_result = (
+        client.table("memory_links")
+        .select("target_id, link_type, strength")
+        .eq("source_id", mem_id)
+        .order("strength", desc=True)
+        .execute()
+    )
+    out_links = out_result.data or []
+
+    # Incoming links (others → this memory)
+    in_result = (
+        client.table("memory_links")
+        .select("source_id, link_type, strength")
+        .eq("target_id", mem_id)
+        .order("strength", desc=True)
+        .execute()
+    )
+    in_links = in_result.data or []
+
+    # Resolve target/source names
+    all_ids = [r["target_id"] for r in out_links] + [r["source_id"] for r in in_links]
+    id_to_name = {}
+    if all_ids:
+        names = client.table("memories").select("id, name, type, project").in_("id", all_ids).execute()
+        id_to_name = {r["id"]: r for r in (names.data or [])}
+
+    # Format outgoing
+    lines.append(f"### Outgoing ({len(out_links)})\n")
+    if out_links:
+        for link in out_links:
+            target = id_to_name.get(link["target_id"], {})
+            tname = target.get("name", link["target_id"][:8])
+            ttype = target.get("type", "?")
+            lines.append(f"- → **{tname}** ({ttype}) [{link['link_type']}, {link['strength']:.3f}]")
+    else:
+        lines.append("- (none)")
+
+    # Format incoming
+    lines.append(f"\n### Incoming ({len(in_links)})\n")
+    if in_links:
+        for link in in_links:
+            source = id_to_name.get(link["source_id"], {})
+            sname = source.get("name", link["source_id"][:8])
+            stype = source.get("type", "?")
+            lines.append(f"- ← **{sname}** ({stype}) [{link['link_type']}, {link['strength']:.3f}]")
+    else:
+        lines.append("- (none)")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def _graph_clusters(client) -> list[TextContent]:
+    """Find clusters of tightly connected memories (mutual links, strength > 0.7)."""
+    # Get all strong links
+    links_result = (
+        client.table("memory_links")
+        .select("source_id, target_id, link_type, strength")
+        .gte("strength", 0.7)
+        .execute()
+    )
+    links = links_result.data or []
+
+    if not links:
+        return [TextContent(type="text", text="No strong links (strength >= 0.7) found.")]
+
+    # Build adjacency: collect neighbors for each memory
+    neighbors: dict[str, set[str]] = {}
+    link_info: dict[tuple[str, str], dict] = {}
+    for link in links:
+        s, t = link["source_id"], link["target_id"]
+        neighbors.setdefault(s, set()).add(t)
+        neighbors.setdefault(t, set()).add(s)
+        link_info[(s, t)] = link
+
+    # Simple clustering: connected components via BFS
+    visited: set[str] = set()
+    clusters: list[set[str]] = []
+    for node in neighbors:
+        if node in visited:
+            continue
+        cluster: set[str] = set()
+        queue = [node]
+        while queue:
+            current = queue.pop(0)
+            if current in visited:
+                continue
+            visited.add(current)
+            cluster.add(current)
+            for neighbor in neighbors.get(current, set()):
+                if neighbor not in visited:
+                    queue.append(neighbor)
+        if len(cluster) >= 2:
+            clusters.append(cluster)
+
+    # Sort clusters by size (largest first)
+    clusters.sort(key=len, reverse=True)
+
+    # Resolve names
+    all_ids = list(set().union(*clusters)) if clusters else []
+    id_to_mem = {}
+    if all_ids:
+        mems = client.table("memories").select("id, name, type, project").in_("id", all_ids).execute()
+        id_to_mem = {r["id"]: r for r in (mems.data or [])}
+
+    lines = [f"## Memory Clusters ({len(clusters)} clusters, strength >= 0.7)\n"]
+
+    for i, cluster in enumerate(clusters[:10], 1):
+        # Calculate average internal strength
+        internal_strengths = []
+        for s, t in link_info:
+            if s in cluster and t in cluster:
+                internal_strengths.append(link_info[(s, t)]["strength"])
+
+        avg_str = sum(internal_strengths) / len(internal_strengths) if internal_strengths else 0
+
+        lines.append(f"### Cluster {i} ({len(cluster)} memories, avg strength: {avg_str:.3f})\n")
+        for mid in sorted(cluster, key=lambda m: id_to_mem.get(m, {}).get("name", "")):
+            mem = id_to_mem.get(mid, {})
+            name = mem.get("name", mid[:8])
+            mtype = mem.get("type", "?")
+            proj = mem.get("project") or "global"
+            lines.append(f"- **{name}** ({mtype}, {proj})")
+        lines.append("")
+
+    if len(clusters) > 10:
+        lines.append(f"... and {len(clusters) - 10} more clusters")
+
+    return [TextContent(type="text", text="\n".join(lines))]
 
 
 # -- Event handlers ---------------------------------------------------------

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -1,0 +1,406 @@
+"""Unit tests for mcp-memory/server.py — pure functions + mocked async.
+
+Covers Memory 2.0 core: temporal scoring, RRF merge, formatting, auto-linking.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+import types
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Mock external dependencies before importing server.py
+# server.py imports mcp, supabase, httpx at module level — we stub them out
+# so tests run without installing the full MCP SDK.
+# ---------------------------------------------------------------------------
+
+# Create stub modules for mcp.*
+_mcp_types = types.ModuleType("mcp.types")
+_mcp_types.CallToolResult = MagicMock
+_mcp_types.TextContent = MagicMock
+_mcp_types.Tool = MagicMock
+
+def _noop_decorator(*args, **kwargs):
+    """Return a no-op decorator that passes the function through."""
+    def decorator(fn):
+        return fn
+    return decorator
+
+
+class _FakeServer:
+    """Minimal stub that supports @server.list_tools() and @server.call_tool() decorators."""
+    def __init__(self, *args, **kwargs):
+        pass
+    def list_tools(self):
+        return _noop_decorator()
+    def call_tool(self):
+        return _noop_decorator()
+
+
+_mcp_server = types.ModuleType("mcp.server")
+_mcp_server.Server = _FakeServer
+
+_mcp_server_stdio = types.ModuleType("mcp.server.stdio")
+_mcp_server_stdio.stdio_server = MagicMock
+
+_mcp = types.ModuleType("mcp")
+
+for mod_name, mod in [
+    ("mcp", _mcp),
+    ("mcp.types", _mcp_types),
+    ("mcp.server", _mcp_server),
+    ("mcp.server.stdio", _mcp_server_stdio),
+]:
+    sys.modules.setdefault(mod_name, mod)
+
+# Stub supabase (only needed if _get_client is called, which we avoid)
+sys.modules.setdefault("supabase", types.ModuleType("supabase"))
+
+# Stub dotenv
+_dotenv = types.ModuleType("dotenv")
+_dotenv.load_dotenv = lambda *a, **kw: None
+sys.modules.setdefault("dotenv", _dotenv)
+
+# Add mcp-memory to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "mcp-memory"))
+
+# Env vars (server reads them for client init)
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_KEY", "test-key")
+
+from server import (
+    _rrf_merge,
+    _apply_temporal_scoring,
+    _format_memories,
+    _create_auto_links,
+    _expand_with_links,
+    TEMPORAL_HALF_LIVES,
+    SUPERSEDE_SIM_THRESHOLD,
+    MAX_AUTO_LINKS,
+)
+
+
+# ---------------------------------------------------------------------------
+# _rrf_merge
+# ---------------------------------------------------------------------------
+
+class TestRRFMerge:
+    """Reciprocal Rank Fusion merges two ranked lists."""
+
+    def test_empty_inputs(self):
+        result = _rrf_merge([], [], limit=5)
+        assert result == []
+
+    def test_single_list(self):
+        rows = [{"id": "a", "name": "mem1"}, {"id": "b", "name": "mem2"}]
+        result = _rrf_merge(rows, [], limit=5)
+        assert len(result) == 2
+        assert result[0]["id"] == "a"  # rank 0 scores higher
+        assert result[1]["id"] == "b"
+
+    def test_overlap_boosts_score(self):
+        """Items in both lists should score higher than items in one."""
+        sem = [{"id": "a", "name": "shared"}, {"id": "b", "name": "sem-only"}]
+        kw = [{"id": "a", "name": "shared"}, {"id": "c", "name": "kw-only"}]
+        result = _rrf_merge(sem, kw, limit=5)
+
+        # 'a' appears in both → highest score
+        assert result[0]["id"] == "a"
+        assert result[0]["_rrf_score"] > result[1]["_rrf_score"]
+
+    def test_limit_respected(self):
+        rows = [{"id": str(i), "name": f"m{i}"} for i in range(10)]
+        result = _rrf_merge(rows, [], limit=3)
+        assert len(result) == 3
+
+    def test_score_calculation(self):
+        """Verify RRF score formula: 1/(k + rank)."""
+        k = 60
+        rows = [{"id": "a", "name": "x"}]
+        result = _rrf_merge(rows, [], limit=5, k=k)
+        expected = 1.0 / (k + 0)
+        assert abs(result[0]["_rrf_score"] - expected) < 1e-10
+
+    def test_score_both_lists(self):
+        """Score = sum of 1/(k+rank) from each list."""
+        k = 60
+        sem = [{"id": "a", "name": "x"}]
+        kw = [{"id": "z", "name": "y"}, {"id": "a", "name": "x"}]  # 'a' at rank 1 in kw
+        result = _rrf_merge(sem, kw, limit=5, k=k)
+
+        a_score = next(r for r in result if r["id"] == "a")
+        expected = 1.0 / (k + 0) + 1.0 / (k + 1)  # rank 0 in sem + rank 1 in kw
+        assert abs(a_score["_rrf_score"] - expected) < 1e-10
+
+    def test_name_fallback_for_id(self):
+        """Rows without 'id' use 'name' as identifier."""
+        rows = [{"name": "alpha"}, {"name": "beta"}]
+        result = _rrf_merge(rows, [], limit=5)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# _apply_temporal_scoring
+# ---------------------------------------------------------------------------
+
+class TestTemporalScoring:
+    """Temporal scoring re-ranks by recency × access boost."""
+
+    @staticmethod
+    def _make_row(mem_type="decision", days_ago=0, accessed_days_ago=None, rrf=0.5):
+        now = datetime.now(timezone.utc)
+        updated = (now - timedelta(days=days_ago)).isoformat()
+        accessed = (now - timedelta(days=accessed_days_ago)).isoformat() if accessed_days_ago is not None else None
+        return {
+            "type": mem_type,
+            "updated_at": updated,
+            "last_accessed_at": accessed,
+            "_rrf_score": rrf,
+        }
+
+    def test_recent_ranks_higher(self):
+        old = self._make_row(days_ago=30)
+        new = self._make_row(days_ago=1)
+        result = _apply_temporal_scoring([old, new])
+        assert result[0]["_temporal_score"] > result[1]["_temporal_score"]
+
+    def test_same_age_equal_scores(self):
+        a = self._make_row(days_ago=5, rrf=0.5)
+        b = self._make_row(days_ago=5, rrf=0.5)
+        result = _apply_temporal_scoring([a, b])
+        assert abs(result[0]["_temporal_score"] - result[1]["_temporal_score"]) < 1e-6
+
+    def test_access_boost(self):
+        """Recently accessed memory gets boosted."""
+        accessed = self._make_row(days_ago=10, accessed_days_ago=1)
+        not_accessed = self._make_row(days_ago=10)
+        result = _apply_temporal_scoring([not_accessed, accessed])
+        assert result[0]["_temporal_score"] > result[1]["_temporal_score"]
+
+    def test_type_half_lives(self):
+        """Project memories decay faster than feedback memories."""
+        project = self._make_row(mem_type="project", days_ago=14)  # half-life 7d
+        feedback = self._make_row(mem_type="feedback", days_ago=14)  # half-life 90d
+        result = _apply_temporal_scoring([project, feedback])
+        # feedback should score higher — 14 days is well within its 90d half-life
+        assert result[0]["type"] == "feedback"
+
+    def test_rrf_weight_preserved(self):
+        """Higher RRF score leads to higher temporal score, all else equal."""
+        high_rrf = self._make_row(rrf=0.9, days_ago=5)
+        low_rrf = self._make_row(rrf=0.1, days_ago=5)
+        result = _apply_temporal_scoring([low_rrf, high_rrf])
+        assert result[0]["_temporal_score"] > result[1]["_temporal_score"]
+
+    def test_handles_missing_timestamps(self):
+        """Gracefully handles rows with missing/invalid timestamps."""
+        row = {"type": "decision", "updated_at": "", "last_accessed_at": None, "_rrf_score": 0.5}
+        result = _apply_temporal_scoring([row])
+        assert "_temporal_score" in result[0]
+        assert result[0]["_temporal_score"] > 0
+
+    def test_zero_days_ago(self):
+        """Just-updated memory gets near-full score."""
+        row = self._make_row(days_ago=0, rrf=1.0)
+        result = _apply_temporal_scoring([row])
+        # recency ≈ 1.0, so temporal_score ≈ rrf * 1.0 * access_factor
+        assert result[0]["_temporal_score"] >= 0.9
+
+    def test_sorted_descending(self):
+        rows = [
+            self._make_row(days_ago=30, rrf=0.3),
+            self._make_row(days_ago=1, rrf=0.8),
+            self._make_row(days_ago=10, rrf=0.5),
+        ]
+        result = _apply_temporal_scoring(rows)
+        scores = [r["_temporal_score"] for r in result]
+        assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# _format_memories
+# ---------------------------------------------------------------------------
+
+class TestFormatMemories:
+    """Memory formatting for LLM output."""
+
+    def test_basic_format(self):
+        mem = {
+            "name": "test_mem",
+            "type": "decision",
+            "project": "jarvis",
+            "description": "A test memory",
+            "content": "Some content here",
+            "tags": ["tag1", "tag2"],
+            "updated_at": "2026-04-09T12:00:00+00:00",
+        }
+        result = _format_memories([mem])
+        assert len(result) == 1
+        assert "## test_mem (decision, jarvis)" in result[0]
+        assert "[tag1, tag2]" in result[0]
+        assert "*A test memory*" in result[0]
+        assert "Some content here" in result[0]
+
+    def test_global_project(self):
+        mem = {"name": "x", "type": "user", "project": None, "description": "", "content": "c", "tags": []}
+        result = _format_memories([mem])
+        assert "(user, global)" in result[0]
+
+    def test_no_tags(self):
+        mem = {"name": "x", "type": "user", "project": None, "description": "", "content": "c"}
+        result = _format_memories([mem])
+        assert "[" not in result[0] or "user" in result[0]
+
+    def test_link_info(self):
+        mem = {
+            "name": "linked_mem",
+            "type": "decision",
+            "project": "jarvis",
+            "description": "desc",
+            "content": "body",
+            "tags": [],
+            "link_type": "related",
+            "link_strength": 0.75,
+            "updated_at": "2026-04-09",
+        }
+        result = _format_memories([mem], link_info=True)
+        assert "← related (0.75)" in result[0]
+
+    def test_link_info_not_shown_without_flag(self):
+        mem = {
+            "name": "x", "type": "decision", "project": None,
+            "description": "", "content": "c", "tags": [],
+            "link_type": "related", "link_strength": 0.75,
+        }
+        result = _format_memories([mem], link_info=False)
+        assert "← related" not in result[0]
+
+    def test_multiple_memories(self):
+        mems = [
+            {"name": f"m{i}", "type": "project", "project": "j", "description": "", "content": f"c{i}", "tags": []}
+            for i in range(5)
+        ]
+        result = _format_memories(mems)
+        assert len(result) == 5
+
+
+# ---------------------------------------------------------------------------
+# _create_auto_links (async, mocked Supabase)
+# ---------------------------------------------------------------------------
+
+class TestCreateAutoLinks:
+    """Auto-linking creates memory_links entries based on similarity."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.table.return_value.upsert.return_value.execute.return_value = MagicMock(data=[])
+        return client
+
+    @pytest.mark.asyncio
+    async def test_creates_related_links(self, mock_client):
+        similar = [
+            {"id": "target-1", "type": "project", "similarity": 0.70},
+            {"id": "target-2", "type": "project", "similarity": 0.65},
+        ]
+        await _create_auto_links(mock_client, "source-id", similar, mem_type="project")
+
+        mock_client.table.assert_called_with("memory_links")
+        call_args = mock_client.table.return_value.upsert.call_args
+        links = call_args[0][0]
+        assert len(links) == 2
+        assert all(l["link_type"] == "related" for l in links)
+        assert links[0]["strength"] == 0.70
+        assert links[1]["strength"] == 0.65
+
+    @pytest.mark.asyncio
+    async def test_supersession_for_similar_decisions(self, mock_client):
+        similar = [
+            {"id": "old-decision", "type": "decision", "similarity": 0.90},  # > 0.85
+        ]
+        await _create_auto_links(mock_client, "new-decision", similar, mem_type="decision")
+
+        links = mock_client.table.return_value.upsert.call_args[0][0]
+        assert links[0]["link_type"] == "supersedes"
+
+    @pytest.mark.asyncio
+    async def test_no_supersession_for_non_decisions(self, mock_client):
+        similar = [
+            {"id": "target", "type": "project", "similarity": 0.90},
+        ]
+        await _create_auto_links(mock_client, "source", similar, mem_type="project")
+
+        links = mock_client.table.return_value.upsert.call_args[0][0]
+        assert links[0]["link_type"] == "related"  # not supersedes
+
+    @pytest.mark.asyncio
+    async def test_max_links_limit(self, mock_client):
+        similar = [{"id": f"t-{i}", "type": "project", "similarity": 0.70} for i in range(10)]
+        await _create_auto_links(mock_client, "source", similar, mem_type="project")
+
+        links = mock_client.table.return_value.upsert.call_args[0][0]
+        assert len(links) == MAX_AUTO_LINKS
+
+    @pytest.mark.asyncio
+    async def test_empty_similar_rows(self, mock_client):
+        await _create_auto_links(mock_client, "source", [], mem_type="project")
+        mock_client.table.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_swallows_exceptions(self, mock_client):
+        """Fire-and-forget: errors don't propagate."""
+        mock_client.table.side_effect = Exception("DB error")
+        # Should not raise
+        await _create_auto_links(mock_client, "source", [{"id": "t", "type": "p", "similarity": 0.7}], "project")
+
+
+# ---------------------------------------------------------------------------
+# _expand_with_links (async, mocked Supabase)
+# ---------------------------------------------------------------------------
+
+class TestExpandWithLinks:
+    """Graph traversal fetches 1-hop linked memories."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_returns_linked_memories(self, mock_client):
+        mock_client.rpc.return_value.execute.return_value = MagicMock(
+            data=[
+                {"id": "linked-1", "name": "linked_mem", "link_type": "related", "link_strength": 0.75},
+            ]
+        )
+        result = await _expand_with_links(mock_client, ["source-id"])
+        assert len(result) == 1
+        assert result[0]["id"] == "linked-1"
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_links(self, mock_client):
+        mock_client.rpc.return_value.execute.return_value = MagicMock(data=[])
+        result = await _expand_with_links(mock_client, ["source-id"])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_swallows_exceptions(self, mock_client):
+        mock_client.rpc.side_effect = Exception("DB error")
+        result = await _expand_with_links(mock_client, ["source-id"])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_passes_memory_ids_to_rpc(self, mock_client):
+        mock_client.rpc.return_value.execute.return_value = MagicMock(data=[])
+        await _expand_with_links(mock_client, ["id-1", "id-2"])
+        mock_client.rpc.assert_called_once_with(
+            "get_linked_memories",
+            {"memory_ids": ["id-1", "id-2"], "link_types": None},
+        )

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -5,13 +5,12 @@ Covers Memory 2.0 core: temporal scoring, RRF merge, formatting, auto-linking.
 
 from __future__ import annotations
 
-import math
 import os
 import sys
 import types
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -62,6 +61,9 @@ for mod_name, mod in [
 
 # Stub supabase (only needed if _get_client is called, which we avoid)
 sys.modules.setdefault("supabase", types.ModuleType("supabase"))
+
+# Stub httpx (used for Voyage AI embedding calls)
+sys.modules.setdefault("httpx", types.ModuleType("httpx"))
 
 # Stub dotenv
 _dotenv = types.ModuleType("dotenv")
@@ -256,7 +258,16 @@ class TestFormatMemories:
     def test_no_tags(self):
         mem = {"name": "x", "type": "user", "project": None, "description": "", "content": "c"}
         result = _format_memories([mem])
-        assert "[" not in result[0] or "user" in result[0]
+        # Header should NOT contain tag brackets when tags are missing
+        header_line = result[0].split("\n")[0]
+        assert "] " not in header_line or header_line.endswith(")")
+
+    def test_empty_tags_list(self):
+        mem = {"name": "x", "type": "user", "project": None, "description": "", "content": "c", "tags": []}
+        result = _format_memories([mem])
+        header_line = result[0].split("\n")[0]
+        # Empty tags list should not produce brackets
+        assert "[]" not in header_line
 
     def test_link_info(self):
         mem = {
@@ -323,7 +334,7 @@ class TestCreateAutoLinks:
     @pytest.mark.asyncio
     async def test_supersession_for_similar_decisions(self, mock_client):
         similar = [
-            {"id": "old-decision", "type": "decision", "similarity": 0.90},  # > 0.85
+            {"id": "old-decision", "type": "decision", "similarity": SUPERSEDE_SIM_THRESHOLD + 0.05},
         ]
         await _create_auto_links(mock_client, "new-decision", similar, mem_type="decision")
 
@@ -404,3 +415,58 @@ class TestExpandWithLinks:
             "get_linked_memories",
             {"memory_ids": ["id-1", "id-2"], "link_types": None},
         )
+
+
+# ---------------------------------------------------------------------------
+# Recall pipeline dedup regression (bidirectional link bug)
+# ---------------------------------------------------------------------------
+
+class TestRecallLinkedDedup:
+    """Regression: bidirectional links should not produce duplicate linked memories."""
+
+    def test_dedup_within_linked_results(self):
+        """If _expand_with_links returns the same memory twice (bidirectional links),
+        the recall pipeline should deduplicate to keep only one."""
+        # Simulate: main results have IDs ["main-1", "main-2"]
+        # Linked results return "linked-A" twice (from both link directions)
+        main_ids = {"main-1", "main-2"}
+        linked = [
+            {"id": "linked-A", "name": "mem_a", "link_type": "related", "link_strength": 0.71},
+            {"id": "linked-A", "name": "mem_a", "link_type": "related", "link_strength": 0.63},
+            {"id": "linked-B", "name": "mem_b", "link_type": "related", "link_strength": 0.65},
+        ]
+
+        # Reproduce the dedup logic from _hybrid_recall
+        found_ids = set(main_ids)
+        seen_linked: set[str] = set()
+        unique_linked = []
+        for r in linked:
+            rid = r.get("id")
+            if rid not in found_ids and rid not in seen_linked:
+                seen_linked.add(rid)
+                unique_linked.append(r)
+
+        assert len(unique_linked) == 2
+        assert unique_linked[0]["id"] == "linked-A"
+        assert unique_linked[0]["link_strength"] == 0.71  # first (strongest) kept
+        assert unique_linked[1]["id"] == "linked-B"
+
+    def test_main_results_excluded_from_linked(self):
+        """Linked results that duplicate main results should be excluded."""
+        main_ids = {"id-1"}
+        linked = [
+            {"id": "id-1", "name": "same_as_main", "link_type": "related", "link_strength": 0.80},
+            {"id": "id-2", "name": "different", "link_type": "related", "link_strength": 0.70},
+        ]
+
+        found_ids = set(main_ids)
+        seen_linked: set[str] = set()
+        unique_linked = []
+        for r in linked:
+            rid = r.get("id")
+            if rid not in found_ids and rid not in seen_linked:
+                seen_linked.add(rid)
+                unique_linked.append(r)
+
+        assert len(unique_linked) == 1
+        assert unique_linked[0]["id"] == "id-2"


### PR DESCRIPTION
## Summary
- **31 unit tests** for `mcp-memory/server.py` — first test coverage for the memory server (RRF merge, temporal scoring, format, auto-linking, graph traversal)
- **`memory_graph` MCP tool** — 3 modes: `overview` (stats + top connected + orphans), `links` (per-memory connections), `clusters` (connected components for consolidation)
- **Bugfix**: `get_linked_memories` SQL returned duplicate entries for bidirectional links. `DISTINCT ON` keeps only strongest link per target.
- Updated **memory-manager skill** with `/memory graph`, `/memory links`, `/memory clusters` commands

## Test plan
- [x] `pytest tests/` — 74/74 passed (no regressions)
- [x] Live test: dedup fix verified via `memory_recall` with `include_links=true`
- [ ] After MCP restart: test `memory_graph(mode="overview")` 
- [ ] After MCP restart: test `memory_graph(mode="links", name="...")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)