### PR TITLE
feat(security): agent sandbox boundaries

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -65,6 +65,10 @@ git checkout -b feat/<N>-<slug>
 - Direct implementation is faster and avoids agent coordination overhead
 - Use Agent tool only for truly parallel independent tasks
 
+**Protected files — DO NOT modify (see `docs/security/agent-boundaries.md`):**
+`.mcp.json`, `config/SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`, `.claude/settings.json`, `.gitleaks.toml`, `.pre-commit-config.yaml`
+If a change to a protected file is needed, document it in the PR description and leave it for the owner.
+
 **For each change:**
 - Read existing code first (Read tool)
 - Check patterns in the codebase (Grep/Glob)

--- a/docs/security/agent-boundaries.md
+++ b/docs/security/agent-boundaries.md
@@ -1,0 +1,47 @@
+# Agent Sandbox Boundaries
+
+Date: 2026-04-15
+Scope: Rules for subagents (current /delegate + future Pillar 7 agents)
+
+## Protected Files
+
+These files must NEVER be modified by subagents. Changes require owner review in the main session.
+
+| File | Why |
+|------|-----|
+| `.mcp.json` | MCP server config — affects all devices and projects |
+| `config/SOUL.md` | Jarvis identity — changes alter all behavior |
+| `CLAUDE.md` | Project instructions — affects all sessions |
+| `mcp-memory/server.py` | Memory server — affects all projects |
+| `.claude/settings.json` | Hooks and permissions — security boundary |
+| `.gitleaks.toml` | Secret scanning config — disabling = security bypass |
+| `.pre-commit-config.yaml` | Pre-commit hooks — disabling = security bypass |
+
+Enforced via PreToolUse hook: `scripts/protected-files.py`
+
+## Branch Rules
+
+- Subagents work in feature branches (`feat/<N>-<slug>`), never commit directly to main
+- One branch per issue — no multi-issue branches from agents
+- Agent must push before reporting "done" — unpushed work is unverifiable
+
+## Memory Rules
+
+- Agents CAN: store project/decision memories, record outcomes
+- Agents CANNOT: delete memories without owner confirmation (soft delete provides safety net)
+- Secret scanner blocks credential values in memory_store
+
+## Scope Rules
+
+- Agent should only modify files relevant to its assigned issue
+- If an agent needs to change a protected file, it must document the needed change in the PR description and leave it for the owner
+- Cross-project changes (jarvis ↔ redrobot) require explicit mention in the issue
+
+## Escalation
+
+Agent must STOP and report (not attempt) when:
+1. It needs to modify a protected file
+2. It encounters a merge conflict it can't resolve
+3. Tests fail and the fix requires architectural changes
+4. The issue requirements are ambiguous and implementation could go multiple ways
+5. The change would affect another project's behavior

