### PR TITLE
feat(memory): Phase 1 — recall correctness

### DIFF
--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -581,3 +581,118 @@ from memory_links l
 where l.link_type = 'supersedes'
   and l.target_id = m.id
   and m.superseded_by is null;
+
+
+-- =========================================================================
+-- Phase 1 (memory overhaul, Osasuwu/jarvis#185) — recall correctness
+--
+-- Goal: drive must_not violations to 0, stabilize MRR.
+--
+-- Changes:
+--   1. Split timestamps properly:
+--      - updated_at: bumped on any UPDATE (existing trigger, unchanged)
+--      - content_updated_at: bumped only when name/description/content/tags
+--        actually change (new trigger). This becomes the decay axis.
+--      - last_accessed_at: set by touch_memories only (existing).
+--      The old behavior bumped updated_at on every recall (via touch), which
+--      meant temporal scoring reshuffled itself on every run → MRR noise.
+--   2. Add default recall filter: exclude expired_at IS NOT NULL,
+--      superseded_by IS NOT NULL, and (valid_to IS NOT NULL AND valid_to <= now()).
+--   3. Add show_history flag to bypass the filter (for audit/debug queries).
+--   4. Return content_updated_at from RPCs so server.py can use it for decay.
+-- =========================================================================
+
+-- Trigger: only bump content_updated_at when the memory's content-bearing
+-- fields actually change. This is the field Phase 1 recall uses for decay,
+-- so it must not be perturbed by touch_memories (which updates only
+-- last_accessed_at but fires the generic update trigger).
+create or replace function update_content_updated_at()
+returns trigger as $$
+begin
+  if (new.name is distinct from old.name)
+     or (new.description is distinct from old.description)
+     or (new.content is distinct from old.content)
+     or (new.tags is distinct from old.tags)
+  then
+    new.content_updated_at = now();
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists memories_content_updated_at on memories;
+create trigger memories_content_updated_at
+  before update on memories
+  for each row execute function update_content_updated_at();
+
+-- Replace match_memories: add lifecycle filter + show_history + return
+-- content_updated_at. Signature adds two trailing optional params so
+-- existing callers keep working.
+drop function if exists match_memories(vector, int, float, text, text);
+drop function if exists match_memories(vector, int, float, text, text, boolean);
+create or replace function match_memories(
+    query_embedding vector,
+    match_limit int default 10,
+    similarity_threshold float default 0.3,
+    filter_project text default null,
+    filter_type text default null,
+    show_history boolean default false
+)
+returns table(
+    id uuid, name text, type text, project text,
+    description text, content text, tags text[],
+    updated_at timestamptz, content_updated_at timestamptz,
+    last_accessed_at timestamptz,
+    similarity float
+)
+language sql stable as $$
+    select m.id, m.name, m.type, m.project,
+           m.description, m.content, m.tags,
+           m.updated_at, m.content_updated_at, m.last_accessed_at,
+           1 - (m.embedding <=> query_embedding) as similarity
+    from memories m
+    where m.embedding is not null
+      and 1 - (m.embedding <=> query_embedding) >= similarity_threshold
+      and (filter_project is null or m.project = filter_project or m.project is null)
+      and (filter_type is null or m.type = filter_type)
+      and (show_history
+           or (m.expired_at is null
+               and m.superseded_by is null
+               and (m.valid_to is null or m.valid_to > now())))
+    order by m.embedding <=> query_embedding
+    limit match_limit;
+$$;
+
+-- Replace keyword_search_memories: same lifecycle filter + content_updated_at.
+drop function if exists keyword_search_memories(text, int, text, text);
+drop function if exists keyword_search_memories(text, int, text, text, boolean);
+create or replace function keyword_search_memories(
+    search_query text,
+    match_limit int default 10,
+    filter_project text default null,
+    filter_type text default null,
+    show_history boolean default false
+)
+returns table(
+    id uuid, name text, type text, project text,
+    description text, content text, tags text[],
+    updated_at timestamptz, content_updated_at timestamptz,
+    last_accessed_at timestamptz,
+    rank real
+)
+language sql stable as $$
+    select m.id, m.name, m.type, m.project,
+           m.description, m.content, m.tags,
+           m.updated_at, m.content_updated_at, m.last_accessed_at,
+           ts_rank(m.fts, websearch_to_tsquery('english', search_query)) as rank
+    from memories m
+    where m.fts @@ websearch_to_tsquery('english', search_query)
+      and (filter_project is null or m.project = filter_project or m.project is null)
+      and (filter_type is null or m.type = filter_type)
+      and (show_history
+           or (m.expired_at is null
+               and m.superseded_by is null
+               and (m.valid_to is null or m.valid_to > now())))
+    order by rank desc
+    limit match_limit;
+$$;

--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -424,6 +424,15 @@ async def list_tools() -> list[Tool]:
                         "description": "Include 1-hop linked memories in results",
                         "default": False,
                     },
