### PR TITLE
test(agents): end-to-end integration suite for event flow

### DIFF
--- a/docs/agents/e2e-test.md
+++ b/docs/agents/e2e-test.md
@@ -1,0 +1,137 @@
+# Pillar 7 End-to-End Test (issue #175)
+
+Validates the full event pipeline:
+
+```
+GitHub event -> event_monitor (fetch -> classify -> store)
+              -> Supabase events + audit_log
+              -> Claude Code reads via MCP events_list
+```
+
+Two layers:
+
+1. **Automated** (`tests/test_agents_integration.py`) — opt-in pytest
+   suite. Injects synthetic events so the pass/fail signal is
+   deterministic; everything downstream of fetch (Ollama, Supabase,
+   Postgres checkpointer) runs for real.
+2. **Manual walkthrough** — you create an actual GitHub issue or PR and
+   watch it flow through the system. Slower, but exercises the parts the
+   automated suite mocks (real GitHub API, real event shape).
+
+Run both when changing anything in `agents/event_monitor.py`,
+`agents/supabase_client.py`, or the `events` / `audit_log` schemas.
+
+## Prerequisites
+
+Same as the setup doc, all running locally:
+
+| Service | Check |
+|---------|-------|
+| Docker Postgres | `docker compose -f docker-compose.agents.yml ps` shows `healthy` |
+| Ollama | `curl -s http://localhost:11434/api/tags` lists `qwen3:4b` |
+| Supabase credentials | `SUPABASE_URL` + `SUPABASE_KEY` set in `.env` |
+| GitHub (manual only) | Push access to a test repo, optional `GITHUB_TOKEN` |
+
+## Automated suite
+
+Opt-in via an env var — CI doesn't have live Ollama / Supabase /
+Postgres, so the default is skip.
+
+```bash
+AGENTS_E2E=1 pytest tests/test_agents_integration.py -v
+```
+
+Three tests:
+
+| Test | Asserts |
+|------|---------|
+| `test_full_pipeline_injects_and_stores` | A synthetic `IssuesEvent` flows through classify + store and reappears via `supabase_client.list_events` with `source=langgraph-monitor` and a payload containing the original event id. |
+| `test_restart_skips_via_cursor` | Invoking the graph twice with the same thread id does **not** create duplicate rows — the checkpointed cursor filters out already-processed events. |
+| `test_audit_log_records_poll` | Every poll (including empty ones) leaves an `audit_log` row with `agent_id=langgraph-monitor`, `tool_name=event_monitor`, `action=poll`. |
+
+Each test tags its rows with a UUID marker and deletes them on teardown.
+Thread ids are also UUID-suffixed so parallel invocations (and the
+production `event-monitor` thread) never collide.
+
+Expected runtime: about one minute — most of it is Ollama classification.
+
+## Manual walkthrough
+
+Use when you want to verify the real GitHub API path, not just the
+classify/store chain.
+
+1. **Pick a fresh thread id** so you're not reading through a polluted
+   checkpoint history:
+
+   ```bash
+   python -m agents.event_monitor --thread manual-$(date +%s)
+   ```
+
+   First run prints `fetched: N, stored: M`. Stored should be ≤ N
+   (the delta is events classified as noise).
+
+2. **Trigger a new event.** Open an issue on `Osasuwu/jarvis` — e.g.:
+
+   ```bash
+   gh issue create --repo Osasuwu/jarvis \
+     --title "e2e test $(date -Iseconds)" \
+     --body "Smoke test — safe to close."
+   ```
+
+3. **Re-run the monitor with the same thread id.**
+
+   ```bash
+   python -m agents.event_monitor --thread <the id from step 1>
+   ```
+
+   Expected: `fetched: 1+` (your new issue plus any other activity),
+   `stored: 1+`. Cursor advances past the new event's id.
+
+4. **Verify Claude Code sees it.** In any Claude Code session:
+
+   ```
+   events_list repo=Osasuwu/jarvis
+   ```
+
+   Your event should appear with `Source: langgraph-monitor`, severity
+   `info` or `medium`, and the payload's `github_event_id` matching the
+   real event id GitHub assigned.
+
+5. **Verify audit trail.** Query Supabase:
+
+   ```sql
+   SELECT timestamp, agent_id, action, target, details
+   FROM audit_log
+   WHERE agent_id = 'langgraph-monitor'
+   ORDER BY timestamp DESC
+   LIMIT 5;
+   ```
+
+   Expect one row per monitor invocation, including the empty polls.
+
+6. **Confirm restart safety.** Run the monitor again **without any new
+   activity**:
+
+   ```bash
+   python -m agents.event_monitor --thread <the same id>
+   ```
+
+   Expected: `fetched: 0, stored: 0`. Cursor unchanged. This is the
+   acceptance criterion from #174/#175 — no duplicate processing.
+
+7. **Clean up.** Close the test issue. Optionally remove the synthetic
+   events:
+
+   ```sql
+   DELETE FROM events WHERE source = 'langgraph-monitor'
+     AND title LIKE '%e2e test%';
+   ```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `postgrest.APIError: column audit_log.created_at does not exist` | Code is reading the wrong column. `audit_log` uses `timestamp`, not `created_at`. See `mcp-memory/server.py` for the canonical schema. |
+| Test fixture fails to clean up | The marker is logged in the assertion message; drop manually with `DELETE FROM events WHERE title LIKE '%<marker>%'`. |
+| `fetched: 0` on run 1 with a new thread | The test repo genuinely has no events in the allow-list. Trigger any event type from `RELEVANT_EVENT_TYPES` (issue/PR/push/comment/review). |
+| `stored: 0` when `fetched: N>0` | Classifier is calling everything noise. Check the Ollama prompt in `_CLASSIFY_SYSTEM` and the events themselves — automated bumps and trivial bot pushes legitimately classify as noise. |

