### PR TITLE
feat(memory): Phase 3 MVP — hybrid fan-out recall (#202)

### DIFF
--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -6,8 +6,10 @@ Reciprocal Rank Fusion. This catches memories that match by literal terms
 but sit below the semantic threshold (e.g. proper nouns, rare keywords)
 without the cost of an LLM call on every prompt.
 
-Types ∈ {feedback, decision}. Scope: current project (cwd basename) +
-global. Capped at ~40K chars (~10K tokens, ~5% of 200K context).
+Types ∈ {feedback, decision, reference}. Scope: current project (cwd
+basename) + global. Capped at ~40K chars (~10K tokens, ~5% of 200K
+context). `user` + `project` are already loaded at session start by
+scripts/session-context.py and excluded here to avoid duplication.
 
 Touches accessed memories via RPC so the ACT-R access-frequency boost
 applies. Any failure → empty context, prompt proceeds unaffected.
@@ -115,14 +117,18 @@ def detect_project(cwd: str) -> str | None:
 def format_memory(m: dict) -> str:
     tags = m.get("tags") or []
     tags_str = f" [{', '.join(tags)}]" if tags else ""
-    # Phase 3: fan-out signal — prefer RRF score if present, else fall back to
-    # raw similarity (semantic-only path) or rank (keyword-only).
+    # Signal-accurate score display. rrf_merge only sets _rrf_score on
+    # rows hit by both signals, so single-signal hits fall through to
+    # their native field (similarity for semantic, rank for keyword/FTS).
     rrf = m.get("_rrf_score")
     sim = m.get("similarity")
+    rank = m.get("rank")
     if rrf is not None:
         score_str = f" (rrf {rrf:.3f})"
     elif sim is not None:
         score_str = f" (sim {sim:.2f})"
+    elif rank is not None:
+        score_str = f" (rank {rank:.2f})"
     else:
         score_str = ""
     proj = m.get("project") or "global"
@@ -136,33 +142,41 @@ def format_memory(m: dict) -> str:
 def rrf_merge(semantic_rows: list[dict], keyword_rows: list[dict], k: int = RRF_K) -> list[dict]:
     """Reciprocal Rank Fusion over two ranked lists.
 
-    Mirrors mcp-memory/server.py::_rrf_merge so the hook and the recall RPC
-    use the same scoring. A row appearing in both lists scores roughly
-    double vs. a row in only one — catches terms the embedding missed
-    (rare keywords, proper nouns) without letting pure-keyword hits
-    dominate over relevant semantic matches.
+    Same RRF math as mcp-memory/server.py::_rrf_merge (k=60, scores additive,
+    ranked desc), with two deliberate differences vs. the server:
+      - Keep the semantic row in `by_id` when a memory appears in both lists,
+        so the row still carries its `similarity` for display fallback. The
+        server overwrites with the keyword row; it doesn't care, we do.
+      - No `limit` slice. The caller caps by CHAR_BUDGET, not row count.
+
+    Only rows hit by BOTH signals get `_rrf_score` set — that's the semantic
+    meaning of "fusion", and `format_memory` depends on it to pick the right
+    display (rrf vs sim vs rank). A row seen once keeps its native score
+    field untouched.
     """
     scores: dict[str, float] = {}
+    hits: dict[str, int] = {}
     by_id: dict[str, dict] = {}
     for rank, row in enumerate(semantic_rows):
         rid = row.get("id") or row.get("name")
         if not rid:
             continue
         scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank)
+        hits[rid] = hits.get(rid, 0) + 1
         by_id[rid] = row
     for rank, row in enumerate(keyword_rows):
         rid = row.get("id") or row.get("name")
         if not rid:
             continue
         scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank)
-        # Keep the row we already have (semantic has similarity score); only
-        # overwrite if this is a keyword-only hit.
+        hits[rid] = hits.get(rid, 0) + 1
         by_id.setdefault(rid, row)
     ranked_ids = sorted(scores.keys(), key=lambda r: scores[r], reverse=True)
     out = []
     for rid in ranked_ids:
         row = by_id[rid]
-        row["_rrf_score"] = scores[rid]
+        if hits[rid] >= 2:
+            row["_rrf_score"] = scores[rid]
         out.append(row)
     return out
 

--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -1,14 +1,16 @@
-"""UserPromptSubmit hook: task-aware semantic recall injected as context.
+"""UserPromptSubmit hook: task-aware hybrid recall injected as context.
 
