### PR TITLE
feat(agents): Supabase bridge for LangGraph agents

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -6,4 +6,4 @@ and PostgreSQL checkpointer for state that survives restart.
 See docs/agents/ for setup and operational notes.
 """
 
-__all__ = ["config", "ollama_client"]
+__all__ = ["config", "ollama_client", "supabase_client"]

--- a/agents/config.py
+++ b/agents/config.py
@@ -27,6 +27,12 @@ class AgentConfig:
     ollama_host: str
     ollama_model: str
     postgres_url: str
+    # Supabase bridge — shared with Claude Code's MCP memory server. Empty
+    # strings are intentionally allowed at load time so imports/tests don't
+    # require live credentials; `agents.supabase_client.get_client` raises
+    # with a clear error if someone tries to use the bridge without them.
+    supabase_url: str
+    supabase_key: str
 
 
 def load_config() -> AgentConfig:
@@ -35,4 +41,6 @@ def load_config() -> AgentConfig:
         ollama_host=os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST),
         ollama_model=os.environ.get("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL),
         postgres_url=os.environ.get("AGENTS_POSTGRES_URL", DEFAULT_POSTGRES_URL),
+        supabase_url=os.environ.get("SUPABASE_URL", ""),
+        supabase_key=os.environ.get("SUPABASE_KEY", ""),
     )

--- a/agents/supabase_client.py
+++ b/agents/supabase_client.py
@@ -1,0 +1,238 @@
+"""Supabase bridge for LangGraph agents.
+
+LangGraph agents call Supabase directly via ``supabase-py`` — MCP is
+Claude Code's protocol and isn't available inside graph nodes. The
+read/write helpers here mirror a subset of ``mcp-memory/server.py`` so
+data written by an agent shows up in Claude Code's ``memory_recall`` /
+``events_list`` / ``goal_list`` and vice versa.
+
+Scope (Sprint 1, issue #173):
+  * Reads — ``list_memories``, ``list_events``, ``list_goals``
+  * Writes — ``store_event``, ``mark_event_processed``,
+    ``update_goal_progress``, ``audit``
+
+Anything more (memory_store, task_outcomes, consolidation, …) stays in
+Claude Code for now. Agents are consumers of the event inbox, not full
+owners of the knowledge base.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from supabase import Client, create_client
+
+from agents.config import AgentConfig, load_config
+
+
+def get_client(config: AgentConfig | None = None) -> Client:
+    """Return a supabase-py client bound to the agent config.
+
+    Raises ``RuntimeError`` with a pointer to ``.env.example`` if the
+    caller hasn't set ``SUPABASE_URL`` / ``SUPABASE_KEY`` — a silent
+    default would let bad config reach production unnoticed.
+    """
+    cfg = config or load_config()
+    if not cfg.supabase_url or not cfg.supabase_key:
+        raise RuntimeError(
+            "SUPABASE_URL and SUPABASE_KEY must be set for the agent Supabase "
+            "bridge — see .env.example."
+        )
+    return create_client(cfg.supabase_url, cfg.supabase_key)
+
+
+# -- Read helpers -----------------------------------------------------------
+
+
+def list_memories(
+    *,
+    project: str | None = None,
+    type: str | None = None,
+    limit: int = 10,
+    client: Client | None = None,
+    config: AgentConfig | None = None,
+) -> list[dict[str, Any]]:
+    """Return memory rows — same table Claude Code reads via ``memory_recall``.
+
+    Ordering matches the MCP server's default: most recently updated first.
+    """
+    cli = client or get_client(config)
+    q = (
+        cli.table("memories")
+        .select("id, name, type, project, description, content, tags, updated_at")
+        .order("updated_at", desc=True)
+        .limit(limit)
+    )
+    if project is not None:
+        q = q.eq("project", project)
+    if type is not None:
+        q = q.eq("type", type)
+    return q.execute().data or []
+
+
+def list_events(
+    *,
+    processed: bool | None = False,
+    repo: str | None = None,
+    event_type: str | None = None,
+    limit: int = 20,
+    client: Client | None = None,
+    config: AgentConfig | None = None,
+) -> list[dict[str, Any]]:
+    """Return event rows.
+
+    ``processed=False`` (default) returns the unprocessed inbox, matching
+    the MCP ``events_list`` default. Pass ``processed=None`` to include
+    both.
+    """
+    cli = client or get_client(config)
+    q = cli.table("events").select("*").order("created_at", desc=True).limit(limit)
+    if processed is not None:
+        q = q.eq("processed", processed)
+    if repo is not None:
+        q = q.eq("repo", repo)
+    if event_type is not None:
+        q = q.eq("event_type", event_type)
+    return q.execute().data or []
+
+
+def list_goals(
+    *,
+    status: str | None = "active",
+    project: str | None = None,
+    limit: int = 50,
+    client: Client | None = None,
+    config: AgentConfig | None = None,
+) -> list[dict[str, Any]]:
+    """Return goals — strategic context Claude Code loads at session start."""
+    cli = client or get_client(config)
+    q = (
+        cli.table("goals")
+        .select(
+            "slug, title, project, status, priority, why, "
+            "success_criteria, progress_pct, updated_at"
+        )
+        .order("priority")
+        .limit(limit)
+    )
+    if status is not None:
+        q = q.eq("status", status)
+    if project is not None:
+        q = q.eq("project", project)
+    return q.execute().data or []
+
+
+# -- Write helpers ----------------------------------------------------------
+
+
+def store_event(
+    *,
+    event_type: str,
+    repo: str,
+    title: str,
+    severity: str = "info",
+    payload: dict[str, Any] | None = None,
+    source: str = "langgraph-agent",
+    client: Client | None = None,
+    config: AgentConfig | None = None,
+) -> dict[str, Any]:
+    """Insert a row into the ``events`` inbox.
+
+    Same queue Claude Code polls via ``events_list`` — agents can emit
+    findings here and the orchestrator picks them up in its next loop.
+    Returns the inserted row (includes the generated ``id``).
+    """
+    cli = client or get_client(config)
+    row = {
+        "event_type": event_type,
+        "severity": severity,
+        "repo": repo,
+        "source": source,
+        "title": title,
+        "payload": payload or {},
+    }
+    result = cli.table("events").insert(row).execute()
+    data = result.data or []
+    if not data:
+        raise RuntimeError(f"Supabase returned no row after inserting event: {row!r}")
+    return data[0]
+
+
+def mark_event_processed(
+    event_id: str,
+    *,
+    processed_by: str,
+    action_taken: str | None = None,
+    client: Client | None = None,
+    config: AgentConfig | None = None,
+) -> None:
+    """Close an event — mirrors the MCP ``events_mark_processed`` tool."""
+    cli = client or get_client(config)
+    update: dict[str, Any] = {
+        "processed": True,
+        "processed_at": datetime.now(timezone.utc).isoformat(),
+        "processed_by": processed_by,
+    }
+    if action_taken is not None:
+        update["action_taken"] = action_taken
+    cli.table("events").update(update).eq("id", event_id).execute()
+
+
+def update_goal_progress(
+    slug: str,
+    progress_entry: dict[str, Any],
+    *,
+    client: Client | None = None,
+    config: AgentConfig | None = None,
+) -> None:
+    """Append an entry to ``goals.progress`` (jsonb list).
+
+    Matches the MCP ``goal_update`` semantics: progress is an append-only
+    log of timestamped observations, not an overwrite.
+    """
+    cli = client or get_client(config)
+    current = cli.table("goals").select("progress").eq("slug", slug).limit(1).execute()
+    rows = current.data or []
+    if not rows:
+        raise RuntimeError(f"Goal not found: slug={slug!r}")
+    prior = rows[0].get("progress")
+    if not isinstance(prior, list):
+        prior = []
+    prior.append(progress_entry)
+    cli.table("goals").update({"progress": prior}).eq("slug", slug).execute()
+
+
+def audit(
+    *,
+    agent_id: str,
+    tool_name: str,
+    action: str,
+    target: str | None = None,
+    details: dict[str, Any] | None = None,
+    outcome: str = "success",
+    client: Client | None = None,
+    config: AgentConfig | None = None,
+) -> None:
+    """Best-effort audit entry — never raises.
+
+    The ``agent_id`` column on ``audit_log`` is how agents identify
+    themselves (e.g. ``"langgraph-monitor"``). Matches the server.py
+    ``_audit_log()`` convention, with ``agent_id`` filled in — MCP writes
+    leave it NULL, so the column doubles as the actor differentiator.
+    """
+    try:
+        cli = client or get_client(config)
+        cli.table("audit_log").insert(
+            {
+                "agent_id": agent_id,
+                "tool_name": tool_name,
+                "action": action,
+                "target": target,
+                "details": details or {},
+                "outcome": outcome,
+            }
+        ).execute()
+    except Exception:
+        # Audit is best-effort — never block operations on logging failure.
+        pass

--- a/agents/supabase_client.py
+++ b/agents/supabase_client.py
@@ -18,6 +18,7 @@ owners of the knowledge base.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Any
 
@@ -55,17 +56,26 @@ def list_memories(
 ) -> list[dict[str, Any]]:
     """Return memory rows — same table Claude Code reads via ``memory_recall``.
 
+    Semantics mirror the MCP server (``mcp-memory/server.py``):
+
+    * Soft-deleted rows (``deleted_at IS NOT NULL``) are excluded — agents
+      must never see memories the user has removed.
+    * When ``project`` is specified, global (NULL-project) memories are
+      included alongside the project-scoped rows. Global memories carry
+      cross-project rules/feedback that the agent still needs.
+
     Ordering matches the MCP server's default: most recently updated first.
     """
     cli = client or get_client(config)
     q = (
         cli.table("memories")
         .select("id, name, type, project, description, content, tags, updated_at")
+        .is_("deleted_at", "null")
         .order("updated_at", desc=True)
         .limit(limit)
     )
     if project is not None:
-        q = q.eq("project", project)
+        q = q.or_(f"project.eq.{project},project.is.null")
     if type is not None:
         q = q.eq("type", type)
     return q.execute().data or []
@@ -107,6 +117,9 @@ def list_goals(
 ) -> list[dict[str, Any]]:
     """Return goals — strategic context Claude Code loads at session start."""
     cli = client or get_client(config)
+    # Ordering mirrors the MCP server's _handle_goal_list: priority first,
+    # deadline as tiebreaker (NULL deadlines last — those are open-ended goals
+    # and should fall behind anything with a concrete date).
     q = (
         cli.table("goals")
         .select(
@@ -114,6 +127,7 @@ def list_goals(
             "success_criteria, progress_pct, updated_at"
         )
         .order("priority")
+        .order("deadline", desc=False, nullsfirst=False)
         .limit(limit)
     )
     if status is not None:
@@ -167,7 +181,12 @@ def mark_event_processed(
     client: Client | None = None,
     config: AgentConfig | None = None,
 ) -> None:
-    """Close an event — mirrors the MCP ``events_mark_processed`` tool."""
+    """Close an event — mirrors the MCP ``events_mark_processed`` tool.
+
+    Raises ``RuntimeError`` if ``event_id`` matched no row. A silent no-op
+    would let the caller think the event was closed when nothing actually
+    changed — typically a sign of a stale id or wrong-environment lookup.
+    """
     cli = client or get_client(config)
     update: dict[str, Any] = {
         "processed": True,
@@ -176,7 +195,31 @@ def mark_event_processed(
     }
     if action_taken is not None:
         update["action_taken"] = action_taken
-    cli.table("events").update(update).eq("id", event_id).execute()
+    result = cli.table("events").update(update).eq("id", event_id).execute()
+    rows = result.data or []
+    if not rows:
+        raise RuntimeError(f"Event not found or not updated: event_id={event_id!r}")
+
+
+def _parse_progress(raw: Any) -> list[Any]:
+    """Normalize ``goals.progress`` into a list.
+
+    PostgREST sometimes surfaces jsonb columns as already-decoded lists and
+    sometimes as JSON strings (depends on client version + column config).
+    The MCP ``_format_goal`` helper handles both; so must the agent bridge
+    — otherwise a string payload would silently reset progress to ``[]``.
+    Only a genuine parse failure (or a non-list/non-string value) falls
+    back to an empty list.
+    """
+    if isinstance(raw, list):
+        return list(raw)
+    if isinstance(raw, str):
+        try:
+            decoded = json.loads(raw)
+        except (ValueError, TypeError):
+            return []
+        return list(decoded) if isinstance(decoded, list) else []
+    return []
 
 
 def update_goal_progress(
@@ -185,22 +228,53 @@ def update_goal_progress(
     *,
     client: Client | None = None,
     config: AgentConfig | None = None,
+    max_retries: int = 3,
 ) -> None:
     """Append an entry to ``goals.progress`` (jsonb list).
 
     Matches the MCP ``goal_update`` semantics: progress is an append-only
     log of timestamped observations, not an overwrite.
+
+    The update is read-modify-write, so concurrent writers could otherwise
+    overwrite each other. We guard with optimistic concurrency: the UPDATE
+    matches on the ``updated_at`` we just read, and on no-row-match we
+    re-read and retry up to ``max_retries`` times before raising.
     """
     cli = client or get_client(config)
-    current = cli.table("goals").select("progress").eq("slug", slug).limit(1).execute()
-    rows = current.data or []
-    if not rows:
-        raise RuntimeError(f"Goal not found: slug={slug!r}")
-    prior = rows[0].get("progress")
-    if not isinstance(prior, list):
-        prior = []
-    prior.append(progress_entry)
-    cli.table("goals").update({"progress": prior}).eq("slug", slug).execute()
+    for _ in range(max_retries):
+        current = (
+            cli.table("goals").select("progress, updated_at").eq("slug", slug).limit(1).execute()
+        )
+        rows = current.data or []
+        if not rows:
+            raise RuntimeError(f"Goal not found: slug={slug!r}")
+
+        row = rows[0]
+        prior = _parse_progress(row.get("progress"))
+        next_progress = [*prior, progress_entry]
+        next_updated_at = datetime.now(timezone.utc).isoformat()
+
+        update_q = (
+            cli.table("goals")
+            .update({"progress": next_progress, "updated_at": next_updated_at})
+            .eq("slug", slug)
+        )
+        current_updated_at = row.get("updated_at")
+        if current_updated_at is None:
+            update_q = update_q.is_("updated_at", "null")
+        else:
+            update_q = update_q.eq("updated_at", current_updated_at)
+
+        result = update_q.execute()
+        if result.data:
+            return
+        # No match → another writer committed between our read and write.
+        # Re-read and retry with fresh state.
+
+    raise RuntimeError(
+        f"Concurrent update prevented appending goal progress after "
+        f"{max_retries} retries: slug={slug!r}"
+    )
 
 
 def audit(

--- a/docs/agents/langgraph-setup.md
+++ b/docs/agents/langgraph-setup.md
@@ -27,6 +27,7 @@ This pulls:
 | `langgraph-checkpoint-postgres` | Postgres checkpointer backend |
 | `psycopg[binary,pool]` | Postgres driver + connection pool |
 | `ollama` | Official Python client (used directly for chat with `think=False`) |
+| `supabase` | Agent bridge to the shared knowledge base (memories, events, goals, audit_log) |
 
 ## Start local Postgres
 
@@ -52,9 +53,13 @@ Copy the relevant lines from `.env.example` into `.env`:
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=qwen3:4b
 AGENTS_POSTGRES_URL=postgresql://jarvis:jarvis@localhost:5433/agents?sslmode=disable
+
+# Supabase bridge — same vars the MCP memory server uses; re-used here.
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_KEY=<anon-or-service-key>
 ```
 
-Defaults in `agents/config.py` match these values, so `.env` is optional for the dev setup. Override when pointing at a different Ollama host or a self-hosted Postgres.
+Defaults in `agents/config.py` match the Ollama and Postgres values, so `.env` is optional for local inference/checkpointing. `SUPABASE_URL` / `SUPABASE_KEY` have no default — the bridge fails loudly (`RuntimeError`) if an agent tries to call Supabase without them configured.
 
 ## Run the minimal graph
 
@@ -95,6 +100,12 @@ See memory `self_hosted_postgres_future_plan`. Sprint 1 uses local Docker Postgr
 ### Why port 5433?
 
 Port 5432 is the default for system Postgres installs. Running the dev container on 5433 avoids collisions and lets the two coexist.
+
+### Why a separate Supabase bridge (not MCP)?
+
+MCP is Claude Code's protocol; it isn't available inside LangGraph nodes. `agents/supabase_client.py` is a thin wrapper over `supabase-py` that exposes the subset of reads/writes agents actually need (`list_memories`, `list_events`, `list_goals`, `store_event`, `mark_event_processed`, `update_goal_progress`, `audit`). Both sides hit the same tables, so what an agent writes shows up in Claude Code's `memory_recall` / `events_list` / `goal_list` and vice versa.
+
+Agent writes to `audit_log` set `agent_id` (e.g. `"langgraph-monitor"`); MCP writes leave it NULL — the column doubles as the actor differentiator.
 
 ## Troubleshooting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,16 @@ memory = [
   "httpx>=0.27",
   "pyyaml>=6.0",
 ]
-# Pillar 7: LangGraph persistent agents (Ollama + Postgres checkpointer)
+# Pillar 7: LangGraph persistent agents (Ollama + Postgres checkpointer + Supabase bridge)
 agents = [
   "langgraph>=0.2.50",
   "langchain-ollama>=0.2.0",
   "langgraph-checkpoint-postgres>=2.0.0",
   "psycopg[binary,pool]>=3.1",
   "ollama>=0.4.0",
+  # Supabase bridge — agents read/write memories/events/goals/audit_log directly
+  # (MCP is Claude-Code-only, so graph nodes need a native client).
+  "supabase>=2.0.0",
 ]
 # All runtime components
 full = [

--- a/tests/test_agents_smoke.py
+++ b/tests/test_agents_smoke.py
@@ -13,7 +13,13 @@ import pytest
 
 def test_config_loads_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     """With no env overrides, config exposes the documented defaults."""
-    for var in ("OLLAMA_HOST", "OLLAMA_MODEL", "AGENTS_POSTGRES_URL"):
+    for var in (
+        "OLLAMA_HOST",
+        "OLLAMA_MODEL",
+        "AGENTS_POSTGRES_URL",
+        "SUPABASE_URL",
+        "SUPABASE_KEY",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     from agents.config import (
@@ -27,6 +33,9 @@ def test_config_loads_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.ollama_host == DEFAULT_OLLAMA_HOST
     assert cfg.ollama_model == DEFAULT_OLLAMA_MODEL
     assert cfg.postgres_url == DEFAULT_POSTGRES_URL
+    # Supabase bridge has no safe default — empty string means "not configured".
+    assert cfg.supabase_url == ""
+    assert cfg.supabase_key == ""
 
 
 def test_config_honours_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -34,6 +43,8 @@ def test_config_honours_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLLAMA_HOST", "http://example:11434")
     monkeypatch.setenv("OLLAMA_MODEL", "llama3.2:3b")
     monkeypatch.setenv("AGENTS_POSTGRES_URL", "postgresql://u:p@host:5432/db?sslmode=disable")
+    monkeypatch.setenv("SUPABASE_URL", "https://proj.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "anon-key-xyz")
 
     from agents.config import load_config
 
@@ -41,6 +52,8 @@ def test_config_honours_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.ollama_host == "http://example:11434"
     assert cfg.ollama_model == "llama3.2:3b"
     assert cfg.postgres_url.startswith("postgresql://u:p@host")
+    assert cfg.supabase_url == "https://proj.supabase.co"
+    assert cfg.supabase_key == "anon-key-xyz"
 
 
 def test_graph_builds_without_runtime() -> None:
@@ -77,5 +90,45 @@ def test_env_example_documents_agent_vars() -> None:
     root = os.path.dirname(here)
     with open(os.path.join(root, ".env.example"), encoding="utf-8") as f:
         content = f.read()
-    for key in ("OLLAMA_HOST", "OLLAMA_MODEL", "AGENTS_POSTGRES_URL"):
+    # Pillar 7 agent-only vars + shared Supabase vars used by the bridge.
+    for key in (
+        "OLLAMA_HOST",
+        "OLLAMA_MODEL",
+        "AGENTS_POSTGRES_URL",
+        "SUPABASE_URL",
+        "SUPABASE_KEY",
+    ):
         assert key in content, f"{key} missing from .env.example"
+
+
+def test_supabase_client_errors_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`get_client` must fail loudly when SUPABASE_URL/KEY are missing.
+
+    Silently defaulting would let a misconfigured agent run against nothing
+    and look healthy until the first write failed.
+    """
+    pytest.importorskip("supabase")
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_KEY", raising=False)
+
+    from agents.supabase_client import get_client
+
+    with pytest.raises(RuntimeError, match="SUPABASE_URL and SUPABASE_KEY"):
+        get_client()
+
+
+def test_supabase_client_surface() -> None:
+    """The bridge must expose the read/write helpers #173 requires."""
+    pytest.importorskip("supabase")
+
+    from agents import supabase_client as sb
+
+    # Reads
+    assert callable(sb.list_memories)
+    assert callable(sb.list_events)
+    assert callable(sb.list_goals)
+    # Writes
+    assert callable(sb.store_event)
+    assert callable(sb.mark_event_processed)
+    assert callable(sb.update_goal_progress)
+    assert callable(sb.audit)

--- a/tests/test_agents_supabase_bridge.py
+++ b/tests/test_agents_supabase_bridge.py
@@ -1,0 +1,363 @@
+"""Unit tests for ``agents.supabase_client`` with a mocked Supabase client.
+
+The smoke suite only covers imports/surface/credential failure. These tests
+pin the semantics the bridge promises to mirror from ``mcp-memory/server.py``:
+
+1. Reads never surface soft-deleted memories (``deleted_at IS NOT NULL``).
+2. Project-scoped reads include global (NULL-project) memories via ``or_()``.
+3. ``list_goals`` orders by priority then deadline (NULLs last).
+4. Writes that affect no rows raise loudly — no silent no-ops
+   (``store_event``, ``mark_event_processed``).
+5. ``update_goal_progress`` parses JSON-string progress and retries on
+   optimistic-concurrency conflicts before surrendering.
+6. ``audit`` is best-effort — backend failures must never propagate.
+
+The supabase-py builder returns ``self`` from every chain method until
+``execute()``. ``_FakeQuery`` mirrors that contract and records every call,
+so tests can assert on both the chained filters and the final payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("supabase")
+
+
+class _FakeResult:
+    def __init__(self, data: list[dict[str, Any]] | None = None) -> None:
+        self.data = data if data is not None else []
+
+
+class _FakeQuery:
+    """Chainable stand-in for a supabase-py query builder."""
+
+    def __init__(
+        self,
+        calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]],
+        result: _FakeResult | Exception,
+    ) -> None:
+        self._calls = calls
+        self._result = result
+
+    def execute(self) -> _FakeResult:
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+    def __getattr__(self, name: str):
+        def chain(*args: Any, **kwargs: Any) -> _FakeQuery:
+            self._calls.append((name, args, kwargs))
+            return self
+
+        return chain
+
+
+class _FakeClient:
+    """Queueable stand-in for a supabase-py client.
+
+    Pre-load per-table results with ``preset``; each ``table(name)`` call
+    pops the next result. Recorded call lists are available under
+    ``chains[name]`` (list of per-query chains, in call order).
+    """
+
+    def __init__(self) -> None:
+        self._presets: dict[str, list[_FakeResult | Exception]] = {}
+        self.chains: dict[str, list[list[tuple[str, tuple[Any, ...], dict[str, Any]]]]] = {}
+
+    def preset(self, table: str, *results: _FakeResult | Exception) -> None:
+        self._presets.setdefault(table, []).extend(results)
+
+    def table(self, name: str) -> _FakeQuery:
+        chain: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+        self.chains.setdefault(name, []).append(chain)
+        pending = self._presets.setdefault(name, [])
+        result = pending.pop(0) if pending else _FakeResult([])
+        return _FakeQuery(chain, result)
+
+
+def _names(chain: list[tuple[str, tuple[Any, ...], dict[str, Any]]]) -> list[str]:
+    return [c[0] for c in chain]
+
+
+def _find(
+    chain: list[tuple[str, tuple[Any, ...], dict[str, Any]]], name: str
+) -> tuple[str, tuple[Any, ...], dict[str, Any]]:
+    for call in chain:
+        if call[0] == name:
+            return call
+    raise AssertionError(f"method {name!r} was not called; chain={chain!r}")
+
+
+# -- list_memories ---------------------------------------------------------
+
+
+def test_list_memories_excludes_soft_deleted() -> None:
+    """Soft-deleted rows must never leak to agents — MCP parity."""
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("memories", _FakeResult(data=[{"id": 1}]))
+
+    rows = supabase_client.list_memories(client=cli)
+
+    assert rows == [{"id": 1}]
+    is_call = _find(cli.chains["memories"][0], "is_")
+    assert is_call[1] == ("deleted_at", "null"), is_call
+
+
+def test_list_memories_project_filter_includes_global() -> None:
+    """`project=X` must OR-in global (NULL-project) memories, not strict-eq."""
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("memories", _FakeResult(data=[]))
+
+    supabase_client.list_memories(project="jarvis", client=cli)
+
+    chain = cli.chains["memories"][0]
+    or_call = _find(chain, "or_")
+    (query_string,) = or_call[1]
+    assert "project.eq.jarvis" in query_string, query_string
+    assert "project.is.null" in query_string, query_string
+    # Must NOT also apply a strict .eq("project", ...) — that would exclude globals.
+    offenders = [c for c in chain if c[0] == "eq" and c[1][:1] == ("project",)]
+    assert not offenders, offenders
+
+
+def test_list_memories_without_project_skips_project_filter() -> None:
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("memories", _FakeResult(data=[]))
+
+    supabase_client.list_memories(client=cli)
+
+    chain = cli.chains["memories"][0]
+    assert "or_" not in _names(chain)
+    assert not any(c[0] == "eq" and c[1][:1] == ("project",) for c in chain)
+
+
+def test_list_memories_type_filter_uses_strict_eq() -> None:
+    """Type filter is strict (no global fallback) — matches MCP."""
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("memories", _FakeResult(data=[]))
+
+    supabase_client.list_memories(type="feedback", client=cli)
+
+    chain = cli.chains["memories"][0]
+    type_eq = [c for c in chain if c[0] == "eq" and c[1][:1] == ("type",)]
+    assert type_eq and type_eq[0][1] == ("type", "feedback"), type_eq
+
+
+# -- list_goals ------------------------------------------------------------
+
+
+def test_list_goals_orders_priority_then_deadline_nullslast() -> None:
+    """Ordering must mirror ``_handle_goal_list`` in mcp-memory/server.py."""
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("goals", _FakeResult(data=[]))
+
+    supabase_client.list_goals(client=cli)
+
+    chain = cli.chains["goals"][0]
+    orders = [c for c in chain if c[0] == "order"]
+    assert len(orders) == 2, orders
+    assert orders[0][1] == ("priority",), orders[0]
+    assert orders[1][1] == ("deadline",), orders[1]
+    # NULL deadlines must sort last: open-ended goals fall behind dated ones.
+    assert orders[1][2].get("nullsfirst") is False, orders[1]
+
+
+# -- store_event -----------------------------------------------------------
+
+
+def test_store_event_raises_when_supabase_returns_no_row() -> None:
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("events", _FakeResult(data=[]))
+
+    with pytest.raises(RuntimeError, match="no row after inserting"):
+        supabase_client.store_event(event_type="github.Foo", repo="o/r", title="t", client=cli)
+
+
+def test_store_event_inserts_full_payload() -> None:
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("events", _FakeResult(data=[{"id": "new"}]))
+
+    row = supabase_client.store_event(
+        event_type="github.IssuesEvent",
+        repo="o/r",
+        title="t",
+        severity="medium",
+        payload={"foo": 1},
+        source="langgraph-monitor",
+        client=cli,
+    )
+
+    assert row == {"id": "new"}
+    insert_call = _find(cli.chains["events"][0], "insert")
+    (payload,) = insert_call[1]
+    assert payload["event_type"] == "github.IssuesEvent"
+    assert payload["severity"] == "medium"
+    assert payload["source"] == "langgraph-monitor"
+    assert payload["payload"] == {"foo": 1}
+
+
+# -- mark_event_processed --------------------------------------------------
+
+
+def test_mark_event_processed_raises_when_no_row_matched() -> None:
+    """Silent no-op would mask a stale id or wrong-environment lookup."""
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("events", _FakeResult(data=[]))
+
+    with pytest.raises(RuntimeError, match="Event not found or not updated"):
+        supabase_client.mark_event_processed("does-not-exist", processed_by="test", client=cli)
+
+
+def test_mark_event_processed_filters_by_id_and_succeeds() -> None:
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("events", _FakeResult(data=[{"id": "abc"}]))
+
+    supabase_client.mark_event_processed("abc", processed_by="test", client=cli)
+
+    eq_call = _find(cli.chains["events"][0], "eq")
+    assert eq_call[1] == ("id", "abc")
+
+
+# -- update_goal_progress --------------------------------------------------
+
+
+def test_update_goal_progress_parses_json_string_progress() -> None:
+    """Progress returned as a JSON string must be parsed, not reset to []."""
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset(
+        "goals",
+        _FakeResult(
+            data=[
+                {
+                    "progress": '[{"item": "existing"}]',
+                    "updated_at": "2025-01-01T00:00:00Z",
+                }
+            ]
+        ),
+        _FakeResult(data=[{"slug": "g"}]),
+    )
+
+    supabase_client.update_goal_progress("g", {"item": "new"}, client=cli)
+
+    # chains["goals"][0] is the SELECT; [1] is the UPDATE we want to inspect.
+    update_call = _find(cli.chains["goals"][1], "update")
+    (payload,) = update_call[1]
+    assert payload["progress"] == [{"item": "existing"}, {"item": "new"}]
+
+
+def test_update_goal_progress_retries_on_optimistic_conflict() -> None:
+    """On no-row-match, re-read and retry with the fresh updated_at."""
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset(
+        "goals",
+        _FakeResult(data=[{"progress": [], "updated_at": "t1"}]),  # read 1
+        _FakeResult(data=[]),  # update 1 lost
+        _FakeResult(data=[{"progress": [], "updated_at": "t2"}]),  # read 2
+        _FakeResult(data=[{"slug": "g"}]),  # update 2 won
+    )
+
+    supabase_client.update_goal_progress("g", {"new": True}, client=cli)
+
+    chains = cli.chains["goals"]
+    assert len(chains) == 4, [_names(c) for c in chains]
+
+    # Each update's .eq("updated_at", …) predicate must match the last read.
+    first_update_pred = [c for c in chains[1] if c[0] == "eq" and c[1][:1] == ("updated_at",)]
+    second_update_pred = [c for c in chains[3] if c[0] == "eq" and c[1][:1] == ("updated_at",)]
+    assert first_update_pred and first_update_pred[0][1] == ("updated_at", "t1")
+    assert second_update_pred and second_update_pred[0][1] == ("updated_at", "t2")
+
+
+def test_update_goal_progress_raises_after_retries_exhausted() -> None:
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    for i in range(3):
+        cli.preset(
+            "goals",
+            _FakeResult(data=[{"progress": [], "updated_at": f"t-{i}"}]),
+            _FakeResult(data=[]),  # update never wins
+        )
+
+    with pytest.raises(RuntimeError, match="Concurrent update prevented"):
+        supabase_client.update_goal_progress("g", {"x": 1}, client=cli, max_retries=3)
+
+
+def test_update_goal_progress_raises_when_goal_missing() -> None:
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("goals", _FakeResult(data=[]))
+
+    with pytest.raises(RuntimeError, match="Goal not found"):
+        supabase_client.update_goal_progress("nope", {"x": 1}, client=cli)
+
+
+# -- audit -----------------------------------------------------------------
+
+
+def test_audit_swallows_backend_errors() -> None:
+    """audit() is best-effort; a failing backend must not propagate."""
+    from agents import supabase_client
+
+    class _BoomClient:
+        def table(self, _name: str) -> None:
+            raise RuntimeError("db down")
+
+    # Absence of exception is the assertion.
+    supabase_client.audit(
+        agent_id="langgraph-monitor",
+        tool_name="event_monitor",
+        action="poll",
+        client=_BoomClient(),  # type: ignore[arg-type]
+    )
+
+
+def test_audit_writes_agent_id_and_defaults() -> None:
+    """agent_id is the actor differentiator vs. MCP writes (which leave it NULL)."""
+    from agents import supabase_client
+
+    cli = _FakeClient()
+    cli.preset("audit_log", _FakeResult(data=[{"id": 1}]))
+
+    supabase_client.audit(
+        agent_id="langgraph-monitor",
+        tool_name="event_monitor",
+        action="poll",
+        target="o/r",
+        client=cli,
+    )
+
+    insert_call = _find(cli.chains["audit_log"][0], "insert")
+    (payload,) = insert_call[1]
+    assert payload["agent_id"] == "langgraph-monitor"
+    assert payload["tool_name"] == "event_monitor"
+    assert payload["action"] == "poll"
+    assert payload["target"] == "o/r"
+    assert payload["outcome"] == "success"  # default
+    assert payload["details"] == {}  # default

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -59,8 +59,13 @@ for mod_name, mod in [
 ]:
     sys.modules.setdefault(mod_name, mod)
 
-# Stub supabase (only needed if _get_client is called, which we avoid)
-sys.modules.setdefault("supabase", types.ModuleType("supabase"))
+# Stub supabase only if it's not actually installed. Blindly stubbing with
+# setdefault would shadow a real install from other test modules that run
+# in the same session (e.g. test_agents_smoke.py imports real `Client`).
+try:
+    import supabase  # noqa: F401
+except ImportError:
+    sys.modules["supabase"] = types.ModuleType("supabase")
 
 # Stub httpx (used for Voyage AI embedding calls)
 sys.modules.setdefault("httpx", types.ModuleType("httpx"))


### PR DESCRIPTION
## Summary

Thin `supabase-py` wrapper (`agents/supabase_client.py`) that lets LangGraph nodes read/write the shared knowledge base. MCP is Claude Code's protocol and isn't available inside a graph — agents need a native client to see and emit events, memories, goals, and audit entries.

## Why

Closes #173. Pillar 7 Sprint 1 needs agents to consume the same event inbox and strategic context Claude Code sees. Without a bridge, the first persistent agent (#174) would have no way to read events or report what it did.

## Decisions & Alternatives

- **Subset of MCP, not a full re-implementation.** Only 3 reads (`list_memories`, `list_events`, `list_goals`) and 4 writes (`store_event`, `mark_event_processed`, `update_goal_progress`, `audit`). Memory writes, task outcomes, consolidation — all left with Claude Code for now. Agents are consumers of the event inbox, not owners of the knowledge base.
- **Actor via existing `audit_log.agent_id` column, not a new field.** Schema already had `agent_id text`. MCP `_audit_log` leaves it NULL; the bridge fills it in (e.g. `"langgraph-monitor"`). Column doubles as the actor differentiator with zero schema churn.
- **`get_client()` raises on missing creds.** Silent defaulting was considered and rejected — a misconfigured agent would look healthy until the first write failed, exactly the failure mode Sprint 1's foundation check exists to catch.
- **Reused `SUPABASE_URL` / `SUPABASE_KEY` env vars** (already in `.env.example` for the MCP server) instead of introducing `AGENTS_SUPABASE_*`. Both sides hit the same project, so a second name would just be a footgun.
- **`supabase-py` sync client**, matching `mcp-memory/server.py`. Async would be cleaner but the sync flavor keeps graph-node code straightforward and mirrors server.py's existing patterns.

## Risk Assessment

- **LOW** — `pyproject.toml` dep add, `.env.example` already had the vars, `docs/agents/langgraph-setup.md` additions.
- **LOW** — `agents/config.py` adds two fields (empty-string defaults, no behavior change for existing callers).
- **MEDIUM** — `agents/supabase_client.py` (new). Unit-level surface is covered by smoke tests (import, signature, credential validation); full round-trip verified manually against the live Jarvis project (see Testing).
- **LOW** — `tests/test_memory_server.py` — one-block change: was always stubbing `supabase` via `sys.modules.setdefault`, now only stubs if the real package isn't installed. Fixes a latent session-isolation bug that surfaced when any other test in the session needed real `Client`. Doesn't change behavior for anyone running without `supabase` installed.

## Testing

```
ruff check agents/ tests/test_agents_smoke.py    → All checks passed
pytest -q                                        → 155 passed
```

Live end-to-end round-trip against the Jarvis Supabase project:

- **Reads** — `list_memories(limit=3)` returned 3 rows; `list_goals(limit=3)` returned 3 goals; `list_events(limit=3)` returned unprocessed inbox items.
- **Event round-trip** — agent wrote `event_type='agent_bridge_smoke'` via `store_event`, then marked it processed with `action_taken='verified round-trip'`. Claude Code's `mcp__memory__events_list(event_type='agent_bridge_smoke', include_processed=true)` returned the same row with PROCESSED status. Row deleted after verification.
- **Audit** — agent wrote with `agent_id='langgraph-bridge-smoketest'`; SQL confirmed row present with agent_id set.

## Files Changed

- `agents/supabase_client.py` (new) — bridge module with 3 read + 4 write helpers
- `agents/config.py` — adds `supabase_url` / `supabase_key` fields
- `agents/__init__.py` — re-exports the new module
- `pyproject.toml` — `supabase>=2.0.0` in `agents` optional-deps group
- `docs/agents/langgraph-setup.md` — bridge rationale, env requirements, actor differentiator note
- `tests/test_agents_smoke.py` — 2 new tests (credential validation, public surface); extended env-var coverage
- `tests/test_memory_server.py` — conditional `supabase` stub (only when real package isn't installed)