### PR TITLE
feat: multi-action orchestrator — batch Low-risk actions

### DIFF
--- a/.claude/skills/autonomous-loop/SKILL.md
+++ b/.claude/skills/autonomous-loop/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 
 # Autonomous Loop Orchestrator
 
-Daily orchestrator that perceives events and perception outputs (goals, risks, research findings), evaluates them against active goals, decides the top action within safety bounds, and executes it autonomously.
+Daily orchestrator that perceives events and perception outputs (goals, risks, research findings), evaluates them against active goals, decides actions within safety bounds, and executes them autonomously. Batches multiple Low-risk actions per run; limits Medium-risk to one.
 
 Implements the perceive→evaluate→decide→act→record loop from the Autonomous Work Loop architecture.
 
@@ -19,7 +19,7 @@ Implements the perceive→evaluate→decide→act→record loop from the Autonom
 ## Architecture
 
 ```
-Load Context → Build Candidates → Score → Pick Top → Risk-Gate → Execute → Record
+Load Context → Build Candidates → Score → Select (batch Low, pick 1 Medium) → Risk-Gate → Execute → Record
 ```
 
 ## Step 1 — Load Context
@@ -57,14 +57,21 @@ score = goal_alignment(0-3) × urgency(1-3) + severity_bonus
 
 **Disqualify:** unaligned (goal_alignment=0) or uncertain candidates.
 
-## Step 4 — Pick Top Action
+## Step 4 — Select Actions
 
-Select the highest-scoring action that:
-1. Falls within autonomy bounds (risk classification in Step 5)
-2. Is not a protected file (`mcp-memory/server.py`, `SOUL.md`, `CLAUDE.md`, `.mcp.json`)
-3. Has not already been actioned (check memory)
+Classify each candidate by risk (see Step 5), then select:
 
-**No high-priority candidates?** Skip gracefully — don't invent work.
+1. **All Low-risk** candidates with score ≥ 3 (up to 5 max)
+2. **Top-1 Medium-risk** candidate (only if score ≥ 5 and no High-risk in the batch)
+3. **High-risk** candidates → save as proposals only, never batch
+
+Selection filters (apply to all):
+- Not a protected file (`mcp-memory/server.py`, `SOUL.md`, `CLAUDE.md`, `.mcp.json`)
+- Not already actioned (check memory)
+
+**No candidates pass?** Skip gracefully — don't invent work.
+
+**Ordering:** Execute Low-risk batch first, then the Medium-risk action (if any). This ensures quick wins land even if the Medium action fails.
 
 ## Step 5 — Risk Classification
 
@@ -74,27 +81,33 @@ Select the highest-scoring action that:
 | **Medium** | Run self-improve, create PR, update goal, tag memory | Auto-execute + record |
 | **High** | Architecture change, SOUL.md, memory schema, protected files | Save proposal only |
 
-## Step 6 — Execute Action
+## Step 6 — Execute Actions
 
-Based on risk classification:
+Process the selected actions in order. Track results as `{action, status, detail}`.
 
-**Low** → execute immediately
+**Partial failure rule:** if one action fails, log it and continue with the rest. Don't abort the batch.
+
+### Low-risk batch (up to 5)
+Execute each independently:
 - Create GitHub issue: `issue_write(method="create", ...)`
 - Memory operations: `memory_store(...)`, `goal_update(...)`
 - Tag or label work: `gh issue edit`, `gh pr edit`
+- Triage events: `events_mark_processed(...)`
 
-**Medium** → execute and record
-- Invoke skill: `/self-improve`, `/research`, `/risk-radar`
+### Medium-risk (at most 1)
+Execute after Low-risk batch completes:
+- Invoke skill: `/self-improve`, `/research`, `/verify`
 - Create PR: delegate via `/delegate` or `gh pr create`
 - Update goal: `goal_update(slug=..., progress=...)`
 
-**High** → save proposal to memory, skip execution
+### High-risk (proposals only)
+Never execute — save to memory:
 - Record: `memory_store(type="project", name="autonomous_proposals", ...)`
 - Output proposal text to user
 
-## Step 7 — Record Outcome
+## Step 7 — Record Outcomes
 
-Every action logs to both memory and task_outcomes (Pillar 3):
+**Each action** gets its own `outcome_record` (Pillar 3):
 
 ```
 outcome_record(
@@ -109,30 +122,32 @@ outcome_record(
 )
 ```
 
-Also update dedup marker and goal progress:
+After all actions complete, update dedup marker with batch summary:
 
 ```
 memory_store(
   type="project",
   name="autonomous_loop_last_run",
-  content="{\"date\": \"YYYY-MM-DD\", \"action\": \"...\", \"score\": N}",
+  content="{\"date\": \"YYYY-MM-DD\", \"actions_count\": N, \"succeeded\": N, \"failed\": N, \"top_action\": \"...\"}",
   description="last orchestrator run"
 )
 ```
 
-If action advances a goal → `goal_update(slug=..., progress_pct=...)`.
+If any action advances a goal → `goal_update(slug=..., progress_pct=...)`.
 
 ## Safety Rules
 
 **Never:**
 - Touch protected files: `.mcp.json`, `SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`
-- Create more than 1 PR per run
+- Create more than 1 PR per run (even in a batch)
+- Execute more than 5 Low-risk + 1 Medium-risk per run
 - Execute High-risk actions without explicit proposal
 
 **Always:**
 - Dedup: check `autonomous_loop_last_run` before acting
 - Risk-gate: only auto-execute Low/Medium actions
-- Record: every action goes to memory for learning
+- Record: every action gets its own `outcome_record`
+- Partial failure: if one action fails, continue with the rest
 - Graceful exit: if no candidates, return "No high-priority actions" and exit
 
 ## Output
@@ -150,15 +165,18 @@ If action advances a goal → `goal_update(slug=..., progress_pct=...)`.
 |--------|-----------|---------|-------|------|
 | <action 1> | <score> | <score> | <total> | Low/Med/High |
 
-## Selected
-**<Title>** — Score: N | Risk: Low/Medium/High
+## Selected (N actions)
+| # | Action | Score | Risk | Status |
+|---|--------|-------|------|--------|
+| 1 | <action> | N | Low | success/failure |
 
 ## Execution
-- [EXECUTED / PROPOSED]: <what was done or proposed>
-- <link to created issue/PR/memory>
+- [EXECUTED / PROPOSED]: <per-action summary>
+- <links to created issues/PRs/memories>
 
 ## Status
-- ✓ Action recorded to memory
+- ✓ N/M actions succeeded
+- ✓ Each action recorded via `outcome_record`
 - ✓ `autonomous_loop_last_run` updated
 ```
 


### PR DESCRIPTION
## Summary
- Autonomous loop now batches up to 5 Low-risk actions per run (was: pick top-1 only)
- Medium-risk limited to 1 per run, executed after Low-risk batch
- Partial failure handling: one failed action doesn't abort the batch
- Each action independently recorded via `outcome_record`
- Safety limits: max 5 Low + 1 Medium per run, still max 1 PR per run

Closes #138

## Test plan
- [ ] Run `/autonomous-loop` with multiple Low-risk candidates — should batch and execute all
- [ ] Verify each action gets its own `outcome_record` entry
- [ ] Simulate a failure mid-batch — other actions should still complete
- [ ] Verify `autonomous_loop_last_run` shows batch summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)