### PR TITLE
feat(memory): Phase 2a — canonical embedding form + supersede column writes

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -184,6 +184,28 @@ VALID_GOAL_STATUSES = ("active", "achieved", "paused", "abandoned")
 
 SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
 
+# -- Canonical embed form (Phase 2a) ---------------------------------------
+
+def _canonical_embed_text(name: str, description: str, tags: list[str], content: str) -> str:
+    """Build the text used for embedding. Structured so name/tags get weight.
+
+    Why: a long-form memory whose key topic is in the name but whose content
+    drifts into narrative detail embeds poorly — name/tags get drowned out.
+    Prefixing them in a separate line gives them comparable weight under the
+    tokenizer.
+    """
+    parts: list[str] = []
+    if name:
+        parts.append(name.replace("_", " "))
+    if tags:
+        parts.append("tags: " + ", ".join(tags))
+    if description:
+        parts.append(description)
+    if content:
+        parts.append(content)
+    return "\n".join(p for p in parts if p).strip()
+
+
 # -- Memory 2.0: temporal scoring + auto-linking ----------------------------
 TEMPORAL_HALF_LIVES = {
     "project": 7, "reference": 30, "decision": 60,
@@ -385,6 +407,14 @@ async def list_tools() -> list[Tool]:
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "Tags for filtering (e.g. ['architecture', 'decision'])",
+                    },
+                    "source_provenance": {
+                        "type": "string",
+                        "description": (
+                            "Where this memory came from (URL, tool name, session id, "
+                            "actor). Populate when not self-evident. JTMS attribution — "
+                            "we can't revise what we can't attribute."
+                        ),
                     },
                 },
                 "required": ["type", "name", "content"],
@@ -1044,12 +1074,15 @@ async def _handle_store(args: dict) -> list[TextContent]:
     if project == "global":
         project = None  # "global" and null are synonymous — normalize to NULL in DB
     tags = args.get("tags", [])
+    source_provenance = args.get("source_provenance")
 
     if mem_type not in VALID_TYPES:
         return [TextContent(type="text", text=f"Invalid type: {mem_type}. Must be one of {VALID_TYPES}")]
 
-    # Generate embedding (async httpx — 5s timeout, falls back gracefully)
-    embed_text = f"{description}\n{content}".strip() if description else content
+    # Phase 2a: canonical-form embedding — include name + tags + description + content.
+    # Name and tags carry high-signal lexical cues that raw content often dilutes
+    # (long narrative memories where the key topic is only in the name).
+    embed_text = _canonical_embed_text(mem_name, description, tags, content)
     embedding = await _embed(embed_text)
 
     data = {
@@ -1061,9 +1094,13 @@ async def _handle_store(args: dict) -> list[TextContent]:
         "tags": tags,
         "deleted_at": None,  # clear soft-delete on store/upsert
     }
+    if source_provenance:
+        data["source_provenance"] = source_provenance
 
     if embedding is not None:
         data["embedding"] = embedding
+        data["embedding_model"] = VOYAGE_MODEL
+        data["embedding_version"] = "v2"  # Phase 2a canonical form
 
     embed_note = " (with embedding)" if embedding is not None else ""
 