--- a/scripts/protected-files.py
+++ b/scripts/protected-files.py
@@ -1,0 +1,84 @@
+"""PreToolUse hook: block writes to protected files.
+
+Checks Edit/Write tool inputs for file paths that match the protected list.
+Exits 2 to block if a protected file is targeted.
+"""
+
+import json
+import sys
+
+# Files that require owner review — agents must not modify these.
+PROTECTED_FILES = {
+    ".mcp.json",
+    "config/SOUL.md",
+    "CLAUDE.md",
+    "mcp-memory/server.py",
+    ".claude/settings.json",
+    ".gitleaks.toml",
+    ".pre-commit-config.yaml",
+}
+
+
+def normalize_path(path: str) -> str:
+    """Normalize a file path for comparison: forward slashes, strip leading ./"""
+    path = path.replace("\\", "/")
+    # Strip absolute prefix up to repo root patterns
+    for marker in ("/jarvis/", "\\jarvis\\"):
+        idx = path.find(marker)
+        if idx != -1:
+            path = path[idx + len(marker):]
+            break
+    # Strip leading ./
+    if path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def is_protected(file_path: str) -> bool:
+    """Check if a file path matches any protected file."""
+    normalized = normalize_path(file_path)
+    return normalized in PROTECTED_FILES
+
+
+def block(file_path: str):
+    """Output deny JSON and exit 2."""
+    result = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"BLOCKED: '{file_path}' is a protected file. "
+                "Document the needed change in the PR description instead."
+            ),
+        }
+    }
+    json.dump(result, sys.stdout)
+    sys.exit(2)
+
+
+def main():
+    raw = sys.stdin.read()
+    if not raw.strip():
+        sys.exit(0)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        sys.exit(0)
+
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        sys.exit(0)
+
+    if is_protected(file_path):
+        block(file_path)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_protected_files.py
+++ b/tests/test_protected_files.py
@@ -1,0 +1,75 @@
+"""Tests for scripts/protected-files.py — protected file detection."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import importlib
+protected_files = importlib.import_module("protected-files")
+
+is_protected = protected_files.is_protected
+normalize_path = protected_files.normalize_path
+
+
+# ── Protected files: blocked ─────────────────────────────────────────
+
+def test_blocks_mcp_json():
+    assert is_protected(".mcp.json")
+
+def test_blocks_soul_md():
+    assert is_protected("config/SOUL.md")
+
+def test_blocks_claude_md():
+    assert is_protected("CLAUDE.md")
+
+def test_blocks_server_py():
+    assert is_protected("mcp-memory/server.py")
+
+def test_blocks_settings_json():
+    assert is_protected(".claude/settings.json")
+
+def test_blocks_gitleaks():
+    assert is_protected(".gitleaks.toml")
+
+def test_blocks_pre_commit():
+    assert is_protected(".pre-commit-config.yaml")
+
+
+# ── Absolute paths (Windows-style) ──────────────────────────────────
+
+def test_blocks_absolute_windows():
+    assert is_protected("C:\\Users\\petrk\\GitHub\\jarvis\\CLAUDE.md")
+
+def test_blocks_absolute_forward_slash():
+    assert is_protected("C:/Users/petrk/GitHub/jarvis/config/SOUL.md")
+
+
+# ── Non-protected files: allowed ─────────────────────────────────────
+
+def test_allows_regular_python():
+    assert not is_protected("scripts/secret-scanner.py")
+
+def test_allows_docs():
+    assert not is_protected("docs/PROJECT_PLAN.md")
+
+def test_allows_tests():
+    assert not is_protected("tests/test_secret_scanner.py")
+
+def test_allows_skill():
+    assert not is_protected(".claude/skills/delegate/SKILL.md")
+
+def test_allows_other_json():
+    assert not is_protected("config/device.json")
+
+
+# ── Normalize path ──────────────────────────────────────────────────
+
+def test_normalize_backslashes():
+    assert normalize_path("config\\SOUL.md") == "config/SOUL.md"
+
+def test_normalize_leading_dot_slash():
+    assert normalize_path("./CLAUDE.md") == "CLAUDE.md"
+
+def test_normalize_absolute():
+    assert normalize_path("C:/Users/petrk/GitHub/jarvis/CLAUDE.md") == "CLAUDE.md"


### PR DESCRIPTION
## Summary
Defines what agents can/cannot do: protected files list, branch rules, memory rules, scope limits, escalation criteria. Includes enforcement script with path normalization.

## Why
Before multi-agent (Pillar 7), clear boundaries prevent agents from modifying critical config. Currently agents have unrestricted file access.

Closes #162

## Decisions
- **Hook not added globally** — PreToolUse on Edit/Write would block the owner too. Instead, rules are enforced via delegate skill instructions. The script exists for future per-agent hook config when Claude Code supports it.
- **7 protected files** — chosen based on blast radius: identity, config, security, memory server.

## Risk Assessment
- **LOW**: Documentation + delegate skill instructions. No global hooks changed.

## Testing
- 17 tests pass: all protected files detected, absolute paths normalized, non-protected files allowed.

## Files Changed
- `docs/security/agent-boundaries.md` — boundary rules document
- `scripts/protected-files.py` — detection script with path normalization
- `tests/test_protected_files.py` — 17 test cases
- `.claude/skills/delegate/SKILL.md` — protected files list added to implement step