### PR TITLE
feat: add /verify skill for outcome verification

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: verify
+description: "Verify pending task outcomes: check PR merge status, test results, update records, extract lessons."
+---
+
+# Verify Outcomes
+
+Closes the outcome tracking loop: did the work actually land?
+
+## When to use
+
+- After delegations have had time to merge
+- As part of autonomous-loop (scheduled)
+- Manual: `/verify` to check all pending outcomes
+
+## Step 1 — Fetch pending outcomes
+
+```
+outcome_list(outcome_status="pending")
+```
+
+If none found → report "No pending outcomes" and stop.
+
+## Step 2 — Verify each outcome
+
+For each pending outcome, verify based on available data:
+
+### If `pr_url` exists (delegation/fix):
+```bash
+gh pr view <pr_url> --json state,mergedAt,statusCheckRollup --jq '{state, mergedAt, checks: [.statusCheckRollup[] | {name: .name, conclusion: .conclusion}]}'
+```
+
+Determine:
+- **success**: PR merged + checks passed
+- **partial**: PR merged but some checks failed, OR PR open but checks pass
+- **failure**: PR closed without merge, OR checks failing
+- **pending**: PR still open, reviews pending → skip (not yet verifiable)
+
+### If `issue_url` exists (no PR):
+```bash
+gh issue view <issue_url> --json state,stateReason --jq '{state, stateReason}'
+```
+
+- **success**: issue closed as completed
+- **failure**: issue closed as not planned
+- **pending**: issue still open → skip
+
+### If neither URL exists (autonomous/research):
+- Outcomes older than 7 days with no URL → mark as **unknown**
+- Otherwise → skip
+
+## Step 3 — Update verified outcomes
+
+For each outcome that changed status, run via `execute_sql`:
+
+```sql
+UPDATE task_outcomes
+SET outcome_status = '<new_status>',
+    pr_merged = <true/false>,
+    tests_passed = <true/false>,
+    verified_at = now(),
+    outcome_summary = COALESCE(outcome_summary, '') || E'\n[Verified] <brief result>'
+WHERE id = '<outcome_id>';
+```
+
+Use Supabase project ID: `svwrzttdkxeselkpxfgm`.
+
+## Step 4 — Extract lessons
+
+Review all outcomes verified in this run. Look for patterns:
+
+1. **Repeated failures** in the same area → save as `feedback` memory
+2. **Successful patterns** worth repeating → save as `feedback` memory
+3. **Quality trends** (low quality_score clusters) → flag in output
+
+Only save non-obvious patterns. Don't save "PR was merged successfully" — that's expected.
+
+## Step 5 — Output
+
+```
+## Outcome Verification — YYYY-MM-DD
+
+### Verified (N)
+- [+] <task_description> → success (PR merged, checks passed)
+- [-] <task_description> → failure (PR closed without merge)
+
+### Still pending (N)
+- [?] <task_description> — PR open, awaiting review
+
+### Patterns found
+- <pattern description, or "None">
+
+### Lessons saved (N)
+- <memory name> — <one-line>
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,11 +149,12 @@ After context compression → `memory_recall(query="working state")` first, then
 
 ## Skill routing
 
-Seven skills. Use them — don't reinvent with raw tools.
+Nine skills. Use them — don't reinvent with raw tools.
 
 | Situation | Skill | Trigger |
 |-----------|-------|---------|
 | Implement a GitHub issue | **/delegate** | Owner says "реализуй", "implement", "#42" — or Jarvis decides to implement. **Always** use /delegate, never raw Agent for issue work |
+| Verify task outcomes | **/verify** | "проверь результаты", "verify outcomes", or scheduled after delegations. Checks PR merge, tests, updates outcome records |
 | End of session | **/end** | Owner says "end", "закончим", "конец сессии". Full: behavioral reflection + decisions + commit (~5 min) |
 | Quick exit | **/end-quick** | Owner says "end quick", "быстро закончим". Checkpoint + commit only (~30 sec) |
 | Project overview | **/status** | Start of work session, "статус", "что происходит", or when Jarvis needs cross-project awareness |


### PR DESCRIPTION
## Summary
- New `/verify` skill that closes the outcome tracking loop (Pillar 3)
- Queries `task_outcomes` with `outcome_status = 'pending'`
- Verifies PR merge status and test results via `gh pr view`
- Updates records in Supabase with `verified_at`, `pr_merged`, `tests_passed`
- Extracts non-obvious patterns into feedback memories
- Added to CLAUDE.md skill routing table

Originally named `/reflect` but renamed to `/verify` to avoid confusion with the behavioral reflection in `/end` (Step 1).

Closes #139

## Test plan
- [ ] Run `/verify` with no pending outcomes — should report "No pending outcomes"
- [ ] Create a pending outcome via `outcome_record`, then run `/verify` — should verify and update
- [ ] Verify SQL UPDATE sets `verified_at` and `outcome_status` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)