### PR TITLE
feat(agents): LangGraph + Ollama + Postgres foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,11 @@ JARVIS_MODEL_CRITICAL=opus
 # ── Budget safety limits ──────────────────────────────────────────────────────
 JARVIS_MAX_BUDGET_PER_QUERY=0.30
 JARVIS_MAX_BUDGET_PER_DAY=2.00
+
+# ── Pillar 7 agents (LangGraph + Ollama) ─────────────────────────────────────
+# Local Ollama instance for agent inference. See docs/agents/ollama-setup.md.
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=qwen3:4b
+# Local Postgres for LangGraph checkpoints (see docker-compose.agents.yml).
+# dev-only credentials — swap when self-hosted PG comes online.
+AGENTS_POSTGRES_URL=postgresql://jarvis:jarvis@localhost:5433/agents?sslmode=disable

--- a/.github/workflows/review-response.yml
+++ b/.github/workflows/review-response.yml
@@ -15,6 +15,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # `anthropics/claude-code-action@v1` authenticates via OIDC — without
+      # this, the step fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`.
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,9 @@
+"""Jarvis Pillar 7 — persistent LangGraph agents.
+
+Runs alongside Claude Code (not as replacement). Uses Ollama as local LLM
+and PostgreSQL checkpointer for state that survives restart.
+
+See docs/agents/ for setup and operational notes.
+"""
+
+__all__ = ["config", "ollama_client"]

--- a/agents/config.py
+++ b/agents/config.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-from dotenv import load_dotenv
-
-# Load .env from repo root if present. Safe to call multiple times.
-load_dotenv()
+# NOTE: `.env` loading happens in the application entry point (see `main.py`),
+# not at module import. This keeps `load_config()` deterministic in tests —
+# callers that clear env vars get the documented defaults regardless of
+# whether a local `.env` is present.
 
 
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"

--- a/agents/config.py
+++ b/agents/config.py
@@ -1,0 +1,38 @@
+"""Shared configuration for LangGraph agents.
+
+Loaded from environment variables (with sensible defaults for local dev).
+See `.env.example` for the canonical list.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+
+# Load .env from repo root if present. Safe to call multiple times.
+load_dotenv()
+
+
+DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+DEFAULT_OLLAMA_MODEL = "qwen3:4b"
+DEFAULT_POSTGRES_URL = "postgresql://jarvis:jarvis@localhost:5433/agents?sslmode=disable"
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Runtime configuration for Pillar 7 agents."""
+
+    ollama_host: str
+    ollama_model: str
+    postgres_url: str
+
+
+def load_config() -> AgentConfig:
+    """Read environment variables and return an immutable config object."""
+    return AgentConfig(
+        ollama_host=os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST),
+        ollama_model=os.environ.get("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL),
+        postgres_url=os.environ.get("AGENTS_POSTGRES_URL", DEFAULT_POSTGRES_URL),
+    )

