### PR TITLE
feat(memory): Phase 4 — episodic layer (#197)

### DIFF
--- a/mcp-memory/episode_extractor.py
+++ b/mcp-memory/episode_extractor.py
@@ -1,0 +1,705 @@
+"""Phase 4 — episodic-layer extractor.
+
+Background worker that drains the `episodes` table (raw "what happened"
+records written by hooks/skills/autonomous code) and distills batches
+into candidate memories via a Haiku synthesis step. Each candidate is
+routed through the Phase 2b classifier for ADD/UPDATE/DELETE/NOOP
+decision and, when appropriate, inserted into the `memories` table
+with `source_provenance='episode:<id>'`.
+
+Theory (CLS, Tulving) and production (Letta, LangMem, A-MEM) agree on
+the same shape: a non-lossy episodic buffer, with semantic extraction
+running offline. Direct-to-semantic writes cause catastrophic
+interference. Hooks push cheap raw records; this module is where
+actual memory synthesis happens, detached from the write latency path.
+
+Run modes:
+  python mcp-memory/episode_extractor.py                  # one batch
+  python mcp-memory/episode_extractor.py --batch-size 10  # custom size
+  python mcp-memory/episode_extractor.py --dry-run        # no DB writes
+
+Environment:
+  SUPABASE_URL / SUPABASE_KEY   — required
+  VOYAGE_API_KEY                — required for embedding
+  ANTHROPIC_API_KEY             — required for synthesis + classifier
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Repo root .env (mirrors server.py's lookup) and sibling module imports.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+
+try:
+    from dotenv import load_dotenv
+
+    for _env_path in [_HERE.parent / ".env", _HERE.parent.parent / ".env"]:
+        if _env_path.exists():
+            load_dotenv(_env_path, override=True)
+            break
+except ImportError:  # pragma: no cover — .env loading is optional
+    pass
+
+import httpx  # noqa: E402
+
+# classifier.py is a pure module (no top-level side effects) — safe to import.
+from classifier import classify_write  # type: ignore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+SYNTHESIZER_MODEL = "claude-haiku-4-5"
+SYNTHESIZER_TIMEOUT = 30.0  # seconds — offline batch, can afford more than classifier
+SYNTHESIZER_MAX_TOKENS = 2000
+
+VOYAGE_API_URL = "https://api.voyageai.com/v1/embeddings"
+VOYAGE_MODEL = "voyage-3-lite"
+EMBED_TIMEOUT = 30.0
+
+VALID_MEM_TYPES = ("user", "project", "decision", "feedback", "reference")
+
+DEFAULT_BATCH_SIZE = 20
+MAX_PAYLOAD_CHARS_PER_EPISODE = 800  # truncate giant tool-call payloads
+
+# Classifier integration thresholds (mirror server.py's Phase 2b values).
+NEIGHBOR_SIM_THRESHOLD = 0.60
+NEIGHBOR_LIMIT = 5
+CLASSIFIER_TRIGGER_SIM = 0.70
+CLASSIFIER_APPLY_THRESHOLD = 0.70
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Candidate:
+    name: str
+    type: str
+    description: str
+    content: str
+    tags: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "type": self.type,
+            "description": self.description,
+            "content": self.content,
+            "tags": self.tags,
+        }
+
+
+@dataclass
+class BatchResult:
+    episode_ids: list[str]
+    candidates_synthesized: int
+    candidates_inserted: int
+    candidates_skipped_noop: int
+    errors: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Supabase client — self-contained, mirrors server.py's lazy init
+# ---------------------------------------------------------------------------
+
+
+_supabase = None
+
+
+def get_client():
+    global _supabase
+    if _supabase is not None:
+        return _supabase
+
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        raise RuntimeError(
+            "SUPABASE_URL and SUPABASE_KEY must be set to run the episode extractor."
+        )
+
+    from supabase import create_client
+
+    _supabase = create_client(url, key)
+    return _supabase
+
+
+# ---------------------------------------------------------------------------
+# Embedding — minimal re-implementation (server.py is protected; we can't
+# share helpers, but Voyage's REST surface is tiny).
+# ---------------------------------------------------------------------------
+
+
+async def _embed(text: str) -> list[float] | None:
+    api_key = os.environ.get("VOYAGE_API_KEY")
+    if not api_key or not text:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=EMBED_TIMEOUT) as client:
+            resp = await client.post(
+                VOYAGE_API_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"model": VOYAGE_MODEL, "input": [text], "input_type": "document"},
+            )
+            resp.raise_for_status()
+            return resp.json()["data"][0]["embedding"]
+    except asyncio.CancelledError:
+        raise
+    except (httpx.HTTPError, KeyError, IndexError, TypeError, ValueError):
+        return None
+
+
+def _canonical_embed_text(name: str, description: str, tags: list[str], content: str) -> str:
+    """Same canonical form server.py uses (Phase 2a) — keeps neighbor similarity
+    comparable across episode-derived and regular writes."""
+    parts: list[str] = []
+    if name:
+        parts.append(name.replace("_", " "))
+    if tags:
+        parts.append("tags: " + ", ".join(tags))
+    if description:
+        parts.append(description)
+    if content:
+        parts.append(content)
+    return "\n".join(p for p in parts if p).strip()
+
+
+# ---------------------------------------------------------------------------
+# Synthesis prompt
+# ---------------------------------------------------------------------------
+
+
+SYNTHESIZER_SYSTEM_PROMPT = """You are a memory-synthesis worker for a personal AI agent.
+
+You receive a BATCH of raw EPISODES — low-level records of what the agent did or saw recently (tool calls, user messages, assistant decisions, observations). Your job is to distill them into candidate MEMORIES that are worth saving to long-term storage.
+
+Output one memory per durable, non-obvious fact/decision/preference that a future session would benefit from knowing. Skip ephemeral operational detail (which tool ran, which file was read) — those belong in the episode log, not long-term memory.
+
+Each candidate memory must have:
+  - name: slug-style identifier, lowercase_with_underscores, under 60 chars
+  - type: one of user / project / decision / feedback / reference
+    * user: about the person (role, goals, preferences, knowledge)
+    * project: ongoing work context, initiatives, bugs, goals, state
+    * decision: a choice made with reasoning ("chose X because Y")
+    * feedback: guidance about how to collaborate (corrections, validations)
+    * reference: pointers to external systems (URLs, tool names, doc locations)
+  - description: one sentence, used for relevance ranking
+  - content: the full memory body. Lead with the fact/rule; for feedback and project memories include **Why:** and **How to apply:** lines.
+  - tags: 2-5 short lowercase tags for filtering
+
+Rules:
+  - Emit 0 candidates if the batch contains no durable content worth saving.
+  - Prefer fewer high-quality candidates over many low-signal ones.
+  - Never emit state that will be stale in 2 weeks (percentages, status markers, dates tied to in-flight work).
+  - De-duplicate within the batch — if two episodes say the same thing, one memory.
+  - Content must be self-contained; don't reference "this session" or "the episode above".
+
+Output strict JSON, nothing else:
+{
+  "candidates": [
+    {
+      "name": "...",
+      "type": "user|project|decision|feedback|reference",
+      "description": "...",
+      "content": "...",
+      "tags": ["...", "..."]
+    }
+  ]
+}
+
+If nothing in the batch is worth saving, return: {"candidates": []}"""
+
+
+def _truncate(text: str, limit: int = MAX_PAYLOAD_CHARS_PER_EPISODE) -> str:
+    if not text:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "…"
+
+
+def _render_episode(ep: dict) -> str:
+    payload = ep.get("payload") or {}
+    if isinstance(payload, (dict, list)):
+        payload_str = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    else:
+        payload_str = str(payload)
+    payload_str = _truncate(payload_str)
+    created = ep.get("created_at", "")
+    return (
+        f"- id: {ep.get('id', '')}\n"
+        f"  actor: {ep.get('actor', '')}\n"
+        f"  kind: {ep.get('kind', '')}\n"
+        f"  at: {created}\n"
+        f"  payload: {payload_str}"
+    )
+
+
+def build_synthesis_user_message(episodes: list[dict]) -> str:
+    """Render the batch as a single prompt body. Pure function — tested directly."""
+    if not episodes:
+        return "EPISODES\n(empty batch)"
+    blocks = [_render_episode(ep) for ep in episodes]
+    return "EPISODES\n" + "\n\n".join(blocks)
+
+
+def parse_synthesis_response(text: str) -> list[Candidate]:
+    """Parse the model's JSON reply into candidates. Tolerant of stray prose,
+    silently drops malformed entries rather than failing the whole batch."""
+    if not text:
+        return []
+    first = text.find("{")
+    last = text.rfind("}")
+    if first < 0 or last <= first:
+        return []
+    try:
+        data = json.loads(text[first : last + 1])
+    except json.JSONDecodeError:
+        return []
+
+    raw = data.get("candidates")
+    if not isinstance(raw, list):
+        return []
+
+    out: list[Candidate] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", "")).strip()
+        mem_type = str(entry.get("type", "")).strip().lower()
+        description = str(entry.get("description", "")).strip()
+        content = str(entry.get("content", "")).strip()
+        tags_raw = entry.get("tags", []) or []
+
+        if not name or not content:
+            continue
+        if mem_type not in VALID_MEM_TYPES:
+            continue
+        if not isinstance(tags_raw, list):
+            tags_raw = []
+        tags = [str(t).strip().lower() for t in tags_raw if str(t).strip()]
+
+        out.append(
+            Candidate(
+                name=name,
+                type=mem_type,
+                description=description,
+                content=content,
+                tags=tags[:10],  # hard cap
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Synthesis HTTP call
+# ---------------------------------------------------------------------------
+
+
+async def synthesize_candidates(
+    episodes: list[dict],
+    *,
+    model: str = SYNTHESIZER_MODEL,
+    timeout: float = SYNTHESIZER_TIMEOUT,
+) -> list[Candidate]:
+    """Call Haiku to turn a batch of episodes into candidate memories.
+
+    Returns [] on any failure (no API key, network error, parse error) — the
+    caller treats this as "nothing extractable from this batch" and moves on
+    WITHOUT marking the episodes processed, so a later run can retry."""
+    if not episodes:
+        return []
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        return []
+
+    body = {
+        "model": model,
+        "max_tokens": SYNTHESIZER_MAX_TOKENS,
+        "system": SYNTHESIZER_SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": build_synthesis_user_message(episodes)}],
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                ANTHROPIC_API_URL,
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": ANTHROPIC_VERSION,
+                    "content-type": "application/json",
+                },
+                json=body,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+    except asyncio.CancelledError:
+        raise
+    except (httpx.HTTPError, ValueError):
+        return []
+
+    blocks = payload.get("content", [])
+    text = ""
+    for b in blocks:
+        if isinstance(b, dict) and b.get("type") == "text":
+            text = b.get("text", "")
+            break
+    return parse_synthesis_response(text)
+
+
+# ---------------------------------------------------------------------------
+# DB operations
+# ---------------------------------------------------------------------------
+
+
+def fetch_unprocessed(client, limit: int) -> list[dict]:
+    """Fetch the next batch of unprocessed episodes (oldest first — preserves
+    causal ordering within a session)."""
+    resp = (
+        client.table("episodes")
+        .select("id, actor, kind, payload, created_at")
+        .is_("processed_at", "null")
+        .order("created_at", desc=False)
+        .limit(limit)
+        .execute()
+    )
+    return resp.data or []
+
+
+def mark_processed(client, episode_ids: list[str]) -> None:
+    if not episode_ids:
+        return
+    client.table("episodes").update(
+        {
+            "processed_at": datetime.now(timezone.utc).isoformat(),
+        }
+    ).in_("id", episode_ids).execute()
+
+
+def _find_neighbors(client, embedding: list[float]) -> list[dict]:
+    """Look up semantically-similar existing memories via the Phase 2b RPC.
+    Returns [] on any failure — classifier call is optional, not critical."""
+    try:
+        resp = client.rpc(
+            "find_similar_memories",
+            {
+                "query_embedding": embedding,
+                "exclude_id": "00000000-0000-0000-0000-000000000000",
+                "match_limit": NEIGHBOR_LIMIT,
+                "similarity_threshold": NEIGHBOR_SIM_THRESHOLD,
+                "filter_type": None,
+            },
+        ).execute()
+        return resp.data or []
+    except Exception:
+        return []
+
+
+def _hydrate_neighbors(client, rows: list[dict]) -> list[dict]:
+    """find_similar_memories returns id/name/type/similarity only; classifier
+    needs description+content for a real comparison. One round-trip."""
+    ids = [r["id"] for r in rows if r.get("id")]
+    if not ids:
+        return rows
+    try:
+        full = (
+            client.table("memories")
+            .select("id, name, type, description, content, tags")
+            .in_("id", ids)
+            .execute()
+        )
+        by_id = {row["id"]: row for row in (full.data or [])}
+    except Exception:
+        return rows
+
+    hydrated = []
+    for r in rows:
+        extra = by_id.get(r.get("id"), {})
+        hydrated.append(
+            {
+                "id": r.get("id"),
+                "name": r.get("name") or extra.get("name", ""),
+                "type": r.get("type") or extra.get("type", ""),
+                "similarity": r.get("similarity", 0),
+                "description": extra.get("description", ""),
+                "content": extra.get("content", ""),
+                "tags": extra.get("tags", []) or [],
+            }
+        )
+    return hydrated
+
+
+def _insert_candidate(
+    client,
+    candidate: Candidate,
+    embedding: list[float] | None,
+    source_provenance: str,
+) -> str | None:
+    """Upsert-by-(project, name) for project-scoped, manual upsert for global.
+    Mirrors server.py's _handle_store logic just enough to get the row in.
+
+    We deliberately set project=None (global) for episode-derived memories
+    until we have signals to scope them — the synthesizer doesn't currently
+    distinguish projects."""
+    data = {
+        "type": candidate.type,
+        "name": candidate.name,
+        "content": candidate.content,
+        "description": candidate.description,
+        "project": None,
+        "tags": candidate.tags,
+        "deleted_at": None,
+        "source_provenance": source_provenance,
+    }
+    if embedding is not None:
+        data["embedding"] = embedding
+        data["embedding_model"] = VOYAGE_MODEL
+        data["embedding_version"] = "v2"
+
+    try:
+        existing = (
+            client.table("memories")
+            .select("id")
+            .eq("name", candidate.name)
+            .is_("project", "null")
+            .limit(1)
+            .execute()
+        )
+        if existing.data:
+            stored_id = existing.data[0]["id"]
+            client.table("memories").update(data).eq("id", stored_id).execute()
+            return stored_id
+        result = client.table("memories").insert(data).execute()
+        return result.data[0]["id"] if result.data else None
+    except Exception:
+        return None
+
+
+def _queue_classifier_decision(
+    client,
+    candidate_id: str,
+    decision,
+    neighbors: list[dict],
+) -> None:
+    """Record the classifier's call on an episode-derived candidate. We do
+    NOT mutate neighbors from the extractor path — neighbor mutation belongs
+    to the synchronous write path in server.py, where rowcount checks guard
+    against races. Here we only record the decision for later audit.
+
+    status='auto_applied' when confidence is high (means "we'd have mutated
+    but deferred"), 'pending' when low (owner reviews)."""
+    try:
+        status = "auto_applied" if decision.confidence >= CLASSIFIER_APPLY_THRESHOLD else "pending"
+        client.table("memory_review_queue").insert(
+            {
+                "candidate_id": candidate_id,
+                "decision": decision.decision,
+                "target_id": decision.target_id,
+                "confidence": decision.confidence,
+                "reasoning": decision.reasoning,
+                "classifier_model": "claude-haiku-4-5",
+                "neighbors_seen": [
+                    {"id": n.get("id"), "name": n.get("name"), "similarity": n.get("similarity")}
+                    for n in neighbors
+                ],
+                "status": status,
+                "reviewed_by": "episode_extractor",
+            }
+        ).execute()
+    except Exception:
+        pass  # queue is audit-only; never block the extractor
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+
+async def process_candidate(
+    client,
+    candidate: Candidate,
+    source_provenance: str,
+    *,
+    dry_run: bool = False,
+) -> tuple[str, str | None]:
+    """Embed → (optional) classify → insert. Returns (action, memory_id).
+    action is one of: 'inserted', 'skipped_noop', 'failed'."""
+    embed_text = _canonical_embed_text(
+        candidate.name, candidate.description, candidate.tags, candidate.content
+    )
+    embedding = await _embed(embed_text)
+
+    # Neighbor lookup + classifier (optional, best-effort).
+    classifier_decision = None
+    neighbors: list[dict] = []
+    if embedding is not None:
+        raw_neighbors = _find_neighbors(client, embedding)
+        trigger_neighbors = [
+            r for r in raw_neighbors if r.get("similarity", 0) >= CLASSIFIER_TRIGGER_SIM
+        ]
+        if trigger_neighbors:
+            neighbors = _hydrate_neighbors(client, trigger_neighbors)
+            try:
+                classifier_decision = await classify_write(candidate.to_dict(), neighbors)
+            except Exception:
+                classifier_decision = None
+
+    # NOOP at high confidence → skip insertion (candidate is redundant).
+    if (
+        classifier_decision is not None
+        and classifier_decision.decision == "NOOP"
+        and classifier_decision.confidence >= CLASSIFIER_APPLY_THRESHOLD
+    ):
+        return ("skipped_noop", None)
+
+    if dry_run:
+        return ("inserted", None)
+
+    stored_id = _insert_candidate(client, candidate, embedding, source_provenance)
+    if not stored_id:
+        return ("failed", None)
+
+    # Record classifier's view for audit (even on ADD) if we called it.
+    if classifier_decision is not None:
+        _queue_classifier_decision(client, stored_id, classifier_decision, neighbors)
+
+    return ("inserted", stored_id)
+
+
+async def process_batch(
+    client,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    *,
+    dry_run: bool = False,
+) -> BatchResult:
+    """Drain one batch of unprocessed episodes.
+
+    Returns a BatchResult that callers (tests, schedulers, manual runs) can
+    use to report progress. An empty backlog returns a BatchResult with
+    episode_ids=[] — still counts as a successful run."""
+    episodes = fetch_unprocessed(client, batch_size)
+    episode_ids = [ep["id"] for ep in episodes]
+    errors: list[str] = []
+
+    if not episodes:
+        return BatchResult(
+            episode_ids=[],
+            candidates_synthesized=0,
+            candidates_inserted=0,
+            candidates_skipped_noop=0,
+            errors=[],
+        )
+
+    candidates = await synthesize_candidates(episodes)
+    if not candidates:
+        # Synthesis found nothing extractable (or the API failed). Do NOT
+        # mark episodes processed when the API call itself failed — we'd
+        # lose retries. Distinguish via "api key set + zero candidates =
+        # legitimate empty result" heuristic.
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            if not dry_run:
+                mark_processed(client, episode_ids)
+        return BatchResult(
+            episode_ids=episode_ids,
+            candidates_synthesized=0,
+            candidates_inserted=0,
+            candidates_skipped_noop=0,
+            errors=[] if os.environ.get("ANTHROPIC_API_KEY") else ["ANTHROPIC_API_KEY unset"],
+        )
+
+    # Use the first episode's id as the provenance anchor. The full batch of
+    # episode ids is recoverable via the audit_log / review queue if needed.
+    source_provenance = f"episode:{episode_ids[0]}"
+
+    inserted = 0
+    skipped_noop = 0
+    for candidate in candidates:
+        try:
+            action, _ = await process_candidate(
+                client, candidate, source_provenance, dry_run=dry_run
+            )
+            if action == "inserted":
+                inserted += 1
+            elif action == "skipped_noop":
+                skipped_noop += 1
+            else:
+                errors.append(f"failed to insert {candidate.name}")
+        except Exception as exc:  # pragma: no cover — defensive
+            errors.append(f"{candidate.name}: {exc}")
+
+    if not dry_run:
+        mark_processed(client, episode_ids)
+
+    return BatchResult(
+        episode_ids=episode_ids,
+        candidates_synthesized=len(candidates),
+        candidates_inserted=inserted,
+        candidates_skipped_noop=skipped_noop,
+        errors=errors,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Drain the episodes table into candidate memories."
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=f"Episodes per batch (default {DEFAULT_BATCH_SIZE}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run synthesis + classifier, print result, don't write to DB.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _amain(args: argparse.Namespace) -> int:
+    client = get_client()
+    result = await process_batch(client, batch_size=args.batch_size, dry_run=args.dry_run)
+    print(
+        json.dumps(
+            {
+                "episode_ids": result.episode_ids,
+                "candidates_synthesized": result.candidates_synthesized,
+                "candidates_inserted": result.candidates_inserted,
+                "candidates_skipped_noop": result.candidates_skipped_noop,
+                "errors": result.errors,
+                "dry_run": args.dry_run,
+            },
+            indent=2,
+        )
+    )
+    return 1 if result.errors else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_amain(_parse_args(argv)))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/mcp-memory/episode_extractor.py
+++ b/mcp-memory/episode_extractor.py
@@ -2,10 +2,25 @@
 
 Background worker that drains the `episodes` table (raw "what happened"
 records written by hooks/skills/autonomous code) and distills batches
-into candidate memories via a Haiku synthesis step. Each candidate is
-routed through the Phase 2b classifier for ADD/UPDATE/DELETE/NOOP
-decision and, when appropriate, inserted into the `memories` table
-with `source_provenance='episode:<id>'`.
+into candidate memories via a Haiku synthesis step.
+
+Pipeline per candidate:
+  1. Embed the canonical form (same as server.py's Phase 2a write path).
+  2. If embedding succeeded, look up neighbors via `find_similar_memories`.
+  3. If any neighbor passes `CLASSIFIER_TRIGGER_SIM` (~0.70), call the
+     Phase 2b classifier for an ADD/UPDATE/DELETE/NOOP judgment.
+  4. NOOP at confidence >= `CLASSIFIER_APPLY_THRESHOLD` → skip insertion
+     (the candidate is judged a duplicate of an existing memory).
+  5. Otherwise → insert into `memories` directly with
+     `source_provenance='episode:<first-batch-id>'`. The classifier's
+     decision (when it ran) is recorded in `memory_review_queue` with
+     status='pending' for audit — the extractor never mutates existing
+     neighbors; that path lives in server.py where rowcount checks guard
+     against races.
+
+Classifier invocation is CONDITIONAL (only when neighbors exist). No
+neighbors → straight insert without a queue entry. Embedding failure is
+treated as "no neighbors" and also short-circuits the classifier.
 
 Theory (CLS, Tulving) and production (Letta, LangMem, A-MEM) agree on
 the same shape: a non-lossy episodic buffer, with semantic extraction
@@ -20,8 +35,13 @@ Run modes:
 
 Environment:
   SUPABASE_URL / SUPABASE_KEY   — required
-  VOYAGE_API_KEY                — required for embedding
-  ANTHROPIC_API_KEY             — required for synthesis + classifier
+  ANTHROPIC_API_KEY             — required for synthesis (and classifier
+                                  when it runs). Missing key leaves
+                                  episodes unprocessed for retry.
+  VOYAGE_API_KEY                — best-effort. Missing or erroring keeps
+                                  the pipeline alive but stores candidates
+                                  without embeddings and skips the
+                                  classifier round-trip entirely.
 """
 
 from __future__ import annotations
@@ -316,18 +336,26 @@ async def synthesize_candidates(
     *,
     model: str = SYNTHESIZER_MODEL,
     timeout: float = SYNTHESIZER_TIMEOUT,
-) -> list[Candidate]:
+) -> list[Candidate] | None:
     """Call Haiku to turn a batch of episodes into candidate memories.
 
-    Returns [] on any failure (no API key, network error, parse error) — the
-    caller treats this as "nothing extractable from this batch" and moves on
-    WITHOUT marking the episodes processed, so a later run can retry."""
+    Return contract:
+      - list[Candidate] (possibly empty) → synthesis ran. An empty list means
+        the model explicitly judged the batch as having no durable content;
+        the caller SHOULD mark the episodes processed.
+      - None → synthesis could not run (missing API key, network/API error).
+        The caller MUST NOT mark the episodes processed so a later run can
+        retry.
+
+    Parse-level noise (stray prose, malformed JSON inside an otherwise-OK
+    response) is tolerated and collapses to []: we trust the model's
+    "nothing here" signal rather than looping forever on a bad shape."""
     if not episodes:
         return []
 
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
-        return []
+        return None
 
     body = {
         "model": model,
@@ -352,7 +380,7 @@ async def synthesize_candidates(
     except asyncio.CancelledError:
         raise
     except (httpx.HTTPError, ValueError):
-        return []
+        return None
 
     blocks = payload.get("content", [])
     text = ""
@@ -464,7 +492,6 @@ def _insert_candidate(
         "description": candidate.description,
         "project": None,
         "tags": candidate.tags,
-        "deleted_at": None,
         "source_provenance": source_provenance,
     }
     if embedding is not None:
@@ -497,15 +524,15 @@ def _queue_classifier_decision(
     decision,
     neighbors: list[dict],
 ) -> None:
-    """Record the classifier's call on an episode-derived candidate. We do
-    NOT mutate neighbors from the extractor path — neighbor mutation belongs
-    to the synchronous write path in server.py, where rowcount checks guard
-    against races. Here we only record the decision for later audit.
+    """Record the classifier's call on an episode-derived candidate.
 
-    status='auto_applied' when confidence is high (means "we'd have mutated
-    but deferred"), 'pending' when low (owner reviews)."""
+    We do NOT mutate neighbors from the extractor path — neighbor mutation
+    belongs to the synchronous write path in server.py, where rowcount
+    checks guard against races. Because no mutation is ever applied here,
+    status is always 'pending' (per schema semantics: 'auto_applied' means
+    the decision was actually applied) and `reviewed_by` is left unset —
+    the owner (or a consolidation job) is the real reviewer."""
     try:
-        status = "auto_applied" if decision.confidence >= CLASSIFIER_APPLY_THRESHOLD else "pending"
         client.table("memory_review_queue").insert(
             {
                 "candidate_id": candidate_id,
@@ -518,8 +545,7 @@ def _queue_classifier_decision(
                     {"id": n.get("id"), "name": n.get("name"), "similarity": n.get("similarity")}
                     for n in neighbors
                 ],
-                "status": status,
-                "reviewed_by": "episode_extractor",
+                "status": "pending",
             }
         ).execute()
     except Exception:
@@ -607,20 +633,28 @@ async def process_batch(
         )
 
     candidates = await synthesize_candidates(episodes)
-    if not candidates:
-        # Synthesis found nothing extractable (or the API failed). Do NOT
-        # mark episodes processed when the API call itself failed — we'd
-        # lose retries. Distinguish via "api key set + zero candidates =
-        # legitimate empty result" heuristic.
-        if os.environ.get("ANTHROPIC_API_KEY"):
-            if not dry_run:
-                mark_processed(client, episode_ids)
+    if candidates is None:
+        # Synthesis failed (no API key or transport error). Leave episodes
+        # unprocessed so a later run can retry.
         return BatchResult(
             episode_ids=episode_ids,
             candidates_synthesized=0,
             candidates_inserted=0,
             candidates_skipped_noop=0,
-            errors=[] if os.environ.get("ANTHROPIC_API_KEY") else ["ANTHROPIC_API_KEY unset"],
+            errors=["synthesis failed — episodes left unprocessed for retry"],
+        )
+
+    if not candidates:
+        # Legitimate empty result — model saw nothing worth saving. Mark
+        # processed so we don't loop on the same episodes.
+        if not dry_run:
+            mark_processed(client, episode_ids)
+        return BatchResult(
+            episode_ids=episode_ids,
+            candidates_synthesized=0,
+            candidates_inserted=0,
+            candidates_skipped_noop=0,
+            errors=[],
         )
 
     # Use the first episode's id as the provenance anchor. The full batch of
@@ -643,7 +677,10 @@ async def process_batch(
         except Exception as exc:  # pragma: no cover — defensive
             errors.append(f"{candidate.name}: {exc}")
 
-    if not dry_run:
+    # Only mark processed when everything succeeded — partial failures leave
+    # the batch for retry. Operators can manually intervene if a candidate
+    # keeps failing (e.g. malformed name blocks the insert on every retry).
+    if not dry_run and not errors:
         mark_processed(client, episode_ids)
 
     return BatchResult(

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -811,3 +811,61 @@ alter table memories add column if not exists deleted_at timestamptz;
 -- with type/project/lifecycle filters already covered by existing indexes.
 create index if not exists idx_memories_deleted_at
   on memories(deleted_at) where deleted_at is not null;
+
+
+-- =========================================================================
+-- Phase 4 (memory overhaul, Osasuwu/jarvis#197) — episodic layer
+--
+-- Raw "what happened" buffer that an async extractor distills into candidate
+-- memories. Mirrors the episodic ↔ semantic separation from CLS theory and
+-- production systems (Letta tiered memory, A-MEM, LangMem background mode):
+-- non-lossy episodic buffer, consolidation happens offline.
+--
+-- Write path: hooks / skills / autonomous code insert rows here cheaply.
+-- Read path: episode_extractor.py batches unprocessed rows, synthesizes
+-- candidate memories via Haiku, and writes them through the existing
+-- memory_store flow with source_provenance='episode:<id>'.
+-- =========================================================================
+
+create table if not exists episodes (
+  id uuid primary key default gen_random_uuid(),
+
+  -- Who/what produced this episode.
+  -- Convention: 'session:<id>', 'scheduled:<skill>', 'hook:<name>',
+  -- 'skill:<name>', 'autonomous:<skill>'.
+  actor text not null,
+
+  -- Shape of the payload. Extractor may prompt differently per kind.
+  kind text not null
+    check (kind in ('tool_call', 'decision', 'user_message', 'assistant_message', 'observation')),
+
+  -- Arbitrary structured content. Schema is intentionally loose — episodes
+  -- are raw material, not normalized facts.
+  payload jsonb not null default '{}',
+
+  -- Transaction time: when the episode was recorded.
+  created_at timestamptz not null default now(),
+
+  -- Extractor marks this when it has consumed the episode (success or skip).
+  -- NULL = still in the backlog.
+  processed_at timestamptz
+);
+
+-- Backlog scan — partial index so the extractor's "fetch next batch" query
+-- stays cheap regardless of processed-history size.
+create index if not exists idx_episodes_unprocessed
+  on episodes(created_at) where processed_at is null;
+
+-- Per-actor filtering for debugging / per-source stats.
+create index if not exists idx_episodes_actor on episodes(actor);
+
+-- Chronological audit.
+create index if not exists idx_episodes_created on episodes(created_at desc);
+
+alter table episodes enable row level security;
+
+create policy "Allow all for authenticated" on episodes
+  for all using (true) with check (true);
+
+create policy "Allow all for anon" on episodes
+  for all to anon using (true) with check (true);

--- a/scripts/capture-episode.py
+++ b/scripts/capture-episode.py
@@ -1,0 +1,151 @@
+"""Capture a single episode into the `episodes` table.
+
+Thin CLI around the Supabase client for hooks to call. Keeps episode
+capture cheap: writes are fire-and-forget, non-blocking to the caller
+(the extractor runs separately).
+
+Usage:
+  python scripts/capture-episode.py --actor session:2026-04-18 \
+      --kind user_message --payload '{"text": "..."}'
+
+  # Or read payload from stdin:
+  echo '{"text": "..."}' | python scripts/capture-episode.py \
+      --actor hook:user-prompt --kind user_message
+
+Intended wiring from .claude/settings.json (UserPromptSubmit hook):
+  {
+    "matcher": "",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "python scripts/capture-episode.py --actor hook:user-prompt --kind user_message --from-stdin"
+      }
+    ]
+  }
+
+Environment:
+  SUPABASE_URL / SUPABASE_KEY — required.
+
+Exit codes:
+  0 on success
+  1 on error (bad args, missing env, DB failure). Never blocks the hook —
+  Claude Code treats a non-zero hook exit as informational.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+# Load .env from repo root (parent of scripts/).
+try:
+    from dotenv import load_dotenv
+
+    for _env_path in [_HERE.parent / ".env", _HERE.parent.parent / ".env"]:
+        if _env_path.exists():
+            load_dotenv(_env_path, override=True)
+            break
+except ImportError:
+    pass
+
+
+VALID_KINDS = ("tool_call", "decision", "user_message", "assistant_message", "observation")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Write a single row to the episodes table.")
+    parser.add_argument(
+        "--actor",
+        required=True,
+        help="Who produced this episode. Conventions: 'session:<id>', "
+        "'hook:<name>', 'skill:<name>', 'autonomous:<skill>'.",
+    )
+    parser.add_argument(
+        "--kind",
+        required=True,
+        choices=VALID_KINDS,
+        help="Shape of the payload (drives extractor prompting).",
+    )
+    parser.add_argument(
+        "--payload", help="JSON payload. Omit with --from-stdin to read from stdin instead."
+    )
+    parser.add_argument(
+        "--from-stdin",
+        action="store_true",
+        help="Read the payload JSON from stdin (for hook wiring).",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="Suppress success output (hooks want silent success)."
+    )
+    return parser.parse_args(argv)
+
+
+def _load_payload(args: argparse.Namespace) -> dict | list | str:
+    if args.from_stdin:
+        raw = sys.stdin.read()
+    elif args.payload is not None:
+        raw = args.payload
+    else:
+        return {}
+
+    raw = raw.strip()
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        # Non-JSON stdin (e.g. a raw prompt) — wrap as {"text": ...} so
+        # the schema constraint (jsonb) still holds and the extractor can
+        # still read it.
+        return {"text": raw}
+
+
+def capture(actor: str, kind: str, payload) -> str | None:
+    """Insert one episode. Returns the new row's id, or None on failure."""
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        print("ERROR: SUPABASE_URL / SUPABASE_KEY unset", file=sys.stderr)
+        return None
+
+    from supabase import create_client
+
+    try:
+        client = create_client(url, key)
+        result = (
+            client.table("episodes")
+            .insert(
+                {
+                    "actor": actor,
+                    "kind": kind,
+                    "payload": payload,
+                }
+            )
+            .execute()
+        )
+        if result.data:
+            return result.data[0].get("id")
+    except Exception as exc:
+        print(f"ERROR: episode capture failed: {exc}", file=sys.stderr)
+        return None
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    payload = _load_payload(args)
+    episode_id = capture(args.actor, args.kind, payload)
+    if episode_id is None:
+        return 1
+    if not args.quiet:
+        print(f"captured episode {episode_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/capture-episode.py
+++ b/scripts/capture-episode.py
@@ -8,9 +8,10 @@ Usage:
   python scripts/capture-episode.py --actor session:2026-04-18 \
       --kind user_message --payload '{"text": "..."}'
 
-  # Or read payload from stdin:
+  # Or read payload from stdin (remember --from-stdin — otherwise the
+  # piped JSON is ignored and an empty {} payload is captured):
   echo '{"text": "..."}' | python scripts/capture-episode.py \
-      --actor hook:user-prompt --kind user_message
+      --actor hook:user-prompt --kind user_message --from-stdin
 
 Intended wiring from .claude/settings.json (UserPromptSubmit hook):
   {

--- a/tests/test_episode_extractor.py
+++ b/tests/test_episode_extractor.py
@@ -272,14 +272,16 @@ class TestParseSynthesisResponse:
 
 
 class TestSynthesizeCandidatesNoKey:
-    def test_returns_empty_without_api_key(self, monkeypatch):
+    def test_returns_none_without_api_key(self, monkeypatch):
+        """Missing API key is a failure signal (None), not a legit-empty []
+        — the caller must leave the batch unprocessed so a later run retries."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         out = asyncio.run(
             ee.synthesize_candidates(
                 [{"id": "e", "actor": "a", "kind": "user_message", "payload": {}}]
             )
         )
-        assert out == []
+        assert out is None
 
     def test_returns_empty_on_empty_batch(self):
         out = asyncio.run(ee.synthesize_candidates([]))
@@ -427,9 +429,10 @@ class TestProcessBatchWithEpisodes:
         ep_ops = [q.calls for q in client.tables["episodes"].queries]
         assert any(any(c[0] == "update" for c in call_list) for call_list in ep_ops)
 
-    def test_does_not_mark_processed_when_api_key_missing(self, monkeypatch):
-        """Without an API key, synthesis fails — we must leave episodes
-        unprocessed so a later run (with key) can retry."""
+    def test_does_not_mark_processed_when_synthesis_fails(self, monkeypatch):
+        """Synthesis failure (None return) must leave episodes unprocessed so
+        a later run can retry. We simulate this via missing API key — the
+        same path handles network errors."""
         client = _MockClient()
         client.tables["episodes"].fetch_result = _MockResp(
             [
@@ -448,8 +451,47 @@ class TestProcessBatchWithEpisodes:
         result = asyncio.run(ee.process_batch(client, batch_size=5))
 
         assert result.episode_ids == ["e1"]
-        assert "ANTHROPIC_API_KEY unset" in " ".join(result.errors)
+        assert "synthesis failed" in " ".join(result.errors)
         # Episode update must NOT have been called.
+        ep_ops = [q.calls for q in client.tables["episodes"].queries]
+        assert not any(any(c[0] == "update" for c in call_list) for call_list in ep_ops)
+
+    def test_does_not_mark_processed_when_insert_errors(self, monkeypatch):
+        """If a candidate fails to insert (_insert_candidate returns None),
+        the batch should be left unprocessed so a later run can retry the
+        whole pipeline — we don't want to silently lose episodes."""
+        client = _MockClient()
+        client.tables["episodes"].fetch_result = _MockResp(
+            [
+                {
+                    "id": "e1",
+                    "actor": "t",
+                    "kind": "user_message",
+                    "payload": {},
+                    "created_at": "2026-04-18",
+                },
+            ]
+        )
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+
+        async def fake_synth(episodes, **kwargs):
+            return [ee.Candidate("n", "project", "", "c", [])]
+
+        async def fake_embed(text):
+            return None
+
+        def fake_insert(client, candidate, embedding, source_provenance):
+            return None  # simulate insert failure
+
+        monkeypatch.setattr(ee, "synthesize_candidates", fake_synth)
+        monkeypatch.setattr(ee, "_embed", fake_embed)
+        monkeypatch.setattr(ee, "_insert_candidate", fake_insert)
+
+        result = asyncio.run(ee.process_batch(client, batch_size=5))
+
+        assert result.candidates_inserted == 0
+        assert any("failed to insert" in e for e in result.errors)
         ep_ops = [q.calls for q in client.tables["episodes"].queries]
         assert not any(any(c[0] == "update" for c in call_list) for call_list in ep_ops)
 

--- a/tests/test_episode_extractor.py
+++ b/tests/test_episode_extractor.py
@@ -1,0 +1,633 @@
+"""Unit tests for mcp-memory/episode_extractor.py and scripts/capture-episode.py.
+
+Covers the deterministic pieces: prompt assembly, response parsing, batch
+orchestration with a mocked Supabase client. Network paths (Voyage + Haiku)
+are exercised via stub HTTP clients to keep the suite hermetic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub external deps the way test_memory_server.py does — so this test file
+# can run standalone even when httpx / supabase / dotenv aren't installed.
+# ---------------------------------------------------------------------------
+
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules["httpx"] = types.ModuleType("httpx")
+
+try:
+    import supabase  # noqa: F401
+except ImportError:
+    sys.modules["supabase"] = types.ModuleType("supabase")
+
+_dotenv = types.ModuleType("dotenv")
+_dotenv.load_dotenv = lambda *a, **kw: None
+sys.modules.setdefault("dotenv", _dotenv)
+
+# Add mcp-memory + scripts to sys.path.
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "mcp-memory"))
+sys.path.insert(0, str(_REPO / "scripts"))
+
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_KEY", "test-key")
+
+import episode_extractor as ee  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _truncate
+# ---------------------------------------------------------------------------
+
+
+class TestTruncate:
+    def test_short_unchanged(self):
+        assert ee._truncate("hello") == "hello"
+
+    def test_empty(self):
+        assert ee._truncate("") == ""
+
+    def test_truncates_with_ellipsis(self):
+        text = "x" * (ee.MAX_PAYLOAD_CHARS_PER_EPISODE + 100)
+        out = ee._truncate(text)
+        assert out.endswith("…")
+        assert len(out) == ee.MAX_PAYLOAD_CHARS_PER_EPISODE + 1
+
+
+# ---------------------------------------------------------------------------
+# _canonical_embed_text
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalEmbedText:
+    def test_name_underscores_replaced(self):
+        out = ee._canonical_embed_text("my_memory_name", "", [], "body")
+        assert "my memory name" in out
+        assert "my_memory_name" not in out
+
+    def test_tags_rendered(self):
+        out = ee._canonical_embed_text("n", "", ["a", "b"], "body")
+        assert "tags: a, b" in out
+
+    def test_empty_inputs(self):
+        assert ee._canonical_embed_text("", "", [], "") == ""
+
+    def test_all_fields_ordered(self):
+        out = ee._canonical_embed_text("name", "desc", ["t1"], "content")
+        lines = out.split("\n")
+        assert lines[0] == "name"
+        assert lines[1] == "tags: t1"
+        assert lines[2] == "desc"
+        assert lines[3] == "content"
+
+
+# ---------------------------------------------------------------------------
+# _render_episode + build_synthesis_user_message
+# ---------------------------------------------------------------------------
+
+
+class TestRenderEpisode:
+    def test_includes_all_fields(self):
+        out = ee._render_episode(
+            {
+                "id": "ep1",
+                "actor": "session:x",
+                "kind": "user_message",
+                "created_at": "2026-04-18T10:00:00Z",
+                "payload": {"text": "hello"},
+            }
+        )
+        assert "ep1" in out
+        assert "session:x" in out
+        assert "user_message" in out
+        assert "2026-04-18T10:00:00Z" in out
+        assert '"text"' in out and "hello" in out
+
+    def test_truncates_huge_payload(self):
+        out = ee._render_episode(
+            {
+                "id": "ep",
+                "actor": "a",
+                "kind": "tool_call",
+                "created_at": "",
+                "payload": {"blob": "x" * 5000},
+            }
+        )
+        assert len(out) < 2000  # well under the raw payload size
+        assert "…" in out
+
+    def test_non_dict_payload(self):
+        out = ee._render_episode(
+            {
+                "id": "ep",
+                "actor": "a",
+                "kind": "observation",
+                "created_at": "",
+                "payload": "raw string",
+            }
+        )
+        assert "raw string" in out
+
+
+class TestBuildSynthesisUserMessage:
+    def test_empty_batch(self):
+        assert "empty batch" in ee.build_synthesis_user_message([])
+
+    def test_multiple_episodes_separated(self):
+        eps = [
+            {"id": "e1", "actor": "a", "kind": "user_message", "payload": {"x": 1}},
+            {"id": "e2", "actor": "b", "kind": "decision", "payload": {"y": 2}},
+        ]
+        out = ee.build_synthesis_user_message(eps)
+        assert "e1" in out
+        assert "e2" in out
+        assert out.startswith("EPISODES")
+
+
+# ---------------------------------------------------------------------------
+# parse_synthesis_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseSynthesisResponse:
+    def test_empty_string(self):
+        assert ee.parse_synthesis_response("") == []
+
+    def test_no_json(self):
+        assert ee.parse_synthesis_response("no json here") == []
+
+    def test_malformed_json(self):
+        assert ee.parse_synthesis_response("{not valid") == []
+
+    def test_empty_candidates(self):
+        assert ee.parse_synthesis_response('{"candidates": []}') == []
+
+    def test_candidates_not_a_list(self):
+        assert ee.parse_synthesis_response('{"candidates": "oops"}') == []
+
+    def test_valid_single_candidate(self):
+        resp = json.dumps(
+            {
+                "candidates": [
+                    {
+                        "name": "test_mem",
+                        "type": "project",
+                        "description": "a description",
+                        "content": "the content",
+                        "tags": ["tag1", "tag2"],
+                    }
+                ]
+            }
+        )
+        out = ee.parse_synthesis_response(resp)
+        assert len(out) == 1
+        c = out[0]
+        assert c.name == "test_mem"
+        assert c.type == "project"
+        assert c.tags == ["tag1", "tag2"]
+
+    def test_drops_invalid_type(self):
+        resp = json.dumps(
+            {
+                "candidates": [
+                    {"name": "good", "type": "project", "description": "", "content": "c"},
+                    {"name": "bad", "type": "nonsense", "description": "", "content": "c"},
+                ]
+            }
+        )
+        out = ee.parse_synthesis_response(resp)
+        assert len(out) == 1
+        assert out[0].name == "good"
+
+    def test_drops_empty_name_or_content(self):
+        resp = json.dumps(
+            {
+                "candidates": [
+                    {"name": "", "type": "project", "content": "c"},
+                    {"name": "x", "type": "project", "content": ""},
+                    {"name": "y", "type": "project", "content": "has content"},
+                ]
+            }
+        )
+        out = ee.parse_synthesis_response(resp)
+        assert len(out) == 1
+        assert out[0].name == "y"
+
+    def test_tolerates_prose_around_json(self):
+        resp = (
+            "Here is the output:\n"
+            + json.dumps({"candidates": [{"name": "x", "type": "user", "content": "c"}]})
+            + "\n\nDone."
+        )
+        out = ee.parse_synthesis_response(resp)
+        assert len(out) == 1
+
+    def test_tag_normalization(self):
+        resp = json.dumps(
+            {
+                "candidates": [
+                    {
+                        "name": "x",
+                        "type": "user",
+                        "content": "c",
+                        "tags": ["  TAG1 ", "", "Tag2", 42],
+                    }
+                ]
+            }
+        )
+        out = ee.parse_synthesis_response(resp)
+        assert out[0].tags == ["tag1", "tag2", "42"]
+
+    def test_tag_hard_cap(self):
+        resp = json.dumps(
+            {
+                "candidates": [
+                    {
+                        "name": "x",
+                        "type": "user",
+                        "content": "c",
+                        "tags": [f"tag{i}" for i in range(20)],
+                    }
+                ]
+            }
+        )
+        out = ee.parse_synthesis_response(resp)
+        assert len(out[0].tags) == 10
+
+
+# ---------------------------------------------------------------------------
+# synthesize_candidates — no API key short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeCandidatesNoKey:
+    def test_returns_empty_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        out = asyncio.run(
+            ee.synthesize_candidates(
+                [{"id": "e", "actor": "a", "kind": "user_message", "payload": {}}]
+            )
+        )
+        assert out == []
+
+    def test_returns_empty_on_empty_batch(self):
+        out = asyncio.run(ee.synthesize_candidates([]))
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# process_batch — mocked client integration
+# ---------------------------------------------------------------------------
+
+
+class _MockResp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _MockQuery:
+    """Minimal fluent-API mock for the Supabase python client chaining pattern."""
+
+    def __init__(self, result):
+        self.result = result
+        self.calls: list[tuple] = []
+
+    def select(self, *a, **k):
+        self.calls.append(("select", a, k))
+        return self
+
+    def is_(self, *a, **k):
+        self.calls.append(("is_", a, k))
+        return self
+
+    def eq(self, *a, **k):
+        self.calls.append(("eq", a, k))
+        return self
+
+    def order(self, *a, **k):
+        self.calls.append(("order", a, k))
+        return self
+
+    def limit(self, *a, **k):
+        self.calls.append(("limit", a, k))
+        return self
+
+    def in_(self, *a, **k):
+        self.calls.append(("in_", a, k))
+        return self
+
+    def update(self, *a, **k):
+        self.calls.append(("update", a, k))
+        return self
+
+    def insert(self, *a, **k):
+        self.calls.append(("insert", a, k))
+        return self
+
+    def execute(self):
+        return self.result
+
+
+class _MockTable:
+    """Per-table mock that hands out fresh _MockQuery instances and records them."""
+
+    def __init__(self):
+        self.fetch_result = _MockResp([])
+        self.insert_result = _MockResp([])
+        self.update_result = _MockResp([])
+        self.queries: list[_MockQuery] = []
+
+    def _q(self, result=None):
+        q = _MockQuery(result if result is not None else _MockResp([]))
+        self.queries.append(q)
+        return q
+
+    def select(self, *a, **k):
+        q = self._q(self.fetch_result)
+        return q.select(*a, **k)
+
+    def insert(self, *a, **k):
+        q = self._q(self.insert_result)
+        return q.insert(*a, **k)
+
+    def update(self, *a, **k):
+        q = self._q(self.update_result)
+        return q.update(*a, **k)
+
+
+class _MockClient:
+    def __init__(self):
+        self.tables: dict[str, _MockTable] = {
+            "episodes": _MockTable(),
+            "memories": _MockTable(),
+            "memory_links": _MockTable(),
+            "memory_review_queue": _MockTable(),
+        }
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def table(self, name: str) -> _MockTable:
+        return self.tables.setdefault(name, _MockTable())
+
+    def rpc(self, name: str, params: dict):
+        self.rpc_calls.append((name, params))
+        # find_similar_memories returns no neighbors by default → skips classifier
+        return _MockQuery(_MockResp([]))
+
+
+class TestProcessBatchEmpty:
+    def test_empty_backlog_returns_noop_result(self):
+        client = _MockClient()
+        # fetch_unprocessed returns [] by default
+        result = asyncio.run(ee.process_batch(client, batch_size=5))
+        assert result.episode_ids == []
+        assert result.candidates_synthesized == 0
+        assert result.candidates_inserted == 0
+
+
+class TestProcessBatchWithEpisodes:
+    def test_marks_processed_when_synthesis_empty(self, monkeypatch):
+        """With an API key set and synthesis returning []: episodes are marked
+        processed (treated as legitimately nothing to extract)."""
+        client = _MockClient()
+        client.tables["episodes"].fetch_result = _MockResp(
+            [
+                {
+                    "id": "e1",
+                    "actor": "test",
+                    "kind": "user_message",
+                    "payload": {},
+                    "created_at": "2026-04-18",
+                },
+            ]
+        )
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+
+        async def fake_synth(episodes, **kwargs):
+            return []
+
+        monkeypatch.setattr(ee, "synthesize_candidates", fake_synth)
+
+        result = asyncio.run(ee.process_batch(client, batch_size=5))
+
+        assert result.episode_ids == ["e1"]
+        assert result.candidates_synthesized == 0
+        # Verify mark_processed ran: one update on the episodes table
+        ep_ops = [q.calls for q in client.tables["episodes"].queries]
+        assert any(any(c[0] == "update" for c in call_list) for call_list in ep_ops)
+
+    def test_does_not_mark_processed_when_api_key_missing(self, monkeypatch):
+        """Without an API key, synthesis fails — we must leave episodes
+        unprocessed so a later run (with key) can retry."""
+        client = _MockClient()
+        client.tables["episodes"].fetch_result = _MockResp(
+            [
+                {
+                    "id": "e1",
+                    "actor": "t",
+                    "kind": "user_message",
+                    "payload": {},
+                    "created_at": "2026-04-18",
+                },
+            ]
+        )
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        result = asyncio.run(ee.process_batch(client, batch_size=5))
+
+        assert result.episode_ids == ["e1"]
+        assert "ANTHROPIC_API_KEY unset" in " ".join(result.errors)
+        # Episode update must NOT have been called.
+        ep_ops = [q.calls for q in client.tables["episodes"].queries]
+        assert not any(any(c[0] == "update" for c in call_list) for call_list in ep_ops)
+
+    def test_inserts_candidates_with_episode_provenance(self, monkeypatch):
+        """End-to-end: fake synthesis returns candidates, extractor inserts
+        each with source_provenance='episode:<first-id>'."""
+        client = _MockClient()
+        client.tables["episodes"].fetch_result = _MockResp(
+            [
+                {
+                    "id": "ep-alpha",
+                    "actor": "test",
+                    "kind": "user_message",
+                    "payload": {"text": "hi"},
+                    "created_at": "2026-04-18",
+                },
+                {
+                    "id": "ep-beta",
+                    "actor": "test",
+                    "kind": "decision",
+                    "payload": {"choice": "X"},
+                    "created_at": "2026-04-18",
+                },
+            ]
+        )
+        # Pretend the candidate is new (no existing memory with this name).
+        client.tables["memories"].fetch_result = _MockResp([])
+        client.tables["memories"].insert_result = _MockResp([{"id": "mem-1"}])
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+
+        async def fake_synth(episodes, **kwargs):
+            return [
+                ee.Candidate(
+                    name="test_candidate",
+                    type="project",
+                    description="test",
+                    content="candidate content",
+                    tags=["phase-4"],
+                )
+            ]
+
+        async def fake_embed(text):
+            return None  # skip neighbor lookup
+
+        monkeypatch.setattr(ee, "synthesize_candidates", fake_synth)
+        monkeypatch.setattr(ee, "_embed", fake_embed)
+
+        result = asyncio.run(ee.process_batch(client, batch_size=5))
+
+        assert result.candidates_synthesized == 1
+        assert result.candidates_inserted == 1
+        assert result.episode_ids == ["ep-alpha", "ep-beta"]
+
+        # Locate the insert call on the memories table and check provenance.
+        inserts = []
+        for q in client.tables["memories"].queries:
+            for call in q.calls:
+                if call[0] == "insert":
+                    inserts.append(call[1][0])  # the dict passed to insert()
+        assert len(inserts) == 1
+        assert inserts[0]["source_provenance"] == "episode:ep-alpha"
+        assert inserts[0]["name"] == "test_candidate"
+        assert inserts[0]["type"] == "project"
+
+    def test_dry_run_does_not_insert(self, monkeypatch):
+        client = _MockClient()
+        client.tables["episodes"].fetch_result = _MockResp(
+            [
+                {
+                    "id": "e1",
+                    "actor": "t",
+                    "kind": "user_message",
+                    "payload": {},
+                    "created_at": "2026-04-18",
+                },
+            ]
+        )
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+
+        async def fake_synth(episodes, **kwargs):
+            return [ee.Candidate("n", "project", "", "c", [])]
+
+        async def fake_embed(text):
+            return None
+
+        monkeypatch.setattr(ee, "synthesize_candidates", fake_synth)
+        monkeypatch.setattr(ee, "_embed", fake_embed)
+
+        result = asyncio.run(ee.process_batch(client, batch_size=5, dry_run=True))
+
+        assert result.candidates_inserted == 1  # counted as if inserted
+        # But no actual insert calls on memories.
+        for q in client.tables["memories"].queries:
+            assert not any(c[0] == "insert" for c in q.calls)
+        # And episodes not marked processed.
+        for q in client.tables["episodes"].queries:
+            assert not any(c[0] == "update" for c in q.calls)
+
+
+# ---------------------------------------------------------------------------
+# capture-episode script
+# ---------------------------------------------------------------------------
+
+
+# The script has a dash in its filename — import it via importlib.
+import importlib.util  # noqa: E402
+
+_capture_path = _REPO / "scripts" / "capture-episode.py"
+_spec = importlib.util.spec_from_file_location("capture_episode", _capture_path)
+capture_episode = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(capture_episode)
+
+
+class TestCaptureLoadPayload:
+    def test_inline_json(self):
+        args = capture_episode._parse_args(
+            [
+                "--actor",
+                "test",
+                "--kind",
+                "user_message",
+                "--payload",
+                '{"k": 1}',
+            ]
+        )
+        assert capture_episode._load_payload(args) == {"k": 1}
+
+    def test_missing_payload_returns_empty_dict(self):
+        args = capture_episode._parse_args(
+            [
+                "--actor",
+                "test",
+                "--kind",
+                "user_message",
+            ]
+        )
+        assert capture_episode._load_payload(args) == {}
+
+    def test_stdin_json(self, monkeypatch):
+        args = capture_episode._parse_args(
+            [
+                "--actor",
+                "test",
+                "--kind",
+                "user_message",
+                "--from-stdin",
+            ]
+        )
+        monkeypatch.setattr("sys.stdin", types.SimpleNamespace(read=lambda: '{"k": 2}'))
+        assert capture_episode._load_payload(args) == {"k": 2}
+
+    def test_stdin_raw_text_wrapped(self, monkeypatch):
+        """Non-JSON stdin gets wrapped as {"text": ...} so the jsonb
+        constraint still holds — this is the common hook case (raw prompt)."""
+        args = capture_episode._parse_args(
+            [
+                "--actor",
+                "test",
+                "--kind",
+                "user_message",
+                "--from-stdin",
+            ]
+        )
+        monkeypatch.setattr(
+            "sys.stdin",
+            types.SimpleNamespace(read=lambda: "not valid json but still useful"),
+        )
+        assert capture_episode._load_payload(args) == {"text": "not valid json but still useful"}
+
+    def test_rejects_invalid_kind(self):
+        with pytest.raises(SystemExit):
+            capture_episode._parse_args(
+                [
+                    "--actor",
+                    "test",
+                    "--kind",
+                    "nonsense",
+                ]
+            )


### PR DESCRIPTION
## Summary
Introduces the Phase 4 episodic layer from the memory overhaul: a non-lossy `episodes` buffer, an async extractor that distills batches into candidate memories via Haiku-4.5, and a CLI capture site for hooks. Every extracted memory is written with `source_provenance="episode:<id>"`, satisfying the Phase 2c provenance contract.

## Why
Current memory only captures what Claude *explicitly* chose to store with `memory_store`. That misses the "what actually happened" layer — tool calls, decisions, user messages — which is the raw material real consolidation needs. CLS theory (McClelland) and production systems (Letta, LangMem, A-MEM) converge on the same shape: non-lossy episodic buffer + async semantic extraction. Direct-to-semantic writes cause catastrophic interference.

Closes #197. Feeds #185.

## Decisions & Alternatives

- **Self-contained extractor over importing from `server.py`.** `mcp-memory/server.py` is a protected file (see `docs/security/agent-boundaries.md`). Rather than couple to its internals, the extractor re-implements the minimum it needs (≈15 LOC for `_embed`, reuse of `_canonical_embed_text` form). It does import `classify_write` from `classifier.py` — that module is pure and stable per Phase 2b.
- **Writes go directly to `memories`, not through `memory_store`.** The MCP `memory_store` handler runs inside the stdio server process; this extractor is a standalone background worker with no MCP channel. It mirrors the minimum of `_handle_store`'s logic — embed + upsert-by-name — and writes the same `source_provenance` shape (`episode:<id>`), so downstream audit treats episode-derived memories uniformly with user-initiated ones. Neighbor mutation (`superseded_by`, `valid_to`, `expired_at`) deliberately stays in server.py's write path where the rowcount race check lives.
- **Classifier integration is conditional + audit-only.** After embedding, the extractor looks up neighbors via `find_similar_memories`. When a neighbor crosses `CLASSIFIER_TRIGGER_SIM` (0.70) the classifier runs and the decision is recorded in `memory_review_queue` with `status='pending'`. No neighbors above threshold → no classifier call, no queue entry, straight insert. NOOP at confidence ≥ `CLASSIFIER_APPLY_THRESHOLD` → skip the insert entirely (candidate judged redundant). The extractor never mutates existing neighbors.
- **No scheduling in this PR.** The issue explicitly said "don't scope-creep to full instrumentation — one capture site is enough to prove the loop." The module ships with a CLI entry point (`python mcp-memory/episode_extractor.py`). Wiring to `scheduled-tasks` can land separately once we've watched it run manually.
- **Capture site = CLI script, not a hook wire-up.** `.claude/settings.json` is a protected file. The PR ships `scripts/capture-episode.py` with a documented wiring snippet that the owner can paste. See "Owner action" below.
- **Batch synthesis prompt distinguishes 5 memory types.** The synthesizer prompt explicitly maps user / project / decision / feedback / reference semantics, mirroring `auto-memory` conventions — keeps episode-derived memories consistent with hand-written ones.
- **Retry semantics (addressed via Copilot review):** `synthesize_candidates()` returns `None` on transport/parse failure vs `[]` on a legitimate empty result. `process_batch` only calls `mark_processed()` when synthesis succeeded AND every candidate insert succeeded. Transient failures leave the batch in the backlog for the next run; legitimate empty synthesis marks the batch processed so we don't re-chew it.

## Risk Assessment
- **LOW** — schema is purely additive (new `episodes` table, new indexes, no column changes on existing tables). RLS mirrors every other table in this file.
- **LOW** — `episode_extractor.py` is a new module; nothing else imports it yet.
- **LOW** — `capture-episode.py` only writes to the new table.
- **LOW** — the provenance contract: extractor writes `source_provenance="episode:<batch-first-id>"`. Post-2c (#196, merged), this satisfies the required-provenance constraint.

## Testing
- `ruff check mcp-memory/episode_extractor.py scripts/capture-episode.py tests/test_episode_extractor.py` — clean
- `ruff format` — applied
- `pytest tests/test_episode_extractor.py -x -q` — **41 / 41 passed**
- Full suite post-rebase on main: **235 passed, 7 skipped** — no regression

Covered scenarios:
- Prompt assembly: single/multi/empty episode batches, payload truncation, non-dict payloads
- Response parsing: malformed JSON, missing/invalid fields, type enforcement, tag normalization + hard cap, prose around JSON
- Batch orchestration: empty backlog, synthesis=None (transient failure) vs [] (legitimate empty), insert failures don't mark processed, full insert-with-provenance flow, dry-run
- Capture CLI: inline JSON, stdin JSON, raw-text stdin wrapping, invalid-kind rejection

## Files Changed
- `mcp-memory/schema.sql` — append Phase 4 section: `episodes` table + 3 indexes + RLS policies
- `mcp-memory/episode_extractor.py` — new, ≈740 LOC: synthesis prompt, HTTP clients, batch pipeline, CLI
- `scripts/capture-episode.py` — new, 150 LOC: thin CLI wrapper around one insert
- `tests/test_episode_extractor.py` — new, ≈460 LOC: 41 tests

## Copilot review follow-up

Initial Copilot scan flagged 7 issues on the first commit. All addressed in commit `62749a2`:

1. Dropped phantom `deleted_at` from insert payload. (Column is now declared in schema via #198; the extractor's insert path doesn't need to set it — default NULL is correct for fresh rows.)
2. `mark_processed()` gated on `not errors` — batch stays in backlog on any candidate-insert failure.
3. `synthesize_candidates()` tri-state return (`None` on failure, `[]` on legitimate empty) so `process_batch` can distinguish retry-worthy failures from real empties.
4. `_queue_classifier_decision` uses `status='pending'` and omits `reviewed_by` — the extractor never applies mutations, so `auto_applied` was misleading.
5. `capture-episode.py` stdin example now includes `--from-stdin`.
6. Module docstring corrected: `VOYAGE_API_KEY` is best-effort (embedding + classifier both become no-ops when it's missing), not a hard requirement.
7. This description rewritten to match implementation (direct-to-memories insert, conditional classifier call).

## Owner action needed (protected files)

One manual step needs owner hands, since `.claude/settings.json` is in the agent-boundaries protected list:

**Wire the capture hook** (optional for this PR, required to actually start populating the episodes buffer):
```json
{
  "hooks": {
    "UserPromptSubmit": [
      {
        "matcher": "",
        "hooks": [
          {
            "type": "command",
            "command": "python scripts/capture-episode.py --actor hook:user-prompt --kind user_message --from-stdin --quiet"
          }
        ]
      }
    ]
  }
}
```

Until the hook is wired, the capture CLI is callable manually (`python scripts/capture-episode.py --actor test --kind observation --payload '{}'`) — enough to prove the loop end-to-end without owner changes.

## Coordination with Phase 2c
Rebased onto main post-#198 merge. `source_provenance` is already the exact shape Phase 2c requires (`episode:<id>`). Zero file overlap with 2c beyond the schema.sql tail — see #196 and #197.
