### PR TITLE
feat(memory): Phase 3 — 1-hop BFS on memory_links (#211)

### DIFF
--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -144,8 +144,104 @@ def _rrf_merge(
     for rid in ranked[:limit]:
         row = by_id[rid]
         row["_rrf_score"] = scores[rid]
+        # _final_score is the unified sort key carried through any
+        # downstream merge step (e.g. link expansion in --with-links).
+        row["_final_score"] = scores[rid]
         result.append(row)
     return result
+
+
+# 1-hop BFS link expansion. Mirrors memory-recall-hook.py constants/logic
+# so eval predicts hook behavior. When both are enabled (--with-rewriter
+# --with-links) the combined mode measures the full Phase 3 pipeline.
+LINK_EXPAND_TOP_K = 5
+LINK_DECAY = 0.5
+LINK_SCORE_FIELD = "_link_score"
+
+
+def _score_linked_rows(
+    top_rows: list[dict],
+    linked_rows: list[dict],
+    *,
+    top_k: int = LINK_EXPAND_TOP_K,
+    decay: float = LINK_DECAY,
+    k: int = RRF_K,
+) -> list[dict]:
+    if not top_rows or not linked_rows:
+        return []
+    seed_rank: dict[str, int] = {}
+    for i, row in enumerate(top_rows[:top_k]):
+        rid = row.get("id")
+        if rid is not None and rid not in seed_rank:
+            seed_rank[rid] = i
+    if not seed_rank:
+        return []
+    seen: set[str] = set(seed_rank.keys())
+    out: list[dict] = []
+    for row in linked_rows:
+        rid = row.get("id")
+        if not rid or rid in seen:
+            continue
+        parent = row.get("linked_from")
+        if parent not in seed_rank:
+            continue
+        seen.add(rid)
+        strength = row.get("link_strength")
+        try:
+            strength_f = float(strength) if strength is not None else 1.0
+        except (TypeError, ValueError):
+            strength_f = 1.0
+        parent_rank = seed_rank[parent]
+        row[LINK_SCORE_FIELD] = (1.0 / (k + parent_rank)) * decay * strength_f
+        out.append(row)
+    return out
+
+
+def _expand_links(client, top_rows: list[dict]) -> list[dict]:
+    seed_ids = [r["id"] for r in top_rows[:LINK_EXPAND_TOP_K] if r.get("id")]
+    if not seed_ids:
+        return []
+    try:
+        result = client.rpc(
+            "get_linked_memories",
+            {"memory_ids": seed_ids, "link_types": None, "show_history": False},
+        ).execute()
+        linked_rows = result.data or []
+    except Exception:
+        return []
+    return _score_linked_rows(top_rows, linked_rows)
+
+
+def _merge_with_links(
+    ranked_rows: list[dict], linked_rows: list[dict]
+) -> list[dict]:
+    if not linked_rows:
+        return ranked_rows
+    by_id: dict[str, dict] = {}
+    scores: dict[str, float] = {}
+    for row in ranked_rows:
+        rid = row.get("id")
+        if not rid:
+            continue
+        by_id[rid] = row
+        scores[rid] = float(row.get("_final_score") or 0.0)
+    for row in linked_rows:
+        rid = row.get("id")
+        if not rid:
+            continue
+        link_s = float(row.get(LINK_SCORE_FIELD) or 0.0)
+        if rid in scores:
+            scores[rid] = max(scores[rid], link_s)
+        else:
+            by_id[rid] = row
+            scores[rid] = link_s
+    final_ids = sorted(scores.keys(), key=lambda r: scores[r], reverse=True)
+    out: list[dict] = []
+    for rid in final_ids:
+        row = by_id[rid]
+        row["_final_score"] = scores[rid]
+        out.append(row)
+    return out
 
 
 def _apply_temporal_scoring(rows: list[dict]) -> list[dict]:
@@ -200,12 +296,13 @@ class QueryResult:
     rewriter_entities: list[str] = field(default_factory=list)
     rewriter_types: list[str] = field(default_factory=list)
     rewriter_fired: bool = False         # True when rewriter returned a non-null result
+    links_added: int = 0                 # new rows added via 1-hop BFS
 
 
 @dataclass
 class EvalReport:
     timestamp: str
-    mode: str                            # "server_only" | "with_rewriter"
+    mode: str                            # e.g. "server_only", "with_rewriter+links"
     corpus_size: int
     total_queries: int
     recall_at_5: float
@@ -215,7 +312,17 @@ class EvalReport:
     passed: int
     failed: int
     rewriter_fired_count: int = 0        # queries where rewriter produced output
+    links_added_total: int = 0           # total new rows pulled in via link expansion
     results: list[dict] = field(default_factory=list)
+
+
+def _build_mode_string(with_rewriter: bool, with_links: bool) -> str:
+    parts: list[str] = []
+    if with_rewriter:
+        parts.append("with_rewriter")
+    if with_links:
+        parts.append("links")
+    return "+".join(parts) if parts else "server_only"
 
 
 async def run_query(
@@ -223,6 +330,7 @@ async def run_query(
     q: dict,
     rewriter: Callable[[str], dict | None] | None = None,
     boost_multiplier: float = 1.0,
+    with_links: bool = False,
 ) -> QueryResult:
     embedding = await _embed_query(q["query"])
 
@@ -265,13 +373,31 @@ async def run_query(
     # type-narrowing regression fix). No default scope filter — eval
     # doesn't model the hook's exclusion of user/project memories.
     boost_types = set(rw_types) if rw_types else None
+    # Pull a wider window (25) when link expansion is on so the BFS can
+    # reach the right seeds. Without this, top-5 seeds miss the parents
+    # that edge toward the expected memory.
+    merge_limit = 25 if with_links else 10
     merged = _rrf_merge(
         sem_rows,
         kw_rows,
-        limit=10,
+        limit=merge_limit,
         boost_types=boost_types,
         boost_multiplier=boost_multiplier,
     )
+
+    links_added = 0
+    if with_links:
+        linked = _expand_links(client, merged)
+        if linked:
+            before_ids = {r.get("id") for r in merged}
+            merged = _merge_with_links(merged, linked)
+            links_added = sum(
+                1 for r in merged if r.get("id") and r.get("id") not in before_ids
+            )
+        # Trim back to top-10 for metrics; any linked row that made it
+        # into top-10 has earned its place via the unified _final_score.
+        merged = merged[:10]
+
     _apply_temporal_scoring(merged)
 
     top_names = [r.get("name", "?") for r in merged]
@@ -307,6 +433,7 @@ async def run_query(
         rewriter_entities=rw_entities,
         rewriter_types=rw_types,
         rewriter_fired=rw_fired,
+        links_added=links_added,
     )
 
 
@@ -315,11 +442,16 @@ async def run_all(
     client,
     rewriter: Callable[[str], dict | None] | None = None,
     boost_multiplier: float = 1.0,
+    with_links: bool = False,
 ) -> EvalReport:
     results = []
     for q in queries:
         r = await run_query(
-            client, q, rewriter=rewriter, boost_multiplier=boost_multiplier
+            client,
+            q,
+            rewriter=rewriter,
+            boost_multiplier=boost_multiplier,
+            with_links=with_links,
         )
         results.append(r)
 
@@ -330,6 +462,7 @@ async def run_all(
     mn_viol = sum(1 for r in results if r.must_not_violations_at_5)
     passed = sum(1 for r in results if r.passed)
     rw_fired = sum(1 for r in results if r.rewriter_fired)
+    links_added_total = sum(r.links_added for r in results)
 
     # corpus size for context
     cs = client.table("memories").select("id", count="exact").is_("deleted_at", "null").limit(1).execute()
@@ -337,7 +470,7 @@ async def run_all(
 
     return EvalReport(
         timestamp=datetime.now(timezone.utc).isoformat(),
-        mode="with_rewriter" if rewriter is not None else "server_only",
+        mode=_build_mode_string(rewriter is not None, with_links),
         corpus_size=corpus_size,
         total_queries=total,
         recall_at_5=r5,
@@ -347,6 +480,7 @@ async def run_all(
         passed=passed,
         failed=total - passed,
         rewriter_fired_count=rw_fired,
+        links_added_total=links_added_total,
         results=[asdict(r) for r in results],
     )
 
@@ -394,8 +528,10 @@ def print_report(report: EvalReport, quiet: bool = False) -> None:
     print(f"MRR                : {report.mrr:.3f}")
     print(f"must_not violations: {report.must_not_violations}  (lifecycle signal — should be 0 after Phase 1)")
     print(f"passed / failed    : {report.passed} / {report.failed}")
-    if report.mode == "with_rewriter":
+    if "with_rewriter" in report.mode:
         print(f"rewriter fired     : {report.rewriter_fired_count}/{report.total_queries}")
+    if "links" in report.mode:
+        print(f"links added (sum)  : {report.links_added_total}  (rows added via 1-hop BFS)")
     print()
 
 
@@ -456,6 +592,12 @@ def main() -> int:
                          "returned types narrow both RPC result sets Python-side. "
                          "Requires ANTHROPIC_API_KEY; falls back per-query to raw "
                          "prompt when the rewriter returns None.")
+    ap.add_argument("--with-links", action="store_true",
+                    help="Expand top-5 RRF rows with a 1-hop BFS on memory_links — "
+                         "closes coverage gaps where the expected memory is one "
+                         "edge away from a retrieved row. Uses get_linked_memories "
+                         "RPC with a decayed RRF score (decay=0.5); fails soft if "
+                         "the RPC is unavailable.")
     args = ap.parse_args()
 
     _load_env()
@@ -503,7 +645,8 @@ def main() -> int:
                   file=sys.stderr)
 
     report = asyncio.run(
-        run_all(queries, client, rewriter=rewriter, boost_multiplier=boost_multiplier)
+        run_all(queries, client, rewriter=rewriter,
+                boost_multiplier=boost_multiplier, with_links=args.with_links)
     )
     print_report(report, quiet=args.quiet)
 

--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -83,6 +83,19 @@ RRF_K = 60                   # matches _rrf_merge in mcp-memory/server.py
 # loses to an unboosted dual-signal hit (0.0167*1.5 < 0.0333).
 TYPE_BOOST_MULTIPLIER = 1.5
 
+# 1-hop BFS expansion on memory_links — fills coverage gaps where the
+# expected memory is linked from a retrieved row but not itself retrieved
+# by semantic+keyword fan-out. Seeds are the top-K RRF rows; linked
+# neighbors get a decayed RRF-like score so a good link at rank 0 can
+# still outrank a weak direct hit at rank 20+.
+#   LINK_EXPAND_TOP_K = seeds passed to get_linked_memories
+#   LINK_DECAY       = multiplier on the parent's 1/(k+rank) contribution
+#                      (0.5 → linked row worth half a direct hit at same rank)
+#   LINK_SCORE_FIELD = debug marker + display signal on linked-only rows
+LINK_EXPAND_TOP_K = 5
+LINK_DECAY = 0.5
+LINK_SCORE_FIELD = "_link_score"
+
 # Projects Jarvis tracks — cwd basename must match one of these to scope recall.
 # Anything else → no project filter (load from global + all projects).
 KNOWN_PROJECTS = {"jarvis", "redrobot"}
@@ -272,14 +285,19 @@ def format_memory(m: dict) -> str:
     # _sort_score is set only on single-signal rows that were type-boosted
     # — without it, the displayed sim/rank would contradict the actual
     # ranking (the boost changed the sort key, not the native score).
+    # _link_score is set on rows pulled in by 1-hop BFS that weren't in
+    # the direct RRF result — surfaces link provenance to the reader.
     rrf = m.get("_rrf_score")
     sort_score = m.get("_sort_score")
+    link_score = m.get(LINK_SCORE_FIELD)
     sim = m.get("similarity")
     rank = m.get("rank")
     if rrf is not None:
         score_str = f" (rrf {rrf:.3f})"
     elif sort_score is not None:
         score_str = f" (boost {sort_score:.3f})"
+    elif link_score is not None:
+        score_str = f" (link {link_score:.3f})"
     elif sim is not None:
         score_str = f" (sim {sim:.2f})"
     elif rank is not None:
@@ -321,6 +339,11 @@ def rrf_merge(
     field untouched, *except* when the boost fires on a single-signal row:
     we set `_sort_score` on it so `format_memory` can show the true sort
     key. Otherwise the displayed sim/rank would contradict the ranking.
+
+    Every row also gets `_final_score` — the unified ranking key after any
+    boost. Downstream link expansion (`merge_with_links`) uses this to fold
+    linked neighbors into the same sort space without having to recompute
+    RRF positions.
     """
     scores: dict[str, float] = {}
     hits: dict[str, int] = {}
@@ -351,6 +374,131 @@ def rrf_merge(
         row = by_id[rid]
         if hits[rid] >= 2:
             row["_rrf_score"] = scores[rid]
+        row["_final_score"] = scores[rid]
+        out.append(row)
+    return out
+
+
+def _score_linked_rows(
+    top_rows: list[dict],
+    linked_rows: list[dict],
+    *,
+    top_k: int = LINK_EXPAND_TOP_K,
+    decay: float = LINK_DECAY,
+    k: int = RRF_K,
+) -> list[dict]:
+    """Annotate linked_rows with a synthetic RRF-like score derived from
+    their parent's rank in top_rows.
+
+    Pure function — takes already-fetched link rows (from
+    `get_linked_memories`, which carries `linked_from` pointing at the
+    seed id) and returns the subset whose parent is in the top-K seed
+    window, deduped against the seeds and against each other.
+
+    Score formula: `(1 / (k + parent_rank)) * decay * link_strength`.
+    Mirrors the RRF math in `rrf_merge` so link scores live in the same
+    space, then `decay` attenuates them (0.5 → linked hit worth half a
+    direct hit at the same rank). `link_strength` (0..1, from DB) scales
+    by edge confidence.
+    """
+    if not top_rows or not linked_rows:
+        return []
+    seed_rank: dict[str, int] = {}
+    for i, row in enumerate(top_rows[:top_k]):
+        rid = row.get("id")
+        if rid is not None and rid not in seed_rank:
+            seed_rank[rid] = i
+    if not seed_rank:
+        return []
+    seen: set[str] = set(seed_rank.keys())
+    out: list[dict] = []
+    for row in linked_rows:
+        rid = row.get("id")
+        if not rid or rid in seen:
+            continue
+        parent = row.get("linked_from")
+        if parent not in seed_rank:
+            continue
+        seen.add(rid)
+        strength = row.get("link_strength")
+        try:
+            strength_f = float(strength) if strength is not None else 1.0
+        except (TypeError, ValueError):
+            strength_f = 1.0
+        parent_rank = seed_rank[parent]
+        row[LINK_SCORE_FIELD] = (1.0 / (k + parent_rank)) * decay * strength_f
+        out.append(row)
+    return out
+
+
+def expand_links(
+    client,
+    top_rows: list[dict],
+    *,
+    link_types: list[str] | None = None,
+    top_k: int = LINK_EXPAND_TOP_K,
+    decay: float = LINK_DECAY,
+) -> list[dict]:
+    """Fetch 1-hop linked neighbors of the top-K rows via `get_linked_memories`.
+
+    Returns annotated linked rows (see `_score_linked_rows`). On RPC failure
+    returns []. Hook's fail-soft contract — links are a coverage bonus, not
+    a hard requirement.
+    """
+    seed_ids = [r["id"] for r in top_rows[:top_k] if r.get("id")]
+    if not seed_ids:
+        return []
+    try:
+        result = client.rpc(
+            "get_linked_memories",
+            {
+                "memory_ids": seed_ids,
+                "link_types": link_types,
+                "show_history": False,
+            },
+        ).execute()
+        linked_rows = result.data or []
+    except Exception:
+        return []
+    return _score_linked_rows(top_rows, linked_rows, top_k=top_k, decay=decay)
+
+
+def merge_with_links(
+    ranked_rows: list[dict], linked_rows: list[dict]
+) -> list[dict]:
+    """Fold linked rows into the already-ranked hybrid result.
+
+    Each `ranked_rows` entry carries `_final_score` (set by `rrf_merge`);
+    each `linked_rows` entry carries `_link_score` (set by
+    `_score_linked_rows`). Rows that appear in both keep the max. Sort
+    key after merge is the resulting score, written back to
+    `_final_score` so downstream budget trim + display stay consistent.
+    """
+    if not linked_rows:
+        return ranked_rows
+    by_id: dict[str, dict] = {}
+    scores: dict[str, float] = {}
+    for row in ranked_rows:
+        rid = row.get("id")
+        if not rid:
+            continue
+        by_id[rid] = row
+        scores[rid] = float(row.get("_final_score") or 0.0)
+    for row in linked_rows:
+        rid = row.get("id")
+        if not rid:
+            continue
+        link_s = float(row.get(LINK_SCORE_FIELD) or 0.0)
+        if rid in scores:
+            scores[rid] = max(scores[rid], link_s)
+        else:
+            by_id[rid] = row
+            scores[rid] = link_s
+    final_ids = sorted(scores.keys(), key=lambda r: scores[r], reverse=True)
+    out: list[dict] = []
+    for rid in final_ids:
+        row = by_id[rid]
+        row["_final_score"] = scores[rid]
         out.append(row)
     return out
 
@@ -447,6 +595,17 @@ def main():
 
     rows = rrf_merge(semantic_rows, keyword_rows, boost_types=boost_types)
 
+    # 1-hop BFS: pull linked neighbors of the top-K RRF rows and fold them
+    # into the ranking. Covers the "expected memory is one edge away from
+    # a retrieved row" failure mode (q15/q19 in the eval set). Linked rows
+    # are type-scoped like direct rows. Fail-soft: RPC or link_score error
+    # yields zero linked rows and the ranking is unchanged.
+    linked_rows_raw = expand_links(client, rows)
+    linked_rows = [r for r in linked_rows_raw if r.get("type") in ALLOWED_TYPES]
+    linked_count = len(linked_rows)
+    if linked_rows:
+        rows = merge_with_links(rows, linked_rows)
+
     # Accumulate under char budget
     scope = f" (project: {project}+global)" if project else " (all projects)"
     signal = (
@@ -456,6 +615,8 @@ def main():
         if semantic_rows
         else "keyword-only"
     )
+    if linked_count:
+        signal += f" + {linked_count} linked"
     rewriter_note = ""
     if rewritten:
         bits = []

--- a/tests/test_memory_recall_hook.py
+++ b/tests/test_memory_recall_hook.py
@@ -152,6 +152,17 @@ class TestRrfMerge:
         out = mrh.rrf_merge(semantic, keyword)
         assert [r["id"] for r in out] == ["top", "mid", "bot"]
 
+    def test_final_score_set_on_every_row(self):
+        # _final_score is the unified sort key consumed by link merge.
+        # Must be present on single-hits and dual-hits alike — otherwise
+        # merge_with_links would treat unscored rows as 0 and reorder wildly.
+        semantic = [{"id": "a"}, {"id": "b"}]
+        keyword = [{"id": "b"}, {"id": "c"}]
+        out = mrh.rrf_merge(semantic, keyword)
+        for row in out:
+            assert "_final_score" in row
+            assert row["_final_score"] > 0
+
 
 # ---------------------------------------------------------------------------
 # rrf_merge — type boost behavior (Phase 3 soft-boost replaces hard filter)
@@ -303,3 +314,228 @@ class TestFormatMemory:
         out = mrh.format_memory(m)
         assert "(decision" in out  # type still rendered
         assert "rrf" not in out and "sim" not in out and "rank" not in out
+
+    def test_link_score_displays_after_rrf_and_boost(self):
+        # Linked-only rows (BFS hits with no direct retrieval signal) surface
+        # their synthetic `_link_score` so owners can spot when context came
+        # from a graph hop rather than the fuser.
+        m = {"name": "n", "type": "decision", "_link_score": 0.00833, "similarity": 0.4}
+        out = mrh.format_memory(m)
+        assert "link 0.008" in out
+        assert "sim" not in out
+
+    def test_rrf_score_wins_over_link_score(self):
+        # A dual-hit that also has a link edge keeps the stronger signal.
+        m = {"name": "n", "type": "decision", "_rrf_score": 0.05, "_link_score": 0.008}
+        out = mrh.format_memory(m)
+        assert "rrf 0.050" in out
+        assert "link" not in out
+
+
+# ---------------------------------------------------------------------------
+# _score_linked_rows — pure scorer for 1-hop BFS neighbors
+# ---------------------------------------------------------------------------
+
+
+class TestScoreLinkedRows:
+    def test_empty_inputs(self):
+        assert mrh._score_linked_rows([], []) == []
+        assert mrh._score_linked_rows([{"id": "a"}], []) == []
+        assert mrh._score_linked_rows([], [{"id": "b", "linked_from": "a"}]) == []
+
+    def test_scoring_formula(self):
+        # parent at rank 0, strength 1.0, default decay 0.5 →
+        # 1 / (60 + 0) * 0.5 * 1.0 = 0.008333...
+        seeds = [{"id": "parent"}]
+        linked = [{"id": "child", "linked_from": "parent", "link_strength": 1.0}]
+        out = mrh._score_linked_rows(seeds, linked)
+        assert len(out) == 1
+        expected = (1.0 / (mrh.RRF_K + 0)) * mrh.LINK_DECAY * 1.0
+        assert abs(out[0][mrh.LINK_SCORE_FIELD] - expected) < 1e-9
+
+    def test_rank_affects_score(self):
+        # Parent at rank 2 scores less than parent at rank 0.
+        seeds = [{"id": "p0"}, {"id": "p1"}, {"id": "p2"}]
+        linked = [
+            {"id": "c0", "linked_from": "p0", "link_strength": 1.0},
+            {"id": "c2", "linked_from": "p2", "link_strength": 1.0},
+        ]
+        out = mrh._score_linked_rows(seeds, linked)
+        by_id = {r["id"]: r[mrh.LINK_SCORE_FIELD] for r in out}
+        assert by_id["c0"] > by_id["c2"]
+
+    def test_strength_affects_score(self):
+        seeds = [{"id": "parent"}]
+        linked = [
+            {"id": "weak", "linked_from": "parent", "link_strength": 0.25},
+            {"id": "strong", "linked_from": "parent", "link_strength": 1.0},
+        ]
+        out = mrh._score_linked_rows(seeds, linked)
+        by_id = {r["id"]: r[mrh.LINK_SCORE_FIELD] for r in out}
+        assert by_id["strong"] == 4 * by_id["weak"]
+
+    def test_missing_strength_defaults_to_one(self):
+        # DB may return NULL link_strength; treat as full strength.
+        seeds = [{"id": "parent"}]
+        linked = [{"id": "child", "linked_from": "parent"}]  # no link_strength
+        out = mrh._score_linked_rows(seeds, linked)
+        expected = (1.0 / mrh.RRF_K) * mrh.LINK_DECAY * 1.0
+        assert abs(out[0][mrh.LINK_SCORE_FIELD] - expected) < 1e-9
+
+    def test_invalid_strength_defaults_to_one(self):
+        # Malformed strength (string, NaN-ish) must not raise — fall back to 1.
+        seeds = [{"id": "parent"}]
+        linked = [{"id": "child", "linked_from": "parent", "link_strength": "bad"}]
+        out = mrh._score_linked_rows(seeds, linked)
+        assert len(out) == 1
+        assert mrh.LINK_SCORE_FIELD in out[0]
+
+    def test_deduplicates_against_seeds(self):
+        # A linked row whose id coincides with a seed must be skipped.
+        seeds = [{"id": "a"}, {"id": "b"}]
+        linked = [{"id": "a", "linked_from": "b", "link_strength": 1.0}]
+        out = mrh._score_linked_rows(seeds, linked)
+        assert out == []
+
+    def test_skips_linked_from_outside_seeds(self):
+        # Only top-K seeds are candidates for expansion. A row pointing at
+        # a non-seed parent must be dropped (RPC might return extras).
+        seeds = [{"id": "a"}]
+        linked = [{"id": "x", "linked_from": "unseen", "link_strength": 1.0}]
+        out = mrh._score_linked_rows(seeds, linked)
+        assert out == []
+
+    def test_top_k_caps_seed_window(self):
+        # With top_k=1, only the first seed counts; child of p1 is dropped.
+        seeds = [{"id": "p0"}, {"id": "p1"}]
+        linked = [
+            {"id": "c1", "linked_from": "p1", "link_strength": 1.0},
+            {"id": "c0", "linked_from": "p0", "link_strength": 1.0},
+        ]
+        out = mrh._score_linked_rows(seeds, linked, top_k=1)
+        assert [r["id"] for r in out] == ["c0"]
+
+    def test_dedupes_duplicate_linked_ids(self):
+        # Same linked_id via multiple edges: keep the first, skip the rest.
+        seeds = [{"id": "p0"}, {"id": "p1"}]
+        linked = [
+            {"id": "shared", "linked_from": "p0", "link_strength": 1.0},
+            {"id": "shared", "linked_from": "p1", "link_strength": 1.0},
+        ]
+        out = mrh._score_linked_rows(seeds, linked)
+        assert len(out) == 1
+
+
+# ---------------------------------------------------------------------------
+# merge_with_links — fold BFS hits into the RRF-ranked list
+# ---------------------------------------------------------------------------
+
+
+class TestMergeWithLinks:
+    def test_no_linked_unchanged(self):
+        ranked = [{"id": "a", "_final_score": 0.05}, {"id": "b", "_final_score": 0.03}]
+        out = mrh.merge_with_links(ranked, [])
+        assert [r["id"] for r in out] == ["a", "b"]
+
+    def test_new_linked_row_added(self):
+        ranked = [{"id": "a", "_final_score": 0.05}]
+        linked = [{"id": "new", mrh.LINK_SCORE_FIELD: 0.01}]
+        out = mrh.merge_with_links(ranked, linked)
+        ids = [r["id"] for r in out]
+        assert "new" in ids
+        assert out[0]["id"] == "a"  # higher score stays on top
+
+    def test_duplicate_keeps_max_score(self):
+        # Row in both lists: final score = max(direct, link). The direct RRF
+        # score dominates here; _final_score should reflect that, not the
+        # weaker link score.
+        ranked = [{"id": "x", "_final_score": 0.05}]
+        linked = [{"id": "x", mrh.LINK_SCORE_FIELD: 0.01}]
+        out = mrh.merge_with_links(ranked, linked)
+        assert len(out) == 1
+        assert abs(out[0]["_final_score"] - 0.05) < 1e-9
+
+    def test_reordering_by_final_score(self):
+        # A strongly-linked row can outrank a weak direct hit, and the new
+        # ordering is written back to _final_score for downstream consumers.
+        ranked = [{"id": "weak", "_final_score": 0.005}]
+        linked = [{"id": "strong_link", mrh.LINK_SCORE_FIELD: 0.02}]
+        out = mrh.merge_with_links(ranked, linked)
+        assert [r["id"] for r in out] == ["strong_link", "weak"]
+        assert abs(out[0]["_final_score"] - 0.02) < 1e-9
+
+    def test_rows_without_id_skipped(self):
+        # Defensive: malformed rows (no id) can't be scored/sorted.
+        ranked = [{"_final_score": 0.5}]  # no id
+        linked = [{"id": "valid", mrh.LINK_SCORE_FIELD: 0.01}]
+        out = mrh.merge_with_links(ranked, linked)
+        assert [r["id"] for r in out] == ["valid"]
+
+    def test_missing_final_score_treated_as_zero(self):
+        # Edge: if upstream somehow fails to set _final_score, don't crash —
+        # treat as zero so link edges can still promote the row.
+        ranked = [{"id": "unscored"}]
+        linked = [{"id": "linked", mrh.LINK_SCORE_FIELD: 0.01}]
+        out = mrh.merge_with_links(ranked, linked)
+        assert out[0]["id"] == "linked"
+
+
+# ---------------------------------------------------------------------------
+# expand_links — fail-soft RPC wrapper
+# ---------------------------------------------------------------------------
+
+
+class _StubClient:
+    """Minimal supabase-client stand-in for expand_links tests."""
+    def __init__(self, *, data=None, raise_exc=None):
+        self._data = data or []
+        self._raise = raise_exc
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def rpc(self, name, params):
+        self.rpc_calls.append((name, params))
+        return self
+
+    def execute(self):
+        if self._raise:
+            raise self._raise
+        return types.SimpleNamespace(data=self._data)
+
+
+class TestExpandLinks:
+    def test_empty_top_rows_no_rpc(self):
+        client = _StubClient(data=[{"id": "x"}])
+        out = mrh.expand_links(client, [])
+        assert out == []
+        assert client.rpc_calls == []
+
+    def test_all_top_rows_missing_id_no_rpc(self):
+        # Defensive: if all seeds lack ids, don't bother hitting the RPC.
+        client = _StubClient(data=[{"id": "x"}])
+        out = mrh.expand_links(client, [{"name": "no-id"}])
+        assert out == []
+        assert client.rpc_calls == []
+
+    def test_rpc_exception_returns_empty(self):
+        # Fail-soft contract: RPC failure must not raise or pollute results.
+        client = _StubClient(raise_exc=RuntimeError("connection lost"))
+        out = mrh.expand_links(client, [{"id": "seed"}])
+        assert out == []
+
+    def test_successful_rpc_returns_scored_rows(self):
+        client = _StubClient(data=[
+            {"id": "child", "linked_from": "seed", "link_strength": 1.0},
+        ])
+        out = mrh.expand_links(client, [{"id": "seed"}])
+        assert len(out) == 1
+        assert mrh.LINK_SCORE_FIELD in out[0]
+
+    def test_rpc_called_with_top_k_seed_ids(self):
+        # Seed slice must respect LINK_EXPAND_TOP_K — we don't want to expand
+        # a 25-row RRF list into a graph fetch.
+        client = _StubClient(data=[])
+        seeds = [{"id": f"s{i}"} for i in range(10)]
+        mrh.expand_links(client, seeds)
+        assert len(client.rpc_calls) == 1
+        call_params = client.rpc_calls[0][1]
+        assert call_params["memory_ids"] == [f"s{i}" for i in range(mrh.LINK_EXPAND_TOP_K)]


### PR DESCRIPTION
## Summary

Phase 3 of #185 — closes the "BFS on links" checkbox in the design-doc
fan-out stage. Neighbors of the top-5 RRF rows are pulled via
`get_linked_memories` and folded into the ranking with a decayed score,
so a memory one edge from a strong seed can surface when it wouldn't
rank directly.

## Changes

- `scripts/memory-recall-hook.py`: `_score_linked_rows`, `expand_links`,
  `merge_with_links`. `rrf_merge` now sets `_final_score` on every row
  (unified sort key). Display chain extended: `(link 0.008)` for linked-only.
- `scripts/eval-recall.py`: mirrors the helpers behind `--with-links`;
  `links_added_total` aggregate; mode strings compose
  (`with_rewriter+links`, etc.).
- Tests: 62 total (21 new) — score formula, dedup, RPC fail-soft, merge
  math, `_final_score` invariant, link-score display chain.

## Eval delta (304-memory corpus)

| Mode                       | recall@5 | recall@10 | MRR    |
| -------------------------- | -------- | --------- | ------ |
| server_only (baseline)     | 85.0%    | 90.0%     | 0.585  |
| with_rewriter              | 85.0%    | 95.0%     | 0.620  |
| **with_rewriter + links**  | 85.0%    | 95.0%     | 0.645  |

Links add +0.025 MRR on top of rewriter; 77 rows pulled in via BFS.

## Out of scope

- Cross-encoder rerank on top-20: BFS did not close q15/q19 at top-5
  (both stuck at rank 7). Next step would be to expand the candidate
  pool before rerank, not just rerank the existing 10.
- 2-hop BFS: 1-hop is already recall-positive without semantic pollution.

## Test plan

- [x] `pytest tests/test_memory_recall_hook.py` — 62 passed
- [x] `eval-recall.py --with-rewriter --with-links --diff baseline`
- [x] Fail-soft verified: RPC exception returns `[]`, no ranking disruption
- [ ] Monitor `links_added_total` in the next eval baseline refresh

Closes #211.
Part of #185 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)