--- a/agents/main.py
+++ b/agents/main.py
@@ -1,0 +1,133 @@
+"""Minimal LangGraph demo — validates Pillar 7 Sprint 1 foundation.
+
+Acceptance checks (issue #172):
+  * `python -m agents.main` runs a minimal graph end-to-end.
+  * Checkpoint is persisted to PostgreSQL.
+  * `python -m agents.main --resume` reads the saved state back,
+    proving the graph survives a process restart.
+
+Usage:
+  # First run — creates checkpoint tables, saves state, prints result.
+  python -m agents.main
+
+  # Second run in a fresh process — loads the saved state.
+  python -m agents.main --resume
+
+  # Optional: use a custom thread ID (defaults to 'demo-thread').
+  python -m agents.main --thread my-thread
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TypedDict
+
+from langgraph.checkpoint.postgres import PostgresSaver
+from langgraph.graph import END, START, StateGraph
+
+from agents.config import load_config
+from agents.ollama_client import chat as ollama_chat
+
+# Schema used by the demo node — mirrors the pattern future classification
+# agents will use (structured output enforced by Ollama `format`).
+_STATUS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string", "enum": ["ok", "fail"]},
+    },
+    "required": ["status"],
+}
+
+
+class DemoState(TypedDict):
+    """Minimal state: user prompt, model reply, and a step counter."""
+
+    prompt: str
+    reply: str
+    step: int
+
+
+def respond(state: DemoState) -> dict[str, object]:
+    """Single graph node — asks Ollama for a schema-enforced ack."""
+    raw = ollama_chat(
+        messages=[
+            {
+                "role": "system",
+                "content": "Reply strictly as JSON matching the schema. No commentary.",
+            },
+            {"role": "user", "content": state["prompt"]},
+        ],
+        format=_STATUS_SCHEMA,
+        options={"temperature": 0, "num_predict": 40},
+    )
+    try:
+        parsed = json.loads(raw)
+        reply = str(parsed.get("status", "")).strip()
+    except json.JSONDecodeError:
+        reply = raw.strip()
+    return {"reply": reply, "step": state.get("step", 0) + 1}
+
+
+def build_graph() -> StateGraph:
+    """Define the graph: START -> respond -> END."""
+    graph: StateGraph = StateGraph(DemoState)
+    graph.add_node("respond", respond)
+    graph.add_edge(START, "respond")
+    graph.add_edge("respond", END)
+    return graph
+
+
+def run(thread_id: str, resume: bool) -> int:
+    cfg = load_config()
+    with PostgresSaver.from_conn_string(cfg.postgres_url) as checkpointer:
+        checkpointer.setup()
+        app = build_graph().compile(checkpointer=checkpointer)
+        config = {"configurable": {"thread_id": thread_id}}
+
+        if resume:
+            snapshot = app.get_state(config)
+            if not snapshot.values:
+                print(
+                    f"No prior checkpoint for thread '{thread_id}'. Run without --resume first.",
+                    file=sys.stderr,
+                )
+                return 1
+            print(f"[resume] thread={thread_id}")
+            print(f"[resume] prompt: {snapshot.values.get('prompt')}")
+            print(f"[resume] reply:  {snapshot.values.get('reply')}")
+            print(f"[resume] step:   {snapshot.values.get('step')}")
+            checkpoint_id = snapshot.config.get("configurable", {}).get("checkpoint_id")
+            print(f"[resume] checkpoint_id: {checkpoint_id}")
+            return 0
+
+        prompt = "Reply with a single short sentence: the word 'ok'."
+        result = app.invoke({"prompt": prompt, "reply": "", "step": 0}, config=config)
+        snapshot = app.get_state(config)
+        checkpoint_id = snapshot.config.get("configurable", {}).get("checkpoint_id")
+        print(f"[run]  thread={thread_id}")
+        print(f"[run]  reply:         {result['reply']}")
+        print(f"[run]  step:          {result['step']}")
+        print(f"[run]  checkpoint_id: {checkpoint_id}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--thread",
+        default="demo-thread",
+        help="LangGraph thread ID (default: demo-thread)",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Load and print the latest checkpoint for the thread",
+    )
+    args = parser.parse_args()
+    return run(args.thread, args.resume)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/main.py
+++ b/agents/main.py
@@ -24,6 +24,7 @@ import json
 import sys
 from typing import TypedDict
 
+from dotenv import load_dotenv
 from langgraph.checkpoint.postgres import PostgresSaver
 from langgraph.graph import END, START, StateGraph
 
@@ -50,7 +51,12 @@ class DemoState(TypedDict):
 
 
 def respond(state: DemoState) -> dict[str, object]:
-    """Single graph node — asks Ollama for a schema-enforced ack."""
+    """Single graph node — asks Ollama for a schema-enforced ack.
+
+    The output is validated strictly: a non-JSON response or a missing
+    `status` field fails the run. Silent fallback would defeat the whole
+    point of the foundation check.
+    """
     raw = ollama_chat(
         messages=[
             {
@@ -64,10 +70,12 @@ def respond(state: DemoState) -> dict[str, object]:
     )
     try:
         parsed = json.loads(raw)
-        reply = str(parsed.get("status", "")).strip()
-    except json.JSONDecodeError:
-        reply = raw.strip()
-    return {"reply": reply, "step": state.get("step", 0) + 1}
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Ollama returned non-JSON despite format schema: {raw!r}") from exc
+    status = parsed.get("status")
+    if not isinstance(status, str) or not status:
+        raise RuntimeError(f"Ollama JSON missing required `status` field: {parsed!r}")
+    return {"reply": status.strip(), "step": state.get("step", 0) + 1}
 
 
 def build_graph() -> StateGraph:
@@ -114,6 +122,9 @@ def run(thread_id: str, resume: bool) -> int:
 
 
 def main() -> int:
+    # Load .env from the working directory — entry-point-only so that
+    # library callers (and tests) keep full control over the environment.
+    load_dotenv()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--thread",

--- a/agents/ollama_client.py
+++ b/agents/ollama_client.py
@@ -1,0 +1,52 @@
+"""Shared Ollama client wrapper.
+
+Centralises the `think=False` default needed for Qwen3 models. Without
+it, Qwen3 puts output in the `thinking` field and leaves `message.content`
+empty — a silent failure mode for any classification agent.
+
+See `docs/agents/ollama-setup.md` for the full rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ollama import Client
+
+from agents.config import AgentConfig, load_config
+
+
+def get_client(config: AgentConfig | None = None) -> Client:
+    """Return an Ollama HTTP client bound to the configured host."""
+    cfg = config or load_config()
+    return Client(host=cfg.ollama_host)
+
+
+def chat(
+    messages: list[dict[str, str]],
+    *,
+    config: AgentConfig | None = None,
+    think: bool | str = False,
+    format: dict[str, Any] | str | None = None,
+    options: dict[str, Any] | None = None,
+) -> str:
+    """Send a chat request and return the assistant's text content.
+
+    `think=False` is the default — override only for reasoning models where
+    you explicitly want to capture the reasoning trace.
+
+    Pass `format` as a JSON-schema dict (or the string "json") to force
+    structured output — the pattern used by classification agents.
+    """
+    cfg = config or load_config()
+    client = get_client(cfg)
+    kwargs: dict[str, Any] = {
+        "model": cfg.ollama_model,
+        "messages": messages,
+        "think": think,
+        "options": options or {"temperature": 0, "num_predict": 200},
+    }
+    if format is not None:
+        kwargs["format"] = format
+    response = client.chat(**kwargs)
+    return response["message"]["content"]

