### PR TITLE
feat(agents): event monitor — first persistent LangGraph agent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -6,4 +6,10 @@ and PostgreSQL checkpointer for state that survives restart.
 See docs/agents/ for setup and operational notes.
 """
 
-__all__ = ["config", "ollama_client", "supabase_client"]
+__all__ = [
+    "config",
+    "event_monitor",
+    "github_client",
+    "ollama_client",
+    "supabase_client",
+]

--- a/agents/event_monitor.py
+++ b/agents/event_monitor.py
@@ -1,0 +1,256 @@
+"""Event monitor agent — first persistent LangGraph agent (issue #174).
+
+Polls the GitHub Events API for a configured list of repos, asks a local
+Ollama model to classify each event as noise / info / action, and pushes
+non-noise events into Supabase so Claude Code picks them up via
+``events_list``.
+
+The agent is an observer, not an actor: it never opens issues, comments,
+or triggers CI. Taking action is Pillar 7 Sprint 2+ territory.
+
+Runs on demand:
+
+    python -m agents.event_monitor
+    python -m agents.event_monitor --repo Osasuwu/jarvis --thread event-monitor
+
+State (including per-repo cursors) is checkpointed to local Postgres via
+``PostgresSaver``. Restart-safe: repeated invocations skip events that were
+already processed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, TypedDict
+
+from dotenv import load_dotenv
+from langgraph.checkpoint.postgres import PostgresSaver
+from langgraph.graph import END, START, StateGraph
+
+from agents import supabase_client
+from agents.config import load_config
+from agents.github_client import fetch_repo_events, summarise_event
+from agents.ollama_client import chat as ollama_chat
+
+# Agent identity stamped into every audit_log / events.source row. Matches
+# the convention in docs/agents/langgraph-setup.md.
+AGENT_ID = "langgraph-monitor"
+
+# Default repo list when --repo isn't passed. Sprint 1 spec says start with
+# this one only; more come online in Sprint 2.
+DEFAULT_REPOS = ["Osasuwu/jarvis"]
+
+# Three-tier classification.
+#   noise  — bot chatter, fork/watch, trivial commits; dropped silently.
+#   info   — new issue/PR/review/comment worth knowing about.
+#   action — needs a human soon (failing check, review request, security).
+# Kept tight so the small Qwen3:4b model can pick reliably with temp=0.
+_CLASSIFY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "classification": {"type": "string", "enum": ["noise", "info", "action"]},
+        "reason": {"type": "string"},
+    },
+    "required": ["classification", "reason"],
+}
+
+_CLASSIFY_SYSTEM = (
+    "You classify GitHub repository events for a personal AI agent. "
+    "Reply with JSON matching the schema — no commentary.\n"
+    "Labels:\n"
+    "  noise  — bots, fork/watch, trivial bumps, merges of already-reviewed PRs\n"
+    "  info   — new issue, new PR, new review, non-trivial comment\n"
+    "  action — needs human soon: failing check, review request, urgent "
+    "comment, security finding"
+)
+
+# Severity mapping into the events table. The MCP server only knows
+# {critical, high, medium, low, info} — see SEVERITY_ORDER in server.py.
+# "action" maps to medium; "info" stays info.
+_SEVERITY = {"info": "info", "action": "medium"}
+
+
+class MonitorState(TypedDict):
+    """Graph state. Persists between runs via the Postgres checkpointer."""
+
+    repos: list[str]
+    # repo -> id of the newest event we've successfully stored. Only
+    # advanced in the store node, so a failure mid-run doesn't cause
+    # skipped events on restart.
+    cursors: dict[str, str]
+    fetched_events: list[dict[str, Any]]
+    classified_events: list[dict[str, Any]]
+    stored_count: int
+
+
+def fetch_events_node(state: MonitorState) -> dict[str, Any]:
+    """Pull new events per repo using the persisted cursors."""
+    cursors = state.get("cursors") or {}
+    fetched: list[dict[str, Any]] = []
+    for repo in state["repos"]:
+        after = cursors.get(repo)
+        events = fetch_repo_events(repo, after_event_id=after, limit=10)
+        fetched.extend(events)
+    return {"fetched_events": fetched}
+
+
+def classify_node(state: MonitorState) -> dict[str, Any]:
+    """Ask Ollama to label each fetched event."""
+    classified: list[dict[str, Any]] = []
+    for event in state.get("fetched_events", []):
+        summary = summarise_event(event)
+        raw = ollama_chat(
+            messages=[
+                {"role": "system", "content": _CLASSIFY_SYSTEM},
+                {"role": "user", "content": summary},
+            ],
+            format=_CLASSIFY_SCHEMA,
+            options={"temperature": 0, "num_predict": 80},
+        )
+        try:
+            parsed = json.loads(raw)
+            label = parsed["classification"]
+            reason = parsed["reason"]
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            # Bad classifier output — prefer surfacing to silent drop.
+            # The reason field records what broke so it shows up in the
+            # events table payload for later inspection.
+            label = "info"
+            reason = f"classifier_error: {exc}"
+        classified.append(
+            {
+                "event": event,
+                "summary": summary,
+                "classification": label,
+                "reason": reason,
+            }
+        )
+    return {"classified_events": classified}
+
+
+def store_node(state: MonitorState) -> dict[str, Any]:
+    """Persist non-noise events to Supabase and advance cursors."""
+    stored = 0
+    for item in state.get("classified_events", []):
+        label = item["classification"]
+        if label == "noise":
+            continue
+        event = item["event"]
+        repo = event.get("repo", {}).get("name", "unknown")
+        supabase_client.store_event(
+            event_type=f"github.{event.get('type', 'UnknownEvent')}",
+            repo=repo,
+            title=item["summary"],
+            severity=_SEVERITY.get(label, "info"),
+            payload={
+                "github_event_id": event.get("id"),
+                "classification": label,
+                "reason": item["reason"],
+                "raw_type": event.get("type"),
+                "actor": event.get("actor", {}).get("login"),
+            },
+            source=AGENT_ID,
+        )
+        stored += 1
+
+    # Advance cursors only after storage completes — if store_event raises
+    # mid-loop, the checkpoint keeps the old cursors and the next run
+    # reprocesses. Duplicate info rows are cheaper than lost events.
+    cursors = dict(state.get("cursors") or {})
+    for event in state.get("fetched_events", []):
+        repo = event.get("repo", {}).get("name")
+        ev_id = event.get("id")
+        if not repo or not ev_id:
+            continue
+        prev = cursors.get(repo)
+        if prev is None or int(ev_id) > int(prev):
+            cursors[repo] = str(ev_id)
+
+    # Audit every run — empty polling cycles included. Useful to confirm
+    # the agent is alive and see what it looked at.
+    supabase_client.audit(
+        agent_id=AGENT_ID,
+        tool_name="event_monitor",
+        action="poll",
+        target=",".join(state["repos"]),
+        details={
+            "fetched": len(state.get("fetched_events", [])),
+            "classified": len(state.get("classified_events", [])),
+            "stored": stored,
+            "cursors": cursors,
+        },
+    )
+    return {"stored_count": stored, "cursors": cursors}
+
+
+def build_graph() -> StateGraph:
+    """Define the monitor graph: fetch → classify → store."""
+    graph: StateGraph = StateGraph(MonitorState)
+    graph.add_node("fetch_events", fetch_events_node)
+    graph.add_node("classify", classify_node)
+    graph.add_node("store", store_node)
+    graph.add_edge(START, "fetch_events")
+    graph.add_edge("fetch_events", "classify")
+    graph.add_edge("classify", "store")
+    graph.add_edge("store", END)
+    return graph
+
+
+def run(thread_id: str, repos: list[str]) -> int:
+    """Invoke one monitoring pass, reusing any persisted cursors."""
+    cfg = load_config()
+    with PostgresSaver.from_conn_string(cfg.postgres_url) as checkpointer:
+        checkpointer.setup()
+        app = build_graph().compile(checkpointer=checkpointer)
+        config = {"configurable": {"thread_id": thread_id}}
+
+        # Read persisted cursors from the last run of this thread. Without
+        # this, invoke() would replace cursors with `{}` and we'd start
+        # over each time — defeating the whole point of checkpointing.
+        snapshot = app.get_state(config)
+        prior_values = snapshot.values or {}
+        cursors = dict(prior_values.get("cursors") or {})
+
+        result = app.invoke(
+            {
+                "repos": repos,
+                "cursors": cursors,
+                "fetched_events": [],
+                "classified_events": [],
+                "stored_count": 0,
+            },
+            config=config,
+        )
+
+        fetched = len(result.get("fetched_events", []))
+        stored = result.get("stored_count", 0)
+        print(f"[monitor] thread={thread_id}")
+        print(f"[monitor] repos:   {', '.join(repos)}")
+        print(f"[monitor] fetched: {fetched}")
+        print(f"[monitor] stored:  {stored}")
+        print(f"[monitor] cursors: {result.get('cursors')}")
+    return 0
+
+
+def main() -> int:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--thread",
+        default="event-monitor",
+        help="LangGraph thread ID (default: event-monitor)",
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        default=None,
+        help=f"Repo to monitor (repeatable). Defaults to {DEFAULT_REPOS[0]}.",
+    )
+    args = parser.parse_args()
+    repos = args.repo or list(DEFAULT_REPOS)
+    return run(args.thread, repos)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/github_client.py
+++ b/agents/github_client.py
@@ -80,6 +80,13 @@ def fetch_repo_events(
         for e in events
         if e.get("type") in RELEVANT_EVENT_TYPES and int(e.get("id", "0")) > cursor
     ]