--- a/docs/agents/e2e-test.md
+++ b/docs/agents/e2e-test.md
@@ -49,9 +49,12 @@ Three tests:
 | `test_restart_skips_via_cursor` | Invoking the graph twice with the same thread id does **not** create duplicate rows — the checkpointed cursor filters out already-processed events. |
 | `test_audit_log_records_poll` | Every poll (including empty ones) leaves an `audit_log` row with `agent_id=langgraph-monitor`, `tool_name=event_monitor`, `action=poll`. |
 
-Each test tags its rows with a UUID marker and deletes them on teardown.
-Thread ids are also UUID-suffixed so parallel invocations (and the
-production `event-monitor` thread) never collide.
+Each test embeds a UUID marker in both the event title and the repo
+name, so teardown can delete its rows from `events` (match on
+`title LIKE '%<marker>%'`) and `audit_log` (match on
+`target LIKE '%<marker>%'`). Thread ids are also UUID-suffixed so
+parallel invocations (and the production `event-monitor` thread) never
+share checkpoint state.
 
 Expected runtime: about one minute — most of it is Ollama classification.
 

--- a/docs/agents/langgraph-setup.md
+++ b/docs/agents/langgraph-setup.md
@@ -117,6 +117,8 @@ GITHUB_TOKEN=ghp_...   # unauthenticated = 60 req/hour per IP
 
 The agent identifies itself in `events.source` and `audit_log.agent_id` as `langgraph-monitor`.
 
+For the full end-to-end validation (automated suite + manual walkthrough), see [e2e-test.md](e2e-test.md).
+
 ## Architecture notes
 
 ### Why both `ollama` and `langchain-ollama`?

