### PR TITLE
fix(memory): rewriter types → soft boost

### DIFF
--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -43,9 +43,9 @@ from typing import Any, Callable
 # ---------------------------------------------------------------------------
 SIMILARITY_THRESHOLD = 0.25
 RRF_K = 60
-# Must match memory-recall-hook.py::TYPE_BOOST_MULTIPLIER so eval's
-# with-rewriter numbers predict hook behavior. Don't re-tune in one place.
-TYPE_BOOST_MULTIPLIER = 1.5
+# TYPE_BOOST_MULTIPLIER intentionally not duplicated here. When --with-rewriter
+# is enabled, we load scripts/memory-recall-hook.py and read its constant,
+# so re-tuning the boost only needs to happen in one place.
 TEMPORAL_HALF_LIVES = {
     "user": 180,
     "feedback": 90,
@@ -62,12 +62,13 @@ VOYAGE_MODEL = "voyage-3-lite"
 EMBED_TIMEOUT = 10.0
 
 
-def _load_rewriter() -> Callable[[str], dict | None] | None:
-    """Load `rewrite_prompt` from scripts/memory-recall-hook.py via importlib.
+def _load_hook_module():
+    """Load scripts/memory-recall-hook.py as a module via importlib.
 
-    Hyphen in the hook filename blocks normal imports. We load it as a module
-    named `memory_recall_hook` so the function is callable. Returns None if
-    the file is missing or import fails — caller then skips rewriter mode.
+    Hyphen in the hook filename blocks normal imports. Returning the whole
+    module lets callers pull both `rewrite_prompt` and `TYPE_BOOST_MULTIPLIER`
+    from the same source — eval and hook stay in lockstep when the boost is
+    re-tuned. Returns None if the file is missing or import fails.
     """
     here = Path(__file__).resolve().parent
     hook_path = here / "memory-recall-hook.py"
@@ -79,9 +80,9 @@ def _load_rewriter() -> Callable[[str], dict | None] | None:
             return None
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        return getattr(mod, "rewrite_prompt", None)
+        return mod
     except Exception as e:
-        print(f"WARN: failed to load rewriter from hook: {e}", file=sys.stderr)
+        print(f"WARN: failed to load hook module: {e}", file=sys.stderr)
         return None
 
 
@@ -122,7 +123,7 @@ def _rrf_merge(
     limit: int,
     k: int = RRF_K,
     boost_types: set[str] | None = None,
-    boost_multiplier: float = TYPE_BOOST_MULTIPLIER,
+    boost_multiplier: float = 1.0,
 ) -> list[dict]:
     scores: dict[str, float] = {}
     by_id: dict[str, dict] = {}
@@ -221,6 +222,7 @@ async def run_query(
     client,
     q: dict,
     rewriter: Callable[[str], dict | None] | None = None,
+    boost_multiplier: float = 1.0,
 ) -> QueryResult:
     embedding = await _embed_query(q["query"])
 
@@ -263,7 +265,13 @@ async def run_query(
     # type-narrowing regression fix). No default scope filter — eval
     # doesn't model the hook's exclusion of user/project memories.
     boost_types = set(rw_types) if rw_types else None
-    merged = _rrf_merge(sem_rows, kw_rows, limit=10, boost_types=boost_types)
+    merged = _rrf_merge(
+        sem_rows,
+        kw_rows,
+        limit=10,
+        boost_types=boost_types,
+        boost_multiplier=boost_multiplier,
+    )
     _apply_temporal_scoring(merged)
 
     top_names = [r.get("name", "?") for r in merged]
@@ -306,10 +314,13 @@ async def run_all(
     queries: list[dict],
     client,
     rewriter: Callable[[str], dict | None] | None = None,
+    boost_multiplier: float = 1.0,
 ) -> EvalReport:
     results = []
     for q in queries:
-        r = await run_query(client, q, rewriter=rewriter)
+        r = await run_query(
+            client, q, rewriter=rewriter, boost_multiplier=boost_multiplier
+        )
         results.append(r)
 
     total = len(results)
@@ -472,18 +483,28 @@ def main() -> int:
     client = create_client(url, key)
 
     rewriter = None
+    boost_multiplier = 1.0  # no-op when rewriter disabled
     if args.with_rewriter:
-        rewriter = _load_rewriter()
-        if rewriter is None:
-            print("ERROR: --with-rewriter set but rewrite_prompt could not be loaded "
-                  "from scripts/memory-recall-hook.py", file=sys.stderr)
+        hook_mod = _load_hook_module()
+        if hook_mod is None:
+            print("ERROR: --with-rewriter set but scripts/memory-recall-hook.py "
+                  "could not be loaded as a module", file=sys.stderr)
             return 2
+        rewriter = getattr(hook_mod, "rewrite_prompt", None)
+        if rewriter is None:
+            print("ERROR: --with-rewriter set but rewrite_prompt not found in hook "
+                  "module", file=sys.stderr)
+            return 2
+        # Source boost calibration from the hook — single source of truth.
+        boost_multiplier = float(getattr(hook_mod, "TYPE_BOOST_MULTIPLIER", 1.5))
         if not os.environ.get("ANTHROPIC_API_KEY"):
             print("WARN: --with-rewriter set but ANTHROPIC_API_KEY missing — "
                   "rewriter will return None for every query (degrades to server_only).",
                   file=sys.stderr)
 
-    report = asyncio.run(run_all(queries, client, rewriter=rewriter))
+    report = asyncio.run(
+        run_all(queries, client, rewriter=rewriter, boost_multiplier=boost_multiplier)
+    )
     print_report(report, quiet=args.quiet)
 
     if args.diff == "baseline":

--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -43,6 +43,9 @@ from typing import Any, Callable
 # ---------------------------------------------------------------------------
 SIMILARITY_THRESHOLD = 0.25
 RRF_K = 60
+# Must match memory-recall-hook.py::TYPE_BOOST_MULTIPLIER so eval's
+# with-rewriter numbers predict hook behavior. Don't re-tune in one place.
+TYPE_BOOST_MULTIPLIER = 1.5
 TEMPORAL_HALF_LIVES = {
     "user": 180,
     "feedback": 90,
@@ -113,7 +116,14 @@ async def _embed_query(text: str) -> list[float]:
         return resp.json()["data"][0]["embedding"]
 
 
-def _rrf_merge(semantic_rows: list[dict], keyword_rows: list[dict], limit: int, k: int = RRF_K) -> list[dict]:
+def _rrf_merge(
+    semantic_rows: list[dict],
+    keyword_rows: list[dict],
+    limit: int,
+    k: int = RRF_K,
+    boost_types: set[str] | None = None,
+    boost_multiplier: float = TYPE_BOOST_MULTIPLIER,
+) -> list[dict]:
     scores: dict[str, float] = {}
     by_id: dict[str, dict] = {}
     for rank, row in enumerate(semantic_rows):
@@ -124,6 +134,10 @@ def _rrf_merge(semantic_rows: list[dict], keyword_rows: list[dict], limit: int, 
         rid = row.get("id") or row["name"]
         scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank)
         by_id[rid] = row
+    if boost_types:
+        for rid, row in by_id.items():
+            if row.get("type") in boost_types:
+                scores[rid] *= boost_multiplier
     ranked = sorted(scores.keys(), key=lambda r: scores[r], reverse=True)
     result = []
     for rid in ranked[:limit]:
@@ -245,17 +259,11 @@ async def run_query(
     }).execute()
     kw_rows = kw.data or []
 
-    # Type narrowing: only apply when rewriter explicitly returned types.
-    # Unlike the hook (which also excludes user/project to avoid duplicating
-    # session-start context), eval does not apply a default type filter —
-    # the goal here is to isolate the rewriter's Phase-3 contribution, not
-    # model the hook's scope-restriction side effect.
-    if rw_types:
-        allowed = set(rw_types)
-        sem_rows = [r for r in sem_rows if r.get("type") in allowed]
-        kw_rows = [r for r in kw_rows if r.get("type") in allowed]
-
-    merged = _rrf_merge(sem_rows, kw_rows, limit=10)
+    # Rewriter types → soft boost (matches hook behavior after the
+    # type-narrowing regression fix). No default scope filter — eval
+    # doesn't model the hook's exclusion of user/project memories.
+    boost_types = set(rw_types) if rw_types else None
+    merged = _rrf_merge(sem_rows, kw_rows, limit=10, boost_types=boost_types)
     _apply_temporal_scoring(merged)
 
     top_names = [r.get("name", "?") for r in merged]

--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -269,11 +269,17 @@ def format_memory(m: dict) -> str:
     # Signal-accurate score display. rrf_merge only sets _rrf_score on
     # rows hit by both signals, so single-signal hits fall through to
     # their native field (similarity for semantic, rank for keyword/FTS).
+    # _sort_score is set only on single-signal rows that were type-boosted
+    # — without it, the displayed sim/rank would contradict the actual
+    # ranking (the boost changed the sort key, not the native score).
     rrf = m.get("_rrf_score")
+    sort_score = m.get("_sort_score")
     sim = m.get("similarity")
     rank = m.get("rank")
     if rrf is not None:
         score_str = f" (rrf {rrf:.3f})"
+    elif sort_score is not None:
+        score_str = f" (boost {sort_score:.3f})"
     elif sim is not None:
         score_str = f" (sim {sim:.2f})"
     elif rank is not None:
@@ -312,7 +318,9 @@ def rrf_merge(
     Only rows hit by BOTH signals get `_rrf_score` set — that's the semantic
     meaning of "fusion", and `format_memory` depends on it to pick the right
     display (rrf vs sim vs rank). A row seen once keeps its native score
-    field untouched.
+    field untouched, *except* when the boost fires on a single-signal row:
+    we set `_sort_score` on it so `format_memory` can show the true sort
+    key. Otherwise the displayed sim/rank would contradict the ranking.
     """
     scores: dict[str, float] = {}
     hits: dict[str, int] = {}
@@ -335,6 +343,8 @@ def rrf_merge(
         for rid, row in by_id.items():
             if row.get("type") in boost_types:
                 scores[rid] *= boost_multiplier
+                if hits[rid] == 1:
+                    row["_sort_score"] = scores[rid]
     ranked_ids = sorted(scores.keys(), key=lambda r: scores[r], reverse=True)
     out = []
     for rid in ranked_ids:

--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -75,6 +75,13 @@ FETCH_LIMIT = 50             # pull wide per signal, cap by budget in Python
 ALLOWED_TYPES = {"feedback", "decision", "reference"}
 MIN_PROMPT_CHARS = 15        # too-short prompts produce noisy embeddings
 RRF_K = 60                   # matches _rrf_merge in mcp-memory/server.py
+# Rewriter types are applied as a soft rank boost, not a hard filter. An
+# earlier version gated rows by requested_types and recall@5 dropped -5pp
+# on the eval set whenever Haiku misclassified a feedback/decision query
+# as `reference`. The boost keeps misclassified-but-relevant memories in
+# the candidate pool; calibrated so a boosted single-signal hit still
+# loses to an unboosted dual-signal hit (0.0167*1.5 < 0.0333).
+TYPE_BOOST_MULTIPLIER = 1.5
 
 # Projects Jarvis tracks — cwd basename must match one of these to scope recall.
 # Anything else → no project filter (load from global + all projects).
@@ -281,7 +288,13 @@ def format_memory(m: dict) -> str:
     return f"{header}\n{body}"
 
 
-def rrf_merge(semantic_rows: list[dict], keyword_rows: list[dict], k: int = RRF_K) -> list[dict]:
+def rrf_merge(
+    semantic_rows: list[dict],
+    keyword_rows: list[dict],
+    k: int = RRF_K,
+    boost_types: set[str] | None = None,
+    boost_multiplier: float = TYPE_BOOST_MULTIPLIER,
+) -> list[dict]:
     """Reciprocal Rank Fusion over two ranked lists.
 
     Same RRF math as mcp-memory/server.py::_rrf_merge (k=60, scores additive,
@@ -290,6 +303,11 @@ def rrf_merge(semantic_rows: list[dict], keyword_rows: list[dict], k: int = RRF_
         so the row still carries its `similarity` for display fallback. The
         server overwrites with the keyword row; it doesn't care, we do.
       - No `limit` slice. The caller caps by CHAR_BUDGET, not row count.
+
+    Optional `boost_types`: when set, rows whose `type` is in the set get
+    their final score multiplied by `boost_multiplier` before the rank sort.
+    Used to apply the Haiku rewriter's type hint as a soft nudge rather than
+    a hard filter — a type misclassification no longer drops relevant rows.
 
     Only rows hit by BOTH signals get `_rrf_score` set — that's the semantic
     meaning of "fusion", and `format_memory` depends on it to pick the right
@@ -313,6 +331,10 @@ def rrf_merge(semantic_rows: list[dict], keyword_rows: list[dict], k: int = RRF_
         scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank)
         hits[rid] = hits.get(rid, 0) + 1
         by_id.setdefault(rid, row)
+    if boost_types:
+        for rid, row in by_id.items():
+            if row.get("type") in boost_types:
+                scores[rid] *= boost_multiplier
     ranked_ids = sorted(scores.keys(), key=lambda r: scores[r], reverse=True)
     out = []
     for rid in ranked_ids:
@@ -366,14 +388,12 @@ def main():
     # else the raw prompt (MVP behavior, still works without Haiku).
     keyword_query = " ".join(entities) if entities else prompt
 
-    # Type narrowing: intersect requested types with ALLOWED_TYPES. If the
-    # rewriter suggested types outside our allowed set (shouldn't happen —
-    # system prompt constrains it — but fail-safe), fall back to defaults.
-    if requested_types:
-        narrowed = ALLOWED_TYPES & set(requested_types)
-        allowed_types = narrowed if narrowed else ALLOWED_TYPES
-    else:
-        allowed_types = ALLOWED_TYPES
+    # Rewriter's type hint becomes a soft boost (see TYPE_BOOST_MULTIPLIER
+    # comment). Intersecting with ALLOWED_TYPES keeps the boost confined
+    # to types the hook actually surfaces; an out-of-set suggestion (e.g.
+    # the rewriter hallucinates `episode`) resolves to no boost instead
+    # of falling through to "boost everything".
+    boost_types = (ALLOWED_TYPES & set(requested_types)) if requested_types else None
 
     try:
         client = create_client(url, key)
@@ -406,15 +426,16 @@ def main():
     except Exception:
         keyword_rows = []
 
-    # Filter both lists to allowed types BEFORE merging, so RRF scores are
-    # computed only over candidates we'll actually surface.
-    semantic_rows = [r for r in semantic_rows if r.get("type") in allowed_types]
-    keyword_rows = [r for r in keyword_rows if r.get("type") in allowed_types]
+    # Level 1 scope: always restrict to types the hook is responsible for.
+    # user/project memories are loaded by scripts/session-context.py at
+    # session start and excluded here to avoid duplication.
+    semantic_rows = [r for r in semantic_rows if r.get("type") in ALLOWED_TYPES]
+    keyword_rows = [r for r in keyword_rows if r.get("type") in ALLOWED_TYPES]
 
     if not semantic_rows and not keyword_rows:
         silent_exit()
 
-    rows = rrf_merge(semantic_rows, keyword_rows)
+    rows = rrf_merge(semantic_rows, keyword_rows, boost_types=boost_types)
 
     # Accumulate under char budget
     scope = f" (project: {project}+global)" if project else " (all projects)"
@@ -430,8 +451,8 @@ def main():
         bits = []
         if entities:
             bits.append(f"entities: {', '.join(entities)}")
-        if requested_types:
-            bits.append(f"types: {', '.join(sorted(requested_types))}")
+        if boost_types:
+            bits.append(f"boost: {', '.join(sorted(boost_types))}")
         if bits:
             rewriter_note = f" — rewriter: {'; '.join(bits)}"
     header = f"# Memories on topic{scope}\n\nHybrid recall ({signal}){rewriter_note}:\n\n"

--- a/tests/test_memory_recall_hook.py
+++ b/tests/test_memory_recall_hook.py
@@ -154,6 +154,97 @@ class TestRrfMerge:
 
 
 # ---------------------------------------------------------------------------
+# rrf_merge — type boost behavior (Phase 3 soft-boost replaces hard filter)
+# ---------------------------------------------------------------------------
+
+
+class TestRrfMergeBoost:
+    def test_boost_none_matches_default(self):
+        # boost_types=None must behave identically to the default arg.
+        semantic = [{"id": "a", "type": "feedback"}, {"id": "b", "type": "decision"}]
+        keyword = []
+        out_none = mrh.rrf_merge(semantic, keyword, boost_types=None)
+        out_default = mrh.rrf_merge(semantic, keyword)
+        assert [r["id"] for r in out_none] == [r["id"] for r in out_default]
+
+    def test_empty_boost_set_treated_as_no_boost(self):
+        # Falsy set → boost branch skipped. Verifies `if boost_types:` guard.
+        semantic = [{"id": "a", "type": "feedback"}, {"id": "b", "type": "decision"}]
+        keyword = []
+        out_empty = mrh.rrf_merge(semantic, keyword, boost_types=set())
+        out_none = mrh.rrf_merge(semantic, keyword, boost_types=None)
+        assert [r["id"] for r in out_empty] == [r["id"] for r in out_none]
+
+    def test_boost_reorders_single_hits(self):
+        # `a` at semantic rank 0 (1/60 ≈ 0.01667) beats `b` at rank 1 (1/61 ≈
+        # 0.01639) without boost. Boosting `b`'s type (1.5×) flips the order.
+        semantic = [{"id": "a", "type": "decision"}, {"id": "b", "type": "feedback"}]
+        keyword = []
+        out = mrh.rrf_merge(semantic, keyword, boost_types={"feedback"})
+        assert [r["id"] for r in out] == ["b", "a"]
+
+    def test_boosted_single_hit_below_unboosted_dual_hit(self):
+        # Calibration invariant (see TYPE_BOOST_MULTIPLIER comment):
+        # boosted single-hit (1/60 × 1.5 = 0.025) must stay under unboosted
+        # dual-hit (2/60 = 0.0333). This guards the 1.5 default against
+        # future re-tuning that would break the fusion ordering.
+        semantic = [
+            {"id": "single", "type": "feedback"},
+            {"id": "dual", "type": "decision"},
+        ]
+        keyword = [{"id": "dual", "type": "decision"}]
+        out = mrh.rrf_merge(semantic, keyword, boost_types={"feedback"})
+        assert [r["id"] for r in out] == ["dual", "single"]
+
+    def test_non_matching_types_unchanged(self):
+        # No row has type="feedback" → boost is a no-op.
+        semantic = [{"id": "a", "type": "decision"}, {"id": "b", "type": "reference"}]
+        keyword = []
+        out = mrh.rrf_merge(semantic, keyword, boost_types={"feedback"})
+        assert [r["id"] for r in out] == ["a", "b"]
+
+    def test_sort_score_set_on_boosted_single_hit(self):
+        # _sort_score transparency: single-hit rows that got boosted must
+        # carry the actual sort key, because their native sim/rank is now
+        # out of sync with the display order.
+        semantic = [{"id": "a", "type": "feedback"}]
+        keyword = []
+        out = mrh.rrf_merge(semantic, keyword, boost_types={"feedback"})
+        assert "_sort_score" in out[0]
+        assert abs(out[0]["_sort_score"] - (1.0 / 60 * mrh.TYPE_BOOST_MULTIPLIER)) < 1e-9
+
+    def test_sort_score_absent_on_unboosted_single_hit(self):
+        # Boost active, but row type doesn't match → no _sort_score written.
+        # (Native sim/rank still reflects ranking for that row.)
+        semantic = [{"id": "a", "type": "decision"}]
+        keyword = []
+        out = mrh.rrf_merge(semantic, keyword, boost_types={"feedback"})
+        assert "_sort_score" not in out[0]
+
+    def test_sort_score_absent_on_boosted_dual_hit(self):
+        # Dual-hits use _rrf_score (set after the boost multiply, so the
+        # value already reflects the boost). _sort_score is single-hit-only.
+        semantic = [{"id": "x", "type": "feedback"}]
+        keyword = [{"id": "x", "type": "feedback"}]
+        out = mrh.rrf_merge(semantic, keyword, boost_types={"feedback"})
+        assert "_sort_score" not in out[0]
+        assert "_rrf_score" in out[0]
+
+    def test_custom_multiplier_overrides_default(self):
+        # Multiplier large enough (3×) that boosted single-hit now beats
+        # unboosted dual-hit — verifies the knob actually reaches the math.
+        semantic = [
+            {"id": "single", "type": "feedback"},
+            {"id": "dual", "type": "decision"},
+        ]
+        keyword = [{"id": "dual", "type": "decision"}]
+        out = mrh.rrf_merge(
+            semantic, keyword, boost_types={"feedback"}, boost_multiplier=3.0
+        )
+        assert [r["id"] for r in out] == ["single", "dual"]
+
+
+# ---------------------------------------------------------------------------
 # detect_project — cwd basename matching
 # ---------------------------------------------------------------------------
 
@@ -180,6 +271,22 @@ class TestFormatMemory:
         out = mrh.format_memory(m)
         assert "rrf 0.420" in out
         assert "sim" not in out
+
+    def test_sort_score_displays_boost_over_similarity(self):
+        # Boosted single-hit rows: sim is stale vs. ranking, so _sort_score
+        # must win the display chain (before sim/rank, after _rrf_score).
+        m = {"name": "n", "type": "feedback", "_sort_score": 0.025, "similarity": 0.5}
+        out = mrh.format_memory(m)
+        assert "boost 0.025" in out
+        assert "sim" not in out
+
+    def test_rrf_score_wins_over_sort_score(self):
+        # If both fields are somehow set, _rrf_score wins — that's the
+        # dual-hit case, and its value already folds in any boost.
+        m = {"name": "n", "type": "feedback", "_rrf_score": 0.08, "_sort_score": 0.025}
+        out = mrh.format_memory(m)
+        assert "rrf 0.080" in out
+        assert "boost" not in out
 
     def test_similarity_fallback(self):
         m = {"name": "n", "type": "decision", "similarity": 0.73}


### PR DESCRIPTION
Closes #209
Parent: #185 (Pillar 4 Phase 3). Re-targets to `main` after #206 merged and auto-closed the original PR #207.

## Why

#206 exposed a regression shipped by #205: treating the rewriter's `requested_types` as a **hard filter** dropped expected memories whenever Haiku misclassified a query's type. Two eval queries confirmed it:

- q01 "VoyageAI rate limits tier paid" → rewriter types=[reference] → `feedback_voyage` (type=feedback) filtered out.
- q19 (кириллический lifecycle query) → rewriter types=[reference] → `jarvis_v2_hybrid_agile` (type=decision) filtered out.

The same filter was live in the hook (`memory-recall-hook.py`), so Main PC production was taking the same -5pp recall on any prompt the rewriter misclassified.

## Fix

Turn the rewriter's type hint from a filter into a **soft boost**.

- `ALLOWED_TYPES = {feedback, decision, reference}` Level-1 scope filter **preserved** — user/project are loaded by `scripts/session-context.py` at session start, we don't re-surface them here.
- Rewriter's types (after intersection with ALLOWED_TYPES) now pass to `rrf_merge` as `boost_types`. Matching rows have their final RRF score multiplied by `TYPE_BOOST_MULTIPLIER = 1.5` before the rank sort.
- Calibration: a boosted single-signal hit (1/60 × 1.5 = 0.025) still loses to an unboosted dual-signal hit (2/60 = 0.033), so strong co-occurrence wins. But a boosted single-hit beats an unboosted single-hit — which is the win when Haiku's guess is correct.

`rrf_merge` and eval's `_rrf_merge` both gain optional `boost_types` + `boost_multiplier`. Defaults preserve existing behavior.

Rewriter note in the injected header renamed from `types:` to `boost:` for accuracy.

## Copilot review (addressed in 4abac41)

1. **`_sort_score` on boosted single-hits** — without it, `format_memory` would display stale sim/rank while the row's actual ranking is driven by a boosted score. Now set only when the boost fires on a single-signal row. `format_memory` displays `(boost 0.025)` before falling back to sim/rank. Dual-hits keep `_rrf_score` (already folds in the boost).
2. **De-duplicated `TYPE_BOOST_MULTIPLIER`** — eval no longer carries its own copy. `_load_hook_module` returns the whole hook module; `main()` reads the constant from it. Single source of truth.
3. **Unit test coverage** — `TestRrfMergeBoost` (9 cases) covers: None/empty_set parity, single-hit reordering, the boosted-single < unboosted-dual calibration invariant, `_sort_score` presence/absence (single vs dual), custom multiplier override. Plus 2 new `TestFormatMemory` cases for the boost display branch.

## Measurement (same 20-query eval as #206)

| mode | recall@5 | recall@10 | MRR | must_not |
|---|---|---|---|---|
| server_only | 85.0% | 90.0% | 0.585 | 0 |
| with_rewriter — pre-fix | 80.0% | 85.0% | 0.606 | 0 |
| **with_rewriter — post-fix** | **85-90%** | **90-95%** | **0.638-0.650** | 0 |

(Range reflects Haiku variance run-to-run.) q01 now lands in top-5. q19 still outside top-5 but that's a retrieval-coverage issue, not rewriter — PR B (BFS on `memory_links`) targets it.

## Remaining 3 eval misses (not rewriter-related)

- **q15** "multi-agent frameworks landscape comparison" — expected at rank 7, coverage issue (PR B target).
- **q17** "DnD dungeon master hobby" — expected is `type=user`, hook scope excludes by design (session-start load).
- **q19** — outside top-10, coverage issue (PR B target).

## Test plan

- [x] `pytest tests/test_memory_recall_hook.py` → 38/38 passed (up from 27). Default `rrf_merge` signature unchanged.
- [x] `python scripts/eval-recall.py --with-rewriter` → recall@5 ≥85%, must_not 0.
- [x] AST parse clean for both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)