+                    "show_history": {
+                        "type": "boolean",
+                        "description": (
+                            "Include superseded/expired memories. Default false "
+                            "(live memory only). Set true for audit/debug to see "
+                            "what beliefs were once held."
+                        ),
+                        "default": False,
+                    },
                 },
             },
         ),
@@ -1127,13 +1136,14 @@ async def _handle_recall(args: dict) -> list[TextContent]:
     limit = args.get("limit", 10)
 
     include_links = args.get("include_links", False)
+    show_history = args.get("show_history", False)
 
     # Hybrid search: combine semantic + keyword results via RRF + temporal scoring
     if query_text:
         query_embedding = await _embed_query(query_text)
         if query_embedding is not None:
             rows, results = await _hybrid_recall(
-                client, query_embedding, query_text, project, mem_type, limit, include_links
+                client, query_embedding, query_text, project, mem_type, limit, include_links, show_history
             )
             # Track reads (fire-and-forget)
             ids = [r["id"] for r in rows if r.get("id")]
@@ -1153,12 +1163,16 @@ async def _handle_recall(args: dict) -> list[TextContent]:
 
 async def _hybrid_recall(
     client, query_embedding: list[float], query_text: str,
-    project, mem_type, limit: int, include_links: bool = False
+    project, mem_type, limit: int, include_links: bool = False,
+    show_history: bool = False,
 ) -> list[TextContent]:
     """Hybrid search: server-side pgvector semantic + pg_trgm keyword, merged via RRF.
 
     Memory 2.0: adds temporal scoring (recency × access frequency) and optional
     1-hop link expansion for graph-aware recall.
+
+    Phase 1: default filters out superseded/expired/valid_to-past memories via
+    the RPC's show_history=false path. Pass show_history=true to bypass.
     """
     try:
         # Fetch double the limit from each source to give RRF good candidates
@@ -1171,6 +1185,7 @@ async def _hybrid_recall(
             "similarity_threshold": SIMILARITY_THRESHOLD,
             "filter_project": project,
             "filter_type": mem_type,
+            "show_history": show_history,
         }).execute()
         semantic_rows = sem_result.data or []
 
@@ -1180,6 +1195,7 @@ async def _hybrid_recall(
             "match_limit": fetch_limit,
             "filter_project": project,
             "filter_type": mem_type,
+            "show_history": show_history,
         }).execute()
         keyword_rows = kw_result.data or []
 
@@ -1373,8 +1389,10 @@ def _apply_temporal_scoring(rows: list[dict]) -> list[dict]:
         mem_type = row.get("type", "decision")
         half_life = TEMPORAL_HALF_LIVES.get(mem_type, DEFAULT_HALF_LIFE)
 
-        # Parse updated_at
-        updated_str = row.get("updated_at", "")
+        # Parse content_updated_at (Phase 1: decay is driven by content edits,
+        # not any write — touch_memories bumps updated_at on every recall).
+        # Fall back to updated_at for rows backfilled before Phase 0.
+        updated_str = row.get("content_updated_at") or row.get("updated_at", "")
         try:
             updated = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
             days_since_update = max(0, (now - updated).total_seconds() / 86400)

--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from typing import Any
 
 # ---------------------------------------------------------------------------
-# Pipeline constants — mirrored from mcp-memory/server.py as of Phase 0.5.
+# Pipeline constants — mirrored from mcp-memory/server.py as of Phase 1.
 # When server.py changes, re-sync OR deliberately let them differ to measure.
 # ---------------------------------------------------------------------------
 SIMILARITY_THRESHOLD = 0.25
@@ -116,7 +116,10 @@ def _apply_temporal_scoring(rows: list[dict]) -> list[dict]:
         mem_type = row.get("type", "decision")
         half_life = TEMPORAL_HALF_LIVES.get(mem_type, DEFAULT_HALF_LIFE)
 
-        updated_str = row.get("updated_at") or ""
+        # Phase 1: decay is driven by content_updated_at (content changes),
+        # not updated_at (which gets bumped by every recall's touch_memories).
+        # Fall back to updated_at for rows without backfilled content_updated_at.
+        updated_str = row.get("content_updated_at") or row.get("updated_at") or ""
         try:
             updated = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
             days_since_update = max(0, (now - updated).total_seconds() / 86400)
