### PR TITLE
feat(memory): Phase 2c — source_provenance required (#196)

### DIFF
--- a/.claude/skills/autonomous-loop/SKILL.md
+++ b/.claude/skills/autonomous-loop/SKILL.md
@@ -173,7 +173,8 @@ memory_store(
   type="project",
   name="autonomous_loop_last_run",
   content="{\"date\": \"YYYY-MM-DD\", \"actions_count\": N, \"succeeded\": N, \"failed\": N, \"top_action\": \"...\"}",
-  description="last orchestrator run"
+  description="last orchestrator run",
+  source_provenance="skill:autonomous-loop"
 )
 ```
 

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -90,7 +90,8 @@ If a pattern is non-obvious, save it:
 memory_store(
   name="lesson_<slug>", type="feedback",
   project=<same as decision or "global">,
-  content="<rule>\n\n**Why:** <what happened>\n**How to apply:** <when this kicks in>"
+  content="<rule>\n\n**Why:** <what happened>\n**How to apply:** <when this kicks in>",
+  source_provenance="skill:reflect"
 )
 ```
 
@@ -111,7 +112,8 @@ Creating new hypotheses (when user says "I think X might be true"):
 ```
 memory_store(
   name="hypothesis_<slug>", type="project",
-  content="claim: <X>\nmetric: <how to verify>\nstatus: testing\nevidence: none yet"
+  content="claim: <X>\nmetric: <how to verify>\nstatus: testing\nevidence: none yet",
+  source_provenance="skill:reflect"
 )
 ```
 

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -64,7 +64,7 @@ One sentence: what makes this confident or uncertain.
 
 Save to Supabase if finding is significant:
 ```
-memory_store(type="reference", name="research_{slug}", description="...", content="...")
+memory_store(type="reference", name="research_{slug}", description="...", content="...", source_provenance="skill:research")
 ```
 
 If finding is actionable → create GitHub issue in appropriate repo:
@@ -108,14 +108,14 @@ For each topic: `WebSearch` or `firecrawl_search`, max 3 searches per topic.
 
 Per topic:
 ```
-memory_store(type="reference", name="research_{slug}", project="{project}", content="...")
+memory_store(type="reference", name="research_{slug}", project="{project}", content="...", source_provenance="skill:research")
 ```
 
 Actionable findings → GitHub issues (check for duplicates first).
 
 Dedup marker:
 ```
-memory_store(type="project", name="research_last_run", content="{date} — topics: {t1}, {t2}, {t3}")
+memory_store(type="project", name="research_last_run", content="{date} — topics: {t1}, {t2}, {t3}", source_provenance="skill:research")
 ```
 
 ---

--- a/.claude/skills/sprint-report/SKILL.md
+++ b/.claude/skills/sprint-report/SKILL.md
@@ -140,7 +140,8 @@ memory_store(
   project="redrobot",
   description="Sprint N results: <one-line summary>",
   tags=["sprint", "report", "release"],
-  content=<sprint summary with key metrics and decisions>
+  content=<sprint summary with key metrics and decisions>,
+  source_provenance="skill:sprint-report"
 )
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,15 @@ Skills that run in both environments must use `execute_sql` as the primary metho
 ### Proactive saving (non-negotiable)
 Save immediately after any: decision, preference, architectural discussion, new fact, rejected approach (with why), working style observation. Don't batch. Don't wait for session end.
 
+### Provenance required (Phase 2c)
+Every `memory_store` call MUST include `source_provenance` — the MCP server rejects writes missing it. Use a namespaced form so audits and consolidation can trace origin:
+- `skill:<name>` — invoked from a skill (e.g. `skill:research`, `skill:autonomous-loop`)
+- `session:<YYYY-MM-DD>` — saved mid-conversation (use today's date)
+- `hook:<name>` — written by a hook (e.g. `hook:session-start`)
+- `user:explicit` — owner said "save this"
+- `episode:<id>` — Phase 4 episode extractor (#197)
+- external source: URL, tool name, or `external:<system>`
+
 ### Working state
 Save working state to Supabase (`memory_store`, name=`working_state_jarvis`, type=project) at natural breakpoints. Clean up with `memory_delete` when task is done.
 

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -763,3 +763,34 @@ create policy "Allow all for authenticated" on memory_review_queue
 
 create policy "Allow all for anon" on memory_review_queue
   for all to anon using (true) with check (true);
+
+
+-- =========================================================================
+-- Phase 2c (memory overhaul, Osasuwu/jarvis#185, #196) — provenance required
+--
+-- Goal: close the audit gap left by Phase 2. Every memory must carry
+-- `source_provenance` so we can revise beliefs knowing who/what produced
+-- them (JTMS principle — can't revise what you can't attribute).
+--
+-- Before 2c: `source_provenance` was a nullable column, populated when
+-- convenient. In practice most rows were null, which defeated the purpose.
+-- After 2c: NOT NULL enforced. MCP server rejects writes missing it.
+-- Pre-policy rows get `legacy:pre-2c` so they're distinguishable from
+-- policy-compliant data without blocking the constraint.
+--
+-- Coordinates with Phase 4 (#197): episode extractor will populate
+-- `source_provenance = 'episode:<episode_id>'` — contract only, no overlap.
+-- =========================================================================
+
+-- Backfill pre-policy rows with a distinguishing marker. Literal string
+-- (not '') so future queries can filter `where source_provenance =
+-- 'legacy:pre-2c'` to find rows with no real provenance.
+update memories
+set source_provenance = 'legacy:pre-2c'
+where source_provenance is null;
+
+-- Enforce going forward. Any caller bypassing the MCP server with a raw
+-- INSERT now errors out — which is the desired failure mode (those writes
+-- also skip the embedding + classifier pipeline and shouldn't exist).
+alter table memories
+    alter column source_provenance set not null;

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -784,13 +784,30 @@ create policy "Allow all for anon" on memory_review_queue
 
 -- Backfill pre-policy rows with a distinguishing marker. Literal string
 -- (not '') so future queries can filter `where source_provenance =
--- 'legacy:pre-2c'` to find rows with no real provenance.
+-- 'legacy:pre-2c'` to find rows with no real provenance. Also catches
+-- whitespace-only values — prior callers could persist '   ' which is
+-- truthy in Python but carries no attribution.
 update memories
 set source_provenance = 'legacy:pre-2c'
-where source_provenance is null;
+where source_provenance is null
+   or btrim(source_provenance) = '';
 
 -- Enforce going forward. Any caller bypassing the MCP server with a raw
 -- INSERT now errors out — which is the desired failure mode (those writes
 -- also skip the embedding + classifier pipeline and shouldn't exist).
 alter table memories
     alter column source_provenance set not null;
+
+-- Soft-delete column. server.py has always written/filtered on this (store
+-- clears it, recall/list/get/delete filter `is deleted_at null`), but the
+-- column was never declared in schema.sql — meaning a fresh provision
+-- would error at runtime. Add as part of the 2c hardening pass since the
+-- provenance work is the first time the audit story is end-to-end.
+alter table memories add column if not exists deleted_at timestamptz;
+
+-- Partial index on tombstones. Mirrors the index already present in the
+-- live DB — small set, fast to scan when purging or auditing deletes.
+-- Live-row queries don't need a dedicated index: they combine deleted_at
+-- with type/project/lifecycle filters already covered by existing indexes.
+create index if not exists idx_memories_deleted_at
+  on memories(deleted_at) where deleted_at is not null;

--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -435,13 +435,15 @@ async def list_tools() -> list[Tool]:
                     "source_provenance": {
                         "type": "string",
                         "description": (
-                            "Where this memory came from (URL, tool name, session id, "
-                            "actor). Populate when not self-evident. JTMS attribution — "
-                            "we can't revise what we can't attribute."
+                            "Where this memory came from. Required as of Phase 2c — "
+                            "JTMS attribution, we can't revise what we can't attribute. "
+                            "Use a namespaced form: 'session:<id>', 'skill:<name>', "
+                            "'hook:<name>', 'user:explicit', 'episode:<episode_id>' "
+                            "(Phase 4), or a URL/tool-name when external."
                         ),
                     },
                 },
-                "required": ["type", "name", "content"],
+                "required": ["type", "name", "content", "source_provenance"],
             },
         ),
         Tool(
@@ -1103,6 +1105,19 @@ async def _handle_store(args: dict) -> list[TextContent]:
     if mem_type not in VALID_TYPES:
         return [TextContent(type="text", text=f"Invalid type: {mem_type}. Must be one of {VALID_TYPES}")]
 
+    # Phase 2c: provenance required. Reject at the MCP boundary so callers get
+    # a readable error instead of a NOT NULL violation from Postgres. Strip
+    # whitespace so an accidental " " doesn't pass the guard.
+    source_provenance = (source_provenance or "").strip()
+    if not source_provenance:
+        return [TextContent(type="text", text=(
+            "Error: source_provenance is required (Phase 2c). "
+            "Use a namespaced source like 'session:<id>', 'skill:<name>', "
+            "'hook:<name>', 'user:explicit', or 'episode:<id>'. This is the "
+            "JTMS attribution for this memory — without it, future revisions "
+            "can't be traced."
+        ))]
+
     # Phase 2a: canonical-form embedding — include name + tags + description + content.
     # Name and tags carry high-signal lexical cues that raw content often dilutes
     # (long narrative memories where the key topic is only in the name).
@@ -1116,10 +1131,9 @@ async def _handle_store(args: dict) -> list[TextContent]:
         "description": description,
         "project": project,
         "tags": tags,
+        "source_provenance": source_provenance,  # Phase 2c: always present, validated above
         "deleted_at": None,  # clear soft-delete on store/upsert
     }
-    if source_provenance:
-        data["source_provenance"] = source_provenance
 
     if embedding is not None:
         data["embedding"] = embedding

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -23,7 +23,20 @@ import pytest
 # Create stub modules for mcp.*
 _mcp_types = types.ModuleType("mcp.types")
 _mcp_types.CallToolResult = MagicMock
-_mcp_types.TextContent = MagicMock
+
+
+class _FakeTextContent:
+    """Minimal TextContent replica so tests can read back .text on returns.
+
+    The real mcp.types.TextContent is a pydantic model; tests don't need
+    validation, just attribute access for the error-path checks below.
+    """
+    def __init__(self, type: str = "text", text: str = ""):
+        self.type = type
+        self.text = text
+
+
+_mcp_types.TextContent = _FakeTextContent
 _mcp_types.Tool = MagicMock
 
 def _noop_decorator(*args, **kwargs):
@@ -94,10 +107,12 @@ from server import (
     _format_memories,
     _create_auto_links,
     _expand_with_links,
+    _handle_store,
     TEMPORAL_HALF_LIVES,
     SUPERSEDE_SIM_THRESHOLD,
     MAX_AUTO_LINKS,
 )
+import server as server_module
 
 
 # ---------------------------------------------------------------------------
@@ -690,3 +705,84 @@ class TestRecallLinkedDedup:
 
         assert len(unique_linked) == 1
         assert unique_linked[0]["id"] == "id-2"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2c: memory_store must reject writes missing source_provenance
+# ---------------------------------------------------------------------------
+
+class TestHandleStoreProvenance:
+    """Phase 2c — every memory write carries a namespaced source_provenance.
+
+    The MCP boundary rejects missing/blank values with a readable error so
+    callers don't hit a raw NOT NULL violation from Postgres downstream.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_client(self, monkeypatch):
+        """Swap _get_client for a mock so validation failures don't need live DB."""
+        self.client = MagicMock()
+        monkeypatch.setattr(server_module, "_get_client", lambda: self.client)
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_provenance(self):
+        result = await _handle_store({
+            "type": "project",
+            "name": "test_missing",
+            "content": "test content",
+            # no source_provenance
+        })
+        assert len(result) == 1
+        assert "source_provenance is required" in result[0].text
+        # Validation fired before any DB access.
+        self.client.table.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_blank_provenance(self):
+        result = await _handle_store({
+            "type": "project",
+            "name": "test_blank",
+            "content": "test content",
+            "source_provenance": "   ",
+        })
+        assert "source_provenance is required" in result[0].text
+        self.client.table.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_none_provenance(self):
+        result = await _handle_store({
+            "type": "project",
+            "name": "test_none",
+            "content": "test content",
+            "source_provenance": None,
+        })
+        assert "source_provenance is required" in result[0].text
+        self.client.table.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provenance_stripped_before_persist(self, monkeypatch):
+        """Accepted provenance is trimmed — no leading/trailing whitespace
+        leaks into the DB row, keeping audit queries clean."""
+        # Short-circuit embedding so we don't need Voyage env/network.
+        async def _fake_embed(_text):
+            return None
+        monkeypatch.setattr(server_module, "_embed", _fake_embed)
+
+        # project="jarvis" takes the upsert branch. Rig the chain to return
+        # a stored id so _handle_store completes without errors.
+        tbl = MagicMock()
+        tbl.upsert.return_value.execute.return_value = MagicMock(data=[{"id": "stored-1"}])
+        self.client.table.return_value = tbl
+
+        await _handle_store({
+            "type": "project",
+            "name": "test_strip",
+            "content": "test content",
+            "project": "jarvis",
+            "source_provenance": "  skill:test  ",
+        })
+
+        upsert_calls = tbl.upsert.call_args_list
+        assert upsert_calls, "expected at least one upsert call"
+        data_arg = upsert_calls[-1][0][0]
+        assert data_arg["source_provenance"] == "skill:test"


### PR DESCRIPTION
## Summary
- MCP `memory_store` now rejects writes without `source_provenance` — JTMS attribution is non-negotiable going forward
- Schema migration backfills 295 legacy rows to `legacy:pre-2c` and adds `NOT NULL` (applied live to Supabase)
- Callers updated: `CLAUDE.md` namespacing guide + 4 SKILL.md files (autonomous-loop, research, reflect, sprint-report)

## Why
Phase 2b landed the classifier but the JTMS loop is only closed once every memory carries its origin. Without required provenance, future revisions (Phase 3 task-aware recall, Phase 5 consolidation) can't trace *who wrote what from where*, which means we can't safely supersede or merge.

## Live migration
Applied via `apply_migration` (name: `phase_2c_require_source_provenance`). Post-migration counts:
- `total=299, null_count=0, legacy=295, real_provenance=4`
- `is_nullable="NO"` confirmed in `information_schema.columns`

## Verification
- Tests: 199 passed, 7 skipped. 4 new tests in `TestHandleStoreProvenance` cover missing/blank/None/whitespace rejection + strip-before-persist
- Eval: `recall@5=85%`, `recall@10=90%`, `must_not=0` violations (same as post-2b baseline — write-path change, no recall regression expected)

## Contract for callers
Every `memory_store` now needs a namespaced source:
- `skill:<name>` — from a skill
- `session:<YYYY-MM-DD>` — mid-conversation
- `hook:<name>` — from a hook
- `user:explicit` — owner said save this
- `episode:<id>` — Phase 4 episode extractor (#197)
- external source or `external:<system>`

Missing/blank returns a readable error at the MCP boundary instead of a Postgres NOT NULL violation.

## Refs
- Closes #196
- Part of #185 (memory overhaul epic)

## Test plan
- [x] Unit tests pass (199 passed, 7 skipped)
- [x] Recall eval: no regression
- [x] Live migration applied, NOT NULL confirmed
- [x] Manual: `memory_store` without provenance returns readable error; with provenance persists normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)