@@ -1325,7 +1362,7 @@ async def _backfill_missing_embeddings(client, project) -> None:
     Batches all missing records into a single Voyage AI call.
     """
     try:
-        q = client.table("memories").select("id, description, content")
+        q = client.table("memories").select("id, name, description, tags, content")
         q = q.is_("embedding", "null").is_("deleted_at", "null")
         if project is not None:
             q = q.or_(f"project.eq.{project},project.is.null")
@@ -1333,26 +1370,44 @@ async def _backfill_missing_embeddings(client, project) -> None:
         if not rows:
             return
 
-        texts = [f"{r.get('description', '')}\n{r['content']}".strip() for r in rows]
+        # Phase 2a: canonical form (name + tags + description + content)
+        texts = [
+            _canonical_embed_text(r.get("name", ""), r.get("description", ""), r.get("tags") or [], r["content"])
+            for r in rows
+        ]
         embeddings = await _embed_batch(texts)
         if embeddings is None:
             return
 
         for mem, embedding in zip(rows, embeddings):
-            client.table("memories").update({"embedding": embedding}).eq("id", mem["id"]).execute()
+            client.table("memories").update({
+                "embedding": embedding,
+                "embedding_model": VOYAGE_MODEL,
+                "embedding_version": "v2",
+            }).eq("id", mem["id"]).execute()
     except Exception:
         pass  # fire-and-forget: silently swallow all errors so caller never fails
 
 
 async def _create_auto_links(client, stored_id: str, similar_rows: list[dict], mem_type: str) -> None:
-    """Fire-and-forget: create links between stored memory and similar ones."""
+    """Fire-and-forget: create links between stored memory and similar ones.
+
+    Phase 2a: supersession no longer gated on type=decision — any two memories
+    of the *same type* above SUPERSEDE_SIM_THRESHOLD are candidates. When
+    supersedes fires, also writes memories.superseded_by on the older row
+    (the link target) so Phase 1 recall filter picks it up immediately.
+    """
     try:
         links = []
+        supersede_target_ids: list[str] = []
         for row in similar_rows[:MAX_AUTO_LINKS]:
             sim = row.get("similarity", 0)
-            # Supersession: two decisions with very high similarity
-            if mem_type == "decision" and row.get("type") == "decision" and sim >= SUPERSEDE_SIM_THRESHOLD:
+            # Supersession: two memories of the same type with very high similarity.
+            # (Phase 2b classifier will replace this heuristic with an LLM decision.)
+            if row.get("type") == mem_type and sim >= SUPERSEDE_SIM_THRESHOLD:
                 link_type = "supersedes"
+                if row.get("id"):
+                    supersede_target_ids.append(row["id"])
             else:
                 link_type = "related"
             links.append({
@@ -1365,6 +1420,15 @@ async def _create_auto_links(client, stored_id: str, similar_rows: list[dict], m
             client.table("memory_links").upsert(
                 links, on_conflict="source_id,target_id,link_type"
             ).execute()
+        # Phase 1 recall filter reads memories.superseded_by, so denormalize
+        # supersedes edges onto the column. Only set when currently null to
+        # preserve an existing supersession chain if the target was already
+        # superseded by something else.
+        if supersede_target_ids:
+            client.table("memories").update({"superseded_by": stored_id}) \
+                .in_("id", supersede_target_ids) \
+                .is_("superseded_by", "null") \
+                .execute()
     except Exception:
         pass
 

--- a/scripts/reembed-canonical.py
+++ b/scripts/reembed-canonical.py
@@ -1,0 +1,114 @@
+"""Re-embed all memories with the Phase 2a canonical form.
+
+Reads name + description + tags + content from every non-deleted memory,
+batches through Voyage AI (voyage-3-lite), writes back embedding +
+embedding_model='voyage-3-lite' + embedding_version='v2'.
+
+Run once after Phase 2a code change. Idempotent: re-running just re-embeds.
+
+Usage:
+    python scripts/reembed-canonical.py                 # dry run: print what would change
+    python scripts/reembed-canonical.py --apply         # actually write
+
+Requires VOYAGE_API_KEY, SUPABASE_URL, SUPABASE_KEY.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Load .env
+try:
+    from dotenv import load_dotenv
+    here = Path(__file__).resolve().parent
+    for c in (here.parent / ".env", here.parent.parent / ".env"):
+        if c.exists():
+            load_dotenv(c)
+            break
+except ImportError:
+    pass
+
+import httpx
+from supabase import create_client
+
+VOYAGE_URL = "https://api.voyageai.com/v1/embeddings"
+VOYAGE_MODEL = "voyage-3-lite"
+BATCH = 64  # Voyage accepts up to 1000 but smaller batches are safer on retries
+
+
+def canonical_text(name: str, description: str | None, tags: list[str] | None, content: str) -> str:
+    parts: list[str] = []
+    if name:
+        parts.append(name.replace("_", " "))
+    if tags:
+        parts.append("tags: " + ", ".join(tags))
+    if description:
+        parts.append(description)
+    if content:
+        parts.append(content)
+    return "\n".join(p for p in parts if p).strip()
+
+
+async def embed_batch(texts: list[str]) -> list[list[float]]:
+    api_key = os.environ["VOYAGE_API_KEY"]
+    async with httpx.AsyncClient(timeout=60.0) as c:
+        resp = await c.post(
+            VOYAGE_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"model": VOYAGE_MODEL, "input": texts, "input_type": "document"},
+        )
+        resp.raise_for_status()
+        data = sorted(resp.json()["data"], key=lambda x: x["index"])
+        return [item["embedding"] for item in data]
+
+
+async def main(apply: bool) -> int:
+    client = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_KEY"])
+
+    rows = (
+        client.table("memories")
+        .select("id, name, description, tags, content")
+        .is_("deleted_at", "null")
+        .execute()
+        .data
+    )
+    total = len(rows)
+    print(f"Found {total} live memories to re-embed")
+
+    if not apply:
+        for r in rows[:3]:
+            text = canonical_text(r.get("name", ""), r.get("description"), r.get("tags"), r.get("content", ""))
+            print(f"\n[dry] {r['name']}: {text[:120]}{'...' if len(text) > 120 else ''}")
+        print(f"\nDry run — pass --apply to write {total} updated embeddings.")
+        return 0
+
+    done = 0
+    for i in range(0, total, BATCH):
+        batch = rows[i : i + BATCH]
+        texts = [
+            canonical_text(r.get("name", ""), r.get("description"), r.get("tags"), r.get("content", ""))
+            for r in batch
+        ]
+        embeddings = await embed_batch(texts)
+        for r, emb in zip(batch, embeddings):
+            client.table("memories").update({
+                "embedding": emb,
+                "embedding_model": VOYAGE_MODEL,
+                "embedding_version": "v2",
+            }).eq("id", r["id"]).execute()
+        done += len(batch)
+        print(f"  {done}/{total}")
+
+    print(f"Done — {done} memories re-embedded with canonical form.")
+    return 0
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--apply", action="store_true", help="Actually write (default: dry run)")
+    args = p.parse_args()
+    sys.exit(asyncio.run(main(apply=args.apply)))