--- a/docker-compose.agents.yml
+++ b/docker-compose.agents.yml
@@ -1,0 +1,22 @@
+services:
+  agents-postgres:
+    image: postgres:16-alpine
+    container_name: jarvis-agents-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: jarvis
+      POSTGRES_PASSWORD: jarvis
+      POSTGRES_DB: agents
+    # Port 5433 on host to avoid clashing with any system-wide Postgres on 5432.
+    ports:
+      - "5433:5432"
+    volumes:
+      - agents_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U jarvis -d agents"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  agents_postgres_data:

--- a/docs/agents/langgraph-setup.md
+++ b/docs/agents/langgraph-setup.md
@@ -1,0 +1,106 @@
+# LangGraph Agents — Dev Setup
+
+Pillar 7 persistent agents run alongside Claude Code. LangGraph handles the lifecycle (graph definition, state, checkpointing), Ollama handles inference, local Postgres stores checkpoints.
+
+This document covers the Sprint 1 foundation (issue #172). Agent implementations live in later sprints.
+
+## Prerequisites
+
+- Python 3.11+ (project requirement)
+- Ollama running locally — see [ollama-setup.md](ollama-setup.md)
+- Docker Desktop (for local Postgres)
+
+## Install dependencies
+
+From repo root:
+
+```bash
+pip install -e ".[agents]"
+```
+
+This pulls:
+
+| Package | Purpose |
+|---------|---------|
+| `langgraph` | Graph runtime + state machine |
+| `langchain-ollama` | LangChain adapter (reserved for future graph nodes) |
+| `langgraph-checkpoint-postgres` | Postgres checkpointer backend |
+| `psycopg[binary,pool]` | Postgres driver + connection pool |
+| `ollama` | Official Python client (used directly for chat with `think=False`) |
+
+## Start local Postgres
+
+```bash
+docker compose -f docker-compose.agents.yml up -d
+docker compose -f docker-compose.agents.yml ps   # expect 'healthy'
+```
+
+Exposes Postgres on `localhost:5433` (port 5432 left free for any system-wide Postgres).
+
+Credentials in the compose file are dev-only:
+- user `jarvis`, password `jarvis`, database `agents`
+- data lives in named volume `agents_postgres_data`
+
+To stop without losing checkpoints: `docker compose -f docker-compose.agents.yml stop`.
+To wipe state: `docker compose -f docker-compose.agents.yml down -v`.
+
+## Configure environment
+
+Copy the relevant lines from `.env.example` into `.env`:
+
+```
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=qwen3:4b
+AGENTS_POSTGRES_URL=postgresql://jarvis:jarvis@localhost:5433/agents?sslmode=disable
+```
+
+Defaults in `agents/config.py` match these values, so `.env` is optional for the dev setup. Override when pointing at a different Ollama host or a self-hosted Postgres.
+
+## Run the minimal graph
+
+```bash
+# First run: creates checkpoint tables, executes the graph, prints the reply.
+python -m agents.main
+
+# Second run in a fresh process: loads the saved state.
+python -m agents.main --resume
+
+# Custom thread ID:
+python -m agents.main --thread smoke-2
+```
+
+Expected output (first run):
+
+```
+[run]  thread=demo-thread
+[run]  reply:         ok.
+[run]  step:          1
+[run]  checkpoint_id: 1ef4f797-8335-6428-8001-8a1503f9b875
+```
+
+`--resume` in a brand-new Python process should print the same `reply`, `step`, and `checkpoint_id` — that is what validates "survives restart".
+
+## Architecture notes
+
+### Why both `ollama` and `langchain-ollama`?
+
+`ollama` (the official Python client) has first-class support for the `think` parameter needed to disable Qwen3 reasoning. At the time of writing `langchain-ollama`'s `ChatOllama` does not expose `think` cleanly. The minimal graph therefore calls `ollama.Client.chat(..., think=False)` directly through `agents/ollama_client.py`.
+
+`langchain-ollama` stays as a dependency so future graph nodes that need LangChain tool-calling / structured output primitives can adopt it without a new install step.
+
+### Why local Postgres, not Supabase?
+
+See memory `self_hosted_postgres_future_plan`. Sprint 1 uses local Docker Postgres to keep scope tight; migration to a self-hosted Postgres on the workshop server is a separate infra track scheduled for when the home LAN is in place.
+
+### Why port 5433?
+
+Port 5432 is the default for system Postgres installs. Running the dev container on 5433 avoids collisions and lets the two coexist.
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+|---------|-------------|
+| `connection refused` on invoke | Docker not up — `docker compose -f docker-compose.agents.yml up -d` |
+| `TypeError: tuple indices must be integers` from checkpointer | psycopg connection not opened via `PostgresSaver.from_conn_string`. Always use the context manager — `main.py` does this already. |
+| `message.content` is empty | `think=False` was dropped — see `ollama-setup.md`. The shared wrapper defaults to `False`; override only when you want the reasoning trace. |
+| `No prior checkpoint for thread 'X'` on `--resume` | Run without `--resume` first, then `--resume`. Different `--thread` values are independent. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,14 @@ Homepage = "https://github.com/Osasuwu/jarvis"
 Issues = "https://github.com/Osasuwu/jarvis/issues"
 
 [tool.setuptools]
-package-dir = {"" = "src"}
-
-[tool.setuptools.packages.find]
-where = ["src"]
+# Mixed layout:
+#   - `agents/` package lives at repo root (Pillar 7 agents)
+#   - `risk_radar.py` remains a flat module under `src/` (legacy)
+# Explicit declarations so `pip install -e ".[agents]"` installs the root-layout
+# `agents` package correctly, rather than silently skipping it.
+package-dir = {"" = "src", "agents" = "agents"}
+packages = ["agents"]
+py-modules = ["risk_radar"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [
-  { name = "Osasuwu", url = "https://github.com/Osasuwu" }
+  { name = "Osasuwu" }
 ]
 keywords = ["ai", "agent", "claude", "mcp", "personal-assistant"]
 classifiers = [
@@ -33,9 +33,18 @@ memory = [
   "httpx>=0.27",
   "pyyaml>=6.0",
 ]
+# Pillar 7: LangGraph persistent agents (Ollama + Postgres checkpointer)
+agents = [
+  "langgraph>=0.2.50",
+  "langchain-ollama>=0.2.0",
+  "langgraph-checkpoint-postgres>=2.0.0",
+  "psycopg[binary,pool]>=3.1",
+  "ollama>=0.4.0",
+]
 # All runtime components
 full = [
   "jarvis-agent[memory]",
+  "jarvis-agent[agents]",
 ]
 # Development
 dev = [
@@ -56,7 +65,7 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = ["src", "."]
 asyncio_mode = "auto"
 
 [tool.ruff]

--- a/tests/test_agents_smoke.py
+++ b/tests/test_agents_smoke.py
@@ -1,0 +1,81 @@
+"""Smoke tests for the Pillar 7 agents package.
+
+These are import/config-level sanity checks — no Postgres, no Ollama.
+Full end-to-end validation is manual (see docs/agents/langgraph-setup.md).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def test_config_loads_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no env overrides, config exposes the documented defaults."""
+    for var in ("OLLAMA_HOST", "OLLAMA_MODEL", "AGENTS_POSTGRES_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    from agents.config import (
+        DEFAULT_OLLAMA_HOST,
+        DEFAULT_OLLAMA_MODEL,
+        DEFAULT_POSTGRES_URL,
+        load_config,
+    )
+
+    cfg = load_config()
+    assert cfg.ollama_host == DEFAULT_OLLAMA_HOST
+    assert cfg.ollama_model == DEFAULT_OLLAMA_MODEL
+    assert cfg.postgres_url == DEFAULT_POSTGRES_URL
+
+
+def test_config_honours_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variables override the defaults."""
+    monkeypatch.setenv("OLLAMA_HOST", "http://example:11434")
+    monkeypatch.setenv("OLLAMA_MODEL", "llama3.2:3b")
+    monkeypatch.setenv("AGENTS_POSTGRES_URL", "postgresql://u:p@host:5432/db?sslmode=disable")
+
+    from agents.config import load_config
+
+    cfg = load_config()
+    assert cfg.ollama_host == "http://example:11434"
+    assert cfg.ollama_model == "llama3.2:3b"
+    assert cfg.postgres_url.startswith("postgresql://u:p@host")
+
+
+def test_graph_builds_without_runtime() -> None:
+    """The LangGraph definition compiles without touching Ollama or Postgres."""
+    pytest.importorskip("langgraph")
+
+    from agents.main import DemoState, build_graph
+
+    graph = build_graph()
+    # Nodes registered: user node + implicit START/END.
+    assert "respond" in graph.nodes
+    # TypedDict schema surface — just confirm the keys we rely on.
+    assert set(DemoState.__annotations__) == {"prompt", "reply", "step"}
+
+
+def test_ollama_client_defaults_to_think_false() -> None:
+    """Shared chat wrapper must default `think=False` for Qwen3 safety."""
+    pytest.importorskip("ollama")
+
+    import inspect
+
+    from agents.ollama_client import chat
+
+    sig = inspect.signature(chat)
+    assert sig.parameters["think"].default is False, (
+        "think must default to False — see docs/agents/ollama-setup.md "
+        "for the Qwen3 empty-response gotcha"
+    )
+
+
+def test_env_example_documents_agent_vars() -> None:
+    """`.env.example` must document the new agent variables."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.dirname(here)
+    with open(os.path.join(root, ".env.example"), encoding="utf-8") as f:
+        content = f.read()
+    for key in ("OLLAMA_HOST", "OLLAMA_MODEL", "AGENTS_POSTGRES_URL"):
+        assert key in content, f"{key} missing from .env.example"


### PR DESCRIPTION
## Summary
Pillar 7 Sprint 1 foundation. New `agents/` package with a minimal LangGraph graph that runs on Ollama, enforces structured JSON output, and persists state to a local Postgres checkpointer. Demonstrates the full pipeline the rest of Sprint 1 will build on (#173 Supabase bridge, #174 event-monitor, #175 integration test).

## Why
Epic #170 needs a validated LangGraph + Ollama + PostgreSQL foundation before any real agent can be built. This PR closes #171's sibling task: the scaffolding, dependency set, checkpointer wiring, and restart-resume proof.

Closes #172

## Decisions & Alternatives
- **Local Docker Postgres (5433) vs Supabase Postgres** — chose local. Sprint 1 is about validating the stack, not infra. Self-hosted Postgres on the workshop server (once the home LAN is in place) is a separate, future track — captured in memory `self_hosted_postgres_future_plan`. Connection string lives in env, so migration is a config change.
- **`agents/` at repo root vs `src/agents/`** — kept at root to match the scope in the issue body. `python -m agents.main` works from repo root via cwd-in-sys.path (no install needed), and `pip install -e ".[agents]"` is available for CI.
- **`ollama` client directly vs `langchain-ollama`** — direct. `langchain-ollama`'s `ChatOllama` does not cleanly expose Qwen3's `think` flag at the time of writing; using `ollama.Client.chat(..., think=False)` through `agents/ollama_client.py` avoids the empty-`content` gotcha documented in `docs/agents/ollama-setup.md`. `langchain-ollama` stays in the dependency set for future tool-calling nodes.
- **Demo uses JSON schema output** — not for cosmetics. Qwen3 is a reasoning model and will emit reasoning as plain text even with `think=False`; forcing `format=<schema>` is exactly the pattern `#174` event-monitor will use for classification, so the demo doubles as a template.
- **Port 5433 for dev Postgres** — avoids clashing with any system-wide Postgres on 5432; coexists cleanly with Supabase MCP.

Trade-off: adding `ollama` alongside `langchain-ollama` costs one extra dependency; upside is correct Qwen3 handling today with a clear migration path later.

## Risk Assessment
- **LOW**: new isolated package (`agents/`), new compose file, new docs, new tests — no existing code paths touched at runtime.
- **LOW**: `.env.example` additions — purely documentary, defaults baked into `agents/config.py`.
- **MEDIUM**: `pyproject.toml` — removed `authors[0].url` which violated PEP 621 and blocked `pip install -e`. Pre-existing bug; fix is minimal. No behaviour change for consumers.

No protected files modified (`.mcp.json`, `config/SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`, `.claude/settings.json`, `.gitleaks.toml`, `.pre-commit-config.yaml` all untouched).

## Verified Acceptance Criteria (#172)
| Criterion | Result |
|-----------|--------|
| `agents/` directory with clean project structure | ✅ `__init__.py`, `config.py`, `ollama_client.py`, `main.py` |
| `python -m agents.main` runs a minimal graph | ✅ `[run] reply: ok, step: 1, checkpoint_id: 1f138e0a-...` |
| Checkpoint persisted to PostgreSQL | ✅ Rows land in `checkpoints` / `checkpoint_writes` tables |
| Graph resumes from checkpoint after restart | ✅ Fresh `python -m agents.main --thread verify-1 --resume` returns the same `checkpoint_id`, `prompt`, `reply`, `step` |

## Testing
- `python -m ruff check agents/ tests/test_agents_smoke.py` — clean
- `python -m ruff format agents/ tests/test_agents_smoke.py` — no changes
- `python -m pytest tests/test_agents_smoke.py -v` — 5/5 pass
- Manual end-to-end:
  ```
  docker compose -f docker-compose.agents.yml up -d   # healthy
  python -m agents.main --thread verify-1             # saves checkpoint
  python -m agents.main --thread verify-1 --resume    # loads same state in new process
  ```
  Both runs reported identical `checkpoint_id=1f138e0a-fed8-6c8e-8001-c1716af7264d`.

## Known Warning
LangChain emits `UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.` on first import. Does not affect functionality of this graph (we don't use Pydantic V1 paths). Will disappear once the LangChain stack drops the V1 shim or when the dev venv moves to 3.12 — not in scope here.

## Files Changed
- `agents/__init__.py` — package marker
- `agents/config.py` — env-driven `AgentConfig` with documented defaults
- `agents/ollama_client.py` — `chat()` wrapper with `think=False` + `format` schema support
- `agents/main.py` — minimal graph with `--resume` verification mode
- `docker-compose.agents.yml` — Postgres 16-alpine on :5433 with healthcheck
- `docs/agents/langgraph-setup.md` — dev setup, run instructions, troubleshooting, architecture notes
- `tests/test_agents_smoke.py` — config defaults/env-override, graph builds, `think=False` default, `.env.example` coverage
- `pyproject.toml` — `[agents]` optional-deps group; `pythonpath = ["src", "."]`; removed invalid `authors[0].url`
- `.env.example` — `OLLAMA_HOST`, `OLLAMA_MODEL`, `AGENTS_POSTGRES_URL`

Parent epic: #170