--- a/tests/test_agents_integration.py
+++ b/tests/test_agents_integration.py
@@ -56,6 +56,12 @@ def _synth_event(event_id: str, marker: str, repo: str) -> dict[str, Any]:
 def _delete_by_marker(marker: str) -> None:
     """Best-effort cleanup of rows tagged with ``marker``.
 
+    Every test embeds ``marker`` into both the event title and the repo
+    name, so the same tag reaches ``events.title`` (via ``_synth_event``)
+    and ``audit_log.target`` (via ``store_node``'s ``",".join(repos)``).
+    Cleaning both tables by that tag keeps the shared Supabase project
+    free of test rows even when the suite runs often.
+
     Called from test teardown; swallowed errors only matter in that they'd
     leave rows behind. The marker keeps those rows obviously-test, so a
     human can spot and drop them manually if cleanup ever fails.
@@ -65,6 +71,7 @@ def _delete_by_marker(marker: str) -> None:
     try:
         cli = get_client()
         cli.table("events").delete().like("title", f"%{marker}%").execute()
+        cli.table("audit_log").delete().like("target", f"%{marker}%").execute()
     except Exception:
         pass
 
@@ -92,7 +99,9 @@ def test_full_pipeline_injects_and_stores(
 
     from agents import event_monitor, supabase_client
 
-    repo = "e2e/marker-repo"
+    # Marker embedded in repo so the audit_log.target row this run writes
+    # is also deletable in teardown — see ``_delete_by_marker``.
+    repo = f"e2e/marker-repo-{marker}"
     fake_events = [_synth_event("900000001", marker, repo)]
 
     # Only fetch is mocked — classify + store run for real.
@@ -126,7 +135,10 @@ def test_restart_skips_via_cursor(
 
     from agents import event_monitor, supabase_client
 
-    repo = "e2e/marker-repo"
+    # Per-test unique repo tag — keeps this run's audit_log.target rows
+    # distinct from other concurrent test runs, and from the first test's
+    # cleanup query in ``_delete_by_marker``.
+    repo = f"e2e/restart-repo-{marker}"
     fake_id = "900000002"
     fake_events = [_synth_event(fake_id, marker, repo)]
 
@@ -191,11 +203,9 @@ def test_audit_log_records_poll(
         .data
         or []
     )
-    try:
-        assert audit_rows, f"no audit rows for target={repo!r}"
-        assert audit_rows[0]["agent_id"] == "langgraph-monitor"
-        assert audit_rows[0]["tool_name"] == "event_monitor"
-        assert audit_rows[0]["action"] == "poll"
-    finally:
-        # Cleanup: remove the audit rows this test created.
-        cli.table("audit_log").delete().eq("target", repo).execute()
+    assert audit_rows, f"no audit rows for target={repo!r}"
+    assert audit_rows[0]["agent_id"] == "langgraph-monitor"
+    assert audit_rows[0]["tool_name"] == "event_monitor"
+    assert audit_rows[0]["action"] == "poll"
+    # Cleanup is handled by the ``marker`` fixture — the repo tag contains
+    # the marker, so audit rows are swept by ``_delete_by_marker``.

--- a/tests/test_agents_integration.py
+++ b/tests/test_agents_integration.py
@@ -1,0 +1,201 @@
+"""End-to-end integration tests for the Pillar 7 event flow (issue #175).
+
+Validates the full pipeline:
+
+    synthetic GitHub event
+      -> agents.event_monitor graph (fetch -> classify -> store)
+      -> Supabase ``events`` + ``audit_log`` tables
+      -> visible to Claude Code via ``events_list`` (read back through the
+         same supabase_client the MCP server uses)
+
+These are **opt-in** — CI doesn't have live Ollama / Supabase / Postgres,
+and we deliberately don't mock the last two because the whole point is to
+verify that the real bridge works. Set ``AGENTS_E2E=1`` to run, e.g.:
+
+    AGENTS_E2E=1 pytest tests/test_agents_integration.py -v
+
+The test harness monkey-patches only ``fetch_repo_events`` (so we don't
+depend on what GitHub happens to be surfacing at test time). Everything
+downstream — Ollama classification, Supabase writes, LangGraph
+checkpointing — runs for real.
+
+Cleanup: every test tags rows with a fresh UUID marker and deletes
+matching rows in teardown. Thread IDs are UUID-suffixed so parallel
+invocations (and the real ``event-monitor`` thread) never collide.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import pytest
+
+# Skip the whole module unless explicitly opted in.
+pytestmark = pytest.mark.skipif(
+    os.environ.get("AGENTS_E2E") != "1",
+    reason="opt-in integration suite — set AGENTS_E2E=1 to run",
+)
+
+
+def _synth_event(event_id: str, marker: str, repo: str) -> dict[str, Any]:
+    """Shape a fake IssuesEvent with a traceable marker in the title."""
+    return {
+        "id": event_id,
+        "type": "IssuesEvent",
+        "actor": {"login": "e2e-test"},
+        "repo": {"name": repo},
+        "payload": {
+            "action": "opened",
+            "issue": {"number": 1, "title": f"e2e smoke {marker}"},
+        },
+    }
+
+
+def _delete_by_marker(marker: str) -> None:
+    """Best-effort cleanup of rows tagged with ``marker``.
+
+    Called from test teardown; swallowed errors only matter in that they'd
+    leave rows behind. The marker keeps those rows obviously-test, so a
+    human can spot and drop them manually if cleanup ever fails.
+    """
+    from agents.supabase_client import get_client
+
+    try:
+        cli = get_client()
+        cli.table("events").delete().like("title", f"%{marker}%").execute()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def marker() -> str:
+    """Per-test UUID tag — fresh marker for every test, cleaned up after."""
+    tag = f"e2e-{uuid.uuid4()}"
+    yield tag
+    _delete_by_marker(tag)
+
+
+@pytest.fixture
+def thread_id() -> str:
+    """Unique thread so each run gets its own LangGraph checkpoint history."""
+    return f"e2e-{uuid.uuid4()}"
+
+
+def test_full_pipeline_injects_and_stores(
+    monkeypatch: pytest.MonkeyPatch, marker: str, thread_id: str
+) -> None:
+    """Inject a synthetic event; expect a stored Supabase row we can read back."""
+    pytest.importorskip("langgraph")
+    pytest.importorskip("supabase")
+
+    from agents import event_monitor, supabase_client
+
+    repo = "e2e/marker-repo"
+    fake_events = [_synth_event("900000001", marker, repo)]
+
+    # Only fetch is mocked — classify + store run for real.
+    monkeypatch.setattr(event_monitor, "fetch_repo_events", lambda *a, **kw: list(fake_events))
+
+    event_monitor.run(thread_id, [repo])
+
+    # Event visible via the same list API Claude Code's MCP server hits.
+    rows = supabase_client.list_events(repo=repo, processed=None, limit=20)
+    matching = [r for r in rows if marker in (r.get("title") or "")]
+    assert matching, f"no events matched marker {marker!r}; got {rows!r}"
+    row = matching[0]
+    assert row["source"] == "langgraph-monitor"
+    assert row["event_type"] == "github.IssuesEvent"
+    payload = row.get("payload") or {}
+    assert payload.get("github_event_id") == "900000001"
+    assert payload.get("classification") in ("info", "action")
+
+
+def test_restart_skips_via_cursor(
+    monkeypatch: pytest.MonkeyPatch, marker: str, thread_id: str
+) -> None:
+    """Second invocation with the same thread must not duplicate the event.
+
+    Simulates GitHub's own cursor filtering: when the cursor has advanced
+    past the synthetic event's id, the mock returns an empty list — which
+    is exactly what the real Events API would do.
+    """
+    pytest.importorskip("langgraph")
+    pytest.importorskip("supabase")
+
+    from agents import event_monitor, supabase_client
+
+    repo = "e2e/marker-repo"
+    fake_id = "900000002"
+    fake_events = [_synth_event(fake_id, marker, repo)]
+
+    def cursor_aware_fetch(
+        _repo: str, *, after_event_id: str | None = None, **_kw: object
+    ) -> list[dict[str, Any]]:
+        if after_event_id is not None and int(after_event_id) >= int(fake_id):
+            return []
+        return list(fake_events)
+
+    monkeypatch.setattr(event_monitor, "fetch_repo_events", cursor_aware_fetch)
+
+    # Run 1: should see and store the event.
+    event_monitor.run(thread_id, [repo])
+    first_rows = [
+        r
+        for r in supabase_client.list_events(repo=repo, processed=None, limit=20)
+        if marker in (r.get("title") or "")
+    ]
+    assert len(first_rows) == 1, first_rows
+
+    # Run 2: cursor persisted from run 1 should make the mock return [],
+    # so no new row lands. Any extra row is a checkpoint regression.
+    event_monitor.run(thread_id, [repo])
+    second_rows = [
+        r
+        for r in supabase_client.list_events(repo=repo, processed=None, limit=20)
+        if marker in (r.get("title") or "")
+    ]
+    assert len(second_rows) == 1, (
+        f"restart produced duplicate rows — cursor didn't persist: {second_rows!r}"
+    )
+
+
+def test_audit_log_records_poll(
+    monkeypatch: pytest.MonkeyPatch, marker: str, thread_id: str
+) -> None:
+    """Every poll should leave an audit row with agent_id=langgraph-monitor."""
+    pytest.importorskip("langgraph")
+    pytest.importorskip("supabase")
+
+    from agents import event_monitor
+    from agents.supabase_client import get_client
+
+    repo = f"e2e/audit-{marker}"  # unique repo tag -> unique audit target string
+    monkeypatch.setattr(
+        event_monitor, "fetch_repo_events", lambda *a, **kw: []
+    )  # empty poll is still audited
+
+    event_monitor.run(thread_id, [repo])
+
+    cli = get_client()
+    # audit_log orders by `timestamp` (not `created_at` — the MCP server
+    # uses a bespoke schema defined in mcp-memory/server.py).
+    audit_rows = (
+        cli.table("audit_log")
+        .select("agent_id, tool_name, action, target")
+        .eq("target", repo)
+        .order("timestamp", desc=True)
+        .limit(5)
+        .execute()
+        .data
+        or []
+    )
+    try:
+        assert audit_rows, f"no audit rows for target={repo!r}"
+        assert audit_rows[0]["agent_id"] == "langgraph-monitor"
+        assert audit_rows[0]["tool_name"] == "event_monitor"
+        assert audit_rows[0]["action"] == "poll"
+    finally:
+        # Cleanup: remove the audit rows this test created.
+        cli.table("audit_log").delete().eq("target", repo).execute()


### PR DESCRIPTION
## Summary
- Opt-in pytest suite (`tests/test_agents_integration.py`) that validates the full Pillar 7 event pipeline end-to-end.
- Manual walkthrough runbook (`docs/agents/e2e-test.md`) for the parts the automated suite mocks — real GitHub API, human-observable flow.
- Closes #175.

## Why
Sprint 1's proof-of-concept claim was \"Ollama + LangGraph + Supabase + checkpointing all cooperate.\" #172 / #173 / #174 each validated their own slice. #175 stitches those slices into a single test that lives in the repo and can be re-run deterministically on every change to the agent code or the `events` / `audit_log` schemas.

## Decisions & Alternatives
- **Opt-in via `AGENTS_E2E=1`** — tests are skipped by default so CI (which has no live Ollama / Supabase / Postgres) passes cleanly. Runs locally in under a minute when opted in. Alternative — mark `@pytest.mark.integration` — was rejected because a marker alone doesn't stop pytest from attempting the import + fixture setup, and those depend on live services.
- **Only `fetch_repo_events` is mocked.** Everything downstream — Ollama classification, Supabase writes, LangGraph checkpointing — runs for real. The whole point of the suite is to catch bugs in the real bridge; mocking further would turn this into a unit test.
- **Synthetic events with UUID markers, cleanup in teardown.** A shared test repo would couple the suite to whatever GitHub happened to be surfacing at test time, and cleanup would race against real activity. Markers make every row obviously-test and lets teardown delete by `LIKE '%<marker>%'`. Thread ids are also UUID-suffixed so checkpoint state never leaks between runs.
- **Cursor-aware mock for the restart test.** The mock's `after_event_id` check mirrors what the real GitHub API does on run 2; this is what actually proves the persisted cursor made it from Postgres back into the next invocation's state.
- **Manual runbook kept separate** (`docs/agents/e2e-test.md`) rather than merged into `langgraph-setup.md` — distinct audience (developer running the pipeline manually) and distinct lifecycle (updated when schemas change, not when setup changes).

## Risk Assessment
- **LOW**: test additions + docs only. No production code paths modified.
- Tests are gated — the default `pytest` invocation still skips them, so no new CI dependency.

## Testing

### Automated suite (AGENTS_E2E=1)
\`\`\`
$ AGENTS_E2E=1 pytest tests/test_agents_integration.py -v
======================= 3 passed, 27 warnings in 58.51s =======================
\`\`\`
All three pass against local Docker Postgres, local Ollama (qwen3:4b), and the live Jarvis Supabase project. Cleanup verified — no stray rows remain in `events` or `audit_log` after the run.

### Default suite (no env var)
\`\`\`
$ pytest -x -q
159 passed, 3 skipped, 1 warning in 2.93s
\`\`\`
Three integration tests cleanly skip; none of the 159 pre-existing tests regress.

### Lint
\`ruff check\` + \`ruff format --check\` clean on the new Python file.

### Manual walkthrough
The runbook in `docs/agents/e2e-test.md` was dry-run during #174 verification — cold start stored 10/10 real events, second run returned \`fetched: 0\` with cursor unchanged, audit_log query showed one `langgraph-monitor` row per invocation. Those steps are now written up verbatim.

## Files Changed
- `tests/test_agents_integration.py` — new. Three opt-in integration tests covering full pipeline, restart safety, and audit trail.
- `docs/agents/e2e-test.md` — new. Prerequisites, automated-suite instructions, manual walkthrough, troubleshooting table.
- `docs/agents/langgraph-setup.md` — one-line link to the new runbook.

## Notes for reviewer
- Stacked on PR #179 (event monitor) which is stacked on PR #178 (Supabase bridge). Base retargets up the stack as lower PRs merge.
- The `audit_log` column is `timestamp`, not `created_at` — caught during test development. The schema lives in `mcp-memory/server.py`; the test and the troubleshooting table both call this out.

Closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)