+    # Re-sort oldest-first before the limit slice. GitHub's response is
+    # newest-first, so a naive ``filtered[:limit]`` would pick the N newest
+    # and the monitor would then advance the cursor to the max id in that
+    # slice — permanently skipping the older-but-still-new events that
+    # didn't fit. Taking the oldest N instead makes the cursor advance
+    # contiguous: next poll resumes right after the last stored event.
+    filtered.sort(key=lambda e: int(e.get("id", "0")))
     return filtered[:limit]
 
 

--- a/agents/github_client.py
+++ b/agents/github_client.py
@@ -1,0 +1,122 @@
+"""Tiny GitHub Events API client for the monitor agent.
+
+Scope (Sprint 1, issue #174): fetch recent repo events for classification.
+Nothing else — no issue creation, no PR management. The agent observes;
+it doesn't act.
+
+Uses ``httpx`` (already pulled in transitively by ``supabase-py``) so no
+new dependency is needed.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+# Events we care about for classification. Everything else (WatchEvent,
+# ForkEvent, CreateEvent of a branch…) is pure noise for the Sprint 1
+# proof of concept. Keeping the allow-list tight avoids paying Ollama
+# tokens on events we'd immediately drop anyway.
+RELEVANT_EVENT_TYPES = frozenset(
+    {
+        "IssuesEvent",
+        "PullRequestEvent",
+        "PullRequestReviewEvent",
+        "IssueCommentEvent",
+        "PullRequestReviewCommentEvent",
+        "PushEvent",
+    }
+)
+
+
+def _headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_repo_events(
+    repo: str,
+    *,
+    after_event_id: str | None = None,
+    limit: int = 10,
+    token: str | None = None,
+    timeout: float = 10.0,
+) -> list[dict[str, Any]]:
+    """Return recent public events for ``repo`` (newest first).
+
+    * ``after_event_id`` — drop any event whose id is <= this one. GitHub
+      event ids are monotonically increasing strings-of-integers, so
+      string-compare by integer value is the correct semantics.
+    * ``limit`` — cap Ollama classification cost; defaults to 10 per run.
+    * ``token`` — optional GitHub token. Unauthenticated requests hit a
+      60 req/hour rate limit per IP, which is fine for low-frequency
+      monitoring but will trip on busy repos.
+
+    Filtered to ``RELEVANT_EVENT_TYPES``. Returns raw GitHub event dicts.
+    """
+    auth_token = token if token is not None else os.environ.get("GITHUB_TOKEN")
+    url = f"https://api.github.com/repos/{repo}/events"
+    response = httpx.get(
+        url,
+        headers=_headers(auth_token),
+        params={"per_page": 30},  # fetch a wider page, filter client-side
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    events: list[dict[str, Any]] = response.json()
+
+    # GitHub returns newest first. For cursor comparison, use integer
+    # conversion — the API guarantees numeric ids.
+    cursor = int(after_event_id) if after_event_id else 0
+    filtered = [
+        e
+        for e in events
+        if e.get("type") in RELEVANT_EVENT_TYPES and int(e.get("id", "0")) > cursor
+    ]
+    return filtered[:limit]
+
+
+def summarise_event(event: dict[str, Any]) -> str:
+    """Return a one-line summary suitable for LLM classification.
+
+    Pulls only the fields the model actually needs — keeps prompts small
+    and removes the URL soup GitHub ships in each event payload.
+    """
+    event_type = event.get("type", "UnknownEvent")
+    actor = event.get("actor", {}).get("login", "unknown")
+    repo_name = event.get("repo", {}).get("name", "unknown")
+    payload = event.get("payload", {}) or {}
+
+    # Type-specific extraction — each branch grabs the one or two human
+    # fields that make the event interpretable.
+    if event_type == "IssuesEvent":
+        action = payload.get("action", "?")
+        issue = payload.get("issue", {}) or {}
+        detail = f"{action} #{issue.get('number')}: {issue.get('title', '')}"
+    elif event_type == "PullRequestEvent":
+        action = payload.get("action", "?")
+        pr = payload.get("pull_request", {}) or {}
+        detail = f"{action} PR #{pr.get('number')}: {pr.get('title', '')}"
+    elif event_type == "PullRequestReviewEvent":
+        review = payload.get("review", {}) or {}
+        pr = payload.get("pull_request", {}) or {}
+        detail = f"review ({review.get('state', '?')}) on PR #{pr.get('number')}"
+    elif event_type in ("IssueCommentEvent", "PullRequestReviewCommentEvent"):
+        action = payload.get("action", "created")
+        issue = payload.get("issue", payload.get("pull_request", {})) or {}
+        detail = f"comment {action} on #{issue.get('number')}"
+    elif event_type == "PushEvent":
+        ref = payload.get("ref", "?")
+        commits = len(payload.get("commits", []) or [])
+        detail = f"push {commits} commits to {ref}"
+    else:
+        detail = "(details omitted)"
+
+    return f"[{event_type}] {repo_name} by {actor}: {detail}"

--- a/docs/agents/langgraph-setup.md
+++ b/docs/agents/langgraph-setup.md
@@ -85,6 +85,38 @@ Expected output (first run):
 
 `--resume` in a brand-new Python process should print the same `reply`, `step`, and `checkpoint_id` — that is what validates "survives restart".
 
+## Run the event monitor (issue #174)
+
+The first real agent. Polls GitHub Events, classifies via Ollama, writes non-noise events to Supabase.
+
+```bash
+# Default: watch Osasuwu/jarvis, thread "event-monitor"
+python -m agents.event_monitor
+
+# Custom repo and thread
+python -m agents.event_monitor --repo Osasuwu/jarvis --thread smoke
+```
+
+Expected output:
+
+```
+[monitor] thread=event-monitor
+[monitor] repos:   Osasuwu/jarvis
+[monitor] fetched: 3
+[monitor] stored:  2
+[monitor] cursors: {'Osasuwu/jarvis': '<latest-event-id>'}
+```
+
+Restart-safety check: run the command twice in a row. The second run should show `fetched: 0` unless new activity landed in between — cursors persist in the Postgres checkpoint.
+
+Optional env for higher rate limits:
+
+```
+GITHUB_TOKEN=ghp_...   # unauthenticated = 60 req/hour per IP
+```
+
+The agent identifies itself in `events.source` and `audit_log.agent_id` as `langgraph-monitor`.
+
 ## Architecture notes
 
 ### Why both `ollama` and `langchain-ollama`?

--- a/tests/test_agents_smoke.py
+++ b/tests/test_agents_smoke.py
@@ -152,6 +152,42 @@ def test_github_client_event_allowlist() -> None:
     assert "ForkEvent" not in RELEVANT_EVENT_TYPES
 
 
+def test_fetch_repo_events_slices_oldest_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When new events outnumber ``limit``, pick the oldest N so the
+    monitor's cursor advance stays contiguous.
+
+    Regression guard for the bug Copilot flagged on #179: GitHub returns
+    newest-first; a naive ``filtered[:limit]`` picks the newest N and the
+    monitor then advances the cursor to the max id — permanently skipping
+    the older-but-still-new events that didn't fit.
+    """
+    from agents import github_client
+
+    # 12 relevant events, newest first — like the real /events endpoint.
+    raw = [
+        {"id": str(i), "type": "IssuesEvent", "actor": {}, "repo": {}, "payload": {}}
+        for i in range(20, 8, -1)
+    ]
+
+    class _Resp:
+        def __init__(self, data: list[dict[str, object]]) -> None:
+            self._data = data
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> list[dict[str, object]]:
+            return self._data
+
+    monkeypatch.setattr(github_client.httpx, "get", lambda *a, **kw: _Resp(raw))
+
+    out = github_client.fetch_repo_events("o/r", after_event_id="8", limit=5)
+
+    # Must return the 5 OLDEST new events (ids 9–13), not the 5 newest (16–20).
+    ids = [int(e["id"]) for e in out]
+    assert ids == [9, 10, 11, 12, 13], ids
+
+
 def test_summarise_event_covers_known_types() -> None:
     """Every event-type branch produces a string with actor + repo + detail."""
     from agents.github_client import summarise_event
