### PR TITLE
feat(memory): Phase 5.1b-β — consolidation apply path + rollback (#221)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ config/device.json
 # Generated self-review reports (runtime artifacts - keep skill definitions)
 reports/self-review-*.md
 
+# Ad-hoc smoke-test / one-shot script artifacts
+.tmp/
+
 # Legacy Python (may remain locally)
 __pycache__/
 *.py[cod]

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -1097,7 +1097,7 @@ create index if not exists idx_review_queue_member_ids_key
 -- apply_consolidation_plan: atomic per cluster.
 --
 -- MERGE: synthesize a new canonical memory from Haiku's output, mark every
--- member superseded_by the new id, drop a `consolidates` link per member.
+-- member superseded_by the new id, insert a `consolidates` link per member.
 -- Embedding is populated out-of-band by the caller (Python has VoyageAI);
 -- the write leaves `embedding IS NULL` temporarily — acceptable since the
 -- lifecycle filter on members immediately hides them from recall, and the
@@ -1147,17 +1147,24 @@ begin
         )
         returning id into v_new_id;
 
-        -- Supersede every member. coalesce() preserves any pre-existing
-        -- lifecycle timestamp rather than clobbering it — matters if a
-        -- member was already expired for an unrelated reason and we're
-        -- consolidating after the fact.
+        -- Supersede every member. Set lifecycle timestamps unconditionally
+        -- (not coalesce) so rollback (which NULLs them) is symmetric. Members
+        -- come from find_consolidation_clusters, which guarantees they're
+        -- live (expired_at IS NULL, superseded_by IS NULL, deleted_at IS NULL,
+        -- valid_to IS NULL OR future). A future valid_to is overwritten by
+        -- now() — that future lifecycle plan is superseded by the consolidation,
+        -- and rollback restores to NULL rather than trying to reconstruct it
+        -- (documented behaviour; owner can re-set manually if needed).
         update memories
         set superseded_by = v_new_id,
-            valid_to = coalesce(valid_to, now()),
-            expired_at = coalesce(expired_at, now())
+            valid_to = now(),
+            expired_at = now()
         where id = any(v_supersede_ids);
         get diagnostics v_rows = row_count;
 
+        -- Insert `consolidates` links (canonical → each member). Rollback
+        -- drops them. ON CONFLICT is a safety net against a retried apply;
+        -- normal flow hits clean (source_id, target_id, link_type) tuples.
         insert into memory_links (source_id, target_id, link_type, strength)
         select v_new_id, unnest_id, 'consolidates', 1.0
         from unnest(v_supersede_ids) as unnest_id
@@ -1174,10 +1181,12 @@ begin
             raise exception 'SUPERSEDE_CONSOLIDATION requires canonical_id';
         end if;
 
+        -- Same lifecycle semantics as MERGE: unconditional now() for
+        -- round-trip symmetry with rollback.
         update memories
         set superseded_by = v_canonical_id,
-            valid_to = coalesce(valid_to, now()),
-            expired_at = coalesce(expired_at, now())
+            valid_to = now(),
+            expired_at = now()
         where id = any(v_supersede_ids)
           and id <> v_canonical_id;
         get diagnostics v_rows = row_count;

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -1037,3 +1037,251 @@ language sql stable as $$
     order by deduped.link_strength desc
     limit 10;
 $$;