--- a/tests/memory-eval/baseline.json
+++ b/tests/memory-eval/baseline.json
@@ -1,13 +1,13 @@
 {
-  "timestamp": "2026-04-18T08:32:05.420190+00:00",
+  "timestamp": "2026-04-18T08:42:33.948278+00:00",
   "corpus_size": 289,
   "total_queries": 20,
-  "recall_at_5": 0.8,
+  "recall_at_5": 0.85,
   "recall_at_10": 0.9,
-  "mrr": 0.5801388888888889,
+  "mrr": 0.6222222222222222,
   "must_not_violations": 0,
-  "passed": 16,
-  "failed": 4,
+  "passed": 17,
+  "failed": 3,
   "results": [
     {
       "id": "q01",
@@ -18,9 +18,10 @@
       ],
       "must_not": [],
       "top_names": [
+        "goals_system_first_real_goals",
         "feedback_voyage"
       ],
-      "first_hit_rank": 1,
+      "first_hit_rank": 2,
       "hits_at_5": [
         "feedback_voyage"
       ],
@@ -40,10 +41,9 @@
       "must_not": [],
       "top_names": [
         "jarvis_event_driven_architecture",
-        "team_agent_v2_plan_complete",
-        "like_spotify_cross_device_simplified",
-        "claude_max_upgrade",
         "scheduled_tasks_subscription_not_api",
+        "team_agent_v2_plan_complete",
+        "claude_max_upgrade",
         "claudemd_consolidation_2026_04_08",
         "like_spotify_tech_profile",
         "planned_integrations_digital_twin"
@@ -68,17 +68,17 @@
       "must_not": [],
       "top_names": [
         "sand_direction_top_down",
-        "bug_fix_reproduce_first",
         "redrobot_sergazy_feedback_apr8",
+        "bug_fix_reproduce_first",
         "zigzag_removed_from_escalation",
         "redrobot_schedule_apr8",
-        "redrobot_agile_switch",
         "read_code_before_implementing",
+        "university_student_cse8012",
         "deficit_first_bulk_planner",
         "ux_ui_principles_always",
-        "_soft_delete_test"
+        "review_before_push"
       ],
-      "first_hit_rank": 2,
+      "first_hit_rank": 3,
       "hits_at_5": [
         "bug_fix_reproduce_first"
       ],
@@ -104,9 +104,9 @@
         "redrobot_hygiene_remaining_2026_04_18",
         "jarvis_public_release_v020",
         "owner_profile",
-        "redrobot_stash_and_milestone_cleanup_candidates",
         "no_hardcoded_context_in_claude_md",
-        "pycache_after_changes"
+        "pycache_after_changes",
+        "docs_in_wiki"
       ],
       "first_hit_rank": 1,
       "hits_at_5": [
@@ -129,10 +129,11 @@
       "top_names": [
         "milestone_structure_v2",
         "be_the_manager",
+        "architecture_final",
         "instructions_overhaul_2026_04_01",
-        "pillar_scope_and_pm_process",
-        "owner_claude_code_setup",
-        "sand_physics_architecture_2026_04_06"
+        "dnd_dm_role",
+        "sand_physics_architecture_2026_04_06",
+        "github_schema_restructured"
       ],
       "first_hit_rank": 2,
       "hits_at_5": [
@@ -155,24 +156,25 @@
       ],
       "must_not": [],
       "top_names": [
+        "jarvis_v2_multiagent_direction",
         "jarvis_v2_vision",
+        "jarvis_wrapping_direction",
         "jarvis_v2_hybrid_agile",
         "jarvis_vs_team_agent",
-        "jarvis_wrapping_direction",
         "multiagent_pm_architecture_vision",
-        "jarvis_v2_multiagent_direction",
         "no_deterministic_pipelines",
-        "research_jarvis_meta_agent",
+        "jarvis_scalable_agent_system",
         "pillar7_personal_vs_company_separation",
         "docs_in_wiki"
       ],
-      "first_hit_rank": 4,
+      "first_hit_rank": 1,
       "hits_at_5": [
+        "jarvis_v2_multiagent_direction",
         "jarvis_wrapping_direction"
       ],
       "hits_at_10": [
-        "jarvis_wrapping_direction",
-        "jarvis_v2_multiagent_direction"
+        "jarvis_v2_multiagent_direction",
+        "jarvis_wrapping_direction"
       ],
       "must_not_violations_at_5": [],
       "passed": true
@@ -187,25 +189,25 @@
       ],
       "must_not": [],
       "top_names": [
-        "autonomous_loop_v1_architecture",
         "no_deterministic_pipelines",
         "autonomous_loop_hygiene_sweep_v1",
         "local_scheduled_tasks_only",
+        "jarvis_v15_skill_restructure",
+        "autonomous_loop_v1_architecture",
         "autonomous_action_log",
-        "milestone_vs_pillar_hygiene",
-        "pm_dispatch_v1_architecture",
         "autonomous_fixing_mode",
-        "working_state_redrobot",
+        "autonomous_loop_last_run",
+        "milestone_vs_pillar_hygiene",
         "autonomous_long_sessions"
       ],
-      "first_hit_rank": 1,
+      "first_hit_rank": 2,
       "hits_at_5": [
-        "autonomous_loop_v1_architecture",
-        "autonomous_loop_hygiene_sweep_v1"
+        "autonomous_loop_hygiene_sweep_v1",
+        "autonomous_loop_v1_architecture"
       ],
       "hits_at_10": [
-        "autonomous_loop_v1_architecture",
-        "autonomous_loop_hygiene_sweep_v1"
+        "autonomous_loop_hygiene_sweep_v1",
+        "autonomous_loop_v1_architecture"
       ],
       "must_not_violations_at_5": [],
       "passed": true
@@ -221,15 +223,15 @@
       "must_not": [],
       "top_names": [
         "memory_server_v2_improvements",
-        "supabase_custom_mcp_preferred",
-        "memory_alternatives",
-        "working_state_jarvis",
         "memory_2_0_implementation",
+        "supabase_custom_mcp_preferred",
         "nightly_mcp_max_result_size",
         "owner_prefers_mcp_over_skills",
-        "linked_dedup_fix",
+        "pipeline_full_diagnostics_dump",
+        "working_state_jarvis",
         "self_hosted_postgres_future_plan",
-        "memory_graph_tool_added"
+        "memory_graph_tool_added",
+        "pipeline_v3_performance_research"
       ],
       "first_hit_rank": 1,
       "hits_at_5": [
@@ -256,14 +258,14 @@
       "top_names": [
         "lessons_agent_delegation",
         "delegate_frontend_to_subagents",
-        "verify_agent_findings_against_memory",
-        "jarvis_scalable_agent_system",
         "prefer_agents_for_parallel_bugs",
-        "pm_dispatch_v1_architecture",
         "pm_methodology_and_delegation",
+        "jarvis_scalable_agent_system",
+        "agent_delegation_precision",
+        "pm_dispatch_v1_architecture",
         "managed_agents_wait_and_see",
-        "claude_code_capabilities",
-        "review_before_push"
+        "jarvis_v2_multiagent_direction",
+        "competitive_landscape_multi_agent_2026"
       ],
       "first_hit_rank": 1,
       "hits_at_5": [
@@ -272,7 +274,8 @@
       ],
       "hits_at_10": [
         "lessons_agent_delegation",
-        "delegate_frontend_to_subagents"
+        "delegate_frontend_to_subagents",
+        "agent_delegation_precision"
       ],
       "must_not_violations_at_5": [],
       "passed": true
@@ -286,18 +289,18 @@
       ],
       "must_not": [],
       "top_names": [
-        "checkpoint_skill_architecture",
         "owner_prefers_mcp_over_skills",
-        "jarvis_wrapping_direction",
-        "nightly_mcp_max_result_size",
-        "claude_code_capabilities",
+        "checkpoint_skill_architecture",
         "mcp_stack_2026_03_31",
+        "claude_code_capabilities",
+        "jarvis_wrapping_direction",
         "pm_dispatch_v1_architecture",
-        "research_jarvis_meta_agent",
-        "use_playwright_for_testing",
-        "competitive_landscape_multi_agent_2026"
+        "competitive_landscape_multi_agent_2026",
+        "nightly_mcp_max_result_size",
+        "owner_claude_code_setup",
+        "team_knowledge_sharing_research_2026"
       ],
-      "first_hit_rank": 5,
+      "first_hit_rank": 4,
       "hits_at_5": [
         "claude_code_capabilities"
       ],
@@ -316,20 +319,26 @@
       ],
       "must_not": [],
       "top_names": [
-        "proactive_goal_tracking",
         "verify_agent_findings_against_memory",
+        "always_recall_before_action",
+        "linked_dedup_fix",
         "nightly_research_sql_fallback",
         "check_diagnostics_diversity",
-        "owner_thinks_architecturally",
+        "proactive_goal_tracking",
+        "pretooluse_action_triggers_idea",
+        "verify_before_assuming_implemented",
         "intel_claude_code_w14_2026_04_04",
-        "research_skill_firecrawl_v2",
-        "pretooluse_action_triggers_idea"
+        "owner_thinks_architecturally"
       ],
-      "first_hit_rank": null,
-      "hits_at_5": [],
-      "hits_at_10": [],
+      "first_hit_rank": 2,
+      "hits_at_5": [
+        "always_recall_before_action"
+      ],
+      "hits_at_10": [
+        "always_recall_before_action"
+      ],
       "must_not_violations_at_5": [],
-      "passed": false
+      "passed": true
     },
     {
       "id": "q12",
@@ -341,13 +350,13 @@
       "must_not": [],
       "top_names": [
         "redrobot_sergazy_feedback_apr8",
-        "sand_direction_top_down",
-        "redrobot_agile_switch",
         "pillar_is_not_one_task",
+        "sand_direction_top_down",
+        "sprint_sizing_feedback",
+        "redrobot_agile_switch",
+        "stage1_enrichment_not_visible",
         "ux_ui_principles_always",
-        "read_code_before_implementing",
         "deficit_first_bulk_planner",
-        "repo_improve_deferred",
         "dont_hallucinate_screenshots",
         "planned_integrations_digital_twin"
       ],
@@ -369,18 +378,18 @@
       ],
       "must_not": [],
       "top_names": [
-        "working_state_redrobot",
-        "autonomous_loop_v1_architecture",
+        "autonomous_loop_last_run",
         "autonomous_fixing_mode",
         "autonomous_action_log",
+        "working_state_redrobot",
         "autonomous_long_sessions",
-        "uw_madison_blade_control",
         "move_curve_caution",
         "nn_optimization_roadmap",
-        "autonomous_loop_hygiene_sweep_v1",
+        "pm_autonomy_redrobot",
+        "uw_madison_blade_control",
         "parallel_simulation_during_execution"
       ],