@@ -180,6 +183,7 @@ async def run_query(client, q: dict) -> QueryResult:
         "similarity_threshold": SIMILARITY_THRESHOLD,
         "filter_project": None,
         "filter_type": None,
+        "show_history": False,
     }).execute()
     sem_rows = sem.data or []
 
@@ -188,6 +192,7 @@ async def run_query(client, q: dict) -> QueryResult:
         "match_limit": 20,
         "filter_project": None,
         "filter_type": None,
+        "show_history": False,
     }).execute()
     kw_rows = kw.data or []
 

--- a/tests/memory-eval/baseline.json
+++ b/tests/memory-eval/baseline.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-04-18T08:14:46.465264+00:00",
+  "timestamp": "2026-04-18T08:32:05.420190+00:00",
   "corpus_size": 289,
   "total_queries": 20,
   "recall_at_5": 0.8,
   "recall_at_10": 0.9,
-  "mrr": 0.5519444444444445,
-  "must_not_violations": 2,
-  "passed": 15,
-  "failed": 5,
+  "mrr": 0.5801388888888889,
+  "must_not_violations": 0,
+  "passed": 16,
+  "failed": 4,
   "results": [
     {
       "id": "q01",
@@ -71,12 +71,12 @@
         "bug_fix_reproduce_first",
         "redrobot_sergazy_feedback_apr8",
         "zigzag_removed_from_escalation",
-        "redrobot_agile_switch",
         "redrobot_schedule_apr8",
+        "redrobot_agile_switch",
         "read_code_before_implementing",
         "deficit_first_bulk_planner",
-        "quality_over_speed",
-        "ux_ui_principles_always"
+        "ux_ui_principles_always",
+        "_soft_delete_test"
       ],
       "first_hit_rank": 2,
       "hits_at_5": [
@@ -99,14 +99,14 @@
       "top_names": [
         "always_commit_and_push",
         "review_auto_fix_workflow",
+        "dedup_hook_live_test_should_block",
+        "reflect_apr10_full_day",
         "redrobot_hygiene_remaining_2026_04_18",
         "jarvis_public_release_v020",
-        "reflect_apr10_full_day",
-        "redrobot_stash_and_milestone_cleanup_candidates",
         "owner_profile",
-        "pycache_after_changes",
-        "open_source_quality_standard",
-        "docs_in_wiki"
+        "redrobot_stash_and_milestone_cleanup_candidates",
+        "no_hardcoded_context_in_claude_md",
+        "pycache_after_changes"
       ],
       "first_hit_rank": 1,
       "hits_at_5": [
@@ -158,15 +158,15 @@
         "jarvis_v2_vision",
         "jarvis_v2_hybrid_agile",
         "jarvis_vs_team_agent",
-        "jarvis_stays_goals_not_agile",
         "jarvis_wrapping_direction",
         "multiagent_pm_architecture_vision",
         "jarvis_v2_multiagent_direction",
         "no_deterministic_pipelines",
         "research_jarvis_meta_agent",
+        "pillar7_personal_vs_company_separation",
         "docs_in_wiki"
       ],
-      "first_hit_rank": 5,
+      "first_hit_rank": 4,
       "hits_at_5": [
         "jarvis_wrapping_direction"
       ],
@@ -405,7 +405,8 @@
         "pipeline_verification_mandatory",
         "bug_analysis_575_576_577",
         "risk_radar_last_run",
-        "bug_fix_reproduce_first"
+        "bug_fix_reproduce_first",
+        "_soft_delete_test"
       ],
       "first_hit_rank": 1,
       "hits_at_5": [
@@ -514,7 +515,6 @@
         "jarvis_stays_goals_not_agile"
       ],
       "top_names": [
-        "jarvis_stays_goals_not_agile",
         "jarvis_v2_hybrid_agile",
         "jarvis_v2_vision",
         "goals_system_first_real_goals",
@@ -523,19 +523,18 @@
         "goals_system_v1",
         "redrobot_agile_full_migration",
         "jarvis_vs_team_agent",
+        "multiagent_pm_architecture_vision",
         "working_state_jarvis"
       ],
-      "first_hit_rank": 2,
+      "first_hit_rank": 1,
       "hits_at_5": [
         "jarvis_v2_hybrid_agile"
       ],
       "hits_at_10": [
         "jarvis_v2_hybrid_agile"
       ],
-      "must_not_violations_at_5": [
-        "jarvis_stays_goals_not_agile"
-      ],
-      "passed": false
+      "must_not_violations_at_5": [],
+      "passed": true
     },
     {
       "id": "q19",
@@ -550,23 +549,21 @@
       "top_names": [
         "jarvis_vs_team_agent",
         "jarvis_wrapping_direction",
-        "jarvis_stays_goals_not_agile",
         "pm_autonomy_redrobot",
         "research_jarvis_meta_agent",
         "multiagent_pm_architecture_vision",
         "jarvis_public_release_v020",
         "jarvis_v2_vision",
         "jarvis_v2_hybrid_agile",
+        "no_deterministic_pipelines",
         "no_jarvis_in_team_docs"
       ],
-      "first_hit_rank": 9,
+      "first_hit_rank": 8,
       "hits_at_5": [],
       "hits_at_10": [
         "jarvis_v2_hybrid_agile"
       ],
-      "must_not_violations_at_5": [
-        "jarvis_stays_goals_not_agile"
-      ],
+      "must_not_violations_at_5": [],
       "passed": false
     },
     {


### PR DESCRIPTION
## Summary

Phase 1 of the memory overhaul (#185). Fixes lifecycle leakage and MRR noise.

Closes #190
Parent: #185

## Changes

### Schema (applied to Supabase as `phase_1_content_updated_at_trigger_and_lifecycle_filters`)

**New trigger** `update_content_updated_at` — only bumps `content_updated_at` when `name/description/content/tags` actually change. The generic `updated_at` trigger still fires on every UPDATE (including `touch_memories`), but `content_updated_at` is now a stable content-edit-time that decay scoring can trust.

**RPC changes** — `match_memories` and `keyword_search_memories` both:
- Add default filter: `expired_at IS NULL AND superseded_by IS NULL AND (valid_to IS NULL OR valid_to > now())`
- Add `show_history boolean default false` param to bypass the filter
- Return `content_updated_at` alongside existing columns

### Server

- `_apply_temporal_scoring` reads `content_updated_at` (falls back to `updated_at` for rows not yet covered by the Phase 0 backfill)
- `memory_recall` tool gains `show_history` input
- Plumbed through `_hybrid_recall`

### Eval

- `scripts/eval-recall.py` mirrors the RPC + decay changes
- `tests/memory-eval/baseline.json` updated to Phase 1 numbers

## Eval delta vs Phase 0 baseline

```
recall@5:             80.0%  (baseline 80.0%, +0.000)
recall@10:            90.0%  (baseline 90.0%, +0.000)
MRR:                  0.580  (baseline 0.552, +0.028)
must_not violations:  0      (baseline 2)

IMPROVEMENTS: ['q18']
REGRESSIONS:  []
```

**MRR stability verified** — two consecutive eval runs produced identical rankings. Phase 0 was showing ±0.1 run-to-run noise because every recall bumped `updated_at` → reshuffled temporal scoring. That feedback loop is now broken.

**q18 lifecycle query** — `jarvis_v2_hybrid_agile` jumps to rank 1 now that the superseded `jarvis_stays_goals_not_agile` is filtered out.

**q19 lifecycle query** — must_not cleared but the expected (`jarvis_v2_hybrid_agile`) still ranks #8 on the Russian query. Embedding quality / query rewriting is Phase 3 territory.

## Remaining failures (out of scope for Phase 1)

- q11, q12, q17 — genuine recall misses (embedding quality for behavioral/profile queries). Phase 2 (canonical form on write) + Phase 3 (query rewriting) target these.
- q19 — lifecycle cleared; recall quality is Phase 2/3.

## Trigger verification

Touching a memory via `touch_memories(array[id])` now only bumps `updated_at` and `last_accessed_at` — `content_updated_at` stays pinned at the last real content edit. Confirmed on `trajectory_planning_naive` and `team_knowledge_sharing_research_2026` after eval run.

## Test plan

- [x] Migration applied to live Supabase (project svwrzttdkxeselkpxfgm)
- [x] Trigger verified: touch doesn't bump content_updated_at
- [x] Eval `must_not violations` = 0 (was 2)
- [x] Eval MRR stable across runs (0.580, 0.580)
- [x] `recall@5` / `recall@10` unchanged (no new regressions)
- [x] schema.sql is re-runnable (uses `drop function if exists` + `create or replace`)

## Next

Phase 2: write-side ADD/UPDATE/DELETE/NOOP classifier (Haiku 4.5). Target q11/q17 via canonical-form consolidation.