+
+
+-- =========================================================================
+-- Phase 5.1b-β (memory overhaul, Osasuwu/jarvis#185, #221) — consolidation
+-- apply path.
+--
+-- Builds on 5.1b-α (#220): the Haiku planner emits per-cluster plans of kind
+-- MERGE / SUPERSEDE / KEEP_DISTINCT. 5.1b-β converts those plans into
+-- actual mutations, gated by confidence (>= 0.85, owner-decided 2026-04-19).
+-- Everything below the gate — and every KEEP_DISTINCT — is recorded in
+-- memory_review_queue so we (a) have an audit trail and (b) don't re-spend
+-- Haiku tokens on the same cluster every week.
+--
+-- Queue strategy (owner-decided: reuse, don't fork):
+--   - Extend memory_review_queue.decision CHECK with MERGE,
+--     SUPERSEDE_CONSOLIDATION, KEEP_DISTINCT. Phase 2 rows keep their ADD/
+--     UPDATE/DELETE/NOOP semantics untouched.
+--   - New column consolidation_payload jsonb holds cluster-level state
+--     (member_ids, canonical_* fields, haiku metadata). Phase 2 rows leave
+--     it NULL; a functional index makes "have I seen this cluster?" checks
+--     cheap for the planner's pre-filter.
+--   - Extend status CHECK with 'rolled_back' so a reverted entry is visibly
+--     distinct from owner-rejected entries (the former means "try again
+--     later", the latter means "never suggest again").
+-- =========================================================================
+
+alter table memory_review_queue
+  drop constraint if exists memory_review_queue_decision_check;
+
+alter table memory_review_queue
+  add constraint memory_review_queue_decision_check
+  check (decision in (
+    'ADD', 'UPDATE', 'DELETE', 'NOOP',
+    'MERGE', 'SUPERSEDE_CONSOLIDATION', 'KEEP_DISTINCT'
+  ));
+
+alter table memory_review_queue
+  drop constraint if exists memory_review_queue_status_check;
+
+alter table memory_review_queue
+  add constraint memory_review_queue_status_check
+  check (status in (
+    'pending', 'approved', 'rejected', 'auto_applied', 'rolled_back'
+  ));
+
+alter table memory_review_queue
+  add column if not exists consolidation_payload jsonb;
+
+-- Functional index on the sorted-member-id key. The planner pre-filter asks
+-- "does any queue row already cover this exact set of members?"; a direct
+-- equality lookup on member_ids_key inside the jsonb is O(log n) with this
+-- index and scales independent of Phase 2 row count.
+create index if not exists idx_review_queue_member_ids_key
+  on memory_review_queue((consolidation_payload->>'member_ids_key'))
+  where consolidation_payload is not null;
+
+
+-- apply_consolidation_plan: atomic per cluster.
+--
+-- MERGE: synthesize a new canonical memory from Haiku's output, mark every
+-- member superseded_by the new id, drop a `consolidates` link per member.
+-- Embedding is populated out-of-band by the caller (Python has VoyageAI);
+-- the write leaves `embedding IS NULL` temporarily — acceptable since the
+-- lifecycle filter on members immediately hides them from recall, and the
+-- caller backfills within a second.
+--
+-- SUPERSEDE_CONSOLIDATION: one existing member wins, all others get
+-- superseded_by = canonical. No new memory, no new embedding needed.
+--
+-- Returns jsonb: { status, decision, canonical_id, superseded_count }.
+create or replace function apply_consolidation_plan(plan jsonb)
+returns jsonb
+language plpgsql volatile
+as $$
+declare
+    v_decision text := plan->>'decision';
+    v_canonical_id uuid := nullif(plan->>'canonical_id', '')::uuid;
+    v_supersede_ids uuid[] := array(
+        select (jsonb_array_elements_text(coalesce(plan->'supersede_ids', '[]'::jsonb)))::uuid
+    );
+    v_tags text[] := array(
+        select jsonb_array_elements_text(coalesce(plan->'canonical_tags', '[]'::jsonb))
+    );
+    v_new_id uuid;
+    v_rows int;
+begin
+    if v_decision = 'MERGE' then
+        if coalesce(plan->>'canonical_name', '') = ''
+           or coalesce(plan->>'canonical_content', '') = ''
+           or coalesce(plan->>'canonical_type', '') = ''
+           or coalesce(plan->>'source_provenance', '') = '' then
+            raise exception 'MERGE plan missing required canonical_* / source_provenance fields';
+        end if;
+
+        insert into memories (
+            project, name, type, description, content, tags,
+            source_provenance, confidence
+        )
+        values (
+            nullif(plan->>'canonical_project', ''),
+            plan->>'canonical_name',
+            plan->>'canonical_type',
+            nullif(plan->>'canonical_description', ''),
+            plan->>'canonical_content',
+            v_tags,
+            plan->>'source_provenance',
+            least(coalesce((plan->>'confidence')::float, 0.8), 0.9)
+        )
+        returning id into v_new_id;
+
+        -- Supersede every member. coalesce() preserves any pre-existing
+        -- lifecycle timestamp rather than clobbering it — matters if a
+        -- member was already expired for an unrelated reason and we're
+        -- consolidating after the fact.
+        update memories
+        set superseded_by = v_new_id,
+            valid_to = coalesce(valid_to, now()),
+            expired_at = coalesce(expired_at, now())
+        where id = any(v_supersede_ids);
+        get diagnostics v_rows = row_count;
+
+        insert into memory_links (source_id, target_id, link_type, strength)
+        select v_new_id, unnest_id, 'consolidates', 1.0
+        from unnest(v_supersede_ids) as unnest_id
+        on conflict (source_id, target_id, link_type) do nothing;
+
+        return jsonb_build_object(
+            'status', 'applied',
+            'decision', 'MERGE',
+            'canonical_id', v_new_id,
+            'superseded_count', v_rows
+        );
+    elsif v_decision = 'SUPERSEDE_CONSOLIDATION' then
+        if v_canonical_id is null then
+            raise exception 'SUPERSEDE_CONSOLIDATION requires canonical_id';
+        end if;
+
+        update memories
+        set superseded_by = v_canonical_id,
+            valid_to = coalesce(valid_to, now()),
+            expired_at = coalesce(expired_at, now())
+        where id = any(v_supersede_ids)
+          and id <> v_canonical_id;
+        get diagnostics v_rows = row_count;
+
+        insert into memory_links (source_id, target_id, link_type, strength)
+        select v_canonical_id, unnest_id, 'supersedes', 1.0
+        from unnest(v_supersede_ids) as unnest_id
+        where unnest_id <> v_canonical_id
+        on conflict (source_id, target_id, link_type) do nothing;
+
+        return jsonb_build_object(
+            'status', 'applied',
+            'decision', 'SUPERSEDE_CONSOLIDATION',
+            'canonical_id', v_canonical_id,
+            'superseded_count', v_rows
+        );
+    else
+        raise exception 'Unsupported decision for apply_consolidation_plan: %', v_decision;
+    end if;
+end;
+$$;
+
+
+-- rollback_consolidation(queue_id): inverse of apply, keyed by the queue
+-- entry so the member-id list is authoritative (not re-derived from links,
+-- which could collide with Phase 2 classifier supersedes).
+--
+-- MERGE rollback:  soft-delete the synthesized canonical, clear members'
+--                  lifecycle cols, remove `consolidates` links.
+-- SUPERSEDE_CONSOLIDATION rollback: leave canonical live, restore the
+--                  losers, remove `supersedes` links created by this apply.
+--
+-- Status transitions: 'auto_applied'/'approved' → 'rolled_back'. Rejecting
+-- an already-applied entry is not supported through this RPC — it would
+-- conflate "owner disapproves future suggestion" with "undo this mutation".
+create or replace function rollback_consolidation(queue_id uuid)
+returns jsonb
+language plpgsql volatile
+as $$
+declare
+    v_payload jsonb;
+    v_decision text;
+    v_status text;
+    v_canonical_id uuid;
+    v_supersede_ids uuid[];
+    v_rows int;
+begin
+    select consolidation_payload, decision, status, target_id
+    into v_payload, v_decision, v_status, v_canonical_id
+    from memory_review_queue
+    where id = queue_id
+    for update;
+
+    if v_payload is null then
+        raise exception 'Queue entry % missing (or has no consolidation_payload)', queue_id;
+    end if;
+
+    if v_decision not in ('MERGE', 'SUPERSEDE_CONSOLIDATION') then
+        raise exception 'Entry % is not a consolidation row (decision=%)', queue_id, v_decision;
+    end if;
+
+    if v_status not in ('auto_applied', 'approved') then
+        raise exception 'Can only roll back auto_applied/approved entries (status=%)', v_status;
+    end if;
+
+    if v_canonical_id is null then
+        raise exception 'Entry % has no target_id to roll back', queue_id;
+    end if;
+
+    v_supersede_ids := array(
+        select (jsonb_array_elements_text(coalesce(v_payload->'supersede_ids', '[]'::jsonb)))::uuid
+    );
+
+    update memories
+    set superseded_by = null,
+        valid_to = null,
+        expired_at = null
+    where id = any(v_supersede_ids)
+      and superseded_by = v_canonical_id;
+    get diagnostics v_rows = row_count;
+
+    delete from memory_links
+    where source_id = v_canonical_id
+      and target_id = any(v_supersede_ids)
+      and link_type in ('consolidates', 'supersedes');
+
+    if v_decision = 'MERGE' then
+        update memories
+        set deleted_at = now()
+        where id = v_canonical_id;
+    end if;
+
+    update memory_review_queue
+    set status = 'rolled_back',
+        reviewed_at = now(),
+        reviewed_by = coalesce(reviewed_by, 'rollback_script')
+    where id = queue_id;
+
+    return jsonb_build_object(
+        'status', 'rolled_back',
+        'decision', v_decision,
+        'canonical_id', v_canonical_id,
+        'canonical_soft_deleted', v_decision = 'MERGE',
+        'restored_count', v_rows
+    );
+end;
+$$;

--- a/scripts/consolidation-merge-plan.py
+++ b/scripts/consolidation-merge-plan.py
@@ -410,28 +410,35 @@ def member_ids_key(ids: list[str]) -> str:
     return ",".join(sorted(ids))
 
 
-def fetch_existing_queue_keys(client) -> set[str]:
-    """Return member_ids_key of every queue row we should treat as "seen".
+def fetch_existing_queue_keys(client, candidate_keys: list[str]) -> set[str]:
+    """Return member_ids_keys that already exist in the queue for current candidates.
 
     Excludes `rolled_back` — those are cases where the owner (or rollback
     script) explicitly wants the cluster reconsidered. Includes `pending`
     because those are awaiting review and we don't need a duplicate row.
+
+    Uses `.in_()` on `consolidation_payload->>member_ids_key` so queries hit
+    the functional index (`idx_review_queue_member_ids_key`) instead of a
+    full scan — matters once the KEEP_DISTINCT audit set grows large.
     """
+    if not candidate_keys:
+        return set()
+    quoted = ",".join(f'"{k}"' for k in candidate_keys)
     rows = (
         client.table("memory_review_queue")
-        .select("consolidation_payload, status")
-        .not_.is_("consolidation_payload", "null")
+        .select("consolidation_payload")
+        .filter("consolidation_payload->>member_ids_key", "in", f"({quoted})")
         .neq("status", "rolled_back")
         .execute()
         .data
     ) or []
-    keys: set[str] = set()
+    found: set[str] = set()
     for r in rows:
         payload = r.get("consolidation_payload") or {}
         k = payload.get("member_ids_key")
         if isinstance(k, str) and k:
-            keys.add(k)
-    return keys
+            found.add(k)
+    return found
 
 
 def canonical_tags_union(members: list[dict]) -> list[str]:
@@ -451,18 +458,20 @@ def canonical_tags_union(members: list[dict]) -> list[str]:
 def _canonical_embed_text(name: str, description: str, tags: list[str], content: str) -> str:
     """Mirror of mcp-memory/server.py:_canonical_embed_text.
 
-    Keeping the canonical form in sync with server.py matters for semantic
-    recall: the canonical memory must be embedded the same way as memories
-    written via the MCP server, otherwise cosine distances drift.
+    Must stay byte-exact with server.py or canonicals embed on a slightly
+    different axis than neighbours written via MCP — cosine drifts, future
+    clustering misses them.
     """
-    parts = [name or ""]
+    parts: list[str] = []
+    if name:
+        parts.append(name.replace("_", " "))
     if tags:
         parts.append("tags: " + ", ".join(tags))
     if description:
         parts.append(description)
     if content:
         parts.append(content)
-    return "\n".join(p for p in parts if p)
+    return "\n".join(p for p in parts if p).strip()
 
 
 def embed_document(text: str, *, timeout: float = VOYAGE_TIMEOUT) -> list[float] | None:
@@ -972,7 +981,8 @@ def main() -> int:
 
     skipped_seen = 0
     if not args.include_seen and clusters:
-        seen_keys = fetch_existing_queue_keys(client)
+        candidate_keys = [member_ids_key([m["id"] for m in c["members"]]) for c in clusters]
+        seen_keys = fetch_existing_queue_keys(client, candidate_keys)
         if seen_keys:
             before = len(clusters)
             clusters = [

--- a/scripts/consolidation-merge-plan.py
+++ b/scripts/consolidation-merge-plan.py
@@ -1,4 +1,4 @@
-"""Memory consolidation — Haiku merge-plan generator (dry-run).
+"""Memory consolidation — Haiku merge-plan generator (dry-run + apply).
 
 Takes the clusters that `scripts/consolidation-report.py` surfaces
 and asks Claude Haiku-4.5 to emit one of:
@@ -9,8 +9,16 @@ and asks Claude Haiku-4.5 to emit one of:
                     the stale ones expired
     KEEP_DISTINCT — same topic but different purposes; leave them alone
 
-**Dry-run only.** No mutations, no --apply flag. Phase 5.1b-β will add
-the apply path with confidence gating + review queue.
+Default mode is dry-run. Pass `--apply` (Phase 5.1b-β) to persist:
+
+  * MERGE / SUPERSEDE, confidence >= gate → apply_consolidation_plan RPC,
+    embedding backfill for MERGE, queue row status=auto_applied, event log.
+  * MERGE / SUPERSEDE, confidence <  gate → queue row status=pending.
+  * KEEP_DISTINCT (any confidence)        → queue row status=auto_applied.
+
+Clusters whose exact member-set already has a queue entry (any status
+except `rolled_back`) are skipped before the Haiku call — prevents
+re-spending tokens on the same cluster every week.
 
 Output: markdown report (default) or JSON. `--save-memory` upserts the
 markdown as `consolidation_plan_YYYY-MM-DD` (`type=project`).
@@ -20,12 +28,14 @@ The Haiku call follows the same pattern as `mcp-memory/classifier.py`
 network/parse failure). No SDK dependency.
 
 Usage:
-    python scripts/consolidation-merge-plan.py                       # markdown
+    python scripts/consolidation-merge-plan.py                       # markdown, dry-run
     python scripts/consolidation-merge-plan.py --json                # machine-readable
     python scripts/consolidation-merge-plan.py --min-size 3 --threshold 0.80
-    python scripts/consolidation-merge-plan.py --save-memory
+    python scripts/consolidation-merge-plan.py --apply --limit 10    # real mutations
+    python scripts/consolidation-merge-plan.py --apply --confidence-gate 0.9
 
-Requires SUPABASE_URL, SUPABASE_KEY, ANTHROPIC_API_KEY. .env auto-loaded.
+Requires SUPABASE_URL, SUPABASE_KEY, ANTHROPIC_API_KEY. VOYAGE_API_KEY
+needed for --apply (canonical embedding). .env auto-loaded.
 """
 
 from __future__ import annotations
@@ -48,6 +58,7 @@ except Exception:
 
 try:
     from dotenv import load_dotenv
+
     here = Path(__file__).resolve().parent
     for c in (here.parent / ".env", here.parent.parent / ".env"):
         if c.exists():
@@ -66,13 +77,29 @@ DEFAULT_MIN_SIZE = 3
 DEFAULT_THRESHOLD = 0.80
 DEFAULT_MODEL = "claude-haiku-4-5"
 DEFAULT_TIMEOUT = 15.0  # per-cluster; clusters are larger than single-write classifier
+DEFAULT_CONFIDENCE_GATE = 0.85  # owner-decided 2026-04-19 (#221)
+DEFAULT_APPLY_LIMIT = 20
 
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
 MAX_TOKENS = 1500  # room for canonical_content on MERGE
 MAX_MEMBER_CONTENT_CHARS = 800  # truncate long memories before sending
 
+VOYAGE_API_URL = "https://api.voyageai.com/v1/embeddings"
+VOYAGE_MODEL = "voyage-3-lite"
+VOYAGE_TIMEOUT = 30.0
+MAX_CANONICAL_TAGS = 15  # trim merged tag UNION — stops tag explosion
+
 VALID_DECISIONS = ("MERGE", "SUPERSEDE", "KEEP_DISTINCT")
+
+# Maps Haiku's output labels to the DB-side CHECK values for
+# memory_review_queue.decision. SUPERSEDE → SUPERSEDE_CONSOLIDATION
+# disambiguates from Phase 2 classifier's single-candidate UPDATE/DELETE.
+DB_DECISION = {
+    "MERGE": "MERGE",
+    "SUPERSEDE": "SUPERSEDE_CONSOLIDATION",
+    "KEEP_DISTINCT": "KEEP_DISTINCT",
+}
 
 
 SYSTEM_PROMPT = """You are a memory-consolidation planner for a personal AI agent's long-term memory store.
@@ -206,13 +233,15 @@ def group_clusters(rpc_rows: list[dict], details_by_id: dict[str, dict]) -> list
     for cid, by_id in by_cluster.items():
         members = sorted(by_id.values(), key=lambda m: m["updated_at"], reverse=True)
         max_sim = max(m["similarity"] for m in members)
-        clusters.append({
-            "cluster_id": cid,
-            "size": len(members),
-            "max_similarity": round(max_sim, 4),
-            "types": sorted({m["type"] for m in members}),
-            "members": members,
-        })
+        clusters.append(
+            {
+                "cluster_id": cid,
+                "size": len(members),
+                "max_similarity": round(max_sim, 4),
+                "types": sorted({m["type"] for m in members}),
+                "members": members,
+            }
+        )
     clusters.sort(key=lambda c: (c["size"], c["max_similarity"]), reverse=True)
     return clusters
 
@@ -289,7 +318,9 @@ def _parse_response(text: str, member_ids: list[str]) -> dict | None:
     if decision == "MERGE":
         name = data.get("canonical_name")
         content = data.get("canonical_content")
-        if not (isinstance(name, str) and name.strip()) or not (isinstance(content, str) and content.strip()):
+        if not (isinstance(name, str) and name.strip()) or not (
+            isinstance(content, str) and content.strip()
+        ):
             return _downgrade(data, "MERGE missing canonical_name or canonical_content")
 
     # Enforce schema invariants — the model's output is advisory; downstream
@@ -321,8 +352,12 @@ def _parse_response(text: str, member_ids: list[str]) -> dict | None:
         "canonical_id": canonical_id,
         "supersede_ids": supersede_ids,
         "canonical_name": (data.get("canonical_name") or None) if decision == "MERGE" else None,
-        "canonical_description": (data.get("canonical_description") or None) if decision == "MERGE" else None,
-        "canonical_content": (data.get("canonical_content") or None) if decision == "MERGE" else None,
+        "canonical_description": (data.get("canonical_description") or None)
+        if decision == "MERGE"
+        else None,
+        "canonical_content": (data.get("canonical_content") or None)
+        if decision == "MERGE"
+        else None,
         "confidence": confidence,
         "reasoning": reasoning,
     }
@@ -357,6 +392,327 @@ def _fallback_keep_distinct(why: str) -> dict:
         "canonical_content": None,
         "confidence": 0.0,
         "reasoning": f"fallback: {why}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Apply path (5.1b-β): queue routing, RPC call, embedding backfill.
+# ---------------------------------------------------------------------------
+
+
+def member_ids_key(ids: list[str]) -> str:
+    """Deterministic key for a cluster's member-id set.
+
+    Must match the SQL index expression `consolidation_payload->>'member_ids_key'`
+    (schema.sql, Phase 5.1b-β). Sorted + comma-joined keeps it both
+    human-readable in the queue row and cheap to index.
+    """
+    return ",".join(sorted(ids))
+
+
+def fetch_existing_queue_keys(client) -> set[str]:
+    """Return member_ids_key of every queue row we should treat as "seen".
+
+    Excludes `rolled_back` — those are cases where the owner (or rollback
+    script) explicitly wants the cluster reconsidered. Includes `pending`
+    because those are awaiting review and we don't need a duplicate row.
+    """
+    rows = (
+        client.table("memory_review_queue")
+        .select("consolidation_payload, status")
+        .not_.is_("consolidation_payload", "null")
+        .neq("status", "rolled_back")
+        .execute()
+        .data
+    ) or []
+    keys: set[str] = set()
+    for r in rows:
+        payload = r.get("consolidation_payload") or {}
+        k = payload.get("member_ids_key")
+        if isinstance(k, str) and k:
+            keys.add(k)
+    return keys
+
+
+def canonical_tags_union(members: list[dict]) -> list[str]:
+    """UNION of member tags, deterministic order, trimmed.
+
+    Sorted alphabetically so repeated runs produce the same canonical —
+    makes the canonical embedding reproducible if we ever need to recompute.
+    """
+    tags: set[str] = set()
+    for m in members:
+        for t in m.get("tags") or []:
+            if isinstance(t, str) and t.strip():
+                tags.add(t.strip())
+    return sorted(tags)[:MAX_CANONICAL_TAGS]
+
+
+def _canonical_embed_text(name: str, description: str, tags: list[str], content: str) -> str:
+    """Mirror of mcp-memory/server.py:_canonical_embed_text.
+
+    Keeping the canonical form in sync with server.py matters for semantic
+    recall: the canonical memory must be embedded the same way as memories
+    written via the MCP server, otherwise cosine distances drift.
+    """
+    parts = [name or ""]
+    if tags:
+        parts.append("tags: " + ", ".join(tags))
+    if description:
+        parts.append(description)
+    if content:
+        parts.append(content)
+    return "\n".join(p for p in parts if p)
+
+
+def embed_document(text: str, *, timeout: float = VOYAGE_TIMEOUT) -> list[float] | None:
+    """Sync VoyageAI call. Returns None on any failure (caller retries / skips)."""
+    api_key = os.environ.get("VOYAGE_API_KEY")
+    if not api_key or not text:
+        return None
+    try:
+        with httpx.Client(timeout=timeout) as http:
+            resp = http.post(
+                VOYAGE_API_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"model": VOYAGE_MODEL, "input": [text], "input_type": "document"},
+            )
+            resp.raise_for_status()
+            return resp.json()["data"][0]["embedding"]
+    except (httpx.HTTPError, KeyError, IndexError, ValueError, TypeError):
+        return None
+
+
+def _cluster_type(cluster: dict) -> str:
+    """find_consolidation_clusters joins on equal type — clusters are homogeneous."""
+    types = cluster.get("types") or []
+    return types[0] if types else "project"
+
+
+def build_payload(cluster: dict, plan: dict, source_provenance: str) -> dict:
+    """Assemble the jsonb payload stored on every queue entry.
+
+    Downstream consumers (apply RPC, rollback RPC, future review UI) rely
+    on field names here — keep them stable.
+    """
+    members = cluster["members"]
+    member_ids = [m["id"] for m in members]
+    canonical_tags = canonical_tags_union(members) if plan["decision"] == "MERGE" else []
+    return {
+        "cluster_id": cluster["cluster_id"],
+        "member_ids": sorted(member_ids),
+        "member_ids_key": member_ids_key(member_ids),
+        "member_names": [m["name"] for m in members],
+        "supersede_ids": sorted(plan.get("supersede_ids") or []),
+        "canonical_project": "jarvis",
+        "canonical_type": _cluster_type(cluster),
+        "canonical_name": plan.get("canonical_name"),
+        "canonical_description": plan.get("canonical_description"),
+        "canonical_content": plan.get("canonical_content"),
+        "canonical_tags": canonical_tags,
+        "source_provenance": source_provenance,
+        "haiku_reasoning": plan.get("reasoning") or "",
+        "haiku_confidence": plan.get("confidence", 0.0),
+        "planned_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _queue_insert(
+    client,
+    *,
+    decision: str,
+    status: str,
+    target_id: str | None,
+    confidence: float,
+    reasoning: str,
+    payload: dict,
+    applied_at: str | None = None,
+) -> str | None:
+    """Insert one row into memory_review_queue. Returns id or None on error."""
+    row = {
+        "decision": decision,
+        "confidence": float(confidence),
+        "reasoning": (reasoning or "")[:1000],
+        "status": status,
+        "consolidation_payload": payload,
+        "classifier_model": DEFAULT_MODEL,
+    }
+    if target_id:
+        row["target_id"] = target_id
+    if applied_at:
+        row["applied_at"] = applied_at
+    try:
+        resp = client.table("memory_review_queue").insert(row).execute()
+        data = resp.data or []
+        return data[0]["id"] if data else None
+    except Exception as e:  # supabase client raises on HTTP errors
+        print(f"! queue insert failed ({decision}, {status}): {e}", file=sys.stderr)
+        return None
+
+
+def _log_event(
+    client,
+    *,
+    canonical_id: str,
+    decision: str,
+    cluster_id: int,
+    superseded_count: int,
+    queue_id: str | None,
+) -> None:
+    """Append an audit trail row to `events`. Best-effort."""
+    try:
+        client.table("events").insert(
+            {
+                "event_type": "consolidation_applied",
+                "severity": "info",
+                "repo": "Osasuwu/jarvis",
+                "source": "manual",
+                "title": f"Consolidation {decision} applied (cluster {cluster_id})",
+                "payload": {
+                    "decision": decision,
+                    "canonical_id": canonical_id,
+                    "cluster_id": cluster_id,
+                    "superseded_count": superseded_count,
+                    "queue_id": queue_id,
+                },
+            }
+        ).execute()
+    except Exception as e:
+        print(f"! event log failed: {e}", file=sys.stderr)
+
+
+def apply_plan(
+    client, cluster: dict, plan: dict, *, today: str, dry_run_embed: bool = False
+) -> dict:
+    """Apply one high-confidence plan. Returns result dict for summary output.
+
+    Order matters: RPC first (atomic member supersede), then embedding
+    backfill, then queue audit row + event. If embedding fails, the
+    canonical is still correct — it just won't be found via semantic
+    recall until a later backfill sweeps nulls (matches server.py's
+    lazy-backfill pattern, memories with NULL embedding).
+    """
+    db_decision = DB_DECISION[plan["decision"]]
+    source_provenance = f"skill:consolidation:{plan['decision'].lower()}:{today}"
+    payload = build_payload(cluster, plan, source_provenance)
+
+    rpc_plan = {
+        "decision": db_decision,
+        "canonical_id": plan.get("canonical_id"),
+        "supersede_ids": payload["supersede_ids"],
+        "canonical_project": payload["canonical_project"],
+        "canonical_type": payload["canonical_type"],
+        "canonical_name": payload.get("canonical_name"),
+        "canonical_description": payload.get("canonical_description"),
+        "canonical_content": payload.get("canonical_content"),
+        "canonical_tags": payload.get("canonical_tags"),
+        "source_provenance": source_provenance,
+        "confidence": plan.get("confidence", 0.8),
+    }
+
+    resp = client.rpc("apply_consolidation_plan", {"plan": rpc_plan}).execute()
+    rpc_out = resp.data or {}
+    canonical_id = rpc_out.get("canonical_id")
+    superseded_count = int(rpc_out.get("superseded_count") or 0)
+    if not canonical_id:
+        raise RuntimeError(f"apply_consolidation_plan returned no canonical_id: {rpc_out!r}")
+
+    embedded = False
+    if plan["decision"] == "MERGE" and not dry_run_embed:
+        embed_text = _canonical_embed_text(
+            plan.get("canonical_name") or "",
+            plan.get("canonical_description") or "",
+            payload.get("canonical_tags") or [],
+            plan.get("canonical_content") or "",
+        )
+        vec = embed_document(embed_text)
+        if vec is not None:
+            try:
+                client.table("memories").update(
+                    {
+                        "embedding": vec,
+                        "embedding_model": VOYAGE_MODEL,
+                        "embedding_version": "v2",
+                    }
+                ).eq("id", canonical_id).execute()
+                embedded = True
+            except Exception as e:
+                print(f"! embedding backfill failed for {canonical_id}: {e}", file=sys.stderr)
+
+    applied_at = datetime.now(timezone.utc).isoformat()
+    queue_id = _queue_insert(
+        client,
+        decision=db_decision,
+        status="auto_applied",
+        target_id=canonical_id,
+        confidence=plan.get("confidence", 0.8),
+        reasoning=plan.get("reasoning") or "",
+        payload=payload,
+        applied_at=applied_at,
+    )
+
+    _log_event(
+        client,
+        canonical_id=canonical_id,
+        decision=db_decision,
+        cluster_id=cluster["cluster_id"],
+        superseded_count=superseded_count,
+        queue_id=queue_id,
+    )
+
+    return {
+        "cluster_id": cluster["cluster_id"],
+        "decision": db_decision,
+        "canonical_id": canonical_id,
+        "superseded_count": superseded_count,
+        "embedded": embedded,
+        "queue_id": queue_id,
+        "status": "applied",
+    }
+
+
+def queue_for_review(client, cluster: dict, plan: dict, *, today: str) -> dict:
+    """Route a low-confidence MERGE/SUPERSEDE plan to the review queue."""
+    db_decision = DB_DECISION[plan["decision"]]
+    source_provenance = f"skill:consolidation:{plan['decision'].lower()}:{today}"
+    payload = build_payload(cluster, plan, source_provenance)
+    target_id = plan.get("canonical_id") if plan["decision"] == "SUPERSEDE" else None
+    queue_id = _queue_insert(
+        client,
+        decision=db_decision,
+        status="pending",
+        target_id=target_id,
+        confidence=plan.get("confidence", 0.0),
+        reasoning=plan.get("reasoning") or "",
+        payload=payload,
+    )
+    return {
+        "cluster_id": cluster["cluster_id"],
+        "decision": db_decision,
+        "queue_id": queue_id,
+        "status": "queued",
+    }
+
+
+def note_keep_distinct(client, cluster: dict, plan: dict, *, today: str) -> dict:
+    """Record KEEP_DISTINCT so the same cluster isn't re-planned next week."""
+    source_provenance = f"skill:consolidation:keep_distinct:{today}"
+    payload = build_payload(cluster, plan, source_provenance)
+    queue_id = _queue_insert(
+        client,
+        decision="KEEP_DISTINCT",
+        status="auto_applied",
+        target_id=None,
+        confidence=plan.get("confidence", 0.0),
+        reasoning=plan.get("reasoning") or "",
+        payload=payload,
+        applied_at=datetime.now(timezone.utc).isoformat(),
+    )
+    return {
+        "cluster_id": cluster["cluster_id"],
+        "decision": "KEEP_DISTINCT",
+        "queue_id": queue_id,
+        "status": "noted",
     }
 
 
@@ -409,7 +765,9 @@ def plan_cluster(cluster: dict, *, model: str, timeout: float) -> dict:
     return parsed
 
 
-def render_markdown(clusters: list[dict], plans: list[dict], min_size: int, threshold: float, model: str) -> str:
+def render_markdown(
+    clusters: list[dict], plans: list[dict], min_size: int, threshold: float, model: str
+) -> str:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     by_decision: dict[str, int] = defaultdict(int)
     for p in plans:
@@ -483,7 +841,9 @@ def render_markdown(clusters: list[dict], plans: list[dict], min_size: int, thre
 
     lines.append("---")
     lines.append("")
-    lines.append("**Next**: review plans; 5.1b-β will add `--apply` with a confidence threshold (≥ 0.9) and a review queue for the rest.")
+    lines.append(
+        "**Next**: rerun with `--apply` to persist high-confidence plans and route the rest to the review queue."
+    )
     return "\n".join(lines)
 
 
@@ -533,18 +893,57 @@ def save_plan_memory(client, plan_md: str, plans: list[dict]) -> None:
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    p.add_argument("--min-size", type=int, default=DEFAULT_MIN_SIZE,
-                   help=f"Minimum cluster size (default {DEFAULT_MIN_SIZE})")
-    p.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
-                   help=f"Cosine similarity threshold (default {DEFAULT_THRESHOLD})")
-    p.add_argument("--model", default=DEFAULT_MODEL,
-                   help=f"Anthropic model id (default {DEFAULT_MODEL})")
-    p.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT,
-                   help=f"Per-cluster API timeout seconds (default {DEFAULT_TIMEOUT})")
-    p.add_argument("--json", action="store_true",
-                   help="Emit JSON instead of markdown")
-    p.add_argument("--save-memory", action="store_true",
-                   help="Upsert the plan as a Jarvis memory (`consolidation_plan_YYYY-MM-DD`)")
+    p.add_argument(
+        "--min-size",
+        type=int,
+        default=DEFAULT_MIN_SIZE,
+        help=f"Minimum cluster size (default {DEFAULT_MIN_SIZE})",
+    )
+    p.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help=f"Cosine similarity threshold (default {DEFAULT_THRESHOLD})",
+    )
+    p.add_argument(
+        "--model", default=DEFAULT_MODEL, help=f"Anthropic model id (default {DEFAULT_MODEL})"
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help=f"Per-cluster API timeout seconds (default {DEFAULT_TIMEOUT})",
+    )
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of markdown")
+    p.add_argument(
+        "--save-memory",
+        action="store_true",
+        help="Upsert the plan as a Jarvis memory (`consolidation_plan_YYYY-MM-DD`)",
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Persist mutations: high-confidence → apply RPC, "
+        "rest → review queue. Default is dry-run.",
+    )
+    p.add_argument(
+        "--confidence-gate",
+        type=float,
+        default=DEFAULT_CONFIDENCE_GATE,
+        help=f"Minimum confidence for auto-apply (default {DEFAULT_CONFIDENCE_GATE})",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_APPLY_LIMIT,
+        help=f"Cap clusters processed per run (default {DEFAULT_APPLY_LIMIT})",
+    )
+    p.add_argument(
+        "--include-seen",
+        action="store_true",
+        help="Don't skip clusters already in memory_review_queue. "
+        "Default: skip (prevents re-spending Haiku tokens).",
+    )
     args = p.parse_args()
 
     sb_url = os.environ.get("SUPABASE_URL")
@@ -555,6 +954,12 @@ def main() -> int:
     if not os.environ.get("ANTHROPIC_API_KEY"):
         print("ANTHROPIC_API_KEY missing from env", file=sys.stderr)
         return 2
+    if args.apply and not os.environ.get("VOYAGE_API_KEY"):
+        print(
+            "! VOYAGE_API_KEY missing — MERGE canonicals will be created without embeddings "
+            "(recall will miss them until backfilled)",
+            file=sys.stderr,
+        )
 
     client = create_client(sb_url, sb_key)
 
@@ -565,25 +970,95 @@ def main() -> int:
     clusters = group_clusters(rpc_rows, details_by_id)
     clusters = [c for c in clusters if c["size"] >= args.min_size]
 
+    skipped_seen = 0
+    if not args.include_seen and clusters:
+        seen_keys = fetch_existing_queue_keys(client)
+        if seen_keys:
+            before = len(clusters)
+            clusters = [
+                c
+                for c in clusters
+                if member_ids_key([m["id"] for m in c["members"]]) not in seen_keys
+            ]
+            skipped_seen = before - len(clusters)
+            if skipped_seen:
+                print(
+                    f"Skipped {skipped_seen} cluster(s) already in review queue "
+                    f"(use --include-seen to override)",
+                    file=sys.stderr,
+                )
+
+    if args.limit and len(clusters) > args.limit:
+        print(
+            f"Capping at --limit {args.limit} (had {len(clusters)} eligible clusters)",
+            file=sys.stderr,
+        )
+        clusters = clusters[: args.limit]
+
     if not clusters:
         if args.json:
-            print(json.dumps({
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-                "params": {"min_size": args.min_size, "threshold": args.threshold},
-                "model": args.model,
-                "clusters": [],
-                "plans": [],
-            }, indent=2))
+            print(
+                json.dumps(
+                    {
+                        "generated_at": datetime.now(timezone.utc).isoformat(),
+                        "params": {"min_size": args.min_size, "threshold": args.threshold},
+                        "model": args.model,
+                        "clusters": [],
+                        "plans": [],
+                        "apply": bool(args.apply),
+                        "skipped_seen": skipped_seen,
+                    },
+                    indent=2,
+                )
+            )
         else:
             print(render_markdown([], [], args.min_size, args.threshold, args.model))
+            if skipped_seen:
+                print(f"\n_Skipped {skipped_seen} already-seen cluster(s)._")
         return 0
 
     print(f"Planning {len(clusters)} cluster(s) with {args.model}...", file=sys.stderr)
     plans = []
     for i, cluster in enumerate(clusters, 1):
-        print(f"  [{i}/{len(clusters)}] cluster {cluster['cluster_id']} "
-              f"({cluster['size']} members)...", file=sys.stderr)
+        print(
+            f"  [{i}/{len(clusters)}] cluster {cluster['cluster_id']} "
+            f"({cluster['size']} members)...",
+            file=sys.stderr,
+        )
         plans.append(plan_cluster(cluster, model=args.model, timeout=args.timeout))
+
+    apply_results: list[dict] = []
+    if args.apply:
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        print(f"Applying plans (confidence gate {args.confidence_gate:.2f})...", file=sys.stderr)
+        for cluster, plan in zip(clusters, plans):
+            try:
+                if plan["decision"] == "KEEP_DISTINCT":
+                    r = note_keep_distinct(client, cluster, plan, today=today)
+                elif plan["confidence"] >= args.confidence_gate:
+                    r = apply_plan(client, cluster, plan, today=today)
+                    print(
+                        f"  ✓ cluster {cluster['cluster_id']}: APPLIED {plan['decision']} "
+                        f"(canonical={r.get('canonical_id')}, superseded={r.get('superseded_count')})",
+                        file=sys.stderr,
+                    )
+                else:
+                    r = queue_for_review(client, cluster, plan, today=today)
+                    print(
+                        f"  ⋯ cluster {cluster['cluster_id']}: queued {plan['decision']} "
+                        f"(confidence {plan['confidence']:.2f} < gate)",
+                        file=sys.stderr,
+                    )
+                apply_results.append(r)
+            except Exception as e:
+                print(f"  ✗ cluster {cluster['cluster_id']}: FAILED — {e}", file=sys.stderr)
+                apply_results.append(
+                    {
+                        "cluster_id": cluster["cluster_id"],
+                        "status": "error",
+                        "error": str(e),
+                    }
+                )
 
     if args.json:
         out = {
@@ -592,11 +1067,28 @@ def main() -> int:
             "model": args.model,
             "clusters": clusters,
             "plans": plans,
+            "apply": bool(args.apply),
+            "confidence_gate": args.confidence_gate,
+            "limit": args.limit,
+            "skipped_seen": skipped_seen,
+            "apply_results": apply_results,
         }
         print(json.dumps(out, indent=2, default=str))
     else:
         md = render_markdown(clusters, plans, args.min_size, args.threshold, args.model)
         print(md)
+        if args.apply and apply_results:
+            print()
+            print("## Apply summary")
+            print()
+            by_status: dict[str, int] = defaultdict(int)
+            for r in apply_results:
+                by_status[r["status"]] += 1
+            for status in ("applied", "queued", "noted", "error"):
+                if by_status.get(status):
+                    print(f"- **{status}**: {by_status[status]}")
+            if skipped_seen:
+                print(f"- **skipped (already in queue)**: {skipped_seen}")
         if args.save_memory:
             save_plan_memory(client, md, plans)
 

--- a/scripts/consolidation-rollback.py
+++ b/scripts/consolidation-rollback.py
@@ -1,0 +1,153 @@
+"""Consolidation rollback — inverse of --apply (Phase 5.1b-β, #221).
+
+Reverts a single auto-applied consolidation by its memory_review_queue id.
+
+Reads the stored consolidation_payload for the authoritative member list
+(not re-derived from memory_links, which may collide with Phase 2
+classifier supersedes), then calls the `rollback_consolidation` RPC.
+
+  * MERGE rollback:  synthesized canonical is soft-deleted, members'
+                     lifecycle columns cleared, `consolidates` links dropped.
+  * SUPERSEDE_CONSOLIDATION rollback:
+                     canonical stays live, losers are restored,
+                     `supersedes` links dropped (scoped to this canonical).
+
+Queue row transitions: auto_applied/approved → rolled_back.
+A rolled_back cluster is eligible for re-planning next week (unlike
+`rejected`, which blocks forever).
+
+Usage:
+    python scripts/consolidation-rollback.py <queue_id>
+    python scripts/consolidation-rollback.py <queue_id> --json
+    python scripts/consolidation-rollback.py --list            # show auto_applied entries
+
+Requires SUPABASE_URL, SUPABASE_KEY. .env auto-loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+try:
+    from dotenv import load_dotenv
+
+    here = Path(__file__).resolve().parent
+    for c in (here.parent / ".env", here.parent.parent / ".env"):
+        if c.exists():
+            load_dotenv(c, override=True)
+            break
+except ImportError:
+    pass
+
+from supabase import create_client
+
+
+def list_applied(client, limit: int = 20) -> list[dict]:
+    """Return recent auto_applied/approved consolidation entries."""
+    rows = (
+        client.table("memory_review_queue")
+        .select(
+            "id, decision, confidence, status, target_id, applied_at, "
+            "consolidation_payload, reasoning"
+        )
+        .in_("decision", ["MERGE", "SUPERSEDE_CONSOLIDATION"])
+        .in_("status", ["auto_applied", "approved"])
+        .order("applied_at", desc=True)
+        .limit(limit)
+        .execute()
+        .data
+    ) or []
+    return rows
+
+
+def print_listing(rows: list[dict]) -> None:
+    if not rows:
+        print(
+            "No rollback-eligible entries (need status=auto_applied or approved, "
+            "decision=MERGE or SUPERSEDE_CONSOLIDATION)."
+        )
+        return
+    print(f"{'id':36}  {'decision':26}  {'conf':>5}  {'applied_at':20}  {'cluster':7}  members")
+    print("-" * 120)
+    for r in rows:
+        payload = r.get("consolidation_payload") or {}
+        cluster_id = payload.get("cluster_id", "?")
+        names = payload.get("member_names") or []
+        names_str = ", ".join(names[:3]) + (f" +{len(names) - 3}" if len(names) > 3 else "")
+        applied = (r.get("applied_at") or "")[:19].replace("T", " ")
+        print(
+            f"{r['id']:36}  {r['decision']:26}  {float(r['confidence']):5.2f}  "
+            f"{applied:20}  {str(cluster_id):7}  {names_str}"
+        )
+
+
+def rollback(client, queue_id: str) -> dict:
+    resp = client.rpc("rollback_consolidation", {"queue_id": queue_id}).execute()
+    return resp.data or {}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("queue_id", nargs="?", help="memory_review_queue.id to roll back")
+    p.add_argument("--list", action="store_true", help="List rollback-eligible entries and exit")
+    p.add_argument("--limit", type=int, default=20, help="Rows shown by --list (default 20)")
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    args = p.parse_args()
+
+    sb_url = os.environ.get("SUPABASE_URL")
+    sb_key = os.environ.get("SUPABASE_KEY")
+    if not sb_url or not sb_key:
+        print("SUPABASE_URL / SUPABASE_KEY missing from env", file=sys.stderr)
+        return 2
+
+    client = create_client(sb_url, sb_key)
+
+    if args.list:
+        rows = list_applied(client, args.limit)
+        if args.json:
+            print(json.dumps(rows, indent=2, default=str))
+        else:
+            print_listing(rows)
+        return 0
+
+    if not args.queue_id:
+        p.print_usage(sys.stderr)
+        print("error: queue_id required (or pass --list)", file=sys.stderr)
+        return 2
+
+    try:
+        result = rollback(client, args.queue_id)
+    except Exception as e:
+        print(f"Rollback failed: {e}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        out = {
+            "queue_id": args.queue_id,
+            "result": result,
+            "rolled_back_at": datetime.now(timezone.utc).isoformat(),
+        }
+        print(json.dumps(out, indent=2, default=str))
+    else:
+        print(f"Rolled back queue entry {args.queue_id}")
+        print(f"  decision:             {result.get('decision')}")
+        print(f"  canonical_id:         {result.get('canonical_id')}")
+        print(f"  canonical_soft_deleted: {result.get('canonical_soft_deleted')}")
+        print(f"  restored_count:       {result.get('restored_count')}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 5.1b-β of the memory overhaul — converts the Haiku merge plans from 5.1b-α (#220) into real mutations, gated by confidence. Also ships `rollback_consolidation` RPC + CLI for surgical undo of a single auto-applied cluster.

## Why
Closes #221.

Phase 5.1b-α added a dry-run planner; without an apply path there was no way to actually compress the memory store. The design needed three things: (1) a confidence gate so high-confidence Haiku decisions auto-apply and ambiguous ones queue for review, (2) a durable record so we don't re-spend Haiku tokens on the same cluster every week, and (3) a reversible apply so a bad merge isn't permanent.

## Decisions & Alternatives

**Confidence gate = 0.85** (owner-decided 2026-04-19). Original plan had 0.9; owner lowered it because 0.85 turned out to be where Haiku rates its best non-obvious calls (e.g. "these 3 memories about multiagent architecture should merge" → conf 0.85–0.92). At 0.9 almost nothing would auto-apply.

**Reuse `memory_review_queue` (owner decision)** rather than forking a new `consolidation_queue` table. Rationale: queue ergonomics — dashboards, review flow, status transitions — are already built for Phase 2 classifier output. Alternatives rejected:
- Separate table ⇒ double-plumbing with no gain.
- Overload `target_id` only ⇒ lose cluster-level context (member list, canonical synthesis, Haiku reasoning).

**`consolidation_payload jsonb` column** holds the cluster-level state: `member_ids`, `member_ids_key` (sorted, comma-joined — used by the functional index for dedup), `canonical_*` fields, `decision`, `confidence`, `reasoning`. Phase 2 rows leave it NULL.

**KEEP_DISTINCT = auto_applied in queue** (owner-decided "по рекомендации"). Trade-off: takes queue space for non-mutations but prevents re-paying Haiku every Sunday for clusters we've already decided to leave alone. The RPC-side seen-filter filters against `status != 'rolled_back'` so rolled-back MERGEs can be re-tried next week, while KEEP_DISTINCT stays sticky.

**`rolled_back` as distinct status** — not `rejected`. A rejected row says "never suggest this again"; a rolled-back row says "I undid this, feel free to re-plan later". Matters for the seen-filter semantics.

**Rollback reads `consolidation_payload`, not `memory_links`** — Phase 2 classifier also writes `supersedes` links. If rollback re-derived the member list from links alone it could conflict with a legitimate Phase 2 supersede sharing the canonical. Keying off the queue row's stored member_ids is authoritative.

**MERGE canonical confidence capped at 0.9 in the RPC** — synthesized canonicals aren't user-stated facts; they're compressions. Leaving the cap in SQL (not Python) makes the invariant robust against future callers.

**Embedding backfill in Python (post-RPC UPDATE), not in SQL** — reuses VoyageAI canonical-embed form from `server.py`. Matters for cosine comparability: a canonical embedded differently from its would-be-peers would confuse future clustering runs.

## Risk Assessment

**MEDIUM** — new mutation path on the memory store, but:
- Every mutation is reversible via `rollback_consolidation`.
- Confidence gate means nothing high-risk auto-applies without owner input.
- Smoke-tested end-to-end on live production DB (one MERGE applied, verified, rolled back, re-cluster verified via SQL).
- Queue dedup prevents runaway cost from scheduled runs re-planning the same clusters.
- Schema changes are additive (new column, extended CHECKs) — no data migration, no ALTER on existing rows.

**LOW** — `.gitignore` addition (`.tmp/`) + docstring updates.

## Testing

Smoke test on live DB against cluster 10 (`jarvis_v2_multiagent_*` × 3):
1. `--apply --confidence-gate 0.9` → 3 decision paths exercised:
   - cluster 15 (KEEP_DISTINCT, conf 0.75): queue row status=auto_applied ✅
   - cluster 10 (MERGE, conf 0.92): canonical `jarvis_v2_multiagent_architecture` inserted, 3 members superseded (valid_to + expired_at set), 3 `consolidates` links created, embedding backfilled, queue row status=auto_applied, `consolidation_applied` event logged ✅
   - cluster 9 (MERGE, conf 0.85 < gate): queue row status=pending ✅
2. Re-run `--apply` → "Skipped 1 cluster(s) already in review queue" — seen-filter via `member_ids_key` works (cluster_id reshuffled 15→8 but members_key matched) ✅
3. `scripts/consolidation-rollback.py 3d506743-...` → canonical soft-deleted, all 3 members restored (lifecycle cols cleared), 3 consolidates links removed, queue status=rolled_back ✅
4. Verified rolled-back cluster re-appears in `find_consolidation_clusters(3, 0.75)` and the seen-filter SQL correctly excludes `status='rolled_back'` ✅
5. `python scripts/eval-recall.py` — 85%@5 / 90%@10 / MRR 0.638, must_not=0 (baseline preserved) ✅

Commands run:
- `ruff check scripts/consolidation-*.py` — all clean
- `ruff format` — applied, no functional changes
- `python scripts/consolidation-merge-plan.py --apply --confidence-gate 0.9 --limit 5` — full end-to-end
- `python scripts/consolidation-rollback.py --list` + `<queue_id>` — both modes

Not tested (deliberate, out of scope):
- `SUPERSEDE_CONSOLIDATION` apply path in production — no live cluster matched that decision. Logic mirrors MERGE but simpler (no new memory, no embedding), covered by the RPC definition.
- Concurrent `--apply` runs — the queue pre-filter uses snapshot reads, so a race could duplicate-apply. Documented as follow-up; mitigation today is the scheduler runs `--apply` once weekly.

## Files Changed
- `mcp-memory/schema.sql` — CHECK extensions + `consolidation_payload` column + functional index + `apply_consolidation_plan` + `rollback_consolidation` RPCs (~248 lines).
- `scripts/consolidation-merge-plan.py` — `--apply` + `--confidence-gate` + `--limit` + `--include-seen` flags, route-per-decision logic, embedding backfill via VoyageAI, queue + events writes (~420 lines).
- `scripts/consolidation-rollback.py` — new, wraps `rollback_consolidation` RPC with `--list` / direct-id modes, JSON output (~140 lines).
- `.gitignore` — ignore `.tmp/` (ad-hoc smoke-test artifacts).

## Residual queue entries (real production state, not test cleanup)
After smoke-testing, the queue contains 3 rows reflecting actual Haiku decisions on live clusters:
- `3d506743…` MERGE status=rolled_back (cluster 10, canonical soft-deleted — will be re-planned next run)
- `225531c1…` MERGE status=pending (cluster 9, zigzag-related, conf 0.85 — owner review)
- `74cce385…` KEEP_DISTINCT status=auto_applied (cluster 15, robot_test memories)

These are the system working as designed; the next weekly run won't re-spend Haiku on any of them.