-      "first_hit_rank": 3,
+      "first_hit_rank": 2,
       "hits_at_5": [
         "autonomous_fixing_mode",
         "autonomous_long_sessions"
@@ -405,8 +414,10 @@
         "pipeline_verification_mandatory",
         "bug_analysis_575_576_577",
         "risk_radar_last_run",
-        "bug_fix_reproduce_first",
-        "_soft_delete_test"
+        "event_dispatch_spam_fix",
+        "_soft_delete_test",
+        "risk_radar_last_run",
+        "risk_radar_latest"
       ],
       "first_hit_rank": 1,
       "hits_at_5": [
@@ -427,18 +438,18 @@
       ],
       "must_not": [],
       "top_names": [
-        "mcp_stack_2026_03_31",
-        "jarvis_scalable_agent_system",
         "competitive_landscape_multi_agent_2026",
-        "research_jarvis_meta_agent",
+        "team_ai_agent_project_initiated",
+        "mcp_stack_2026_03_31",
         "research_pillar7_multi_agent_frameworks",
+        "jarvis_scalable_agent_system",
         "jarvis_v2_vision",
+        "research_jarvis_meta_agent",
         "managed_agents_wait_and_see",
         "multiagent_pm_architecture_vision",
-        "team_ai_agent_project_initiated",
-        "lessons_agent_delegation"
+        "jarvis_v2_multiagent_direction"
       ],
