### PR TITLE
fix(agents): address Copilot review on #181 (pagination, ollama errors, httpx dep)

### DIFF
--- a/agents/event_monitor.py
+++ b/agents/event_monitor.py
@@ -100,22 +100,24 @@ def classify_node(state: MonitorState) -> dict[str, Any]:
     classified: list[dict[str, Any]] = []
     for event in state.get("fetched_events", []):
         summary = summarise_event(event)
-        raw = ollama_chat(
-            messages=[
-                {"role": "system", "content": _CLASSIFY_SYSTEM},
-                {"role": "user", "content": summary},
-            ],
-            format=_CLASSIFY_SCHEMA,
-            options={"temperature": 0, "num_predict": 80},
-        )
         try:
+            raw = ollama_chat(
+                messages=[
+                    {"role": "system", "content": _CLASSIFY_SYSTEM},
+                    {"role": "user", "content": summary},
+                ],
+                format=_CLASSIFY_SCHEMA,
+                options={"temperature": 0, "num_predict": 80},
+            )
             parsed = json.loads(raw)
             label = parsed["classification"]
             reason = parsed["reason"]
-        except (json.JSONDecodeError, KeyError, TypeError) as exc:
-            # Bad classifier output — prefer surfacing to silent drop.
-            # The reason field records what broke so it shows up in the
-            # events table payload for later inspection.
+        except Exception as exc:  # noqa: BLE001 — classifier failures must never abort the run
+            # Any classifier failure — Ollama daemon down, network/timeout,
+            # malformed output — defaults to "info" so the event still
+            # surfaces and the store node's audit write for this run still
+            # happens. The reason field records what broke for later
+            # inspection via the events table.
             label = "info"
             reason = f"classifier_error: {exc}"
         classified.append(

--- a/agents/github_client.py
+++ b/agents/github_client.py
@@ -4,8 +4,9 @@ Scope (Sprint 1, issue #174): fetch recent repo events for classification.
 Nothing else — no issue creation, no PR management. The agent observes;
 it doesn't act.
 
-Uses ``httpx`` (already pulled in transitively by ``supabase-py``) so no
-new dependency is needed.
+Uses ``httpx``, declared as a direct dependency of the ``[agents]`` extra
+in ``pyproject.toml``. (It was originally picked up transitively via
+``supabase-py`` — see #183 for why the contract was tightened.)
 """
 
 from __future__ import annotations

--- a/agents/github_client.py
+++ b/agents/github_client.py
@@ -41,6 +41,12 @@ def _headers(token: str | None) -> dict[str, str]:
     return headers
 
 
+# GitHub's /events endpoint serves at most ~300 events total across up to
+# 3 pages. ``per_page=100`` is the maximum the API accepts.
+_MAX_EVENTS_PAGES = 3
+_PER_PAGE = 100
+
+
 def fetch_repo_events(
     repo: str,
     *,
@@ -49,45 +55,63 @@ def fetch_repo_events(
     token: str | None = None,
     timeout: float = 10.0,
 ) -> list[dict[str, Any]]:
-    """Return recent public events for ``repo`` (newest first).
+    """Return recent events for ``repo`` filtered to RELEVANT_EVENT_TYPES,
+    oldest first.
+
+    GitHub returns events newest-first; this function paginates (up to 3
+    pages of 100), filters to the allow-list, and re-sorts ascending before
+    slicing to ``limit``. Taking the oldest N makes the monitor's cursor
+    advance contiguous: the next poll resumes right after the last stored
+    event rather than skipping past older-but-still-new activity that didn't
+    fit in the slice.
 
     * ``after_event_id`` — drop any event whose id is <= this one. GitHub
-      event ids are monotonically increasing strings-of-integers, so
-      string-compare by integer value is the correct semantics.
-    * ``limit`` — cap Ollama classification cost; defaults to 10 per run.
+      event ids are monotonically increasing integer-strings; this function
+      converts them with ``int(...)`` and compares numerically.
+    * ``limit`` — cap how many matching events to return per call (and
+      therefore how many Ollama classifications are paid for). Default 10.
     * ``token`` — optional GitHub token. Unauthenticated requests hit a
       60 req/hour rate limit per IP, which is fine for low-frequency
       monitoring but will trip on busy repos.
 
-    Filtered to ``RELEVANT_EVENT_TYPES``. Returns raw GitHub event dicts.
+    Pagination stops early when a page's oldest event id is <= the cursor
+    (nothing newer can exist on later pages) or when a short page signals
+    the end of available history. This prevents silent event loss on busy
+    repos where more than one page of relevant activity lands between polls.
     """
     auth_token = token if token is not None else os.environ.get("GITHUB_TOKEN")
-    url = f"https://api.github.com/repos/{repo}/events"
-    response = httpx.get(
-        url,
-        headers=_headers(auth_token),
-        params={"per_page": 30},  # fetch a wider page, filter client-side
-        timeout=timeout,
-    )
-    response.raise_for_status()
-    events: list[dict[str, Any]] = response.json()
-
-    # GitHub returns newest first. For cursor comparison, use integer
-    # conversion — the API guarantees numeric ids.
     cursor = int(after_event_id) if after_event_id else 0
-    filtered = [
-        e
-        for e in events
-        if e.get("type") in RELEVANT_EVENT_TYPES and int(e.get("id", "0")) > cursor
-    ]
-    # Re-sort oldest-first before the limit slice. GitHub's response is
-    # newest-first, so a naive ``filtered[:limit]`` would pick the N newest
-    # and the monitor would then advance the cursor to the max id in that
-    # slice — permanently skipping the older-but-still-new events that
-    # didn't fit. Taking the oldest N instead makes the cursor advance
-    # contiguous: next poll resumes right after the last stored event.
-    filtered.sort(key=lambda e: int(e.get("id", "0")))
-    return filtered[:limit]
+    url = f"https://api.github.com/repos/{repo}/events"
+
+    collected: list[dict[str, Any]] = []
+    for page in range(1, _MAX_EVENTS_PAGES + 1):
+        response = httpx.get(
+            url,
+            headers=_headers(auth_token),
+            params={"per_page": _PER_PAGE, "page": page},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        page_events: list[dict[str, Any]] = response.json()
+        if not page_events:
+            break
+
+        for event in page_events:
+            if event.get("type") in RELEVANT_EVENT_TYPES and int(event.get("id", "0")) > cursor:
+                collected.append(event)
+
+        # The last element on each page is the oldest on that page (GitHub
+        # returns newest-first). If it's already <= cursor, every event on
+        # subsequent pages is strictly older — no further matches possible.
+        oldest_on_page = int(page_events[-1].get("id", "0"))
+        if oldest_on_page <= cursor:
+            break
+        # A partial page means GitHub has no more history to return.
+        if len(page_events) < _PER_PAGE:
+            break
+
+    collected.sort(key=lambda e: int(e.get("id", "0")))
+    return collected[:limit]
 
 
 def summarise_event(event: dict[str, Any]) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ agents = [
   # Supabase bridge — agents read/write memories/events/goals/audit_log directly
   # (MCP is Claude-Code-only, so graph nodes need a native client).
   "supabase>=2.0.0",
+  # GitHub Events API client. supabase-py pulls httpx transitively today,
+  # but agents/github_client.py depends on it unconditionally — declare it
+  # explicitly so the contract doesn't depend on a transitive.
+  "httpx>=0.27",
 ]
 # All runtime components
 full = [

--- a/tests/test_agents_smoke.py
+++ b/tests/test_agents_smoke.py
@@ -11,6 +11,20 @@ import os
 import pytest
 
 
+def _require_supabase() -> None:
+    """Skip if real ``supabase`` isn't installed.
+
+    ``importorskip`` alone is too lenient: ``test_memory_server.py`` puts an
+    empty stub module in ``sys.modules`` when real supabase is missing, so
+    ``import supabase`` succeeds but later ``from supabase import Client``
+    fails with an unhelpful ImportError. Check for ``Client`` to detect the
+    stub case and skip properly.
+    """
+    sb = pytest.importorskip("supabase")
+    if not hasattr(sb, "Client"):
+        pytest.skip("real supabase not installed (only stub present)")
+
+
 def test_config_loads_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     """With no env overrides, config exposes the documented defaults."""
     for var in (
@@ -107,7 +121,7 @@ def test_supabase_client_errors_without_credentials(monkeypatch: pytest.MonkeyPa
     Silently defaulting would let a misconfigured agent run against nothing
     and look healthy until the first write failed.
     """
-    pytest.importorskip("supabase")
+    _require_supabase()
     monkeypatch.delenv("SUPABASE_URL", raising=False)
     monkeypatch.delenv("SUPABASE_KEY", raising=False)
 
@@ -119,7 +133,7 @@ def test_supabase_client_errors_without_credentials(monkeypatch: pytest.MonkeyPa
 
 def test_supabase_client_surface() -> None:
     """The bridge must expose the read/write helpers #173 requires."""
-    pytest.importorskip("supabase")
+    _require_supabase()
 
     from agents import supabase_client as sb
 
@@ -136,6 +150,7 @@ def test_supabase_client_surface() -> None:
 
 def test_github_client_event_allowlist() -> None:
     """Allow-list includes the six event types the monitor acts on."""
+    pytest.importorskip("httpx")
     from agents.github_client import RELEVANT_EVENT_TYPES
 
     for needed in (
@@ -152,6 +167,19 @@ def test_github_client_event_allowlist() -> None:
     assert "ForkEvent" not in RELEVANT_EVENT_TYPES
 
 
+class _Resp:
+    """Minimal stand-in for an ``httpx.Response`` — used by the fetch tests."""
+
+    def __init__(self, data: list[dict[str, object]]) -> None:
+        self._data = data
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> list[dict[str, object]]:
+        return self._data
+
+
 def test_fetch_repo_events_slices_oldest_first(monkeypatch: pytest.MonkeyPatch) -> None:
     """When new events outnumber ``limit``, pick the oldest N so the
     monitor's cursor advance stays contiguous.
@@ -161,23 +189,15 @@ def test_fetch_repo_events_slices_oldest_first(monkeypatch: pytest.MonkeyPatch) 
     monitor then advances the cursor to the max id — permanently skipping
     the older-but-still-new events that didn't fit.
     """
+    pytest.importorskip("httpx")
     from agents import github_client
 
     # 12 relevant events, newest first — like the real /events endpoint.
+    # 12 < per_page=100, so the first page is also the last page.
     raw = [
         {"id": str(i), "type": "IssuesEvent", "actor": {}, "repo": {}, "payload": {}}
         for i in range(20, 8, -1)
     ]
-
-    class _Resp:
-        def __init__(self, data: list[dict[str, object]]) -> None:
-            self._data = data
-
-        def raise_for_status(self) -> None:
-            return None
-
-        def json(self) -> list[dict[str, object]]:
-            return self._data
 
     monkeypatch.setattr(github_client.httpx, "get", lambda *a, **kw: _Resp(raw))
 
@@ -188,8 +208,98 @@ def test_fetch_repo_events_slices_oldest_first(monkeypatch: pytest.MonkeyPatch) 
     assert ids == [9, 10, 11, 12, 13], ids
 
 
+def test_fetch_repo_events_paginates_past_first_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    """More than one page of relevant events: must keep reading until the
+    cursor is crossed, then return the oldest N across all collected pages.
+
+    Regression guard for the pagination bug Copilot flagged on #181: a
+    single page of 30 meant events older than the first page (but still
+    newer than the cursor) were permanently skipped once the cursor
+    advanced to the newest-seen id.
+    """
+    pytest.importorskip("httpx")
+    from agents import github_client
+
+    # Simulate a 250-event backlog, newest-first. per_page=100, so this is
+    # 3 pages: ids 250..151, 150..51, 50..1. Cursor = 0 → everything new.
+    pages = [
+        [
+            {"id": str(i), "type": "IssuesEvent", "actor": {}, "repo": {}, "payload": {}}
+            for i in range(250, 150, -1)
+        ],
+        [
+            {"id": str(i), "type": "IssuesEvent", "actor": {}, "repo": {}, "payload": {}}
+            for i in range(150, 50, -1)
+        ],
+        [
+            {"id": str(i), "type": "IssuesEvent", "actor": {}, "repo": {}, "payload": {}}
+            for i in range(50, 0, -1)
+        ],
+    ]
+    calls: list[dict[str, object]] = []
+
+    def fake_get(*args: object, **kwargs: object) -> _Resp:
+        params = kwargs.get("params", {}) or {}
+        calls.append(dict(params))
+        page = int(params.get("page", 1))
+        return _Resp(pages[page - 1])
+
+    monkeypatch.setattr(github_client.httpx, "get", fake_get)
+
+    out = github_client.fetch_repo_events("o/r", after_event_id=None, limit=5)
+
+    # Oldest 5 across the whole 250-event backlog — only reachable via
+    # page 3. A single-page implementation would return 146..150 instead.
+    ids = [int(e["id"]) for e in out]
+    assert ids == [1, 2, 3, 4, 5], ids
+    # And we made it through all three pages.
+    pages_requested = sorted(int(c.get("page", 1)) for c in calls)
+    assert pages_requested == [1, 2, 3], pages_requested
+
+
+def test_fetch_repo_events_stops_at_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pagination halts as soon as a page's oldest event id is <= cursor,
+    since every subsequent page is strictly older.
+    """
+    pytest.importorskip("httpx")
+    from agents import github_client
+
+    # Page 1 has ids 120..21 (100 events); cursor=50 means the oldest on
+    # page 1 (id=21) is already <= cursor, so page 2 must NOT be fetched.
+    pages = [
+        [
+            {"id": str(i), "type": "IssuesEvent", "actor": {}, "repo": {}, "payload": {}}
+            for i in range(120, 20, -1)
+        ],
+        [  # If we accidentally fetch this, test will catch via pages_requested.
+            {"id": str(i), "type": "IssuesEvent", "actor": {}, "repo": {}, "payload": {}}
+            for i in range(20, 0, -1)
+        ],
+    ]
+    calls: list[dict[str, object]] = []
+
+    def fake_get(*args: object, **kwargs: object) -> _Resp:
+        params = kwargs.get("params", {}) or {}
+        calls.append(dict(params))
+        page = int(params.get("page", 1))
+        return _Resp(pages[page - 1] if page - 1 < len(pages) else [])
+
+    monkeypatch.setattr(github_client.httpx, "get", fake_get)
+
+    out = github_client.fetch_repo_events("o/r", after_event_id="50", limit=5)
+
+    # Matches are ids 51..120; oldest 5 of those are 51..55.
+    ids = [int(e["id"]) for e in out]
+    assert ids == [51, 52, 53, 54, 55], ids
+    # Must have stopped at page 1 — page 2 would only yield events older
+    # than the cursor, so fetching it is wasted rate-limit budget.
+    pages_requested = sorted(int(c.get("page", 1)) for c in calls)
+    assert pages_requested == [1], pages_requested
+
+
 def test_summarise_event_covers_known_types() -> None:
     """Every event-type branch produces a string with actor + repo + detail."""
+    pytest.importorskip("httpx")
     from agents.github_client import summarise_event
 
     common = {"actor": {"login": "alice"}, "repo": {"name": "o/r"}}
@@ -232,6 +342,7 @@ def test_event_monitor_graph_builds() -> None:
     """The monitor graph compiles to fetch -> classify -> store."""
     pytest.importorskip("langgraph")
     pytest.importorskip("supabase")
+    pytest.importorskip("httpx")
 
     from agents.event_monitor import MonitorState, build_graph
 
@@ -244,10 +355,12 @@ def test_event_monitor_graph_builds() -> None:
 
 def test_event_monitor_classification_schema() -> None:
     """Classifier enum stays three-tier — Ollama prompt depends on it."""
-    # agents.event_monitor imports langgraph + supabase at module load, so
-    # skip (not error) when the optional [agents] extras aren't installed.
+    # agents.event_monitor imports langgraph + supabase + httpx (via
+    # github_client) at module load, so skip (not error) when the optional
+    # [agents] extras aren't installed.
     pytest.importorskip("langgraph")
     pytest.importorskip("supabase")
+    pytest.importorskip("httpx")
 
     from agents.event_monitor import _CLASSIFY_SCHEMA
 

--- a/tests/test_agents_smoke.py
+++ b/tests/test_agents_smoke.py
@@ -11,14 +11,29 @@ import os
 import pytest
 
 
+def _require_httpx() -> None:
+    """Skip if real ``httpx`` isn't installed.
+
+    ``importorskip`` alone is too lenient: ``test_memory_server.py`` may put
+    an empty stub module in ``sys.modules`` when real httpx is missing, so
+    ``import httpx`` succeeds but the stub has no ``get`` attribute — and
+    ``monkeypatch.setattr(github_client.httpx, "get", ...)`` then raises
+    ``AttributeError``. Check for ``get`` to detect the stub case and skip
+    properly.
+    """
+    hx = pytest.importorskip("httpx")
+    if not hasattr(hx, "get"):
+        pytest.skip("real httpx not installed (only stub present)")
+
+
 def _require_supabase() -> None:
     """Skip if real ``supabase`` isn't installed.
 
-    ``importorskip`` alone is too lenient: ``test_memory_server.py`` puts an
-    empty stub module in ``sys.modules`` when real supabase is missing, so
-    ``import supabase`` succeeds but later ``from supabase import Client``
-    fails with an unhelpful ImportError. Check for ``Client`` to detect the
-    stub case and skip properly.
+    Same rationale as ``_require_httpx``: ``test_memory_server.py`` may put
+    an empty stub module in ``sys.modules`` when real supabase is missing,
+    so ``import supabase`` succeeds but later ``from supabase import
+    Client`` fails with an unhelpful ImportError. Check for ``Client`` to
+    detect the stub case and skip properly.
     """
     sb = pytest.importorskip("supabase")
     if not hasattr(sb, "Client"):
@@ -150,7 +165,7 @@ def test_supabase_client_surface() -> None:
 
 def test_github_client_event_allowlist() -> None:
     """Allow-list includes the six event types the monitor acts on."""
-    pytest.importorskip("httpx")
+    _require_httpx()
     from agents.github_client import RELEVANT_EVENT_TYPES
 
     for needed in (
@@ -189,7 +204,7 @@ def test_fetch_repo_events_slices_oldest_first(monkeypatch: pytest.MonkeyPatch) 
     monitor then advances the cursor to the max id — permanently skipping
     the older-but-still-new events that didn't fit.
     """
-    pytest.importorskip("httpx")
+    _require_httpx()
     from agents import github_client
 
     # 12 relevant events, newest first — like the real /events endpoint.
@@ -217,7 +232,7 @@ def test_fetch_repo_events_paginates_past_first_page(monkeypatch: pytest.MonkeyP
     newer than the cursor) were permanently skipped once the cursor
     advanced to the newest-seen id.
     """
-    pytest.importorskip("httpx")
+    _require_httpx()
     from agents import github_client
 
     # Simulate a 250-event backlog, newest-first. per_page=100, so this is
@@ -261,7 +276,7 @@ def test_fetch_repo_events_stops_at_cursor(monkeypatch: pytest.MonkeyPatch) -> N
     """Pagination halts as soon as a page's oldest event id is <= cursor,
     since every subsequent page is strictly older.
     """
-    pytest.importorskip("httpx")
+    _require_httpx()
     from agents import github_client
 
     # Page 1 has ids 120..21 (100 events); cursor=50 means the oldest on
@@ -299,7 +314,7 @@ def test_fetch_repo_events_stops_at_cursor(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_summarise_event_covers_known_types() -> None:
     """Every event-type branch produces a string with actor + repo + detail."""
-    pytest.importorskip("httpx")
+    _require_httpx()
     from agents.github_client import summarise_event
 
     common = {"actor": {"login": "alice"}, "repo": {"name": "o/r"}}
@@ -341,8 +356,8 @@ def test_summarise_event_covers_known_types() -> None:
 def test_event_monitor_graph_builds() -> None:
     """The monitor graph compiles to fetch -> classify -> store."""
     pytest.importorskip("langgraph")
-    pytest.importorskip("supabase")
-    pytest.importorskip("httpx")
+    _require_supabase()
+    _require_httpx()
 
     from agents.event_monitor import MonitorState, build_graph
 
@@ -359,8 +374,8 @@ def test_event_monitor_classification_schema() -> None:
     # github_client) at module load, so skip (not error) when the optional
     # [agents] extras aren't installed.
     pytest.importorskip("langgraph")
-    pytest.importorskip("supabase")
-    pytest.importorskip("httpx")
+    _require_supabase()
+    _require_httpx()
 
     from agents.event_monitor import _CLASSIFY_SCHEMA
 

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -67,8 +67,14 @@ try:
 except ImportError:
     sys.modules["supabase"] = types.ModuleType("supabase")
 
-# Stub httpx (used for Voyage AI embedding calls)
-sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+# Stub httpx only if it's not actually installed. A blind setdefault
+# would shadow a real install for the rest of the pytest session (e.g.
+# test_agents_smoke.py needs real `httpx.get` to monkey-patch the
+# GitHub client).
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules["httpx"] = types.ModuleType("httpx")
 
 # Stub dotenv
 _dotenv = types.ModuleType("dotenv")


### PR DESCRIPTION
## Summary

Four follow-ups from the automated Copilot review of #181 (event monitor merge). All offline-safe — no Ollama/Postgres needed to validate.

## What changed

### 1. Pagination bug in `fetch_repo_events` (silent event loss)
Previous impl fetched a single `per_page=30` page. On any poll where >30 relevant events landed, the older-but-still-new ones fell off page 1 and were **permanently skipped** once the cursor advanced to the newest-seen id. Now paginates up to 3 pages of 100, stopping early when:
- a page's oldest event id is `<= cursor` (nothing newer on later pages), or
- a short page signals the end of GitHub's ~300-event history.

Two new regression tests:
- `test_fetch_repo_events_paginates_past_first_page` — 250-event backlog, verifies oldest 5 are reachable only by paging to page 3.
- `test_fetch_repo_events_stops_at_cursor` — page 1 already crosses the cursor, verifies page 2 is NOT requested.

### 2. Docstring/contract mismatch in `fetch_repo_events`
Docstring claimed "newest first" and "string-compare by integer value". Impl sorts ascending and uses `int(...)` comparison. Updated to describe the actual oldest-first, numeric-comparison behavior.

### 3. `classify_node` aborted the whole run on Ollama failure
PR #181 promised "classifier errors default to info, not silent drop". Implementation only caught malformed JSON output — if `ollama_chat()` itself raised (daemon down, network error, timeout), the whole polling run aborted, **including the "audit every run" write**. Widened the try/except to cover the `ollama_chat` call; failures now reliably fall back to `label="info"` with `reason="classifier_error: ..."`.

### 4. `httpx` was a transitive dependency used directly
`agents/github_client.py` imports `httpx` unconditionally but it was only declared in the `[memory]` extra (pulled in transitively by supabase-py). Declared explicitly in `[agents]` and added `pytest.importorskip("httpx")` to github_client smoke tests so minimal dev installs skip rather than crash at import.

## Drive-by test hygiene

Surfaced while fixing #4 — same class of bug:

- `tests/test_memory_server.py` was installing an empty `httpx` stub via `sys.modules.setdefault` at module load, **shadowing the real install for the rest of the pytest session**. Switched to the same `try/except ImportError` pattern already used for supabase in that file.
- Added a `_require_supabase()` helper in `test_agents_smoke.py` that treats the stub module as "not installed" — plain `pytest.importorskip("supabase")` was too lenient and let two tests proceed to `from supabase import Client` and fail with an unhelpful error.

## Testing

- Full suite: **156 passed, 10 skipped, 0 failed**
- `ruff check` / `ruff format --check` clean on all modified files
- Live end-to-end against Ollama/Postgres NOT re-run — hardware constraint (integrated GPU can't run the model on this machine). Will re-validate on powerful hardware before Pillar 7 Sprint 2.

## Test plan

- [x] Unit tests (offline): 156 passed, 10 skipped
- [x] Ruff clean on modified files
- [ ] Live validation with real Ollama (deferred to next session on capable hardware)

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)