### PR TITLE
feat(memory): Phase 5.1a — consolidation cluster report

### DIFF
--- a/scripts/consolidation-report.py
+++ b/scripts/consolidation-report.py
@@ -1,0 +1,286 @@
+"""Memory consolidation — cluster detection report (Phase 5.1a, deterministic).
+
+Calls the `find_consolidation_clusters` RPC, filters out dead memories
+(expired_at / superseded_by / deleted_at) post-hoc in Python, and prints a
+human-readable report of similarity clusters that are genuine candidates for
+merge/supersede.
+
+No LLM. No mutations. Pure read.
+
+Follow-ups (separate PRs):
+    5.1b — Haiku merger emits merge/supersede plan per cluster (dry-run + --apply)
+    5.1c — RPC migration: filter dead memories at source; replace archive_memories
+           type-suffix hack with expired_at + superseded_by writes
+    5.1d — Weekly scheduled task + owner-review queue
+
+Usage:
+    python scripts/consolidation-report.py                 # markdown report to stdout
+    python scripts/consolidation-report.py --json          # machine-readable
+    python scripts/consolidation-report.py --min-size 4    # require 4+ memories per cluster
+    python scripts/consolidation-report.py --threshold 0.85
+    python scripts/consolidation-report.py --save-memory   # also upsert report as a memory
+
+Requires SUPABASE_URL and SUPABASE_KEY. .env in repo root auto-loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Reports contain non-ASCII characters (em-dashes, arrows, Cyrillic in
+# descriptions). On Windows the default console codec is cp1251 which
+# can't encode them; force UTF-8 so the script works on all 3 devices.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+try:
+    from dotenv import load_dotenv
+    here = Path(__file__).resolve().parent
+    for c in (here.parent / ".env", here.parent.parent / ".env"):
+        if c.exists():
+            load_dotenv(c)
+            break
+except ImportError:
+    pass
+
+from supabase import create_client
+
+
+DEFAULT_MIN_SIZE = 3
+DEFAULT_THRESHOLD = 0.80
+
+
+def fetch_clusters(client, min_size: int, threshold: float) -> list[dict]:
+    """Call find_consolidation_clusters RPC. Returns rows as-is from Postgres."""
+    resp = client.rpc(
+        "find_consolidation_clusters",
+        {"min_cluster_size": min_size, "sim_threshold": threshold},
+    ).execute()
+    return resp.data or []
+
+
+def fetch_lifecycle_columns(client, memory_ids: list[str]) -> dict[str, dict]:
+    """Fetch lifecycle columns + description/tags for the given memory ids."""
+    if not memory_ids:
+        return {}
+    rows = (
+        client.table("memories")
+        .select(
+            "id, name, type, description, tags, "
+            "expired_at, superseded_by, deleted_at, "
+            "updated_at, content_updated_at"
+        )
+        .in_("id", memory_ids)
+        .execute()
+        .data
+    )
+    return {r["id"]: r for r in rows}
+
+
+def is_live(row: dict) -> bool:
+    """Phase 1 default-recall semantics: memory is live iff not expired, not
+    superseded, not soft-deleted. Kept in sync with server.py `_hybrid_recall`."""
+    return (
+        row.get("expired_at") is None
+        and row.get("superseded_by") is None
+        and row.get("deleted_at") is None
+    )
+
+
+def group_clusters(rpc_rows: list[dict], live_by_id: dict[str, dict]) -> list[dict]:
+    """Re-group RPC rows by cluster_id, enrich with lifecycle+description,
+    and drop clusters where <min stayed live.
+
+    A memory appears in the RPC output once per pair-membership (anchor +
+    each neighbor) so the raw rows contain duplicates. Dedup by memory_id
+    within a cluster, keeping the highest similarity seen for that row.
+    """
+    by_cluster: dict[int, dict[str, dict]] = defaultdict(dict)
+    for r in rpc_rows:
+        mid = r["memory_id"]
+        live = live_by_id.get(mid)
+        if live is None:
+            continue  # memory vanished between RPC call and lookup
+        if not is_live(live):
+            continue
+        sim = float(r["similarity"])
+        existing = by_cluster[r["cluster_id"]].get(mid)
+        if existing and existing["similarity"] >= sim:
+            continue
+        by_cluster[r["cluster_id"]][mid] = {
+            "id": mid,
+            "name": r["memory_name"],
+            "type": r["memory_type"],
+            "similarity": sim,
+            "updated_at": r["updated_at"],
+            "description": live.get("description") or "",
+            "tags": live.get("tags") or [],
+            "content_updated_at": live.get("content_updated_at"),
+        }
+
+    clusters: list[dict] = []
+    for cid, by_id in by_cluster.items():
+        members = sorted(by_id.values(), key=lambda m: m["updated_at"], reverse=True)
+        max_sim = max(m["similarity"] for m in members)
+        avg_sim = sum(m["similarity"] for m in members) / len(members)
+        clusters.append({
+            "cluster_id": cid,
+            "size": len(members),
+            "max_similarity": round(max_sim, 4),
+            "avg_similarity": round(avg_sim, 4),
+            "types": sorted({m["type"] for m in members}),
+            "members": members,
+        })
+    clusters.sort(key=lambda c: (c["size"], c["max_similarity"]), reverse=True)
+    return clusters
+
+
+def render_markdown(
+    clusters: list[dict],
+    min_size: int,
+    threshold: float,
+    raw_rows: int,
+    dead_filtered: int,
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    total_members = sum(c["size"] for c in clusters)
+    lines = [
+        f"# Memory consolidation report — {now}",
+        "",
+        f"- RPC: `find_consolidation_clusters(min_cluster_size={min_size}, sim_threshold={threshold})`",
+        f"- Raw RPC rows: {raw_rows}",
+        f"- Dead memories filtered (expired/superseded/deleted): {dead_filtered}",
+        f"- Live clusters (size >= {min_size}): **{len(clusters)}**",
+        f"- Total live memories in clusters: {total_members}",
+        "",
+    ]
+    if not clusters:
+        lines.append("_No live clusters found at current thresholds. Nothing to consolidate._")
+        return "\n".join(lines)
+
+    for c in clusters:
+        lines.append(
+            f"## Cluster {c['cluster_id']} — {c['size']} members, "
+            f"max sim {c['max_similarity']:.3f}, avg {c['avg_similarity']:.3f}, "
+            f"types: {', '.join(c['types'])}"
+        )
+        lines.append("")
+        lines.append("| name | type | updated_at | sim | description |")
+        lines.append("|------|------|------------|-----|-------------|")
+        for m in c["members"]:
+            desc = (m["description"] or "").replace("\n", " ").replace("|", "\\|")
+            if len(desc) > 120:
+                desc = desc[:117] + "..."
+            # RPC sim for each row is the sim to *some* pair; keep as signal.
+            lines.append(
+                f"| `{m['name']}` | {m['type']} | {m['updated_at'][:10]} | "
+                f"{m['similarity']:.3f} | {desc} |"
+            )
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append("**Next**: Phase 5.1b will feed these clusters to Haiku for a merge/supersede plan.")
+    return "\n".join(lines)
+
+
+def save_report_memory(client, report_md: str, cluster_count: int, member_count: int) -> None:
+    """Upsert as a project memory so owner can recall recent consolidation state.
+
+    Name is date-stamped so successive daily/weekly runs don't clobber; kept
+    type=project because this is operational state, not a decision.
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    name = f"consolidation_report_{today}"
+    description = (
+        f"Consolidation clusters {today}: {cluster_count} live clusters, "
+        f"{member_count} memories. Deterministic RPC snapshot (Phase 5.1a)."
+    )
+    existing = (
+        client.table("memories")
+        .select("id")
+        .eq("project", "jarvis")
+        .eq("name", name)
+        .execute()
+        .data
+    )
+    payload = {
+        "project": "jarvis",
+        "name": name,
+        "type": "project",
+        "description": description,
+        "content": report_md,
+        "tags": ["memory", "consolidation", "phase-5"],
+        "source_provenance": "skill:consolidation",
+    }
+    if existing:
+        client.table("memories").update(payload).eq("id", existing[0]["id"]).execute()
+        print(f"Updated memory `{name}` (id={existing[0]['id']})", file=sys.stderr)
+    else:
+        client.table("memories").insert(payload).execute()
+        print(f"Inserted memory `{name}`", file=sys.stderr)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--min-size", type=int, default=DEFAULT_MIN_SIZE,
+                   help=f"Minimum cluster size (default {DEFAULT_MIN_SIZE})")
+    p.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
+                   help=f"Cosine similarity threshold (default {DEFAULT_THRESHOLD})")
+    p.add_argument("--json", action="store_true",
+                   help="Emit JSON instead of markdown")
+    p.add_argument("--save-memory", action="store_true",
+                   help="Upsert the markdown report as a Jarvis memory "
+                        "(`consolidation_report_YYYY-MM-DD`, type=project)")
+    args = p.parse_args()
+
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        print("SUPABASE_URL / SUPABASE_KEY missing from env", file=sys.stderr)
+        return 2
+
+    client = create_client(url, key)
+
+    rpc_rows = fetch_clusters(client, args.min_size, args.threshold)
+    raw_count = len(rpc_rows)
+
+    ids = sorted({r["memory_id"] for r in rpc_rows})
+    live_by_id = fetch_lifecycle_columns(client, ids)
+    dead_filtered = sum(1 for r in live_by_id.values() if not is_live(r))
+
+    clusters = group_clusters(rpc_rows, live_by_id)
+    # Dead filtering + dedup can shrink clusters below the requested size.
+    clusters = [c for c in clusters if c["size"] >= args.min_size]
+
+    if args.json:
+        out = {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "params": {"min_size": args.min_size, "threshold": args.threshold},
+            "raw_rpc_rows": raw_count,
+            "dead_filtered": dead_filtered,
+            "cluster_count": len(clusters),
+            "clusters": clusters,
+        }
+        print(json.dumps(out, indent=2, default=str))
+    else:
+        md = render_markdown(clusters, args.min_size, args.threshold, raw_count, dead_filtered)
+        print(md)
+        if args.save_memory:
+            total_members = sum(c["size"] for c in clusters)
+            save_report_memory(client, md, len(clusters), total_members)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/consolidation-report.py
+++ b/scripts/consolidation-report.py
@@ -1,11 +1,13 @@
 """Memory consolidation — cluster detection report (Phase 5.1a, deterministic).
 
 Calls the `find_consolidation_clusters` RPC, filters out dead memories
-(expired_at / superseded_by / deleted_at) post-hoc in Python, and prints a
-human-readable report of similarity clusters that are genuine candidates for
-merge/supersede.
+(expired_at / valid_to / superseded_by / deleted_at) post-hoc in Python, and
+prints a human-readable report of similarity clusters that are genuine
+candidates for merge/supersede.
 
-No LLM. No mutations. Pure read.
+No LLM. Default mode is a pure read — safe against prod. The only write
+path is the opt-in `--save-memory` flag, which upserts the markdown report
+into the `memories` table as a dated `consolidation_report_YYYY-MM-DD` row.
 
 Follow-ups (separate PRs):
     5.1b — Haiku merger emits merge/supersede plan per cluster (dry-run + --apply)
@@ -76,7 +78,7 @@ def fetch_lifecycle_columns(client, memory_ids: list[str]) -> dict[str, dict]:
         client.table("memories")
         .select(
             "id, name, type, description, tags, "
-            "expired_at, superseded_by, deleted_at, "
+            "expired_at, valid_to, superseded_by, deleted_at, "
             "updated_at, content_updated_at"
         )
         .in_("id", memory_ids)
@@ -86,14 +88,38 @@ def fetch_lifecycle_columns(client, memory_ids: list[str]) -> dict[str, dict]:
     return {r["id"]: r for r in rows}
 
 
+def _parse_ts(ts) -> datetime | None:
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+    try:
+        # Postgres returns ISO-8601 with offset; handle the `Z` suffix too.
+        s = str(ts).replace("Z", "+00:00")
+        return datetime.fromisoformat(s)
+    except (TypeError, ValueError):
+        return None
+
+
 def is_live(row: dict) -> bool:
     """Phase 1 default-recall semantics: memory is live iff not expired, not
