### PR TITLE
feat(memory): Phase 5.1d — consolidation durability polish (#224)

### DIFF
--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -1108,11 +1108,17 @@ create index if not exists idx_review_queue_member_ids_key
 --
 -- queue_meta (optional): when non-null, also inserts a memory_review_queue
 -- row in the same transaction. This is the auto_applied audit trail and is
--- required for rollback — without it the mutation would be unreverteable.
+-- required for rollback — without it the mutation would be irreversible.
 -- Keeping it in-RPC means a queue-insert failure rolls the mutation back
 -- rather than leaving orphaned memory state (#224 fix).
 --
 -- Returns jsonb: { status, decision, canonical_id, superseded_count, queue_id? }.
+--
+-- Signature changed from 1-arg to 2-arg-with-default in #224. Postgres will
+-- keep both variants installed side-by-side unless the old one is explicitly
+-- dropped, and 1-arg callers will continue hitting the pre-#224 body. Mirrors
+-- the `get_linked_memories` migration pattern.
+drop function if exists apply_consolidation_plan(jsonb);
 create or replace function apply_consolidation_plan(
     plan jsonb,
     queue_meta jsonb default null
@@ -1221,13 +1227,32 @@ begin
         raise exception 'Unsupported decision for apply_consolidation_plan: %', v_decision;
     end if;
 
-    -- Queue audit row, transactional with the memory mutations. classifier_model
-    -- is authoritative (not coalesced to a default) — it records which model
-    -- actually produced the plan. target_id is set to the canonical the RPC
-    -- just computed (v_new_id for MERGE, v_canonical_id for SUPERSEDE) —
-    -- rollback_consolidation reads it and raises on NULL, so owning the
-    -- assignment here avoids the caller having to echo it back.
+    -- Queue audit row, transactional with the memory mutations. The RPC owns
+    -- the load-bearing fields so a misbuilt caller payload can't corrupt the
+    -- audit trail:
+    --   * decision: always v_decision (validated above). If queue_meta carries
+    --     a different decision, raise — silently overwriting hides a bug.
+    --   * classifier_model: required + non-blank. The audit trail is the only
+    --     place the model attribution survives; a NULL/empty write would lose
+    --     it silently and break provenance tracing.
+    --   * target_id: the canonical the RPC just computed (v_new_id for MERGE,
+    --     v_canonical_id for SUPERSEDE) — rollback_consolidation reads it and
+    --     raises on NULL, so owning the assignment here avoids the caller
+    --     having to echo it back.
     if queue_meta is not null then
+        if queue_meta ? 'decision'
+           and queue_meta->>'decision' is not null
+           and queue_meta->>'decision' <> v_decision then
+            raise exception
+                'queue_meta decision % does not match plan decision %',
+                queue_meta->>'decision', v_decision;
+        end if;
+
+        if coalesce(nullif(trim(queue_meta->>'classifier_model'), ''), '') = '' then
+            raise exception
+                'queue_meta.classifier_model is required and must be non-blank for audit provenance';
+        end if;
+
         insert into memory_review_queue (
             decision,
             confidence,
@@ -1239,12 +1264,12 @@ begin
             applied_at
         )
         values (
-            queue_meta->>'decision',
+            v_decision,
             coalesce((queue_meta->>'confidence')::float, 0.0),
             left(coalesce(queue_meta->>'reasoning', ''), 1000),
             coalesce(queue_meta->>'status', 'auto_applied'),
             queue_meta->'consolidation_payload',
-            queue_meta->>'classifier_model',
+            trim(queue_meta->>'classifier_model'),
             v_queue_target,
             coalesce(
                 nullif(queue_meta->>'applied_at', '')::timestamptz,

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -1106,8 +1106,17 @@ create index if not exists idx_review_queue_member_ids_key
 -- SUPERSEDE_CONSOLIDATION: one existing member wins, all others get
 -- superseded_by = canonical. No new memory, no new embedding needed.
 --
--- Returns jsonb: { status, decision, canonical_id, superseded_count }.
-create or replace function apply_consolidation_plan(plan jsonb)
+-- queue_meta (optional): when non-null, also inserts a memory_review_queue
+-- row in the same transaction. This is the auto_applied audit trail and is
+-- required for rollback — without it the mutation would be unreverteable.
+-- Keeping it in-RPC means a queue-insert failure rolls the mutation back
+-- rather than leaving orphaned memory state (#224 fix).
+--
+-- Returns jsonb: { status, decision, canonical_id, superseded_count, queue_id? }.
+create or replace function apply_consolidation_plan(
+    plan jsonb,
+    queue_meta jsonb default null
+)
 returns jsonb
 language plpgsql volatile
 as $$
@@ -1122,6 +1131,9 @@ declare
     );
     v_new_id uuid;
     v_rows int;
+    v_queue_id uuid;
+    v_result jsonb;
+    v_queue_target uuid;
 begin
     if v_decision = 'MERGE' then
         if coalesce(plan->>'canonical_name', '') = ''
@@ -1170,12 +1182,13 @@ begin
         from unnest(v_supersede_ids) as unnest_id
         on conflict (source_id, target_id, link_type) do nothing;
 
-        return jsonb_build_object(
+        v_result := jsonb_build_object(
             'status', 'applied',
             'decision', 'MERGE',
             'canonical_id', v_new_id,
             'superseded_count', v_rows
         );
+        v_queue_target := v_new_id;
     elsif v_decision = 'SUPERSEDE_CONSOLIDATION' then
         if v_canonical_id is null then
             raise exception 'SUPERSEDE_CONSOLIDATION requires canonical_id';
@@ -1197,15 +1210,53 @@ begin
         where unnest_id <> v_canonical_id
         on conflict (source_id, target_id, link_type) do nothing;
 
-        return jsonb_build_object(
+        v_result := jsonb_build_object(
             'status', 'applied',
             'decision', 'SUPERSEDE_CONSOLIDATION',
             'canonical_id', v_canonical_id,
             'superseded_count', v_rows
         );
+        v_queue_target := v_canonical_id;
     else
         raise exception 'Unsupported decision for apply_consolidation_plan: %', v_decision;
     end if;
+
+    -- Queue audit row, transactional with the memory mutations. classifier_model
+    -- is authoritative (not coalesced to a default) — it records which model
+    -- actually produced the plan. target_id is set to the canonical the RPC
+    -- just computed (v_new_id for MERGE, v_canonical_id for SUPERSEDE) —
+    -- rollback_consolidation reads it and raises on NULL, so owning the
+    -- assignment here avoids the caller having to echo it back.
+    if queue_meta is not null then
+        insert into memory_review_queue (
+            decision,
+            confidence,
+            reasoning,
+            status,
+            consolidation_payload,
+            classifier_model,
+            target_id,
+            applied_at
+        )
+        values (
+            queue_meta->>'decision',
+            coalesce((queue_meta->>'confidence')::float, 0.0),
+            left(coalesce(queue_meta->>'reasoning', ''), 1000),
+            coalesce(queue_meta->>'status', 'auto_applied'),
+            queue_meta->'consolidation_payload',
+            queue_meta->>'classifier_model',
+            v_queue_target,
+            coalesce(
+                nullif(queue_meta->>'applied_at', '')::timestamptz,
+                now()
+            )
+        )
+        returning id into v_queue_id;
+
+        v_result := v_result || jsonb_build_object('queue_id', v_queue_id);
+    end if;
+
+    return v_result;
 end;
 $$;
 

--- a/scripts/consolidation-merge-plan.py
+++ b/scripts/consolidation-merge-plan.py
@@ -700,7 +700,12 @@ def apply_plan(
 
 
 def queue_for_review(client, cluster: dict, plan: dict, *, today: str, model: str) -> dict:
-    """Route a low-confidence MERGE/SUPERSEDE plan to the review queue."""
+    """Route a low-confidence MERGE/SUPERSEDE plan to the review queue.
+
+    Raises RuntimeError if the queue insert returns no id — otherwise the
+    cluster would be silently dropped (and re-planned next week, burning
+    tokens) while the caller thinks it was queued.
+    """
     db_decision = DB_DECISION[plan["decision"]]
     source_provenance = f"skill:consolidation:{plan['decision'].lower()}:{today}"
     payload = build_payload(cluster, plan, source_provenance)
@@ -715,6 +720,11 @@ def queue_for_review(client, cluster: dict, plan: dict, *, today: str, model: st
         payload=payload,
         classifier_model=model,
     )
+    if not queue_id:
+        raise RuntimeError(
+            f"Queue insert returned no id for cluster {cluster['cluster_id']} "
+            f"({db_decision}) — refusing to report as queued"
+        )
     return {
         "cluster_id": cluster["cluster_id"],
         "decision": db_decision,
@@ -724,7 +734,12 @@ def queue_for_review(client, cluster: dict, plan: dict, *, today: str, model: st
 
 
 def note_keep_distinct(client, cluster: dict, plan: dict, *, today: str, model: str) -> dict:
-    """Record KEEP_DISTINCT so the same cluster isn't re-planned next week."""
+    """Record KEEP_DISTINCT so the same cluster isn't re-planned next week.
+
+    Raises RuntimeError if the queue insert returns no id — otherwise the
+    same cluster will be replanned on the next run (wasting Haiku tokens)
+    with no indication the audit row failed.
+    """
     source_provenance = f"skill:consolidation:keep_distinct:{today}"
     payload = build_payload(cluster, plan, source_provenance)
     queue_id = _queue_insert(
@@ -738,6 +753,11 @@ def note_keep_distinct(client, cluster: dict, plan: dict, *, today: str, model: 
         classifier_model=model,
         applied_at=datetime.now(timezone.utc).isoformat(),
     )
+    if not queue_id:
+        raise RuntimeError(
+            f"KEEP_DISTINCT queue insert returned no id for cluster "
+            f"{cluster['cluster_id']} — refusing to report as noted"
+        )
     return {
         "cluster_id": cluster["cluster_id"],
         "decision": "KEEP_DISTINCT",

--- a/scripts/consolidation-merge-plan.py
+++ b/scripts/consolidation-merge-plan.py
@@ -535,16 +535,22 @@ def _queue_insert(
     confidence: float,
     reasoning: str,
     payload: dict,
+    classifier_model: str,
     applied_at: str | None = None,
 ) -> str | None:
-    """Insert one row into memory_review_queue. Returns id or None on error."""
+    """Insert one row into memory_review_queue. Returns id or None on error.
+
+    Used for status in {pending, auto_applied:KEEP_DISTINCT} — paths that
+    don't mutate memories. For auto_applied MERGE/SUPERSEDE the queue insert
+    is done inside `apply_consolidation_plan` (transactional with mutations).
+    """
     row = {
         "decision": decision,
         "confidence": float(confidence),
         "reasoning": (reasoning or "")[:1000],
         "status": status,
         "consolidation_payload": payload,
-        "classifier_model": DEFAULT_MODEL,
+        "classifier_model": classifier_model,
     }
     if target_id:
         row["target_id"] = target_id
@@ -591,19 +597,26 @@ def _log_event(
 
 
 def apply_plan(
-    client, cluster: dict, plan: dict, *, today: str, dry_run_embed: bool = False
+    client,
+    cluster: dict,
+    plan: dict,
+    *,
+    today: str,
+    model: str,
+    dry_run_embed: bool = False,
 ) -> dict:
     """Apply one high-confidence plan. Returns result dict for summary output.
 
-    Order matters: RPC first (atomic member supersede), then embedding
-    backfill, then queue audit row + event. If embedding fails, the
-    canonical is still correct — it just won't be found via semantic
-    recall until a later backfill sweeps nulls (matches server.py's
-    lazy-backfill pattern, memories with NULL embedding).
+    The RPC mutates memories + links AND writes the auto_applied queue row
+    in one transaction — if the queue insert fails, the memory mutations
+    roll back with it (#224). Embedding backfill runs after; if it fails,
+    the canonical is still correct, just not recallable until the next
+    lazy-backfill (matches server.py's NULL-embedding behaviour).
     """
     db_decision = DB_DECISION[plan["decision"]]
     source_provenance = f"skill:consolidation:{plan['decision'].lower()}:{today}"
     payload = build_payload(cluster, plan, source_provenance)
+    applied_at = datetime.now(timezone.utc).isoformat()
 
     rpc_plan = {
         "decision": db_decision,
@@ -618,13 +631,31 @@ def apply_plan(
         "source_provenance": source_provenance,
         "confidence": plan.get("confidence", 0.8),
     }
+    queue_meta = {
+        "decision": db_decision,
+        "status": "auto_applied",
+        "confidence": float(plan.get("confidence", 0.8)),
+        "reasoning": (plan.get("reasoning") or "")[:1000],
+        "classifier_model": model,
+        "consolidation_payload": payload,
+        "applied_at": applied_at,
+        # target_id is set inside the RPC (to the canonical it just computed
+        # or picked) — the caller doesn't know v_new_id for MERGE, and it's
+        # load-bearing for rollback_consolidation.
+    }
 
-    resp = client.rpc("apply_consolidation_plan", {"plan": rpc_plan}).execute()
+    resp = client.rpc(
+        "apply_consolidation_plan",
+        {"plan": rpc_plan, "queue_meta": queue_meta},
+    ).execute()
     rpc_out = resp.data or {}
     canonical_id = rpc_out.get("canonical_id")
     superseded_count = int(rpc_out.get("superseded_count") or 0)
+    queue_id = rpc_out.get("queue_id")
     if not canonical_id:
         raise RuntimeError(f"apply_consolidation_plan returned no canonical_id: {rpc_out!r}")
+    if not queue_id:
+        raise RuntimeError(f"apply_consolidation_plan returned no queue_id: {rpc_out!r}")
 
     embedded = False
     if plan["decision"] == "MERGE" and not dry_run_embed:
@@ -648,18 +679,6 @@ def apply_plan(
             except Exception as e:
                 print(f"! embedding backfill failed for {canonical_id}: {e}", file=sys.stderr)
 
-    applied_at = datetime.now(timezone.utc).isoformat()
-    queue_id = _queue_insert(
-        client,
-        decision=db_decision,
-        status="auto_applied",
-        target_id=canonical_id,
-        confidence=plan.get("confidence", 0.8),
-        reasoning=plan.get("reasoning") or "",
-        payload=payload,
-        applied_at=applied_at,
-    )
-
     _log_event(
         client,
         canonical_id=canonical_id,
@@ -680,7 +699,7 @@ def apply_plan(
     }
 
 
-def queue_for_review(client, cluster: dict, plan: dict, *, today: str) -> dict:
+def queue_for_review(client, cluster: dict, plan: dict, *, today: str, model: str) -> dict:
     """Route a low-confidence MERGE/SUPERSEDE plan to the review queue."""
     db_decision = DB_DECISION[plan["decision"]]
     source_provenance = f"skill:consolidation:{plan['decision'].lower()}:{today}"
@@ -694,6 +713,7 @@ def queue_for_review(client, cluster: dict, plan: dict, *, today: str) -> dict:
         confidence=plan.get("confidence", 0.0),
         reasoning=plan.get("reasoning") or "",
         payload=payload,
+        classifier_model=model,
     )
     return {
         "cluster_id": cluster["cluster_id"],
@@ -703,7 +723,7 @@ def queue_for_review(client, cluster: dict, plan: dict, *, today: str) -> dict:
     }
 
 
-def note_keep_distinct(client, cluster: dict, plan: dict, *, today: str) -> dict:
+def note_keep_distinct(client, cluster: dict, plan: dict, *, today: str, model: str) -> dict:
     """Record KEEP_DISTINCT so the same cluster isn't re-planned next week."""
     source_provenance = f"skill:consolidation:keep_distinct:{today}"
     payload = build_payload(cluster, plan, source_provenance)
@@ -715,6 +735,7 @@ def note_keep_distinct(client, cluster: dict, plan: dict, *, today: str) -> dict
         confidence=plan.get("confidence", 0.0),
         reasoning=plan.get("reasoning") or "",
         payload=payload,
+        classifier_model=model,
         applied_at=datetime.now(timezone.utc).isoformat(),
     )
     return {
@@ -775,12 +796,26 @@ def plan_cluster(cluster: dict, *, model: str, timeout: float) -> dict:
 
 
 def render_markdown(
-    clusters: list[dict], plans: list[dict], min_size: int, threshold: float, model: str
+    clusters: list[dict],
+    plans: list[dict],
+    min_size: int,
+    threshold: float,
+    model: str,
+    *,
+    apply: bool = False,
+    confidence_gate: float = DEFAULT_CONFIDENCE_GATE,
 ) -> str:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     by_decision: dict[str, int] = defaultdict(int)
     for p in plans:
         by_decision[p["decision"]] += 1
+
+    mode_line = (
+        f"_Apply mode (confidence gate {confidence_gate:.2f}). "
+        "High-confidence plans auto-applied; rest routed to review queue._"
+        if apply
+        else "_Dry-run only. No mutations. Rerun with `--apply` to persist high-confidence plans._"
+    )
 
     lines = [
         f"# Memory consolidation plan — {now}",
@@ -792,7 +827,7 @@ def render_markdown(
         f"SUPERSEDE={by_decision.get('SUPERSEDE', 0)}, "
         f"KEEP_DISTINCT={by_decision.get('KEEP_DISTINCT', 0)}",
         "",
-        "_Dry-run only. No mutations. Apply path lands in 5.1b-β with confidence gating._",
+        mode_line,
         "",
     ]
 
@@ -850,9 +885,13 @@ def render_markdown(
 
     lines.append("---")
     lines.append("")
-    lines.append(
-        "**Next**: rerun with `--apply` to persist high-confidence plans and route the rest to the review queue."
-    )
+    if apply:
+        lines.append("**Next**: see _Apply summary_ below for per-cluster outcomes.")
+    else:
+        lines.append(
+            "**Next**: rerun with `--apply` to persist high-confidence plans "
+            "and route the rest to the review queue."
+        )
     return "\n".join(lines)
 
 
@@ -1022,7 +1061,17 @@ def main() -> int:
                 )
             )
         else:
-            print(render_markdown([], [], args.min_size, args.threshold, args.model))
+            print(
+                render_markdown(
+                    [],
+                    [],
+                    args.min_size,
+                    args.threshold,
+                    args.model,
+                    apply=bool(args.apply),
+                    confidence_gate=args.confidence_gate,
+                )
+            )
             if skipped_seen:
                 print(f"\n_Skipped {skipped_seen} already-seen cluster(s)._")
         return 0
@@ -1044,16 +1093,16 @@ def main() -> int:
         for cluster, plan in zip(clusters, plans):
             try:
                 if plan["decision"] == "KEEP_DISTINCT":
-                    r = note_keep_distinct(client, cluster, plan, today=today)
+                    r = note_keep_distinct(client, cluster, plan, today=today, model=args.model)
                 elif plan["confidence"] >= args.confidence_gate:
-                    r = apply_plan(client, cluster, plan, today=today)
+                    r = apply_plan(client, cluster, plan, today=today, model=args.model)
                     print(
                         f"  ✓ cluster {cluster['cluster_id']}: APPLIED {plan['decision']} "
                         f"(canonical={r.get('canonical_id')}, superseded={r.get('superseded_count')})",
                         file=sys.stderr,
                     )
                 else:
-                    r = queue_for_review(client, cluster, plan, today=today)
+                    r = queue_for_review(client, cluster, plan, today=today, model=args.model)
                     print(
                         f"  ⋯ cluster {cluster['cluster_id']}: queued {plan['decision']} "
                         f"(confidence {plan['confidence']:.2f} < gate)",
@@ -1085,7 +1134,15 @@ def main() -> int:
         }
         print(json.dumps(out, indent=2, default=str))
     else:
-        md = render_markdown(clusters, plans, args.min_size, args.threshold, args.model)
+        md = render_markdown(
+            clusters,
+            plans,
+            args.min_size,
+            args.threshold,
+            args.model,
+            apply=bool(args.apply),
+            confidence_gate=args.confidence_gate,
+        )
         print(md)
         if args.apply and apply_results:
             print()


### PR DESCRIPTION
## Summary
Three follow-up corrections to Phase 5.1b-β's apply path (#221 review) — move the queue insert inside the SQL RPC so it's transactional with the memory mutations, thread \`classifier_model\` through authoritatively (not via silent \`DEFAULT_MODEL\` fallback), and fix \`render_markdown\` to match the actual mode (\`--apply\` vs dry-run).

## Why
Closes #224. Post-#221 review surfaced three correctness gaps:

1. **Queue row was orphan-prone** — RPC mutated memories + links, caller wrote the audit-trail queue row separately. A queue-insert failure left the mutation unreverteable (rollback reads from the queue).
2. **\`classifier_model\` silently coerced** — \`_queue_insert\` hardcoded \`DEFAULT_MODEL\`, ignoring \`--model\`. Audit trail misrepresented which model produced the plan.
3. **Stale markdown banner** — even in \`--apply\` runs the header said "Dry-run only. No mutations."

## Decisions & Alternatives
- **Queue insert in-RPC over retry/raise-in-Python**: considered making Python's \`_queue_insert\` raise on failure so caller can compensate. Rejected — can't cleanly compensate a multi-statement mutation from the client (no cross-statement txn guarantee on supabase-py), and two round-trips is worse than one. RPC transactionality is the right tool.
- **\`target_id\` owned by RPC, not caller**: caller doesn't know \`v_new_id\` for MERGE (created inside the RPC). Passing \`queue_meta.target_id\` would force a round-trip pattern. Having the RPC pick the right canonical (\`v_new_id\` for MERGE, \`v_canonical_id\` for SUPERSEDE) is simpler and matches what \`rollback_consolidation\` reads.
- **Migration drops the old 1-arg function first**: adding a default arg changes the Postgres signature resolution rules in a way that can leave both variants installed; \`drop ... if exists\` then \`create or replace\` is the clean path.

## Risk Assessment
- **MEDIUM**: RPC signature change (adds optional \`queue_meta\`). Existing callers that pass a single arg still work — default null means the queue branch is skipped. Verified against live DB.
- **LOW**: Python changes are all call-site threading + comment updates. Linted, dry-run CLI still prints expected output.

## Testing
Smoke tested against live DB on Main PC:
- ✓ RPC returns \`{status, decision, canonical_id, superseded_count, queue_id}\` (queue_id present when queue_meta supplied)
- ✓ Queue row has authoritative \`classifier_model\` (smoketest value, not default) and \`target_id = canonical\`
- ✓ Rollback round-trips: \`rollback_consolidation\` clears member lifecycle, soft-deletes canonical, drops \`consolidates\` links, transitions queue status to \`rolled_back\` (\`live_members=3, canonical_deleted=true, queue_status=rolled_back, links_remaining=0\`)
- ✓ Transactional guarantee: synthetic plan with invalid \`status\` value in queue_meta raises the CHECK constraint and rolls back the memory mutations (no leaked canonical, members still live)
- \`ruff check\` / \`ruff format\` clean
- \`--help\` and dry-run output render correctly in both modes

## Files Changed
- \`mcp-memory/schema.sql\` — \`apply_consolidation_plan\` signature \`(plan jsonb, queue_meta jsonb default null)\`, queue row insert inside the same transaction, \`queue_id\` returned in result
- \`scripts/consolidation-merge-plan.py\` — \`apply_plan\` reads \`queue_id\` from RPC; drops the post-RPC \`_queue_insert\` call; threads \`model\` through \`apply_plan\` / \`queue_for_review\` / \`note_keep_distinct\`; \`render_markdown\` takes \`apply\` + \`confidence_gate\` kwargs and switches the header/trailing-next lines