@@ -208,6 +244,11 @@ def test_event_monitor_graph_builds() -> None:
 
 def test_event_monitor_classification_schema() -> None:
     """Classifier enum stays three-tier — Ollama prompt depends on it."""
+    # agents.event_monitor imports langgraph + supabase at module load, so
+    # skip (not error) when the optional [agents] extras aren't installed.
+    pytest.importorskip("langgraph")
+    pytest.importorskip("supabase")
+
     from agents.event_monitor import _CLASSIFY_SCHEMA
 
     enum = _CLASSIFY_SCHEMA["properties"]["classification"]["enum"]

--- a/tests/test_agents_smoke.py
+++ b/tests/test_agents_smoke.py
@@ -132,3 +132,84 @@ def test_supabase_client_surface() -> None:
     assert callable(sb.mark_event_processed)
     assert callable(sb.update_goal_progress)
     assert callable(sb.audit)
+
+
+def test_github_client_event_allowlist() -> None:
+    """Allow-list includes the six event types the monitor acts on."""
+    from agents.github_client import RELEVANT_EVENT_TYPES
+
+    for needed in (
+        "IssuesEvent",
+        "PullRequestEvent",
+        "PullRequestReviewEvent",
+        "IssueCommentEvent",
+        "PullRequestReviewCommentEvent",
+        "PushEvent",
+    ):
+        assert needed in RELEVANT_EVENT_TYPES
+    # Things we intentionally drop as noise.
+    assert "WatchEvent" not in RELEVANT_EVENT_TYPES
+    assert "ForkEvent" not in RELEVANT_EVENT_TYPES
+
+
+def test_summarise_event_covers_known_types() -> None:
+    """Every event-type branch produces a string with actor + repo + detail."""
+    from agents.github_client import summarise_event
+
+    common = {"actor": {"login": "alice"}, "repo": {"name": "o/r"}}
+    cases = [
+        {
+            **common,
+            "type": "IssuesEvent",
+            "payload": {"action": "opened", "issue": {"number": 42, "title": "bug"}},
+        },
+        {
+            **common,
+            "type": "PullRequestEvent",
+            "payload": {"action": "opened", "pull_request": {"number": 7, "title": "feat"}},
+        },
+        {
+            **common,
+            "type": "PullRequestReviewEvent",
+            "payload": {"review": {"state": "approved"}, "pull_request": {"number": 7}},
+        },
+        {
+            **common,
+            "type": "IssueCommentEvent",
+            "payload": {"action": "created", "issue": {"number": 42}},
+        },
+        {
+            **common,
+            "type": "PushEvent",
+            "payload": {"ref": "refs/heads/main", "commits": [{}, {}]},
+        },
+        {**common, "type": "WeirdEvent", "payload": {}},  # fallback branch
+    ]
+    for event in cases:
+        s = summarise_event(event)
+        assert "alice" in s, s
+        assert "o/r" in s, s
+        assert event["type"] in s, s
+
+
+def test_event_monitor_graph_builds() -> None:
+    """The monitor graph compiles to fetch -> classify -> store."""
+    pytest.importorskip("langgraph")
+    pytest.importorskip("supabase")
+
+    from agents.event_monitor import MonitorState, build_graph
+
+    graph = build_graph()
+    assert {"fetch_events", "classify", "store"} <= set(graph.nodes)
+    assert {"repos", "cursors", "fetched_events", "classified_events", "stored_count"} <= set(
+        MonitorState.__annotations__
+    )
+
+
+def test_event_monitor_classification_schema() -> None:
+    """Classifier enum stays three-tier — Ollama prompt depends on it."""
+    from agents.event_monitor import _CLASSIFY_SCHEMA
+
+    enum = _CLASSIFY_SCHEMA["properties"]["classification"]["enum"]
+    assert set(enum) == {"noise", "info", "action"}
+    assert set(_CLASSIFY_SCHEMA["required"]) == {"classification", "reason"}