-Reads the user's prompt, embeds it, and returns all memories (type ∈
-{feedback, decision}) above similarity threshold 0.7, scoped to current project
-(from cwd basename) + global. Result is injected as additionalContext under a
-'# Memories on topic' header, capped at ~40K chars (~10K tokens, ~5% of 200K
-context window — owner's budget).
+Phase 3 MVP (fan-out, no LLM rewriter yet): embeds the prompt AND runs a
+keyword/FTS search over the same text, then merges both ranked lists via
+Reciprocal Rank Fusion. This catches memories that match by literal terms
+but sit below the semantic threshold (e.g. proper nouns, rare keywords)
+without the cost of an LLM call on every prompt.
 
-Also touches accessed memories (access_count++) via RPC.
+Types ∈ {feedback, decision}. Scope: current project (cwd basename) +
+global. Capped at ~40K chars (~10K tokens, ~5% of 200K context).
 
-Graceful degradation: any failure → empty context, prompt proceeds unaffected.
+Touches accessed memories via RPC so the ACT-R access-frequency boost
+applies. Any failure → empty context, prompt proceeds unaffected.
 """
 
 import json
@@ -47,9 +49,15 @@ SIMILARITY_THRESHOLD = 0.30  # calibrated 2026-04-17: real user prompts hit 0.35
 # clearly-relevant matches without firing on unrelated memories (which sit <0.25).
 # server.py default SIMILARITY_THRESHOLD is also 0.25 for the same reason.
 CHAR_BUDGET = 40_000         # ~10K tokens, ~5% of 200K window
-FETCH_LIMIT = 50             # pull wide, cap by budget in Python
-ALLOWED_TYPES = {"feedback", "decision"}
+FETCH_LIMIT = 50             # pull wide per signal, cap by budget in Python
+# Types loaded per-prompt. Excluded:
+#   'user'    — loaded at session start (scripts/session-context.py top-2)
+#   'project' — dominated by working_state_* which is session-specific and
+#               already session-loaded; broader project memories will be
+#               pulled in once Phase 3 gains a proper tag filter.
+ALLOWED_TYPES = {"feedback", "decision", "reference"}
 MIN_PROMPT_CHARS = 15        # too-short prompts produce noisy embeddings
+RRF_K = 60                   # matches _rrf_merge in mcp-memory/server.py
 
 # Projects Jarvis tracks — cwd basename must match one of these to scope recall.
 # Anything else → no project filter (load from global + all projects).
@@ -107,14 +115,56 @@ def detect_project(cwd: str) -> str | None:
 def format_memory(m: dict) -> str:
     tags = m.get("tags") or []
     tags_str = f" [{', '.join(tags)}]" if tags else ""
+    # Phase 3: fan-out signal — prefer RRF score if present, else fall back to
+    # raw similarity (semantic-only path) or rank (keyword-only).
+    rrf = m.get("_rrf_score")
     sim = m.get("similarity")
-    sim_str = f" (sim {sim:.2f})" if sim is not None else ""
+    if rrf is not None:
+        score_str = f" (rrf {rrf:.3f})"
+    elif sim is not None:
+        score_str = f" (sim {sim:.2f})"
+    else:
+        score_str = ""
     proj = m.get("project") or "global"
     desc = m.get("description") or ""
     content = m.get("content") or ""
-    header = f"## {m['name']} ({m['type']}, {proj}){tags_str}{sim_str}"
+    header = f"## {m['name']} ({m['type']}, {proj}){tags_str}{score_str}"
     body = f"*{desc}*\n\n{content}" if desc else content
     return f"{header}\n{body}"
+
+
+def rrf_merge(semantic_rows: list[dict], keyword_rows: list[dict], k: int = RRF_K) -> list[dict]:
+    """Reciprocal Rank Fusion over two ranked lists.
+
+    Mirrors mcp-memory/server.py::_rrf_merge so the hook and the recall RPC
+    use the same scoring. A row appearing in both lists scores roughly
+    double vs. a row in only one — catches terms the embedding missed
+    (rare keywords, proper nouns) without letting pure-keyword hits
+    dominate over relevant semantic matches.
+    """
+    scores: dict[str, float] = {}
+    by_id: dict[str, dict] = {}
+    for rank, row in enumerate(semantic_rows):
+        rid = row.get("id") or row.get("name")
+        if not rid:
+            continue
+        scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank)
+        by_id[rid] = row
+    for rank, row in enumerate(keyword_rows):
+        rid = row.get("id") or row.get("name")
+        if not rid:
+            continue
+        scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank)
+        # Keep the row we already have (semantic has similarity score); only
+        # overwrite if this is a keyword-only hit.
+        by_id.setdefault(rid, row)
+    ranked_ids = sorted(scores.keys(), key=lambda r: scores[r], reverse=True)
+    out = []
+    for rid in ranked_ids:
+        row = by_id[rid]
+        row["_rrf_score"] = scores[rid]
+        out.append(row)
+    return out
 
 
 def main():
@@ -145,32 +195,61 @@ def main():
         silent_exit()
 
     query_embedding = embed(prompt)
-    if query_embedding is None:
-        silent_exit()
+    # Semantic can fail-soft (no API key / timeout): still run keyword search
+    # on the prompt. Keyword-only is better than silent_exit — a user typing a
+    # literal identifier should still get relevant memories surfaced.
 
     try:
         client = create_client(url, key)
-        result = client.rpc("match_memories", {
-            "query_embedding": query_embedding,
-            "match_limit": FETCH_LIMIT,
-            "similarity_threshold": SIMILARITY_THRESHOLD,
-            "filter_project": project,  # None → no project filter
-            "filter_type": None,        # filter types in Python
-        }).execute()
-        rows = result.data or []
     except Exception:
         silent_exit()
 
-    # Filter to allowed types, sort by similarity desc
-    rows = [r for r in rows if r.get("type") in ALLOWED_TYPES]
-    rows.sort(key=lambda r: r.get("similarity", 0.0), reverse=True)
+    semantic_rows: list[dict] = []
+    if query_embedding is not None:
+        try:
+            sem = client.rpc("match_memories", {
+                "query_embedding": query_embedding,
+                "match_limit": FETCH_LIMIT,
+                "similarity_threshold": SIMILARITY_THRESHOLD,
+                "filter_project": project,  # None → no project filter
+                "filter_type": None,        # filter types in Python
+            }).execute()
+            semantic_rows = sem.data or []
+        except Exception:
+            semantic_rows = []
 
-    if not rows:
+    keyword_rows: list[dict] = []
+    try:
+        kw = client.rpc("keyword_search_memories", {
+            "search_query": prompt,
+            "match_limit": FETCH_LIMIT,
+            "filter_project": project,
+            "filter_type": None,
+        }).execute()
+        keyword_rows = kw.data or []
+    except Exception:
+        keyword_rows = []
+
+    # Filter both lists to allowed types BEFORE merging, so RRF scores are
+    # computed only over candidates we'll actually surface.
+    semantic_rows = [r for r in semantic_rows if r.get("type") in ALLOWED_TYPES]
+    keyword_rows = [r for r in keyword_rows if r.get("type") in ALLOWED_TYPES]
+
+    if not semantic_rows and not keyword_rows:
         silent_exit()
+
+    rows = rrf_merge(semantic_rows, keyword_rows)
 
     # Accumulate under char budget
     scope = f" (project: {project}+global)" if project else " (all projects)"
-    header = f"# Memories on topic{scope}\n\nSemantic recall, threshold={SIMILARITY_THRESHOLD}:\n\n"
+    signal = (
+        "semantic+keyword (RRF)"
+        if semantic_rows and keyword_rows
+        else "semantic-only"
+        if semantic_rows
+        else "keyword-only"
+    )
+    header = f"# Memories on topic{scope}\n\nHybrid recall ({signal}):\n\n"
     parts = [header]
     total = len(header)
     included_ids = []


### PR DESCRIPTION
Closes #202. First slice of Phase 3 from epic #185 — no LLM rewriter yet.

## Why

`scripts/memory-recall-hook.py` was semantic-only. Prompts like \"telegram integration channels\" or \"multi-agent framework landscape\" dominate by literal terms — the embedding sits below the 0.30 threshold, the hook injects nothing, and the model has to operate blind to memories that match by keyword.

## What

- Parallel call to `keyword_search_memories` alongside `match_memories` over the same prompt.
- Client-side Reciprocal Rank Fusion (`k=60`, same algorithm as `mcp-memory/server.py::_rrf_merge`). Memories hit by both signals score ~double a single-signal hit.
- `ALLOWED_TYPES` expanded to `{feedback, decision, reference}` — `user` and `project` stay session-start-only to avoid duplicating what's already in context.
- Fails soft on either signal: keyword-only if Voyage key missing, semantic-only if FTS returns nothing, silent exit if both empty.
- Row format: `(rrf 0.033)` when both signals fired, `(sim 0.42)` when semantic-only.

## Verified

Smoke test (prompt: \"telegram integration channels\"):

| Before | After |
|---|---|
| keyword signal silently dropped by old `ALLOWED_TYPES` filter | `claude_code_channels (reference)` as top hit, rrf 0.033 — 2× the single-signal hits below |

Both prompts below previously missed by semantic alone now surface keyword-relevant memories:
- \"multi-agent framework landscape comparison\" → `research_pillar7_multi_agent_frameworks` pulled in by keyword rank
- \"telegram integration channels\" → `claude_code_channels` doubled via both signals

## Not in this PR

- **Haiku rewriter** — the epic's Phase 3 calls for an LLM rewrite of the prompt to structured `{intent, entities, type_filter, tag_filter, timeframe}`. Deferred to a follow-up: Haiku per-prompt is ~2-6 $/mo (within budget, not free), and `ANTHROPIC_API_KEY` isn't set on all devices yet. Fan-out alone should capture the majority of keyword-hit prompts.
- **Cross-encoder rerank** — last-20% complexity for incremental quality; revisit after we have usage data showing where the ranker fails.
- **Eval harness changes** — `tests/memory-eval/queries.yaml` tests `memory_recall` (server.py), not this hook. Hook-level eval needs its own harness.

Epic: #185

## Test plan

- [x] Smoke test: keyword-heavy prompt surfaces a `reference` memory that was being dropped pre-change
- [x] Smoke test: mixed-language prompt still returns semantic-only path when FTS misses
- [x] Smoke test: failure in one signal falls back to the other, no exception leak
- [ ] Next session: observe injected context on real prompts — does RRF rank feel right?
- [ ] Follow-up PR: Haiku rewriter + type/tag filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)