### PR TITLE
feat(security): add gitleaks pre-commit hook and CI workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,14 +3,14 @@ name: Gitleaks Secret Scanning
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
       - 'docs/**'
       - '.gitignore'
   push:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
       - 'docs/**'
       - '.gitignore'
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,37 @@
+name: Gitleaks Secret Scanning
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.gitignore'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.gitignore'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    name: Detect secrets with gitleaks
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          config-path: .gitleaks.toml
+          exit-code: 1
+          verbose: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,39 +2,34 @@
 # https://github.com/gitleaks/gitleaks
 
 title = "Gitleaks config for Jarvis"
-extend_exclude_regex = '''
-  # Build artifacts
-  \.build/|dist/|node_modules/|\.venv/|__pycache__/|
-  # IDE/Editor files
-  \.vscode/|\.idea/|\.mypy_cache/|\.pytest_cache/|\.ruff_cache/|
-  # OS specific
-  \.DS_Store|Thumbs\.db|
-  # Test fixtures (if any contain intentional secrets for testing)
-  tests/fixtures/|test-data/
-'''
 
-[[rules]]
-id = "jarvis-env-local"
-description = "Ignore local .env files which are already in .gitignore"
-regex = '''(?i)^\.env\.local$'''
-path = '''\.env\.local'''
-entropy = 0.0
-secretGroup = 1
-
-# Allowlist for common false positives specific to this project
-[[allowlist]]
-description = "AWS region patterns - common in examples, not secrets"
-regex = '''(us-east-1|us-west-2|eu-west-1|ap-southeast-1)'''
+# Paths to exclude from scanning
+[extend]
 paths = [
-  '''docs/.*\.md$''',
-  '''\.md$''',
+  '''.build/''',
+  '''dist/''',
+  '''node_modules/''',
+  '''.venv/''',
+  '''__pycache__/''',
+  '''.vscode/''',
+  '''.idea/''',
+  '''.mypy_cache/''',
+  '''.pytest_cache/''',
+  '''.ruff_cache/''',
+  '''tests/fixtures/''',
+  '''test-data/''',
 ]
 
-[[allowlist]]
-description = "Supabase URL patterns in docs/config - these are meant to be public"
-regex = '''(supabase\.co|https://[a-z0-9]+\.supabase\.co)'''
+# Allowlist for common false positives specific to this project
+[allowlist]
+description = "Global allowlist"
 paths = [
-  '''docs/.*\.md$''',
-  '''config/.*\.md$''',
   '''\.gitleaks\.toml$''',
+]
+regexTarget = "match"
+regexes = [
+  # AWS region patterns in docs — not secrets
+  '''(us-east-1|us-west-2|eu-west-1|ap-southeast-1|ap-south-1)''',
+  # Supabase public project URLs
+  '''https://[a-z0-9]+\.supabase\.co''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,40 @@
+# Gitleaks configuration for Jarvis project
+# https://github.com/gitleaks/gitleaks
+
+title = "Gitleaks config for Jarvis"
+extend_exclude_regex = '''
+  # Build artifacts
+  \.build/|dist/|node_modules/|\.venv/|__pycache__/|
+  # IDE/Editor files
+  \.vscode/|\.idea/|\.mypy_cache/|\.pytest_cache/|\.ruff_cache/|
+  # OS specific
+  \.DS_Store|Thumbs\.db|
+  # Test fixtures (if any contain intentional secrets for testing)
+  tests/fixtures/|test-data/
+'''
+
+[[rules]]
+id = "jarvis-env-local"
+description = "Ignore local .env files which are already in .gitignore"
+regex = '''(?i)^\.env\.local$'''
+path = '''\.env\.local'''
+entropy = 0.0
+secretGroup = 1
+
+# Allowlist for common false positives specific to this project
+[[allowlist]]
+description = "AWS region patterns - common in examples, not secrets"
+regex = '''(us-east-1|us-west-2|eu-west-1|ap-southeast-1)'''
+paths = [
+  '''docs/.*\.md$''',
+  '''\.md$''',
+]
+
+[[allowlist]]
+description = "Supabase URL patterns in docs/config - these are meant to be public"
+regex = '''(supabase\.co|https://[a-z0-9]+\.supabase\.co)'''
+paths = [
+  '''docs/.*\.md$''',
+  '''config/.*\.md$''',
+  '''\.gitleaks\.toml$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.2
+    hooks:
+      - id: gitleaks
+        name: Detect secrets with gitleaks
+        entry: gitleaks detect --verbose --exit-code 1 -c .gitleaks.toml
+        language: system
+        types: [text]
+        stages: [commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,5 +6,5 @@ repos:
         name: Detect secrets with gitleaks
         entry: gitleaks detect --verbose --exit-code 1 -c .gitleaks.toml
         language: system
-        types: [text]
-        stages: [commit]
+        pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary

Implements pre-commit hook and GitHub Actions workflow for secret detection using gitleaks, closing #126.

## Changes

- **`.pre-commit-config.yaml`** — Configures the pre-commit framework with gitleaks v8.18.2 hook
- **`.gitleaks.toml`** — Configuration with sensible defaults for Python/JS codebase, including:
  - Extended excludes for build artifacts, IDE files, OS-specific files
  - Allowlists for common false positives (AWS regions in docs, Supabase public URLs)
  - Configured to exclude test fixtures if they contain intentional secrets
- **`.github/workflows/gitleaks.yml`** — GitHub Actions workflow that:
  - Runs on all PRs and pushes to main
  - Uses `gitleaks/gitleaks-action@v2` for maximum compatibility
  - Ignores documentation-only changes to reduce CI noise
  - Exits with code 1 on secret detection

## Notes

- Pre-commit hook uses `system` language type (requires gitleaks binary installed locally). Developers can set this up with `brew install gitleaks` (macOS) or `choco install gitleaks` (Windows) before first commit
- GitHub Actions is the primary safety net — PRs are blocked if secrets are detected
- `.gitleaks.toml` is designed to be minimal and maintainable; additional allowlists can be added as false positives are discovered
- The hook stages for `commit` only (not `push`), keeping overhead minimal on local development

Closes #126

Co-Authored-By: Jarvis <jarvis@personal-ai-agent>