### PR TITLE
feat(memory): Phase 5.1c — RPC-side live filter + fix archive_memories

### DIFF
--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -228,7 +228,11 @@ create policy "Allow all for anon" on memory_links
 -- Returns clusters for LLM-driven merge (content merging is not pure SQL)
 -- =========================================================================
 
--- Find groups of memories that should be consolidated
+-- Find groups of memories that should be consolidated.
+-- Phase 5.1c: the `live` CTE applies Phase 1 default-recall semantics at the
+-- source so consumers never see stale memories in a cluster. Legacy
+-- `%_archived` types are also excluded defensively (0 rows as of 2026-04-19,
+-- left in place so a stray row from old logic cannot poison consolidation).
 create or replace function find_consolidation_clusters(
   min_cluster_size int default 3,
   sim_threshold float default 0.80
@@ -244,7 +248,17 @@ returns table (
 )
 language sql stable
 as $$
-  with pairs as (
+  with live as (
+    select id, name, type, content, embedding, updated_at
+    from memories
+    where embedding is not null
+      and expired_at is null
+      and superseded_by is null
+      and deleted_at is null
+      and (valid_to is null or valid_to > now())
+      and type not like '%\_archived' escape '\'
+  ),
+  pairs as (
     select
       a.id as id_a, b.id as id_b,
       a.name as name_a, b.name as name_b,
@@ -252,11 +266,9 @@ as $$
       a.content as content_a, b.content as content_b,
       a.updated_at as updated_a, b.updated_at as updated_b,
       1 - (a.embedding <=> b.embedding) as sim
-    from memories a
-    join memories b on a.id < b.id
+    from live a
+    join live b on a.id < b.id
       and a.type = b.type
-      and a.embedding is not null
-      and b.embedding is not null
     where 1 - (a.embedding <=> b.embedding) >= sim_threshold
   ),
   -- Group connected pairs into clusters via the oldest memory as anchor
@@ -290,8 +302,10 @@ as $$
   order by cid, updated_at desc;
 $$;
 
--- Archive superseded memories: mark as archived (soft delete)
--- Keeps data but prevents recall from returning them
+-- Archive superseded memories (Phase 5.1c): set `expired_at` instead of
+-- renaming type. Leaves type intact so type-filtered recall isn't poisoned
+-- (audit gap #6 in docs/design/memory-overhaul.md). Idempotent — skips rows
+-- already expired and doesn't double-prefix the description.
 create or replace function archive_memories(memory_ids uuid[])
 returns int
 language plpgsql volatile
@@ -300,10 +314,13 @@ declare
   archived_count int;
 begin
   update memories
-  set type = type || '_archived',
-      description = '[ARCHIVED — consolidated] ' || coalesce(description, '')
+  set expired_at = coalesce(expired_at, now()),
+      description = case
+        when description like '[ARCHIVED%' then description
+        else '[ARCHIVED — consolidated] ' || coalesce(description, '')
+      end
   where id = any(memory_ids)
-    and type not like '%_archived';
+    and expired_at is null;
   get diagnostics archived_count = row_count;
   return archived_count;
 end;

--- a/scripts/consolidation-report.py
+++ b/scripts/consolidation-report.py
@@ -1,4 +1,4 @@
-"""Memory consolidation — cluster detection report (Phase 5.1a, deterministic).
+"""Memory consolidation — cluster detection report (deterministic).
 
 Calls the `find_consolidation_clusters` RPC and prints a human-readable
 report of similarity clusters that are genuine candidates for merge/supersede.

--- a/scripts/consolidation-report.py
+++ b/scripts/consolidation-report.py
@@ -1,9 +1,13 @@
 """Memory consolidation — cluster detection report (Phase 5.1a, deterministic).
 
-Calls the `find_consolidation_clusters` RPC, filters out dead memories
-(expired_at / valid_to / superseded_by / deleted_at) post-hoc in Python, and
-prints a human-readable report of similarity clusters that are genuine
-candidates for merge/supersede.
+Calls the `find_consolidation_clusters` RPC and prints a human-readable
+report of similarity clusters that are genuine candidates for merge/supersede.
+
+As of Phase 5.1c the RPC filters dead memories (expired_at, valid_to,
+superseded_by, deleted_at) at the SQL source, so `dead_filtered` in the
+report should be 0 against any current DB. The Python-side live check is
+kept as a cheap defensive guard for older DB revisions and is a no-op in
+normal operation.
 
 No LLM. Default mode is a pure read — safe against prod. The only write
 path is the opt-in `--save-memory` flag, which upserts the markdown report
@@ -184,7 +188,7 @@ def render_markdown(
         "",
         f"- RPC: `find_consolidation_clusters(min_cluster_size={min_size}, sim_threshold={threshold})`",
         f"- Raw RPC rows: {raw_rows}",
-        f"- Dead memories filtered (expired/superseded/deleted): {dead_filtered}",
+        f"- Dead memories filtered post-hoc (defensive, expected 0): {dead_filtered}",
         f"- Live clusters (size >= {min_size}): **{len(clusters)}**",
         f"- Total live memories in clusters: {total_members}",
         "",


### PR DESCRIPTION
## Summary
Deterministic SQL-only step for Phase 5.1. Closes audit gap #6 (memory-overhaul §1) — archive stops being a type-suffix hack — and moves dead-memory filtering into `find_consolidation_clusters` so consumers never see stale rows.

- `find_consolidation_clusters`: new `live` CTE applies Phase 1 default-recall semantics (`expired_at IS NULL AND superseded_by IS NULL AND deleted_at IS NULL AND (valid_to IS NULL OR valid_to > now())`) before the similarity join. Defensive `%_archived` exclusion kept in case any legacy row sneaks in.
- `archive_memories`: sets `expired_at = now()` and prefixes description. Type is no longer mutated. Idempotent, no double-prefix.
- Migration already applied in prod (`phase5_1c_consolidation_live_filter`). `schema.sql` updated to match live DB.
- `scripts/consolidation-report.py` messaging updated — Python-side filter is now a cheap defensive no-op.

## Data state (verified before migration)
| check | count |
|---|---|
| `type LIKE '%_archived'` | **0** (no data migration needed) |
| `expired_at NOT NULL` | 1 |
| `superseded_by NOT NULL` | 4 |
| `deleted_at NOT NULL` | 6 |
| `valid_to <= now()` | 0 |
| total live memories | 303 / 310 |

## Smoke
- `consolidation-report.py --threshold 0.75` against live corpus: same 3 clusters (9 members) as before 5.1c. `raw_rpc_rows` shrank 16→12 because dead rows no longer reach Python. `Dead memories filtered post-hoc (defensive, expected 0): 0`.
- `archive_memories` probe on a throwaway uuid → type stays `project`, `expired_at` set, description prefixed `[ARCHIVED — consolidated] …`. Row cleaned up.
- `eval-recall --quiet`: server_only 85.0% / 90.0% / 0.663 MRR — unchanged.

## Test plan
- [x] Migration applies cleanly (no error)
- [x] `find_consolidation_clusters` returns only live memories
- [x] `archive_memories` sets expired_at + keeps type intact (probe)
- [x] `consolidation-report.py` runs and reports same clusters
- [x] `eval-recall` baseline unchanged

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)