### PR DESCRIPTION
## Summary
- First real persistent agent: polls GitHub Events, classifies with Ollama (qwen3:4b), writes non-noise events to Supabase.
- Observer only — no issue/PR creation, no comments. Action agents are Sprint 2+ territory.
- Checkpointer-backed: per-repo cursors persist across restarts, so repeated invocations don't reprocess history.

## Why
Proof-of-concept for the whole Pillar 7 stack: if Ollama + LangGraph + Postgres checkpointer + the Supabase bridge all cooperate, the architecture is validated. Closes #174.

## Decisions & Alternatives
- **Cursors advanced in `store` node, not `fetch`.** If classify or store raises partway through, the checkpoint keeps the old cursor and the next run reprocesses. Duplicate info rows are cheaper than silently dropped events. Alternative — advance cursors in `fetch` — was rejected for exactly that reason.
- **Three-tier classification `noise / info / action`.** Tight enough that qwen3:4b picks reliably with `temperature=0`; loose enough to survive unseen event shapes. Four-tier felt over-engineered for a proof of concept.
- **Classifier errors default to `info`, not silent drop.** Surfacing a broken classification (with `reason="classifier_error: ..."` in the payload) is better than losing visibility into repo activity.
- **Severity mapping `action -> medium`.** The MCP server's `SEVERITY_ORDER` only knows `{critical, high, medium, low, info}` — there's no `warning`, so `action` events land in `medium`.
- **Audit every run, even empty polls.** One row in `audit_log` per invocation — confirms the agent is alive and records what it looked at.
- **Agent identity stamped on writes.** `events.source="langgraph-monitor"` and `audit_log.agent_id="langgraph-monitor"` — the same convention #173 set up.
- **Stacked on `feat/173-supabase-event-bridge`.** This PR depends on the bridge's `store_event` / `audit` helpers. Base will retarget to main when #178 merges.