-      "first_hit_rank": 3,
+      "first_hit_rank": 1,
       "hits_at_5": [
         "competitive_landscape_multi_agent_2026"
       ],
@@ -461,9 +472,8 @@
         "telegram_mcp_integration",
         "lesson_cloud_mcp_limitations",
         "lessons_cloud_infrastructure",
-        "architecture_final",
-        "team_knowledge_sharing_research_2026",
-        "jarvis_v2_infra_flexibility",
+        "nightly_research_setup",
+        "user_university_student",
         "team_agent_complement_not_restrict",
         "windows_claude_installation",
         "supabase_connector_status"
@@ -488,14 +498,15 @@
       ],
       "must_not": [],
       "top_names": [
-        "nightly_research_sql_fallback",
-        "proactive_goal_tracking",
-        "owner_profile",
-        "sculpture_vision_system",
-        "research_skill_firecrawl_v2",
-        "owner_thinks_architecturally",
         "research_threejs_heightmap_visualization",
-        "intel_claude_code_w14_2026_04_04",
+        "sculpture_vision_system",
+        "nightly_research_sql_fallback",
+        "research_skill_firecrawl_v2",
+        "proactive_goal_tracking",
+        "cratergrader_technical_details",
+        "owner_thinks_architecturally",
+        "trajectory_visualization_research",
+        "skill_proliferation_antipattern",
         "redrobot_repo_location"
       ],
       "first_hit_rank": null,
