### PR TITLE
feat(security): scan memory_store for secrets

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,15 @@
             "command": "python scripts/secret-scanner.py"
           }
         ]
+      },
+      {
+        "matcher": "mcp__memory__memory_store",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python scripts/secret-scanner.py"
+          }
+        ]
       }
     ]
   }

--- a/scripts/secret-scanner.py
+++ b/scripts/secret-scanner.py
@@ -1,8 +1,9 @@
 """PreToolUse hook: scan tool inputs for secret patterns before execution.
 
-Handles two tool types:
+Handles three tool types:
 - GitHub MCP write tools: scans body/title/content fields
 - Bash tool: scans command string for secrets and dangerous exfiltration patterns
+- Memory MCP tools: scans content/description fields for secrets
 
 Reads tool_input from stdin (JSON). Exits 2 to block if secrets detected.
 Does NOT scan for personal data — only credentials that grant access.
@@ -101,6 +102,16 @@ def extract_bash_command(tool_input: dict) -> str:
     return cmd if isinstance(cmd, str) else ""
 
 
+def extract_memory_text(tool_input: dict) -> str:
+    """Pull text fields from memory_store input."""
+    parts = []
+    for key in ("content", "description", "name"):
+        val = tool_input.get(key)
+        if isinstance(val, str):
+            parts.append(val)
+    return "\n".join(parts)
+
+
 # Regex to match heredoc bodies: <<'EOF'...EOF or <<EOF...EOF (multiline)
 _HEREDOC_RE = re.compile(
     r"<<-?\s*'?(\w+)'?\s*\n.*?\n\s*\1\s*(?:\)|$)",
@@ -188,6 +199,12 @@ def main():
         findings.extend(scan_secrets(command))
         # Check for dangerous exfiltration patterns
         findings.extend(scan_bash_dangers(command))
+    elif "memory" in tool_name:
+        # Memory MCP tools (memory_store)
+        text = extract_memory_text(tool_input)
+        if not text:
+            sys.exit(0)
+        findings.extend(scan_secrets(text))
     else:
         # GitHub MCP tools
         text = extract_github_text(tool_input)

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -17,6 +17,7 @@ scan_secrets = secret_scanner.scan_secrets
 scan_bash_dangers = secret_scanner.scan_bash_dangers
 extract_github_text = secret_scanner.extract_github_text
 extract_bash_command = secret_scanner.extract_bash_command
+extract_memory_text = secret_scanner.extract_memory_text
 strip_heredocs = secret_scanner.strip_heredocs
 
 
@@ -205,6 +206,56 @@ def test_extract_bash_command():
 def test_extract_bash_empty():
     cmd = extract_bash_command({})
     assert cmd == ""
+
+
+# ── Memory extraction ──────────────────────────────────────────────────
+
+def test_extract_memory_fields():
+    text = extract_memory_text({"name": "test", "content": "data", "description": "desc"})
+    assert "data" in text and "desc" in text and "test" in text
+
+def test_extract_memory_empty():
+    assert extract_memory_text({}) == ""
+
+
+# ── Memory scanning: blocked ──────────────────────────────────────────
+
+def test_memory_blocks_api_key():
+    text = extract_memory_text({"content": "key is sk-ant-api03-abc123def456ghi789jklmnop", "name": "test"})
+    assert scan_secrets(text)
+
+def test_memory_blocks_jwt():
+    text = extract_memory_text({"content": "token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0", "name": "creds"})
+    assert scan_secrets(text)
+
+def test_memory_blocks_github_token():
+    text = extract_memory_text({"content": "Use ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij for access", "name": "setup"})
+    assert scan_secrets(text)
+
+
+# ── Memory scanning: allowed ─────────────────────────────────────────
+
+def test_memory_allows_credential_metadata():
+    text = extract_memory_text({
+        "content": "ANTHROPIC_API_KEY stored in .env, expires 2026-06-01. Rotate via Anthropic console.",
+        "description": "Anthropic credential metadata",
+        "name": "credential_anthropic",
+    })
+    assert not scan_secrets(text)
+
+def test_memory_allows_normal_content():
+    text = extract_memory_text({
+        "content": "Decision: use soft delete for memories. 30-day retention. Cleanup via scheduled task.",
+        "name": "soft_delete_decision",
+    })
+    assert not scan_secrets(text)
+
+def test_memory_allows_project_state():
+    text = extract_memory_text({
+        "content": "Sprint 2 in progress. Issues #158-#163. Focus on security before multi-agent.",
+        "name": "working_state_jarvis",
+    })
+    assert not scan_secrets(text)
 
 
 # ── Run ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Extends secret scanner to intercept `memory_store` MCP calls. Blocks API keys, JWTs, and tokens from being persisted to Supabase memory. Credential metadata (env var names, expiry dates) passes through fine.

## Why
Memory was the only unscanned write path. An agent could accidentally store a secret value in memory content. Closes the gap identified in the threat model.

Closes #159

## Risk Assessment
- **LOW**: Extends existing scanner with same patterns. New hook only triggers on memory_store.

## Testing
- 54 tests pass (8 new): API key in memory blocked, JWT blocked, GitHub token blocked, credential metadata allowed, normal content allowed, project state allowed
- `python -m pytest tests/test_secret_scanner.py -x -q` — all pass

## Files Changed
- `scripts/secret-scanner.py` — `extract_memory_text()` + memory branch in `main()`
- `tests/test_secret_scanner.py` — 8 new test cases
- `.claude/settings.json` — new PreToolUse hook for `mcp__memory__memory_store`