## Risk Assessment
- **LOW**: docs additions, test additions, `__init__.py` exports.
- **MEDIUM**: new agent code path writing to Supabase `events` and `audit_log`. Worst case on a bug: noisy rows in those tables, which are already expected to be append-only inboxes.
- No protected files touched (`.mcp.json`, `config/SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py` all untouched).

## Testing

### Unit (pytest)
- `tests/test_agents_smoke.py` now has 13 tests; all 159 in the full suite pass.
- New cases cover the `RELEVANT_EVENT_TYPES` allow-list, every `summarise_event` branch, graph construction (`fetch_events -> classify -> store`), and the classifier JSON schema.

### Lint
- `ruff check` clean, `ruff format --check` clean on all three new/edited source files.

### Live end-to-end (against real GitHub + Ollama + Supabase + local Postgres)
Ran three invocations with `--thread smoke-174`:
1. **Cold start** — fetched 10, stored 10 (cursor advanced to `8451357780`).
2. **Second run** — fetched 3 (new activity since run 1), stored 0 (all classified `noise`). Cursor advanced.
3. **Third run** — fetched 0, stored 0, cursor unchanged. **Restart-safety confirmed.**

Spot-checked the 10 stored rows in Supabase via `events_list`: all have `Source: langgraph-monitor`, severity `info`, sensible titles matching the events (Copilot reviews, issue comments, labeled/opened actions).

## Files Changed
- `agents/event_monitor.py` — new. The LangGraph graph + CLI entry point.
- `agents/github_client.py` — new (also bundled here for #174). Tiny httpx wrapper over the GitHub Events API. No new dependency — httpx is already transitive via `supabase-py`.
- `agents/__init__.py` — export the two new modules.
- `tests/test_agents_smoke.py` — +5 tests for github_client + event_monitor.
- `docs/agents/langgraph-setup.md` — "Run the event monitor" section with expected output and restart-safety instructions.

Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)