@@ -517,14 +528,14 @@
       "top_names": [
         "jarvis_v2_hybrid_agile",
         "jarvis_v2_vision",
-        "goals_system_first_real_goals",
         "no_deterministic_pipelines",
         "autonomous_action_log",
         "goals_system_v1",
         "redrobot_agile_full_migration",
+        "jarvis_v15_skill_final_plan",
+        "working_state_jarvis",
         "jarvis_vs_team_agent",
-        "multiagent_pm_architecture_vision",
-        "working_state_jarvis"
+        "jarvis_v2_multiagent_direction"
       ],
       "first_hit_rank": 1,
       "hits_at_5": [
@@ -547,22 +558,20 @@
         "jarvis_stays_goals_not_agile"
       ],
       "top_names": [
-        "jarvis_vs_team_agent",
         "jarvis_wrapping_direction",
-        "pm_autonomy_redrobot",
-        "research_jarvis_meta_agent",
-        "multiagent_pm_architecture_vision",
-        "jarvis_public_release_v020",
+        "jarvis_vs_team_agent",
         "jarvis_v2_vision",
-        "jarvis_v2_hybrid_agile",
-        "no_deterministic_pipelines",
-        "no_jarvis_in_team_docs"
+        "multiagent_pm_architecture_vision",
+        "jarvis_v15_skill_final_plan",
+        "jarvis_public_release_v020",
+        "research_jarvis_meta_agent",
+        "no_jarvis_in_team_docs",
+        "jarvis_v15_skill_restructure",
+        "working_state_jarvis"
       ],