-    superseded, not soft-deleted. Kept in sync with server.py `_hybrid_recall`."""
-    return (
-        row.get("expired_at") is None
-        and row.get("superseded_by") is None
-        and row.get("deleted_at") is None
-    )
+    past its valid_to, not superseded, not soft-deleted.
+    Kept in sync with server.py `_hybrid_recall` filter:
+        expired_at IS NULL
+        AND (valid_to IS NULL OR valid_to > now())
+        AND superseded_by IS NULL
+    Plus deleted_at (soft-delete).
+    """
+    if row.get("expired_at") is not None:
+        return False
+    if row.get("superseded_by") is not None:
+        return False
+    if row.get("deleted_at") is not None:
+        return False
+    valid_to = _parse_ts(row.get("valid_to"))
+    if valid_to is not None and valid_to <= datetime.now(timezone.utc):
+        return False
+    return True
 
 
 def group_clusters(rpc_rows: list[dict], live_by_id: dict[str, dict]) -> list[dict]:
@@ -205,11 +231,15 @@ def save_report_memory(client, report_md: str, cluster_count: int, member_count:
         f"Consolidation clusters {today}: {cluster_count} live clusters, "
         f"{member_count} memories. Deterministic RPC snapshot (Phase 5.1a)."
     )
+    # Only match a *live* prior row for update; if owner soft-deleted the old
+    # report, treat that as a deliberate tombstone and insert a fresh row
+    # instead of silently reviving it.
     existing = (
         client.table("memories")
         .select("id")
         .eq("project", "jarvis")
         .eq("name", name)
+        .is_("deleted_at", "null")
         .execute()
         .data
     )


