### PR TITLE
feat(memory): Phase 1 finish — chain collapse + touch-safe session (#185)

### DIFF
--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -869,3 +869,141 @@ create policy "Allow all for authenticated" on episodes
 
 create policy "Allow all for anon" on episodes
   for all to anon using (true) with check (true);
+
+
+-- =========================================================================
+-- Phase 1 cont'd (memory overhaul, Osasuwu/jarvis#185) — supersedes-chain
+-- collapse in link expansion.
+--
+-- Problem: match_memories and keyword_search_memories already filter out
+-- superseded rows on the default path (show_history=false). But
+-- get_linked_memories walks memory_links directly, which still points at
+-- the older versions of a chain. So recall with include_links=true can
+-- surface a memory whose current head was deliberately hidden by the
+-- lifecycle filter — re-introducing the bug Phase 1 was meant to fix.
+--
+-- Fix:
+--   1. find_chain_head(uuid, int) — recursive CTE walking superseded_by
+--      to the terminal node. Returns the input id if it's already a head,
+--      or the deepest reachable descendant (capped at max_depth to guard
+--      against cycles from manual edits).
+--   2. get_linked_memories replaced to (a) resolve the neighbor id through
+--      find_chain_head before joining memories, (b) apply the same
+--      lifecycle filter the other recall RPCs use (show_history param),
+--      and (c) return content_updated_at + last_accessed_at so the caller
+--      can temporally rescore linked memories consistently with primaries.
+-- =========================================================================
+
+-- Touch-safe update_updated_at: don't bump updated_at when the only column
+-- changed is last_accessed_at (i.e. touch_memories RPC on recall). The
+-- schema-level comment under Phase 0 already flagged this ("last_accessed_at
+-- set by touch_memories only") but the generic trigger was rippling every
+-- touch into updated_at, making session-start reads look like edits.
+--
+-- Why this matters: the fallback _keyword_recall orders by updated_at, and
+-- session-context.py selects user memories by updated_at — neither should
+-- be perturbed by the access-frequency touch.
+--
+-- Implementation: JSONB diff of old/new rows with the touch-affected columns
+-- stripped. Generated columns (fts, project_key) are also stripped because
+-- BEFORE UPDATE triggers see them as NULL in NEW while OLD has the stored
+-- value (PostgreSQL quirk for GENERATED ALWAYS STORED), so including them
+-- would always register as a diff. If new generated columns are added,
+-- list them here too.
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  if (to_jsonb(new) - 'last_accessed_at' - 'updated_at' - 'fts' - 'project_key')
+       = (to_jsonb(old) - 'last_accessed_at' - 'updated_at' - 'fts' - 'project_key') then
+    return new;
+  end if;
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+
+create or replace function find_chain_head(mid uuid, max_depth int default 20)
+returns uuid
+language sql stable as $$
+    with recursive chain as (
+        select m.id, m.superseded_by, 0 as depth
+        from memories m
+        where m.id = mid
+        union all
+        select m.id, m.superseded_by, c.depth + 1
+        from chain c
+        join memories m on m.id = c.superseded_by
+        where c.superseded_by is not null
+          and c.depth < max_depth
+    )
+    -- Terminal node: either superseded_by IS NULL (a true head) or we hit
+    -- max_depth (chain too long or cyclic — return deepest we saw).
+    select id from chain order by depth desc limit 1;
+$$;
+
+drop function if exists get_linked_memories(uuid[], text[]);
+drop function if exists get_linked_memories(uuid[], text[], boolean);
+create or replace function get_linked_memories(
+    memory_ids uuid[],
+    link_types text[] default null,
+    show_history boolean default false
+)
+returns table(
+    id uuid, name text, type text, project text,
+    description text, content text, tags text[],
+    updated_at timestamptz, content_updated_at timestamptz,
+    last_accessed_at timestamptz,
+    link_type text, link_strength float, linked_from uuid
+)
+language sql stable as $$
+    select * from (
+        -- DISTINCT ON collapses multiple edges between the same pair of
+        -- memories — keep the strongest one after chain resolution. Two
+        -- different originals may resolve to the same head, so we dedup
+        -- on the resolved id rather than the raw link target.
+        select distinct on (sub.id)
+            sub.id, sub.name, sub.type, sub.project, sub.description,
+            sub.content, sub.tags,
+            sub.updated_at, sub.content_updated_at, sub.last_accessed_at,
+            sub.link_type, sub.link_strength, sub.linked_from
+        from (
+            -- Outgoing edges: source ∈ memory_ids, target resolved to head.
+            select m.id, m.name, m.type, m.project, m.description, m.content,
+                   m.tags, m.updated_at, m.content_updated_at, m.last_accessed_at,
+                   l.link_type, l.strength as link_strength, l.source_id as linked_from
+            from memory_links l
+            join memories m on m.id = coalesce(
+                case when show_history then l.target_id
+                     else find_chain_head(l.target_id) end,
+                l.target_id)
+            where l.source_id = any(memory_ids)
+              and not (m.id = any(memory_ids))
+              and (link_types is null or l.link_type = any(link_types))
+              and (show_history
+                   or (m.expired_at is null
+                       and m.superseded_by is null
+                       and (m.valid_to is null or m.valid_to > now())))
+            union all
+            -- Incoming edges: target ∈ memory_ids, source resolved to head.
+            select m.id, m.name, m.type, m.project, m.description, m.content,
+                   m.tags, m.updated_at, m.content_updated_at, m.last_accessed_at,
+                   l.link_type, l.strength as link_strength, l.target_id as linked_from
+            from memory_links l
+            join memories m on m.id = coalesce(
+                case when show_history then l.source_id
+                     else find_chain_head(l.source_id) end,
+                l.source_id)
+            where l.target_id = any(memory_ids)
+              and not (m.id = any(memory_ids))
+              and (link_types is null or l.link_type = any(link_types))
+              and (show_history
+                   or (m.expired_at is null
+                       and m.superseded_by is null
+                       and (m.valid_to is null or m.valid_to > now())))
+        ) sub
+        order by sub.id, sub.link_strength desc, sub.link_type, sub.linked_from
+    ) deduped
+    order by deduped.link_strength desc
+    limit 10;
+$$;

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -44,6 +44,13 @@ alter table memories add column if not exists fts tsvector
 
 create index if not exists idx_memories_fts on memories using gin(fts);
 
+-- Generated project scope key for tiebreakers / grouping on a non-null text.
+-- Applied in production via an out-of-band migration; re-declared here so
+-- schema.sql matches the live DB. Must stay in update_updated_at's strip
+-- list (GENERATED ALWAYS STORED cols appear NULL in BEFORE UPDATE NEW).
+alter table memories add column if not exists project_key text
+  generated always as (coalesce(project, '')) stored;
+
 -- Auto-update updated_at on changes
 create or replace function update_updated_at()
 returns trigger as $$
@@ -904,17 +911,23 @@ create policy "Allow all for anon" on episodes
 -- session-context.py selects user memories by updated_at — neither should
 -- be perturbed by the access-frequency touch.
 --
--- Implementation: JSONB diff of old/new rows with the touch-affected columns
--- stripped. Generated columns (fts, project_key) are also stripped because
--- BEFORE UPDATE triggers see them as NULL in NEW while OLD has the stored
--- value (PostgreSQL quirk for GENERATED ALWAYS STORED), so including them
--- would always register as a diff. If new generated columns are added,
--- list them here too.
+-- Implementation: cheap short-circuit first — if last_accessed_at isn't
+-- changing, this is a normal edit and updated_at must bump. Only on
+-- touch-shaped UPDATEs do we pay for a JSONB diff of old vs new. This keeps
+-- the hot path (regular writes) free of to_jsonb cost on the full row
+-- (content can be kilobytes).
+--
+-- The JSONB diff strips last_accessed_at + updated_at (touch cols) and the
+-- generated cols (fts, project_key), which appear NULL in NEW under BEFORE
+-- UPDATE while OLD has the stored value (PostgreSQL quirk for GENERATED
+-- ALWAYS STORED), so including them would always register as a diff. If
+-- new generated columns are added, list them here too.
 create or replace function update_updated_at()
 returns trigger as $$
 begin
-  if (to_jsonb(new) - 'last_accessed_at' - 'updated_at' - 'fts' - 'project_key')
-       = (to_jsonb(old) - 'last_accessed_at' - 'updated_at' - 'fts' - 'project_key') then
+  if new.last_accessed_at is distinct from old.last_accessed_at
+     and (to_jsonb(new) - 'last_accessed_at' - 'updated_at' - 'fts' - 'project_key')
+           = (to_jsonb(old) - 'last_accessed_at' - 'updated_at' - 'fts' - 'project_key') then
     return new;
   end if;
   new.updated_at = now();

--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -1303,7 +1303,7 @@ async def _hybrid_recall(
         if include_links:
             ids = [r["id"] for r in merged if r.get("id")]
             if ids:
-                linked = await _expand_with_links(client, ids)
+                linked = await _expand_with_links(client, ids, show_history=show_history)
                 if linked:
                     # Deduplicate against already-found IDs and within linked results
                     found_ids = set(ids)
@@ -1678,12 +1678,19 @@ async def _apply_legacy_supersede(
         pass
 
 
-async def _expand_with_links(client, memory_ids: list[str]) -> list[dict]:
-    """Fetch 1-hop linked memories via graph traversal RPC."""
+async def _expand_with_links(
+    client, memory_ids: list[str], show_history: bool = False,
+) -> list[dict]:
+    """Fetch 1-hop linked memories via graph traversal RPC.
+
+    show_history mirrors the primary recall flag: when true, skip the
+    lifecycle filter so history views don't drop linked neighbors.
+    """
     try:
         result = client.rpc("get_linked_memories", {
             "memory_ids": memory_ids,
             "link_types": None,
+            "show_history": show_history,
         }).execute()
         return result.data or []
     except Exception:

--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -104,8 +104,9 @@ def main():
     # access-frequency boost in temporal scoring off this column, so
     # session-start loads should count as access. The content_updated_at /
     # updated_at trigger is not fired because we go through the touch_memories
-    # RPC which updates only last_accessed_at.
-    _touch_accessed(client, touched_ids)
+    # RPC which updates only last_accessed_at. Dedup preserves order — same
+    # memory can surface in multiple sections (e.g. always_load + user).
+    _touch_accessed(client, list(dict.fromkeys(touched_ids)))
 
     # Output
     if sections:
@@ -169,8 +170,9 @@ def _query_always_load(client):
 def _touch_accessed(client, ids):
     """Bump last_accessed_at via the same RPC server.py uses on recall.
 
-    Fire-and-forget — never block session start on this. Failures are
-    logged to stderr for visibility but don't surface to the user.
+    Best-effort / non-fatal: the call is synchronous (one REST round-trip,
+    typically 50-200ms), but any exception is logged to stderr and swallowed
+    so session start is never blocked by Supabase issues.
     """
     if not ids:
         return

--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -68,33 +68,44 @@ def main():
 
     project = _detect_project()
     sections = []
+    touched_ids: list[str] = []
 
     # 1. User memories — who is the owner (always)
-    section = _query_memories(client, mem_type="user", limit=2)
+    section, ids = _query_memories(client, mem_type="user", limit=2)
     if section:
         sections.append("## User Profile\n" + section)
+        touched_ids.extend(ids)
 
     # 2. Always-load memories — evergreen rules not tied to any single project.
     #    Everything else (feedback/decisions) is loaded task-aware via
     #    UserPromptSubmit hook (scripts/memory-recall-hook.py).
-    section = _query_always_load(client)
+    section, ids = _query_always_load(client)
     if section:
         sections.append("## Always-Load Rules\n" + section)
+        touched_ids.extend(ids)
 
     # 3. Working state — ONLY when session is inside a known project dir.
     #    In a non-project cwd (e.g. scheduled research) working_state is noise.
     if project:
-        section = _query_memories(
+        section, ids = _query_memories(
             client, mem_type="project", limit=1,
             extra_filter=lambda q: q.eq("name", f"working_state_{project}"),
         )
         if section:
             sections.append(f"## Working State ({project})\n" + section)
+            touched_ids.extend(ids)
 
     # 4. Active goals (always)
     goal_section = _query_goals(client)
     if goal_section:
         sections.append(goal_section)
+
+    # Bump last_accessed_at for every memory we just loaded. Phase 1 drives the
+    # access-frequency boost in temporal scoring off this column, so
+    # session-start loads should count as access. The content_updated_at /
+    # updated_at trigger is not fired because we go through the touch_memories
+    # RPC which updates only last_accessed_at.
+    _touch_accessed(client, touched_ids)
 
     # Output
     if sections:
@@ -111,25 +122,33 @@ def main():
 # Memory queries
 # ---------------------------------------------------------------------------
 
-_MEMORY_COLS = "name, type, project, description, content, tags, updated_at"
+_MEMORY_COLS = "id, name, type, project, description, content, tags, updated_at"
 
 
 def _query_memories(client, *, mem_type, limit, extra_filter=None):
-    """Query memories table with type filter, return formatted string or None."""
+    """Query memories table with type filter.
+
+    Returns (formatted_text, ids) — ids are used to bump last_accessed_at.
+    """
     try:
         q = client.table("memories").select(_MEMORY_COLS).eq("type", mem_type)
         if extra_filter:
             q = extra_filter(q)
         result = q.order("updated_at", desc=True).limit(limit).execute()
         if result.data:
-            return "\n---\n".join(_fmt_memory(m) for m in result.data)
+            text = "\n---\n".join(_fmt_memory(m) for m in result.data)
+            ids = [m["id"] for m in result.data if m.get("id")]
+            return text, ids
     except Exception as e:
         print(f"[session-context] {mem_type} query failed: {e}", file=sys.stderr)
-    return None
+    return None, []
 
 
 def _query_always_load(client):
-    """Query memories tagged 'always_load' (evergreen, cross-project rules)."""
+    """Query memories tagged 'always_load' (evergreen, cross-project rules).
+
+    Returns (formatted_text, ids).
+    """
     try:
         result = (
             client.table("memories")
@@ -139,10 +158,26 @@ def _query_always_load(client):
             .execute()
         )
         if result.data:
-            return "\n---\n".join(_fmt_memory(m) for m in result.data)
+            text = "\n---\n".join(_fmt_memory(m) for m in result.data)
+            ids = [m["id"] for m in result.data if m.get("id")]
+            return text, ids
     except Exception as e:
         print(f"[session-context] always_load query failed: {e}", file=sys.stderr)
-    return None
+    return None, []
+
+
+def _touch_accessed(client, ids):
+    """Bump last_accessed_at via the same RPC server.py uses on recall.
+
+    Fire-and-forget — never block session start on this. Failures are
+    logged to stderr for visibility but don't surface to the user.
+    """
+    if not ids:
+        return
+    try:
+        client.rpc("touch_memories", {"memory_ids": ids}).execute()
+    except Exception as e:
+        print(f"[session-context] touch_memories failed: {e}", file=sys.stderr)
 
 
 def _fmt_memory(m):

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -648,7 +648,16 @@ class TestExpandWithLinks:
         await _expand_with_links(mock_client, ["id-1", "id-2"])
         mock_client.rpc.assert_called_once_with(
             "get_linked_memories",
-            {"memory_ids": ["id-1", "id-2"], "link_types": None},
+            {"memory_ids": ["id-1", "id-2"], "link_types": None, "show_history": False},
+        )
+
+    @pytest.mark.asyncio
+    async def test_passes_show_history_to_rpc(self, mock_client):
+        mock_client.rpc.return_value.execute.return_value = MagicMock(data=[])
+        await _expand_with_links(mock_client, ["id-1"], show_history=True)
+        mock_client.rpc.assert_called_once_with(
+            "get_linked_memories",
+            {"memory_ids": ["id-1"], "link_types": None, "show_history": True},
         )
 
 


### PR DESCRIPTION
Closes #201. Finishes the last two Phase 1 checkboxes in #185. Three small, related fixes — all driven by the same bug: recall still surfaces stale versions or scores touches as edits, undoing Phase 1's lifecycle gains for `include_links` callers and the session-start hook.

## Summary

- **Supersedes-chain collapse in `get_linked_memories`** — `find_chain_head(uuid, int)` (recursive CTE, depth-capped) resolves neighbor ids to the terminal head before joining. Same lifecycle filter as `match_memories`/`keyword_search_memories`. `show_history=true` bypasses.
- **Session-start hook bumps `last_accessed_at`** — `scripts/session-context.py` calls the existing `touch_memories` RPC for the memories it surfaces (user / always_load / working_state). Fire-and-forget.
- **Touch-safe `update_updated_at` trigger** — the schema comment already flagged this as a Phase 1 intent but the generic trigger rippled every touch into `updated_at`. Rewritten to skip when only `last_accessed_at` changed (jsonb diff stripped of touch + generated cols; generated cols appear NULL in BEFORE UPDATE NEW).

## Why the third change was needed

`touch_memories` sets only `last_accessed_at`, but the row-level `BEFORE UPDATE` trigger was unconditionally bumping `updated_at = now()`. That meant:
- fallback `_keyword_recall` (orders by `updated_at`) reshuffled on every recall
- `session-context.py` (selects user memories by `updated_at`) returned the same rows self-reinforcingly

Decay scoring was already protected (uses `content_updated_at`) but the two `updated_at` callers weren't. Fixing the trigger completes the Phase 1 intent without further application-side changes.

## Eval (tests/memory-eval/queries.yaml, 20 queries)

| Metric | Before | After | Δ |
|---|---|---|---|
| recall@5 | 0.850 | 0.850 | 0.000 |
| recall@10 | 0.900 | 0.900 | 0.000 |
| MRR | 0.585 | 0.610 | +0.025 |
| must_not violations | 0 | 0 | 0 |

One q15 ranking regression inside top-5 (was already failing), one q12 improvement. Aggregate pass rate held at 17/20.

## Verified live in Supabase

- `find_chain_head(working_state_redrobot)` → `phase_2c_provenance_approach` via `working_state_jarvis` (2-hop chain walked correctly)
- `get_linked_memories` on `jarvis_v2_vision`: returns `jarvis_v2_hybrid_agile` instead of the superseded `jarvis_stays_goals_not_agile`
- Touch on `owner_profile` bumps `last_accessed_at` without touching `updated_at` or `content_updated_at`

Migrations applied already:
- `phase1_chain_collapse_in_recall`
- `phase1_touch_safe_updated_at_trigger` (superseded by the next)
- `phase1_touch_safe_trigger_fix_generated_cols`

Epic: #185

## Test plan

- [x] Eval harness: no regression vs baseline.json
- [x] Chain collapse verified via SQL on a known 2-hop chain
- [x] Session-context run: `last_accessed_at` advances, `updated_at` holds
- [ ] Watch next scheduled recall run — access-frequency boost should start surfacing working_state_jarvis more consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)