### PR TITLE
fix(ci): validate and fix cross-repo event dispatch

### DIFF
--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -15,8 +15,8 @@ name: Event Dispatch
 on:
   workflow_run:
     workflows:
+      - "Gitleaks Secret Scanning"
       - "Copilot Review Response"
-      - "Issue Checks"
       - "PR Body Check"
       - "PR Merged"
       - "Project Sync"
@@ -24,13 +24,12 @@ on:
     types: [completed]
     branches: [main, master]
 
+  pull_request:
+    types: [closed]
+    branches: [main, master]
+
   pull_request_review:
     types: [submitted]
-
-  # Dependabot alerts (if available)
-  # Note: requires 'security_events: read' permission
-  # dependabot_alert:
-  #   types: [created]
 
 jobs:
   # ── CI Failure on default branch ──────────────────────────────────
@@ -111,6 +110,48 @@ jobs:
                 \"pr_number\": ${PR_NUM},
                 \"pr_title\": \"${PR_TITLE_ESCAPED}\",
                 \"reviewer\": \"${REVIEWER}\",
+                \"url\": \"${PR_URL}\"
+              },
+              \"event_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+            }"
+
+  # ── PR Merged ─────────────────────────────────────────────────────
+  pr-merged:
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch PR merged event
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUM="${{ github.event.pull_request.number }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+
+          PR_TITLE_ESCAPED=$(echo "$PR_TITLE" | sed 's/"/\\"/g')
+
+          curl -s -X POST "${SUPABASE_URL}/rest/v1/events" \
+            -H "apikey: ${SUPABASE_ANON_KEY}" \
+            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
+            -H "Content-Type: application/json" \
+            -H "Prefer: return=minimal" \
+            -d "{
+              \"event_type\": \"pr_merged\",
+              \"severity\": \"info\",
+              \"repo\": \"${REPO}\",
+              \"source\": \"github_action\",
+              \"title\": \"PR #${PR_NUM} merged: ${PR_TITLE_ESCAPED}\",
+              \"payload\": {
+                \"pr_number\": ${PR_NUM},
+                \"pr_title\": \"${PR_TITLE_ESCAPED}\",
+                \"author\": \"${AUTHOR}\",
+                \"merge_sha\": \"${MERGE_SHA}\",
                 \"url\": \"${PR_URL}\"
               },
               \"event_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"


### PR DESCRIPTION
## Summary
- Removed "Issue Checks" from monitored workflows (source of 136 spam events)
- Added "Gitleaks Secret Scanning" to monitored workflows
- Added `pr_merged` event type — tracks PR merges into Supabase events table
- Added `pull_request` closed trigger for merge detection

## Why
Cross-repo event dispatch was never validated end-to-end (#137). Investigation found:
- Jarvis→Supabase works but was spamming 136+ duplicate `ci_failure` events from Issue Checks
- Redrobot workflow was broken (missing `workflows:` filter — separate PR in redrobot)
- No `pr_merged` events were being captured

Closes #137

## Decisions & Alternatives
- **Removed Issue Checks from triggers** — it fires on every issue edit/create, generating noise. CI-relevant workflows (Gitleaks, PR Body Check) are kept
- **Added pr_merged as a direct pull_request event** rather than workflow_run — more reliable, doesn't depend on PR Merged workflow completing first

## Risk Assessment
- **LOW**: workflow config change, non-breaking, easily reversible

## Testing
- Verified 137 events exist in Supabase events table (136 jarvis + 1 redrobot)
- Bulk-cleaned spam events (marked 107 as processed)
- Redrobot fix: separate PR adds `workflows:` filter

## Files Changed
- `.github/workflows/event-dispatch.yml` — trigger cleanup + pr_merged job added