### PR TITLE
feat(memory): Phase 0.5 — eval harness + baseline

### DIFF
--- a/docs/design/memory-overhaul.md
+++ b/docs/design/memory-overhaul.md
@@ -1,0 +1,216 @@
+# Memory overhaul — research synthesis + design proposal
+
+**Status:** research complete, design pending owner review.
+**Context:** Pillar 4 (memory). Current system has measurable lifecycle bugs; before fixing ad-hoc, owner asked for research on (a) how production LLM agent systems solve the same problems, (b) theory of agent memory. Two parallel research agents ran; this doc consolidates findings with our local audit.
+
+## 1. Local audit — what's actually broken
+
+Verified against live Supabase state (2026-04-18):
+
+| # | Gap | Evidence | Impact |
+|---|-----|----------|--------|
+| 1 | `supersedes` link type defined, never created | 223 links, all `related`, zero `supersedes` | Contradicting decisions coexist in recall |
+| 2 | `SUPERSEDE_SIM_THRESHOLD=0.85` unreachable | Real paraphrase similarity ≈0.80 | Auto-link never marks supersession |
+| 3 | Auto-link supersedes gated on `type=decision` only | `_create_auto_links` in server.py | User/feedback/project memories can't supersede |
+| 4 | Recall has no supersedes/archived filter | `_hybrid_recall`, `match_memories` RPC | Even if links existed, stale items still surface |
+| 5 | Temporal scoring uses `updated_at` | `_apply_temporal_scoring` | Session-start touching memories resets age-decay clock |
+| 6 | Archive is a dirty hack (`type = type \|\| '_archived'`) | `archive_memories` RPC | Breaks type-filtered recall; abuses type column |
+| 7 | `deleted_at` column exists, most RPCs don't check it | Schema alter + RPC grep | Soft-delete is inconsistent |
+| 8 | `find_consolidation_clusters` RPC exists, never invoked | No scheduled task calls it | Consolidation capability idle |
+| 9 | No provenance on memories | No `source` column | Can't tell owner-stated from tool-output |
+| 10 | No confidence / entrenchment ordering | No column | Contraction undefined when conflicts exist |
+
+Two concrete contradicting memories observed: `jarvis_stays_goals_not_agile` (Jan) and `jarvis_v2_hybrid_agile` (Mar). Description of the latter explicitly says "replaces" the former. They're linked as `related` (strength 0.757), both surface in recall, no supersession marker.
+
+## 2. Convergent signals from theory + production
+
+Items flagged by **both** research streams — strongest evidence, should be in any design:
+
+### 2a. Bi-temporal timestamps (valid time ≠ transaction time)
+- **Theory (Snodgrass / Allen):** bitemporal is the minimum correct schema; single `updated_at` makes retroactive correction formally impossible.
+- **Production (Zep/Graphiti):** every edge carries four timestamps: `created_at`, `expired_at`, `valid_from`, `valid_to`. Non-destructive; on contradiction, older edge's `valid_to` = new edge's `valid_from`.
+- **Us:** only `updated_at`, bumped by session-start.
+
+### 2b. Provenance / justification on every fact
+- **Theory (Doyle, JTMS):** beliefs without justifications cannot be revised correctly. Revision needs source chain.
+- **Production (memory-poisoning lit, 2025):** `MemoryGraft`, `AgentPoison` — stored-memory injection is a real attack class. Defense starts from provenance tagging (`owner_stated` / `tool_output` / `web_ingested` / `subagent_reported`).
+- **Us:** no source column. Web-research output and owner statements are indistinguishable.
+
+### 2c. ACT-R-style retrieval scoring (not raw cosine)
+- **Theory (Anderson-Schooler, ACT-R):** rank by `relevance × recency-weighted usage frequency × context match × entrenchment / interference penalty`. Cosine alone is a category error.
+- **Production (Claude Code memory-MCP, Memary):** `confidence × log(access_count+1) × decay(type, age)`. Type-dependent half-lives.
+- **Us:** we do RRF hybrid + temporal re-rank, but use `updated_at` (wrong axis), no confidence, no access frequency, no context match.
+
+### 2d. Explicit write-time classifier (ADD / UPDATE / DELETE / NOOP)
+- **Theory (AGM Levi identity):** `K ∗ p = (K ÷ ¬p) + p` — contract negation *before* adding new belief. Requires an explicit decision, not append.
+- **Production (Mem0):** LLM sees top-k neighbors + candidate, emits one of ADD/UPDATE/DELETE/NOOP. Their published LoCoMo benchmark is 91.6, p95 200ms.
+- **Us:** our new dedup hook (`memory-dedup-check.py`) is the *detection* half (block on ≥0.78 similarity). Still missing the decision half.
+
+### 2e. Episodic ↔ semantic separation with consolidation
+- **Theory (McClelland CLS, Tulving):** single-shot writes to the "distilled" store cause catastrophic interference. Fast episodic buffer + slow semantic consolidation (offline batched) is the computational argument.
+- **Production (Letta tiered memory, A-MEM evolution, LangMem background mode):** raw episodes non-lossy, semantic extraction async. Reruns with better models later.
+- **Us:** single `memories` table. Every write goes direct to the "distilled" layer.
+
+### 2f. Entrenchment / confidence ordering
+- **Theory (Gärdenfors):** contraction nondeterministic without explicit entrenchment preorder. Drop least entrenched. User-stated > inferred > default.
+- **Production:** confidence scores on writes, low-confidence hidden from default recall.
+- **Us:** none.
+
+### 2g. Background consolidation as a *real* job
+- **Theory (CLS offline consolidation, Darwiche-Pearl iterated revision):** proper revision needs batch re-coherence, not per-write.
+- **Production (LangMem background mode, Zep community summaries):** Haiku-class model runs async, groups by type+tag, detects pairwise conflicts, emits merge plan.
+- **Us:** weekly hygiene task exists, doesn't do anything useful. `find_consolidation_clusters` RPC idle.
+
+### 2h. Retrieval-induced forgetting / context rot
+- **Theory:** repeatedly retrieving belief A inhibits sibling B/C; long-running retrieval history silently diverges from storage.
+- **Production (LongMemEval):** more memory at session start actively *hurts* — 30-60% accuracy drop with full long memory vs curated extracts.
+- **Us:** session-start hook injects profile + feedback + decisions + working state + goals. No measurement. Could be hurting us; we'd never know.
+
+## 3. Signals only one side flagged — still worth catching
+
+**Production-only:**
+- **Embedding model migration hazard.** Voyage-3-lite → next model = whole corpus becomes incomparable. Store `embedding_model` + `embedding_version`, support dual columns during migration. (Our single biggest unnoticed production risk.)
+- **Collections vs Profiles split.** Some memories should be overwrite-single-row (`owner_preferences`, `device_config`); others append (`decisions`). Without the distinction, you fight supersession bugs forever on the overwrite ones. One column: `single_instance BOOLEAN`.
+- **Task-aware recall = query rewriting.** Cheap LLM call turns `{user_prompt, recent_turns}` into `{intent, entities, type_filter, tag_filter, timeframe}` *before* vector search. Don't embed the raw prompt — biggest quality win on relevance.
+- **A-MEM memory evolution (second step).** New memory arrives → LLM also rewrites context/tags of linked neighbors. We have auto-linking; we don't have the in-place rewrite. Without it: linked graph of frozen interpretations.
+- **Evaluation set.** 20 hand-written `(query, expected_memory_ids)` pairs, re-run weekly, track recall@5 and MRR. Without this, every "improvement" is vibes.
+- **Cross-session actor namespacing.** Memory written in autonomous mode ("I decided X because no one was around") ≠ owner-stated. Namespace by actor, not just project.
+- **Embed canonical form not raw content** (Cognee, A-MEM). Embed `{name, type, tags, one_line_description}` not raw note text — survives rewrites and model upgrades.
+
+**Theory-only:**
+- **Metacognition (Nelson-Narens).** Feeling-of-knowing, confidence, explicit "known unknowns". Without this, agent detects contradictions but not *gaps*. ToT state is the missing piece.
+- **Darwiche-Pearl iterated revision.** Storing beliefs isn't enough — you need to store the *belief state* (beliefs + their entrenchment ordering) and update both. Single-pass AGM drifts across iterations.
+- **Spohn ranking functions.** The right formal substrate for quantitative belief change (ordinal conditional functions, ranks as grades of disbelief).
+- **Quine web-of-belief / holism.** Revising one belief has non-local consequences. Central beliefs should be more entrenched precisely because revising them cascades.
+
+## 4. What the theorists flagged as traps (we hit most of them)
+
+1. Justification-free facts → we're here
+2. Monolithic similarity → we're here (mitigated by hybrid + RRF, not enough)
+3. Catastrophic interference from direct writes to distilled layer → we're here
+4. One-shot revision (no iterated-revision state) → we're here
+5. No transaction time (only `updated_at`) → we're here
+6. No entrenchment ordering → we're here
+7. Collapsing types (episodic = semantic) → we're here
+8. No metacognition → we're here
+9. Holism ignored → we're here (links exist but no cascade)
+10. Retrieval-induced forgetting silent drift → unmeasured
+11. "Forgetting is bug" mindset → we're here (archive is a hack, nothing decays properly)
+
+## 5. Proposed design — phased
+
+Priorities ordered by (value × low-cost). Each phase is independently shippable and independently valuable.
+
+### Phase 0 — schema foundation (migration only, no code)
+
+One migration, zero risk if reversible:
+
+```sql
+ALTER TABLE memories
+  ADD COLUMN content_updated_at timestamptz,      -- split from updated_at
+  ADD COLUMN last_accessed_at_v2 timestamptz,     -- distinct from updated_at; rename after backfill
+  ADD COLUMN valid_from timestamptz,              -- bi-temporal: when true in world
+  ADD COLUMN valid_to timestamptz,                -- when it stopped being true
+  ADD COLUMN expired_at timestamptz,              -- when we stopped believing it
+  ADD COLUMN superseded_by uuid REFERENCES memories(id),
+  ADD COLUMN confidence real DEFAULT 0.5,         -- [0, 1]
+  ADD COLUMN source_provenance text,              -- owner_stated / tool_output / web_ingested / subagent_reported / autonomous_agent
+  ADD COLUMN single_instance boolean DEFAULT false,
+  ADD COLUMN embedding_model text DEFAULT 'voyage-3-lite',
+  ADD COLUMN embedding_version text DEFAULT 'v1';
+```
+
+Backfill defaults; don't drop old columns yet.
+
+### Phase 1 — recall correctness (immediate wins)
+
+Gates everything else. Without this, no amount of write-side sophistication helps.
+
+1. Split timestamps — `updated_at` becomes "any write"; `content_updated_at` gates age decay; `last_accessed_at` tracks recall frequency. Session-start hook updates only `last_accessed_at`.
+2. Default recall filter: `WHERE expired_at IS NULL AND (valid_to IS NULL OR valid_to > now()) AND superseded_by IS NULL`. Add `show_history` mode that ignores this.
+3. Collapse `supersedes` chains in recall: follow `superseded_by` chain, return only the head. (Even without write-side fixes, this makes manually-added `superseded_by` pointers immediately useful.)
+4. Fix temporal scoring to use `content_updated_at` not `updated_at`.
+
+### Phase 2 — write-side correctness
+
+1. Replace append-on-write with Mem0-style ADD/UPDATE/DELETE/NOOP classifier. Haiku-class model, sees top-5 neighbors. Cost: ~$0.001/write, budget-negligible.
+2. Lower `SUPERSEDE_SIM_THRESHOLD` from 0.85 to ~0.75; remove `type=decision` gate (all types can supersede).
+3. On UPDATE/DELETE decision: set `superseded_by` + `valid_to` + `expired_at` on old, not `type='…_archived'` rename.
+4. Provenance required on every write (default `owner_stated` if unset — but log warnings to force callers to be explicit).
+5. Embed canonical form `"{name}\n{description}\n{tags}"` not raw content.
+
+### Phase 3 — task-aware recall
+
+1. New hook: UserPromptSubmit. Cheap LLM call rewrites prompt → structured query `{intent, entities, type_filter, tag_filter, timeframe}`.
+2. Fan out: semantic + keyword + metadata filter + BFS on links.
+3. RRF with cross-encoder rerank of top 20 (one Haiku call).
+
+### Phase 4 — episodic layer
+
+1. New `episodes` table — non-lossy conversation/tool-call log, minimal schema (id, actor, kind, payload, created_at).
+2. Extractor runs async: episodes → candidate memories → Phase 2 classifier.
+3. Benefit: re-extract with better models later without losing source data.
+
+### Phase 5 — consolidation + metacognition
+
+1. Wire up `find_consolidation_clusters` to a real weekly job. Haiku groups by `(type, tag)`, detects pairwise contradictions, emits merge/supersede plan. Auto-apply above confidence 0.9; else queue for owner review.
+2. A-MEM evolution second step: on UPDATE, also rewrite linked-neighbor context/tags if meaning shifted.
+3. Confidence self-monitor: after each recall, store feeling-of-knowing judgment (did answer sufficiency hit). Feeds entrenchment over time.
+4. Known-unknowns table: propositions the agent knows it *should* know but can't retrieve — surfaced proactively.
+
+### Phase 6 — evaluation harness
+
+**Actually belongs at Phase 0.5** — build before Phase 1 so we can measure every subsequent change. Listed last only because it's purely infrastructure:
+
+1. 20 hand-written `(query, expected_memory_ids, expected_types)` pairs.
+2. `scripts/eval-recall.py` runs them, prints recall@5 + MRR.
+3. Baseline before each phase, diff after.
+
+### Phase 7 — scale (premature now)
+
+- Community summaries (Graphiti). Only past thousands of memories.
+- Ontology canonicalization (Cognee). Only when entity dedup becomes a pain.
+- Dual-embedding migration machinery. When we actually upgrade models.
+
+## 6. Open questions for owner
+
+1. **Phase ordering.** Above is cost-ordered. Alternative: do Phase 6 (eval) first so we can measure Phase 1-2 quantitatively. Adds ~half-day upfront. Recommend: eval first.
+2. **Classifier model.** Mem0 uses GPT-4o at write. We'd use Haiku-4.5. Risk: classifier errors become silent corruption. Mitigation: low-confidence decisions require owner review (above a threshold, auto-apply; below, queue).
+3. **Migration strategy for existing corpus.** ~600 memories currently. Options: (a) leave as-is with defaults, rely on Phase 1 filters to gate the worst cases; (b) run one-off backfill through classifier to tag provenance, detect chains; (c) wipe and restart. Recommend: (a). (c) loses decision history.
+4. **Scope.** Phases 0-3 + eval is ~a week's work. Phases 4-5 are another week. Stop after Phase 3 and measure, or commit to the whole stack?
+5. **The `jarvis_stays_goals_not_agile` / `jarvis_v2_hybrid_agile` concrete pair.** Manually set `superseded_by` now (one-line SQL), or wait for Phase 2 auto-detection. Recommend: manual now, it's a known live bug poisoning recall today.
+
+## 7. Explicitly out of scope
+
+- Replacing pgvector / moving to a different store.
+- Switching away from voyage-3-lite.
+- Moving memory server out of Python (only justified Python per CLAUDE.md is here).
+- Letta/Mem0 wholesale adoption — their write paths are LLM-heavy and we're budget-constrained.
+
+## 8. References
+
+**Local:**
+- `mcp-memory/server.py` — current implementation
+- `mcp-memory/schema.sql` — current schema
+- `scripts/memory-dedup-check.py` — detection half, shipped
+- Memory `memory_management_strategy_v1` — prior thinking
+
+**Production systems (research A):**
+- Mem0 — [paper](https://arxiv.org/abs/2504.19413), [blog](https://mem0.ai/blog/mem0-the-token-efficient-memory-algorithm)
+- Zep/Graphiti — [paper](https://arxiv.org/abs/2501.13956), [blog](https://blog.getzep.com/beyond-static-knowledge-graphs/)
+- Letta/MemGPT — [docs](https://docs.letta.com/concepts/memgpt/)
+- A-MEM — [paper](https://arxiv.org/abs/2502.12110)
+- LangMem — [concepts](https://langchain-ai.github.io/langmem/concepts/conceptual_guide/)
+- Memory poisoning — [MemoryGraft](https://arxiv.org/abs/2512.16962), [AgentPoison](https://billchan226.github.io/AgentPoison.html)
+- LongMemEval — [paper](https://arxiv.org/pdf/2410.10813)
+- Embedding migration post-mortem — [Decompressed](https://decompressed.io/learn/rag-observability-postmortem)
+
+**Theory (research B):**
+- McClelland, McNaughton, O'Reilly (1995) — Complementary Learning Systems
+- Alchourrón, Gärdenfors, Makinson (1985) — AGM
+- Anderson & Schooler (1991) — Rational analysis of forgetting
+- Doyle (1979) — TMS
+- Nelson & Narens (1990) — Metamemory
+- Darwiche & Pearl (1997) — Iterated belief revision
+- Tulving — Episodic/semantic distinction
+- Allen (1983) — Interval algebra

--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -1,0 +1,397 @@
+"""Memory recall evaluation harness.
+
+Runs the query set in tests/memory-eval/queries.yaml against the live Supabase
+corpus, reproduces the server.py recall pipeline (pgvector match_memories +
+pg_trgm keyword_search_memories + RRF + temporal scoring), and reports:
+
+    - recall@5, recall@10:  fraction of queries where >=1 expected name is in top-k
+    - MRR:                  mean reciprocal rank of the first expected hit
+    - must_not violations:  queries where a "should not surface" memory landed
+                            in top 5 (tracked separately — this is the lifecycle
+                            signal we want to drive to zero)
+
+Usage:
+    python scripts/eval-recall.py                 # run, pretty-print, don't save
+    python scripts/eval-recall.py --save-baseline # run + overwrite baseline.json
+    python scripts/eval-recall.py --diff baseline # run + print delta vs baseline.json
+    python scripts/eval-recall.py --quiet         # only print aggregates
+
+No dependency on mcp-memory/server.py: we duplicate the pipeline constants here
+so Phase-by-phase server.py changes are measurable as deltas against the
+previous baseline. Keep this file's constants in sync with server.py OR, when
+pipeline diverges intentionally, the delta in eval output *is* the thing we
+wanted to measure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Pipeline constants — mirrored from mcp-memory/server.py as of Phase 0.5.
+# When server.py changes, re-sync OR deliberately let them differ to measure.
+# ---------------------------------------------------------------------------
+SIMILARITY_THRESHOLD = 0.25
+RRF_K = 60
+TEMPORAL_HALF_LIVES = {
+    "user": 180,
+    "feedback": 90,
+    "decision": 60,
+    "reference": 30,
+    "project": 7,
+}
+DEFAULT_HALF_LIFE = 30
+ACCESS_BOOST_MAX = 0.3
+ACCESS_HALF_LIFE = 14
+
+VOYAGE_URL = "https://api.voyageai.com/v1/embeddings"
+VOYAGE_MODEL = "voyage-3-lite"
+EMBED_TIMEOUT = 10.0
+
+
+def _load_env() -> None:
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
+    here = Path(__file__).resolve().parent
+    for candidate in (here.parent / ".env", here.parent.parent / ".env"):
+        if candidate.exists():
+            load_dotenv(candidate)
+            return
+
+
+async def _embed_query(text: str) -> list[float]:
+    """Sync-in-async Voyage embed. Raises on error — eval should fail loud, not open."""
+    import httpx
+
+    api_key = os.environ["VOYAGE_API_KEY"]
+    async with httpx.AsyncClient(timeout=EMBED_TIMEOUT) as client:
+        resp = await client.post(
+            VOYAGE_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "model": VOYAGE_MODEL,
+                "input": [text],
+                "input_type": "query",
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()["data"][0]["embedding"]
+
+
+def _rrf_merge(semantic_rows: list[dict], keyword_rows: list[dict], limit: int, k: int = RRF_K) -> list[dict]:
+    scores: dict[str, float] = {}
+    by_id: dict[str, dict] = {}
+    for rank, row in enumerate(semantic_rows):
+        rid = row.get("id") or row["name"]
+        scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank)
+        by_id[rid] = row
+    for rank, row in enumerate(keyword_rows):
+        rid = row.get("id") or row["name"]
+        scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank)
+        by_id[rid] = row
+    ranked = sorted(scores.keys(), key=lambda r: scores[r], reverse=True)
+    result = []
+    for rid in ranked[:limit]:
+        row = by_id[rid]
+        row["_rrf_score"] = scores[rid]
+        result.append(row)
+    return result
+
+
+def _apply_temporal_scoring(rows: list[dict]) -> list[dict]:
+    now = datetime.now(timezone.utc)
+    for row in rows:
+        rrf = row.get("_rrf_score", 0.01)
+        mem_type = row.get("type", "decision")
+        half_life = TEMPORAL_HALF_LIVES.get(mem_type, DEFAULT_HALF_LIFE)
+
+        updated_str = row.get("updated_at") or ""
+        try:
+            updated = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
+            days_since_update = max(0, (now - updated).total_seconds() / 86400)
+        except (ValueError, AttributeError):
+            days_since_update = half_life
+
+        accessed_str = row.get("last_accessed_at") or ""
+        try:
+            accessed = datetime.fromisoformat(accessed_str.replace("Z", "+00:00"))
+            days_since_access = max(0, (now - accessed).total_seconds() / 86400)
+        except (ValueError, AttributeError):
+            days_since_access = days_since_update * 2
+
+        recency = math.exp(-0.693 * days_since_update / half_life)
+        access = 1.0 + ACCESS_BOOST_MAX * math.exp(-0.693 * days_since_access / ACCESS_HALF_LIFE)
+        row["_temporal_score"] = rrf * recency * access
+
+    rows.sort(key=lambda r: r.get("_temporal_score", 0), reverse=True)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Eval core
+# ---------------------------------------------------------------------------
+
+@dataclass
+class QueryResult:
+    id: str
+    query: str
+    kind: str
+    expected: list[str]
+    must_not: list[str]
+    top_names: list[str]                 # top-10 names in order
+    first_hit_rank: int | None           # 1-indexed, None if no expected hit in top-10
+    hits_at_5: list[str]                 # expected names that appeared in top-5
+    hits_at_10: list[str]
+    must_not_violations_at_5: list[str]  # must_not names that appeared in top-5
+    passed: bool                         # recall@5 >= 1 AND no must_not violations
+
+
+@dataclass
+class EvalReport:
+    timestamp: str
+    corpus_size: int
+    total_queries: int
+    recall_at_5: float
+    recall_at_10: float
+    mrr: float
+    must_not_violations: int
+    passed: int
+    failed: int
+    results: list[dict] = field(default_factory=list)
+
+
+async def run_query(client, q: dict) -> QueryResult:
+    embedding = await _embed_query(q["query"])
+
+    sem = client.rpc("match_memories", {
+        "query_embedding": embedding,
+        "match_limit": 20,
+        "similarity_threshold": SIMILARITY_THRESHOLD,
+        "filter_project": None,
+        "filter_type": None,
+    }).execute()
+    sem_rows = sem.data or []
+
+    kw = client.rpc("keyword_search_memories", {
+        "search_query": q["query"],
+        "match_limit": 20,
+        "filter_project": None,
+        "filter_type": None,
+    }).execute()
+    kw_rows = kw.data or []
+
+    merged = _rrf_merge(sem_rows, kw_rows, limit=10)
+    _apply_temporal_scoring(merged)
+
+    top_names = [r.get("name", "?") for r in merged]
+    expected = set(q.get("expected") or [])
+    must_not = set(q.get("must_not") or [])
+
+    top5 = top_names[:5]
+    top10 = top_names[:10]
+    hits_5 = [n for n in top5 if n in expected]
+    hits_10 = [n for n in top10 if n in expected]
+    mn_viol = [n for n in top5 if n in must_not]
+
+    first_hit_rank = None
+    for i, name in enumerate(top10, start=1):
+        if name in expected:
+            first_hit_rank = i
+            break
+
+    passed = bool(hits_5) and not mn_viol
+
+    return QueryResult(
+        id=q["id"],
+        query=q["query"],
+        kind=q.get("kind", ""),
+        expected=sorted(expected),
+        must_not=sorted(must_not),
+        top_names=top_names,
+        first_hit_rank=first_hit_rank,
+        hits_at_5=hits_5,
+        hits_at_10=hits_10,
+        must_not_violations_at_5=mn_viol,
+        passed=passed,
+    )
+
+
+async def run_all(queries: list[dict], client) -> EvalReport:
+    results = []
+    for q in queries:
+        r = await run_query(client, q)
+        results.append(r)
+
+    total = len(results)
+    r5 = sum(1 for r in results if r.hits_at_5) / total if total else 0.0
+    r10 = sum(1 for r in results if r.hits_at_10) / total if total else 0.0
+    mrr = sum(1.0 / r.first_hit_rank for r in results if r.first_hit_rank) / total if total else 0.0
+    mn_viol = sum(1 for r in results if r.must_not_violations_at_5)
+    passed = sum(1 for r in results if r.passed)
+
+    # corpus size for context
+    cs = client.table("memories").select("id", count="exact").is_("deleted_at", "null").limit(1).execute()
+    corpus_size = cs.count or 0
+
+    return EvalReport(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        corpus_size=corpus_size,
+        total_queries=total,
+        recall_at_5=r5,
+        recall_at_10=r10,
+        mrr=mrr,
+        must_not_violations=mn_viol,
+        passed=passed,
+        failed=total - passed,
+        results=[asdict(r) for r in results],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting / CLI
+# ---------------------------------------------------------------------------
+
+def _fmt_pct(x: float) -> str:
+    return f"{x*100:5.1f}%"
+
+
+def print_report(report: EvalReport, quiet: bool = False) -> None:
+    if not quiet:
+        print(f"\nQueries: {report.total_queries}   Corpus: {report.corpus_size} memories\n")
+        print(f"{'id':<5} {'kind':<10} {'rank':>5}  {'hit5':>5}  {'viol':>5}  query")
+        print("-" * 100)
+        for r in report.results:
+            rank_s = str(r["first_hit_rank"]) if r["first_hit_rank"] else "-"
+            hit = "Y" if r["hits_at_5"] else " "
+            viol = "!" if r["must_not_violations_at_5"] else " "
+            q = r["query"] if len(r["query"]) <= 60 else r["query"][:57] + "..."
+            print(f"{r['id']:<5} {r['kind']:<10} {rank_s:>5}  {hit:>5}  {viol:>5}  {q}")
+
+        # fail details
+        fails = [r for r in report.results if not r["passed"]]
+        if fails:
+            print("\nFAILED queries (recall@5 miss or must_not violation):")
+            for r in fails:
+                print(f"\n  [{r['id']}] {r['query']}")
+                print(f"    expected:  {r['expected']}")
+                if r["must_not"]:
+                    print(f"    must_not:  {r['must_not']}")
+                print(f"    top-5:     {r['top_names'][:5]}")
+                if r["must_not_violations_at_5"]:
+                    print(f"    violated:  {r['must_not_violations_at_5']}")
+
+    print("\n=== AGGREGATES ===")
+    print(f"recall@5           : {_fmt_pct(report.recall_at_5)}  ({report.passed}/{report.total_queries} queries retrieved at least one expected memory in top-5)")
+    print(f"recall@10          : {_fmt_pct(report.recall_at_10)}")
+    print(f"MRR                : {report.mrr:.3f}")
+    print(f"must_not violations: {report.must_not_violations}  (lifecycle signal — should be 0 after Phase 1)")
+    print(f"passed / failed    : {report.passed} / {report.failed}")
+    print()
+
+
+def print_diff(current: EvalReport, baseline: dict) -> None:
+    def delta(k: str) -> str:
+        cur = getattr(current, k)
+        base = baseline.get(k, 0)
+        d = cur - base
+        sign = "+" if d >= 0 else ""
+        return f"{cur:.3f}  (baseline {base:.3f}, {sign}{d:.3f})"
+
+    print("=== DELTA vs baseline.json ===")
+    print(f"baseline saved : {baseline.get('timestamp', '?')}")
+    print(f"recall@5       : {delta('recall_at_5')}")
+    print(f"recall@10      : {delta('recall_at_10')}")
+    print(f"MRR            : {delta('mrr')}")
+    print(f"must_not viol  : {current.must_not_violations}  (baseline {baseline.get('must_not_violations', '?')})")
+    print()
+
+    # per-query regression
+    base_results = {r["id"]: r for r in baseline.get("results", [])}
+    regressed = []
+    improved = []
+    for r in current.results:
+        br = base_results.get(r["id"])
+        if not br:
+            continue
+        if br["passed"] and not r["passed"]:
+            regressed.append(r["id"])
+        elif not br["passed"] and r["passed"]:
+            improved.append(r["id"])
+    if regressed:
+        print(f"REGRESSIONS: {regressed}")
+    if improved:
+        print(f"IMPROVEMENTS: {improved}")
+    if not regressed and not improved:
+        print("(no per-query status changes vs baseline)")
+    print()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--save-baseline", action="store_true",
+                    help="Overwrite tests/memory-eval/baseline.json with this run's results")
+    ap.add_argument("--diff", choices=["baseline"],
+                    help="Print delta vs baseline.json")
+    ap.add_argument("--quiet", action="store_true")
+    ap.add_argument("--queries", default=None,
+                    help="Path to queries.yaml (default: tests/memory-eval/queries.yaml)")
+    args = ap.parse_args()
+
+    _load_env()
+
+    repo = Path(__file__).resolve().parent.parent
+    queries_path = Path(args.queries) if args.queries else repo / "tests" / "memory-eval" / "queries.yaml"
+    baseline_path = repo / "tests" / "memory-eval" / "baseline.json"
+
+    import yaml
+    with queries_path.open("r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+    queries = doc["queries"]
+
+    try:
+        from supabase import create_client
+    except ImportError:
+        print("ERROR: supabase package not installed in venv", file=sys.stderr)
+        return 2
+
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        print("ERROR: SUPABASE_URL / SUPABASE_KEY not set", file=sys.stderr)
+        return 2
+    client = create_client(url, key)
+
+    report = asyncio.run(run_all(queries, client))
+    print_report(report, quiet=args.quiet)
+
+    if args.diff == "baseline":
+        if not baseline_path.exists():
+            print(f"(no baseline at {baseline_path} — run --save-baseline first)")
+        else:
+            with baseline_path.open("r", encoding="utf-8") as f:
+                baseline = json.load(f)
+            print_diff(report, baseline)
+
+    if args.save_baseline:
+        baseline_path.parent.mkdir(parents=True, exist_ok=True)
+        with baseline_path.open("w", encoding="utf-8") as f:
+            json.dump(asdict(report), f, indent=2, ensure_ascii=False)
+        print(f"Baseline saved to {baseline_path}")
+
+    # exit code: 0 if all queries passed, 1 otherwise — CI-friendly
+    return 0 if report.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/memory-eval/README.md
+++ b/tests/memory-eval/README.md
@@ -1,0 +1,71 @@
+# Memory recall eval
+
+Measures recall quality of the memory system against a live Supabase corpus.
+Used to quantify each phase of the memory overhaul (see Osasuwu/jarvis#185 and
+[docs/design/memory-overhaul.md](../../docs/design/memory-overhaul.md)).
+
+## Run
+
+```bash
+# from repo root, with .venv activated
+python scripts/eval-recall.py                  # show per-query + aggregates
+python scripts/eval-recall.py --quiet          # aggregates only
+python scripts/eval-recall.py --save-baseline  # overwrite baseline.json
+python scripts/eval-recall.py --diff baseline  # compare to saved baseline
+```
+
+Requires `VOYAGE_API_KEY`, `SUPABASE_URL`, `SUPABASE_KEY` in `.env`.
+
+## Metrics
+
+| metric | meaning | target |
+|---|---|---|
+| `recall@5`  | fraction of queries where ≥1 expected memory is in top-5 | drive up |
+| `recall@10` | same, top-10                                              | drive up |
+| `MRR`       | mean reciprocal rank of first expected hit (0 if no hit)   | drive up |
+| `must_not violations` | queries where a superseded/archived memory surfaced in top-5 | drive to 0 |
+
+`must_not` is the **lifecycle signal**. Phase 0.5 baseline will have violations
+(we have no supersedes filter yet). Phase 1 is expected to drive this to 0.
+
+## Query set
+
+See [queries.yaml](queries.yaml). 20 queries across:
+
+- `direct` — unique memory, name-based query
+- `topic` — multiple valid memories on a topic
+- `behavior` — feedback/rules
+- `reference` — research digests
+- `user` — owner profile
+- `lifecycle` — **stress the superseded/stale handling** — expected memory
+  must surface AND the superseded version must NOT surface in top-5
+
+## Adding queries
+
+- Use memory `name` not `id` (survives ID churn)
+- Keep queries short-ish — real recall happens from fragmentary user prompts
+- Mix Russian + English (we work bilingually)
+- If a query exposes a new lifecycle problem, tag `kind: lifecycle` and add
+  `must_not` names
+
+## Phase workflow
+
+1. Before a phase:  `python scripts/eval-recall.py --diff baseline`
+2. Do the phase work.
+3. After the phase:  `python scripts/eval-recall.py --diff baseline`
+4. If phase succeeded (delta positive, no regressions):
+   `python scripts/eval-recall.py --save-baseline`
+5. Commit `baseline.json` alongside the phase PR — it's the quantitative
+   record of what the phase bought us.
+
+## Design notes
+
+The harness deliberately **duplicates** the recall pipeline constants from
+`mcp-memory/server.py` instead of importing them. This means:
+
+- Eval is independent of server.py's MCP/async wiring
+- When server.py's pipeline changes, the delta in eval output **is** the
+  measurement we want
+- When constants should follow server.py verbatim (e.g. Phase 0 adds new
+  columns but same constants), keep in sync manually — there's a comment at
+  the top of eval-recall.py flagging this

--- a/tests/memory-eval/baseline.json
+++ b/tests/memory-eval/baseline.json
@@ -1,0 +1,606 @@
+{
+  "timestamp": "2026-04-18T08:14:46.465264+00:00",
+  "corpus_size": 289,
+  "total_queries": 20,
+  "recall_at_5": 0.8,
+  "recall_at_10": 0.9,
+  "mrr": 0.5519444444444445,
+  "must_not_violations": 2,
+  "passed": 15,
+  "failed": 5,
+  "results": [
+    {
+      "id": "q01",
+      "query": "VoyageAI rate limits tier paid",
+      "kind": "direct",
+      "expected": [
+        "feedback_voyage"
+      ],
+      "must_not": [],
+      "top_names": [
+        "feedback_voyage"
+      ],
+      "first_hit_rank": 1,
+      "hits_at_5": [
+        "feedback_voyage"
+      ],
+      "hits_at_10": [
+        "feedback_voyage"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q02",
+      "query": "Claude Max subscription tokens",
+      "kind": "direct",
+      "expected": [
+        "claude_max_upgrade"
+      ],
+      "must_not": [],
+      "top_names": [
+        "jarvis_event_driven_architecture",
+        "team_agent_v2_plan_complete",
+        "like_spotify_cross_device_simplified",
+        "claude_max_upgrade",
+        "scheduled_tasks_subscription_not_api",
+        "claudemd_consolidation_2026_04_08",
+        "like_spotify_tech_profile",
+        "planned_integrations_digital_twin"
+      ],
+      "first_hit_rank": 4,
+      "hits_at_5": [
+        "claude_max_upgrade"
+      ],
+      "hits_at_10": [
+        "claude_max_upgrade"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q03",
+      "query": "TDD сначала пишем тест который падает",
+      "kind": "direct",
+      "expected": [
+        "bug_fix_reproduce_first"
+      ],
+      "must_not": [],
+      "top_names": [
+        "sand_direction_top_down",
+        "bug_fix_reproduce_first",
+        "redrobot_sergazy_feedback_apr8",
+        "zigzag_removed_from_escalation",
+        "redrobot_agile_switch",
+        "redrobot_schedule_apr8",
+        "read_code_before_implementing",
+        "deficit_first_bulk_planner",
+        "quality_over_speed",
+        "ux_ui_principles_always"
+      ],
+      "first_hit_rank": 2,
+      "hits_at_5": [
+        "bug_fix_reproduce_first"
+      ],
+      "hits_at_10": [
+        "bug_fix_reproduce_first"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q04",
+      "query": "always commit and push",
+      "kind": "direct",
+      "expected": [
+        "always_commit_and_push"
+      ],
+      "must_not": [],
+      "top_names": [
+        "always_commit_and_push",
+        "review_auto_fix_workflow",
+        "redrobot_hygiene_remaining_2026_04_18",
+        "jarvis_public_release_v020",
+        "reflect_apr10_full_day",
+        "redrobot_stash_and_milestone_cleanup_candidates",
+        "owner_profile",
+        "pycache_after_changes",
+        "open_source_quality_standard",
+        "docs_in_wiki"
+      ],
+      "first_hit_rank": 1,
+      "hits_at_5": [
+        "always_commit_and_push"
+      ],
+      "hits_at_10": [
+        "always_commit_and_push"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q05",
+      "query": "act as senior engineer not executor",
+      "kind": "direct",
+      "expected": [
+        "be_the_manager"
+      ],
+      "must_not": [],
+      "top_names": [
+        "milestone_structure_v2",
+        "be_the_manager",
+        "instructions_overhaul_2026_04_01",
+        "pillar_scope_and_pm_process",
+        "owner_claude_code_setup",
+        "sand_physics_architecture_2026_04_06"
+      ],
+      "first_hit_rank": 2,
+      "hits_at_5": [
+        "be_the_manager"
+      ],
+      "hits_at_10": [
+        "be_the_manager"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q06",
+      "query": "Jarvis architecture direction v2",
+      "kind": "topic",
+      "expected": [
+        "architecture_final",
+        "jarvis_v2_multiagent_direction",
+        "jarvis_wrapping_direction"
+      ],
+      "must_not": [],
+      "top_names": [
+        "jarvis_v2_vision",
+        "jarvis_v2_hybrid_agile",
+        "jarvis_vs_team_agent",
+        "jarvis_stays_goals_not_agile",
+        "jarvis_wrapping_direction",
+        "multiagent_pm_architecture_vision",
+        "jarvis_v2_multiagent_direction",
+        "no_deterministic_pipelines",
+        "research_jarvis_meta_agent",
+        "docs_in_wiki"
+      ],
+      "first_hit_rank": 5,
+      "hits_at_5": [
+        "jarvis_wrapping_direction"
+      ],
+      "hits_at_10": [
+        "jarvis_wrapping_direction",
+        "jarvis_v2_multiagent_direction"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q07",
+      "query": "autonomous loop design",
+      "kind": "topic",
+      "expected": [
+        "autonomous_loop_hygiene_sweep_v1",
+        "autonomous_loop_v1_architecture"
+      ],
+      "must_not": [],
+      "top_names": [
+        "autonomous_loop_v1_architecture",
+        "no_deterministic_pipelines",
+        "autonomous_loop_hygiene_sweep_v1",
+        "local_scheduled_tasks_only",
+        "autonomous_action_log",
+        "milestone_vs_pillar_hygiene",
+        "pm_dispatch_v1_architecture",
+        "autonomous_fixing_mode",
+        "working_state_redrobot",
+        "autonomous_long_sessions"
+      ],
+      "first_hit_rank": 1,
+      "hits_at_5": [
+        "autonomous_loop_v1_architecture",
+        "autonomous_loop_hygiene_sweep_v1"
+      ],
+      "hits_at_10": [
+        "autonomous_loop_v1_architecture",
+        "autonomous_loop_hygiene_sweep_v1"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q08",
+      "query": "memory server improvements pgvector",
+      "kind": "topic",
+      "expected": [
+        "memory_2_0_implementation",
+        "memory_server_v2_improvements"
+      ],
+      "must_not": [],
+      "top_names": [
+        "memory_server_v2_improvements",
+        "supabase_custom_mcp_preferred",
+        "memory_alternatives",
+        "working_state_jarvis",
+        "memory_2_0_implementation",
+        "nightly_mcp_max_result_size",
+        "owner_prefers_mcp_over_skills",
+        "linked_dedup_fix",
+        "self_hosted_postgres_future_plan",
+        "memory_graph_tool_added"
+      ],
+      "first_hit_rank": 1,
+      "hits_at_5": [
+        "memory_server_v2_improvements",
+        "memory_2_0_implementation"
+      ],
+      "hits_at_10": [
+        "memory_server_v2_improvements",
+        "memory_2_0_implementation"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q09",
+      "query": "delegating to subagents best practices",
+      "kind": "topic",
+      "expected": [
+        "agent_delegation_precision",
+        "delegate_frontend_to_subagents",
+        "lessons_agent_delegation"
+      ],
+      "must_not": [],
+      "top_names": [
+        "lessons_agent_delegation",
+        "delegate_frontend_to_subagents",
+        "verify_agent_findings_against_memory",
+        "jarvis_scalable_agent_system",
+        "prefer_agents_for_parallel_bugs",
+        "pm_dispatch_v1_architecture",
+        "pm_methodology_and_delegation",
+        "managed_agents_wait_and_see",
+        "claude_code_capabilities",
+        "review_before_push"
+      ],
+      "first_hit_rank": 1,
+      "hits_at_5": [
+        "lessons_agent_delegation",
+        "delegate_frontend_to_subagents"
+      ],
+      "hits_at_10": [
+        "lessons_agent_delegation",
+        "delegate_frontend_to_subagents"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q10",
+      "query": "Claude Code native capabilities MCP hooks skills",
+      "kind": "topic",
+      "expected": [
+        "claude_code_capabilities"
+      ],
+      "must_not": [],
+      "top_names": [
+        "checkpoint_skill_architecture",
+        "owner_prefers_mcp_over_skills",
+        "jarvis_wrapping_direction",
+        "nightly_mcp_max_result_size",
+        "claude_code_capabilities",
+        "mcp_stack_2026_03_31",
+        "pm_dispatch_v1_architecture",
+        "research_jarvis_meta_agent",
+        "use_playwright_for_testing",
+        "competitive_landscape_multi_agent_2026"
+      ],
+      "first_hit_rank": 5,
+      "hits_at_5": [
+        "claude_code_capabilities"
+      ],
+      "hits_at_10": [
+        "claude_code_capabilities"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q11",
+      "query": "recall memory before acting",
+      "kind": "behavior",
+      "expected": [
+        "always_recall_before_action"
+      ],
+      "must_not": [],
+      "top_names": [
+        "proactive_goal_tracking",
+        "verify_agent_findings_against_memory",
+        "nightly_research_sql_fallback",
+        "check_diagnostics_diversity",
+        "owner_thinks_architecturally",
+        "intel_claude_code_w14_2026_04_04",
+        "research_skill_firecrawl_v2",
+        "pretooluse_action_triggers_idea"
+      ],
+      "first_hit_rank": null,
+      "hits_at_5": [],
+      "hits_at_10": [],
+      "must_not_violations_at_5": [],
+      "passed": false
+    },
+    {
+      "id": "q12",
+      "query": "не галлюцинируй скриншоты",
+      "kind": "behavior",
+      "expected": [
+        "dont_hallucinate_screenshots"
+      ],
+      "must_not": [],
+      "top_names": [
+        "redrobot_sergazy_feedback_apr8",
+        "sand_direction_top_down",
+        "redrobot_agile_switch",
+        "pillar_is_not_one_task",
+        "ux_ui_principles_always",
+        "read_code_before_implementing",
+        "deficit_first_bulk_planner",
+        "repo_improve_deferred",
+        "dont_hallucinate_screenshots",
+        "planned_integrations_digital_twin"
+      ],
+      "first_hit_rank": 9,
+      "hits_at_5": [],
+      "hits_at_10": [
+        "dont_hallucinate_screenshots"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": false
+    },
+    {
+      "id": "q13",
+      "query": "autonomous mode keep going don't stop",
+      "kind": "behavior",
+      "expected": [
+        "autonomous_fixing_mode",
+        "autonomous_long_sessions"
+      ],
+      "must_not": [],
+      "top_names": [
+        "working_state_redrobot",
+        "autonomous_loop_v1_architecture",
+        "autonomous_fixing_mode",
+        "autonomous_action_log",
+        "autonomous_long_sessions",
+        "uw_madison_blade_control",
+        "move_curve_caution",
+        "nn_optimization_roadmap",
+        "autonomous_loop_hygiene_sweep_v1",
+        "parallel_simulation_during_execution"
+      ],
+      "first_hit_rank": 3,
+      "hits_at_5": [
+        "autonomous_fixing_mode",
+        "autonomous_long_sessions"
+      ],
+      "hits_at_10": [
+        "autonomous_fixing_mode",
+        "autonomous_long_sessions"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q14",
+      "query": "check diagnostics for value diversity",
+      "kind": "behavior",
+      "expected": [
+        "check_diagnostics_diversity"
+      ],
+      "must_not": [],
+      "top_names": [
+        "check_diagnostics_diversity",
+        "pipeline_verification_mandatory",
+        "bug_analysis_575_576_577",
+        "risk_radar_last_run",
+        "bug_fix_reproduce_first"
+      ],
+      "first_hit_rank": 1,
+      "hits_at_5": [
+        "check_diagnostics_diversity"
+      ],
+      "hits_at_10": [
+        "check_diagnostics_diversity"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q15",
+      "query": "multi-agent frameworks landscape comparison",
+      "kind": "reference",
+      "expected": [
+        "competitive_landscape_multi_agent_2026"
+      ],
+      "must_not": [],
+      "top_names": [
+        "mcp_stack_2026_03_31",
+        "jarvis_scalable_agent_system",
+        "competitive_landscape_multi_agent_2026",
+        "research_jarvis_meta_agent",
+        "research_pillar7_multi_agent_frameworks",
+        "jarvis_v2_vision",
+        "managed_agents_wait_and_see",
+        "multiagent_pm_architecture_vision",
+        "team_ai_agent_project_initiated",
+        "lessons_agent_delegation"
+      ],
+      "first_hit_rank": 3,
+      "hits_at_5": [
+        "competitive_landscape_multi_agent_2026"
+      ],
+      "hits_at_10": [
+        "competitive_landscape_multi_agent_2026"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q16",
+      "query": "Telegram Claude integration channels",
+      "kind": "reference",
+      "expected": [
+        "claude_code_channels"
+      ],
+      "must_not": [],
+      "top_names": [
+        "claude_code_channels",
+        "telegram_mcp_integration",
+        "lesson_cloud_mcp_limitations",
+        "lessons_cloud_infrastructure",
+        "architecture_final",
+        "team_knowledge_sharing_research_2026",
+        "jarvis_v2_infra_flexibility",
+        "team_agent_complement_not_restrict",
+        "windows_claude_installation",
+        "supabase_connector_status"
+      ],
+      "first_hit_rank": 1,
+      "hits_at_5": [
+        "claude_code_channels"
+      ],
+      "hits_at_10": [
+        "claude_code_channels"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    },
+    {
+      "id": "q17",
+      "query": "DnD dungeon master hobby",
+      "kind": "user",
+      "expected": [
+        "dnd_dm_philosophy",
+        "dnd_dm_role"
+      ],
+      "must_not": [],
+      "top_names": [
+        "nightly_research_sql_fallback",
+        "proactive_goal_tracking",
+        "owner_profile",
+        "sculpture_vision_system",
+        "research_skill_firecrawl_v2",
+        "owner_thinks_architecturally",
+        "research_threejs_heightmap_visualization",
+        "intel_claude_code_w14_2026_04_04",
+        "redrobot_repo_location"
+      ],
+      "first_hit_rank": null,
+      "hits_at_5": [],
+      "hits_at_10": [],
+      "must_not_violations_at_5": [],
+      "passed": false
+    },
+    {
+      "id": "q18",
+      "query": "planning process Jarvis agile or goals",
+      "kind": "lifecycle",
+      "expected": [
+        "jarvis_v2_hybrid_agile"
+      ],
+      "must_not": [
+        "jarvis_stays_goals_not_agile"
+      ],
+      "top_names": [
+        "jarvis_stays_goals_not_agile",
+        "jarvis_v2_hybrid_agile",
+        "jarvis_v2_vision",
+        "goals_system_first_real_goals",
+        "no_deterministic_pipelines",
+        "autonomous_action_log",
+        "goals_system_v1",
+        "redrobot_agile_full_migration",
+        "jarvis_vs_team_agent",
+        "working_state_jarvis"
+      ],
+      "first_hit_rank": 2,
+      "hits_at_5": [
+        "jarvis_v2_hybrid_agile"
+      ],
+      "hits_at_10": [
+        "jarvis_v2_hybrid_agile"
+      ],
+      "must_not_violations_at_5": [
+        "jarvis_stays_goals_not_agile"
+      ],
+      "passed": false
+    },
+    {
+      "id": "q19",
+      "query": "как Jarvis планирует работу сейчас",
+      "kind": "lifecycle",
+      "expected": [
+        "jarvis_v2_hybrid_agile"
+      ],
+      "must_not": [
+        "jarvis_stays_goals_not_agile"
+      ],
+      "top_names": [
+        "jarvis_vs_team_agent",
+        "jarvis_wrapping_direction",
+        "jarvis_stays_goals_not_agile",
+        "pm_autonomy_redrobot",
+        "research_jarvis_meta_agent",
+        "multiagent_pm_architecture_vision",
+        "jarvis_public_release_v020",
+        "jarvis_v2_vision",
+        "jarvis_v2_hybrid_agile",
+        "no_jarvis_in_team_docs"
+      ],
+      "first_hit_rank": 9,
+      "hits_at_5": [],
+      "hits_at_10": [
+        "jarvis_v2_hybrid_agile"
+      ],
+      "must_not_violations_at_5": [
+        "jarvis_stays_goals_not_agile"
+      ],
+      "passed": false
+    },
+    {
+      "id": "q20",
+      "query": "cloud scheduled tasks remote MCP",
+      "kind": "topic",
+      "expected": [
+        "lesson_cloud_mcp_limitations",
+        "local_scheduled_tasks_only"
+      ],
+      "must_not": [],
+      "top_names": [
+        "local_scheduled_tasks_only",
+        "event_driven_perception_v1",
+        "lesson_cloud_mcp_limitations",
+        "autonomous_loop_v1_architecture",
+        "pm_dispatch_v1_architecture",
+        "mcp_stack_2026_03_31",
+        "checkpoint_skill_architecture",
+        "claude_code_capabilities",
+        "scheduled_tasks_subscription_not_api",
+        "sentry_mcp_pending"
+      ],
+      "first_hit_rank": 1,
+      "hits_at_5": [
+        "local_scheduled_tasks_only",
+        "lesson_cloud_mcp_limitations"
+      ],
+      "hits_at_10": [
+        "local_scheduled_tasks_only",
+        "lesson_cloud_mcp_limitations"
+      ],
+      "must_not_violations_at_5": [],
+      "passed": true
+    }
+  ]
+}

--- a/tests/memory-eval/queries.yaml
+++ b/tests/memory-eval/queries.yaml
@@ -1,0 +1,127 @@
+# Memory recall eval set
+#
+# 20 hand-curated queries against the live Supabase corpus. Each query lists
+# the memory names that *should* appear in the top-k results. Metrics we score:
+#   - recall@5:  did at least one expected memory land in top 5?
+#   - recall@10: top 10?
+#   - mrr: reciprocal rank of the first expected hit (0 if none)
+#
+# The expected memories use `name` (not `id`) so the set survives ID churn. The
+# harness resolves names -> ids at runtime.
+#
+# Guidelines for adding queries:
+#   - Mix short (2-3 words) and long (natural-language) forms
+#   - Include both Russian and English
+#   - Tag `lifecycle: true` for queries that stress stale/superseded handling
+#     (these are the Phase 1+ improvement targets)
+#   - `expected` is a list; any match counts for recall. Use `must_not` for
+#     memories that *should not* surface (e.g. superseded).
+
+queries:
+  # --- Direct retrieval: unique, well-known memories ---
+  - id: q01
+    query: "VoyageAI rate limits tier paid"
+    expected: [feedback_voyage]
+    kind: direct
+
+  - id: q02
+    query: "Claude Max subscription tokens"
+    expected: [claude_max_upgrade]
+    kind: direct
+
+  - id: q03
+    query: "TDD сначала пишем тест который падает"
+    expected: [bug_fix_reproduce_first]
+    kind: direct
+
+  - id: q04
+    query: "always commit and push"
+    expected: [always_commit_and_push]
+    kind: direct
+
+  - id: q05
+    query: "act as senior engineer not executor"
+    expected: [be_the_manager]
+    kind: direct
+
+  # --- Topic queries: multiple valid memories ---
+  - id: q06
+    query: "Jarvis architecture direction v2"
+    expected: [jarvis_v2_multiagent_direction, jarvis_wrapping_direction, architecture_final]
+    kind: topic
+
+  - id: q07
+    query: "autonomous loop design"
+    expected: [autonomous_loop_v1_architecture, autonomous_loop_hygiene_sweep_v1]
+    kind: topic
+
+  - id: q08
+    query: "memory server improvements pgvector"
+    expected: [memory_server_v2_improvements, memory_2_0_implementation]
+    kind: topic
+
+  - id: q09
+    query: "delegating to subagents best practices"
+    expected: [lessons_agent_delegation, agent_delegation_precision, delegate_frontend_to_subagents]
+    kind: topic
+
+  - id: q10
+    query: "Claude Code native capabilities MCP hooks skills"
+    expected: [claude_code_capabilities]
+    kind: topic
+
+  # --- Behavioral/feedback queries ---
+  - id: q11
+    query: "recall memory before acting"
+    expected: [always_recall_before_action]
+    kind: behavior
+
+  - id: q12
+    query: "не галлюцинируй скриншоты"
+    expected: [dont_hallucinate_screenshots]
+    kind: behavior
+
+  - id: q13
+    query: "autonomous mode keep going don't stop"
+    expected: [autonomous_fixing_mode, autonomous_long_sessions]
+    kind: behavior
+
+  - id: q14
+    query: "check diagnostics for value diversity"
+    expected: [check_diagnostics_diversity]
+    kind: behavior
+
+  # --- Reference queries ---
+  - id: q15
+    query: "multi-agent frameworks landscape comparison"
+    expected: [competitive_landscape_multi_agent_2026]
+    kind: reference
+
+  - id: q16
+    query: "Telegram Claude integration channels"
+    expected: [claude_code_channels]
+    kind: reference
+
+  # --- User profile queries ---
+  - id: q17
+    query: "DnD dungeon master hobby"
+    expected: [dnd_dm_role, dnd_dm_philosophy]
+    kind: user
+
+  # --- LIFECYCLE queries (Phase 1+ targets) ---
+  - id: q18
+    query: "planning process Jarvis agile or goals"
+    expected: [jarvis_v2_hybrid_agile]
+    must_not: [jarvis_stays_goals_not_agile]  # superseded
+    kind: lifecycle
+
+  - id: q19
+    query: "как Jarvis планирует работу сейчас"
+    expected: [jarvis_v2_hybrid_agile]
+    must_not: [jarvis_stays_goals_not_agile]
+    kind: lifecycle
+
+  - id: q20
+    query: "cloud scheduled tasks remote MCP"
+    expected: [lesson_cloud_mcp_limitations, local_scheduled_tasks_only]
+    kind: topic


### PR DESCRIPTION
## Summary

Phase 0.5 of the memory overhaul (#185). Measurement foundation before functional changes.

Closes #187

## Contents
- `docs/design/memory-overhaul.md` — research synthesis + 7-phase plan
- `tests/memory-eval/queries.yaml` — 20 queries (direct / topic / behavior / reference / user / lifecycle) with expected + must_not names
- `scripts/eval-recall.py` — recall@5, recall@10, MRR, must_not violations; supports --save-baseline / --diff baseline
- `tests/memory-eval/baseline.json` — captured baseline

## Baseline

```
recall@5:  80.0%  (15/20)
recall@10: 90.0%
MRR:       0.552
must_not violations: 2
```

The 2 violations: lifecycle queries where superseded `jarvis_stays_goals_not_agile` outranks its replacement `jarvis_v2_hybrid_agile`. Phase 1 target.

The 3 non-lifecycle misses (q11/q12/q17): bilingual + near-synonym gaps. Phase 3 target.

## Test plan
- [x] Harness runs end-to-end against live Supabase
- [x] 20 queries resolve; metrics match hand-computation
- [x] --save-baseline produces valid JSON
- [x] --diff baseline command registered

## Next
- Phase 0: schema migration (bi-temporal + provenance + confidence + embedding_version)
- Phase 1: recall correctness — must_not violations → 0

Parent: #185