### PR DESCRIPTION
## Summary

Wires the idle `find_consolidation_clusters` RPC into a human-readable report. Deterministic half of Phase 5.1 per `phase_split_pattern` — ship detection before the Haiku merger.

- `scripts/consolidation-report.py`: calls RPC, filters dead memories (expired_at / superseded_by / deleted_at) in Python, dedupes anchor/neighbor pairs, prints markdown or `--json`.
- Optional `--save-memory` upserts the report as `consolidation_report_YYYY-MM-DD` (`type=project`, `source_provenance=skill:consolidation`).
- No LLM. No mutations. Pure read — safe to run against prod.

## Sample output (threshold 0.75)

```
- RPC: find_consolidation_clusters(min_cluster_size=3, sim_threshold=0.75)
- Raw RPC rows: 16
- Dead memories filtered: 1
- Live clusters (size >= 3): 3

## Cluster 18 — 3 members, max sim 0.844  (project: april-10 robot test)
  reflect_apr10_full_day / robot_test_apr10_results / zigzag_status_apr10

## Cluster 12 — 3 members, max sim 0.789  (decision: multi-agent architecture)
  jarvis_v2_multiagent_direction / multiagent_pm_architecture_vision / pm_dispatch_v1_architecture

## Cluster 11 — 3 members, max sim 0.771  (decision: deficit-first pipeline)
  deficit_first_all_phases / zigzag_removed_from_escalation / targeted_deficit_filling_strategy
```

Cluster 12 looks like a genuine merge candidate; cluster 18 is distinct per-purpose memories on the same topic. Exactly the kind of judgment call 5.1b (Haiku) will handle.

## Eval

`scripts/eval-recall.py --quiet` → server_only 85.0% / 90.0% / 0.663 MRR / 0 must_not violations. Unchanged (no server.py touched).

## Follow-ups (tracked under #185 Phase 5)

- **5.1b**: Haiku merger emits merge/supersede plan per cluster (dry-run + `--apply`)
- **5.1c**: RPC-side dead filter + replace `archive_memories` type-suffix hack with `expired_at` + `superseded_by` writes (gap 6 in memory-overhaul audit)
- **5.1d**: weekly scheduled task + owner-review queue

Closes #215

## Test plan
- [x] `python scripts/consolidation-report.py` against live Supabase — prints markdown
- [x] `--json` emits valid JSON
- [x] `--threshold 0.75 --min-size 3` surfaces 3 clusters; 1 dead memory filtered
- [x] `eval-recall --quiet` baseline unchanged
- [ ] `--save-memory` path exercised after merge (avoided smoke-writing to prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)