-      "first_hit_rank": 8,
+      "first_hit_rank": null,
       "hits_at_5": [],
-      "hits_at_10": [
-        "jarvis_v2_hybrid_agile"
-      ],
+      "hits_at_10": [],
       "must_not_violations_at_5": [],
       "passed": false
     },
@@ -577,14 +586,14 @@
       "must_not": [],
       "top_names": [
         "local_scheduled_tasks_only",
+        "supabase_custom_mcp_preferred",
         "event_driven_perception_v1",
         "lesson_cloud_mcp_limitations",
-        "autonomous_loop_v1_architecture",
-        "pm_dispatch_v1_architecture",
         "mcp_stack_2026_03_31",
+        "multiagent_pm_architecture_vision",
         "checkpoint_skill_architecture",
+        "pm_dispatch_v1_architecture",
         "claude_code_capabilities",
-        "scheduled_tasks_subscription_not_api",
         "sentry_mcp_pending"
       ],
       "first_hit_rank": 1,


### PR DESCRIPTION
## Summary

Phase 2a of the memory overhaul (#185). Deterministic write-side improvements — Phase 2b will add the Haiku ADD/UPDATE/DELETE/NOOP classifier.

Closes #192
Parent: #185

## Changes

### Canonical embed form
Embedding text is now `name + tags + description + content` structured as:
```
milestone vs pillar hygiene
tags: milestone, sprint, pillar, workflow, hygiene
<description>
<content>
```
instead of just `description + content`. Name and tags carry high-signal lexical cues that long content dilutes — a memory about \`recall memory before acting\` whose content drifts into narrative detail now has its topic word surfaced at the embedding boundary.

Applied to `_handle_store` and `_backfill_missing_embeddings`. Rows get `embedding_model='voyage-3-lite'`, `embedding_version='v2'` on write.

### One-shot backfill
`scripts/reembed-canonical.py` re-embeds every live memory with the new form. Already run against the 289 live memories. Idempotent — safe to re-run.

### Supersession improvements
- Drop `type=decision` gate — any two same-type memories above `SUPERSEDE_SIM_THRESHOLD` (0.85) now trigger a supersedes edge. Cross-type (e.g. project ↔ decision) still doesn't supersede.
- `_create_auto_links` now denormalizes supersedes edges onto `memories.superseded_by`, so Phase 1 recall filter picks up the supersession immediately (no waiting for manual link sweeps).

### memory_store
New optional `source_provenance` param (JTMS attribution). Not required yet — Phase 2b classifier will make it effectively required.

## Eval delta vs Phase 1 baseline

```
recall@5:             85.0%  (baseline 80.0%, +5.0%)    17/20 passing
recall@10:            90.0%  (baseline 90.0%, +0.000)
MRR:                  0.622  (baseline 0.580, +0.042)
must_not violations:  0      (baseline 0)

IMPROVEMENTS: q11 (\"recall memory before acting\" — now rank 2, was missed)
```

q11 was the flagship miss — the memory \`always_recall_before_action\` is a critical behavioral rule. Canonical form put \`recall\` + \`memory\` + the action name directly into the embedding and it now ranks.

### Known trade-off
q19 (Russian lifecycle query \"как Jarvis планирует работу сейчас\") regressed from rank 8 to out-of-top-10. Other jarvis-planning memories embed better with canonical form and crowd the expected one out. Phase 3 (query rewriting) and Phase 2b (classifier-driven supersession at lower threshold) should fix this.

### MRR residual drift
±0.01 across eval runs is `last_accessed_at`-driven access-boost noise, not content decay. Phase 5 metacognition can stabilize this by moving access-boost out of the scoring path. Out of scope here.

## Out of scope (Phase 2b)

- Haiku-4.5 ADD/UPDATE/DELETE/NOOP classifier on write
- Review queue table for low-confidence classifications
- Lowering `SUPERSEDE_SIM_THRESHOLD` to 0.75 (needs classifier to prevent false positives at lower threshold)

## Test plan

- [x] Canonical form helper produces expected structure (dry-run output verified)
- [x] 289 memories re-embedded with v2
- [x] Eval: recall@5 lift confirmed, must_not still 0
- [x] Supersede-by-column denormalization: will exercise next time two same-type memories cross 0.85 similarity on write