### PR TITLE
feat(memory): Phase 5.1d-β — consolidation-review CLI (#226)

### DIFF
--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -1370,3 +1370,175 @@ begin
     );
 end;
 $$;
+
+
+-- approve_consolidation(queue_id, reviewer): owner-review approval path for
+-- Phase 5.1d-β (#226). Reads the stored consolidation_payload, rebuilds the
+-- plan, calls apply_consolidation_plan in the same transaction (SELECT FOR
+-- UPDATE against concurrent approves), and transitions the queue row to
+-- status=approved. The queue_meta arg is intentionally omitted — we're
+-- updating an existing row, not inserting a new one.
+--
+-- source_provenance on the synthesized canonical is stamped
+-- `cli:review:<date>` so audit traces distinguish CLI-approved merges from
+-- auto_applied ones. canonical embedding is backfilled out-of-band by the
+-- Python caller (VoyageAI); the row is live-hidden until embedding lands
+-- because the member lifecycle filter already masks it from recall.
+--
+-- Race: two concurrent approves of the same row both take FOR UPDATE on the
+-- queue row, serialize, and the second one sees status='approved' and raises.
+create or replace function approve_consolidation(
+    queue_id uuid,
+    reviewer text default 'cli_review'
+)
+returns jsonb
+language plpgsql volatile
+as $$
+declare
+    v_decision text;
+    v_status text;
+    v_payload jsonb;
+    v_existing_target uuid;
+    v_plan jsonb;
+    v_applied jsonb;
+    v_canonical_id uuid;
+    v_today text := to_char(now() at time zone 'UTC', 'YYYY-MM-DD');
+begin
+    select decision, status, consolidation_payload, target_id
+    into v_decision, v_status, v_payload, v_existing_target
+    from memory_review_queue
+    where id = queue_id
+    for update;
+
+    if not found then
+        raise exception 'Queue entry % not found', queue_id;
+    end if;
+
+    if v_payload is null then
+        raise exception 'Queue entry % has no consolidation_payload', queue_id;
+    end if;
+
+    if v_status <> 'pending' then
+        raise exception 'Can only approve pending entries (status=%)', v_status;
+    end if;
+
+    if v_decision not in ('MERGE', 'SUPERSEDE_CONSOLIDATION') then
+        raise exception 'Entry % is not a consolidation row (decision=%)', queue_id, v_decision;
+    end if;
+
+    -- Rebuild the plan from the stored payload. source_provenance gets
+    -- overwritten to reflect reviewer provenance (cli:review:<today>) rather
+    -- than the original skill:consolidation:... stamp from the planner.
+    v_plan := jsonb_build_object(
+        'decision', v_decision,
+        'supersede_ids', coalesce(v_payload->'supersede_ids', '[]'::jsonb),
+        'source_provenance', 'cli:review:' || v_today,
+        'confidence', coalesce((v_payload->>'haiku_confidence')::float, 0.85)
+    );
+
+    if v_decision = 'MERGE' then
+        v_plan := v_plan || jsonb_build_object(
+            'canonical_name', v_payload->>'canonical_name',
+            'canonical_type', v_payload->>'canonical_type',
+            'canonical_description', v_payload->>'canonical_description',
+            'canonical_content', v_payload->>'canonical_content',
+            'canonical_project', v_payload->>'canonical_project',
+            'canonical_tags', coalesce(v_payload->'canonical_tags', '[]'::jsonb)
+        );
+    else
+        -- SUPERSEDE_CONSOLIDATION: canonical_id lives in target_id on the
+        -- pending queue row (set by queue_for_review). Fall back to payload
+        -- if the caller didn't populate target_id historically.
+        v_canonical_id := v_existing_target;
+        if v_canonical_id is null then
+            v_canonical_id := nullif(v_payload->>'canonical_id', '')::uuid;
+        end if;
+        if v_canonical_id is null then
+            raise exception 'SUPERSEDE_CONSOLIDATION queue row % has no canonical_id (target_id + payload both null)', queue_id;
+        end if;
+        v_plan := v_plan || jsonb_build_object('canonical_id', v_canonical_id);
+    end if;
+
+    -- Apply. Don't pass queue_meta — we're updating this existing row, not
+    -- creating a new audit entry.
+    v_applied := apply_consolidation_plan(v_plan);
+    v_canonical_id := (v_applied->>'canonical_id')::uuid;
+
+    update memory_review_queue
+    set status = 'approved',
+        reviewed_at = now(),
+        reviewed_by = reviewer,
+        applied_at = now(),
+        target_id = v_canonical_id
+    where id = queue_id;
+
+    return v_applied || jsonb_build_object(
+        'queue_id', queue_id,
+        'approved_by', reviewer
+    );
+end;
+$$;
+
+
+-- reject_consolidation(queue_id, reason, reviewer): mark a pending queue
+-- entry rejected so it won't be replanned (see find_consolidation_clusters
+-- dedup, which excludes 'rolled_back' but INCLUDES 'rejected'). Atomic —
+-- SELECT FOR UPDATE + status validation + UPDATE happen in one transaction.
+-- Two concurrent rejects of the same row serialize; the second sees
+-- status='rejected' and raises.
+--
+-- The reason (when provided) is appended to the reasoning column so the
+-- CLI `--list` view shows why it was rejected, without losing the original
+-- Haiku reasoning.
+create or replace function reject_consolidation(
+    queue_id uuid,
+    reason text default null,
+    reviewer text default 'cli_review'
+)
+returns jsonb
+language plpgsql volatile
+as $$
+declare
+    v_decision text;
+    v_status text;
+    v_reasoning text;
+    v_new_reasoning text;
+begin
+    select decision, status, reasoning
+    into v_decision, v_status, v_reasoning
+    from memory_review_queue
+    where id = queue_id
+    for update;
+
+    if not found then
+        raise exception 'Queue entry % not found', queue_id;
+    end if;
+
+    if v_status <> 'pending' then
+        raise exception 'Can only reject pending entries (status=%)', v_status;
+    end if;
+
+    v_new_reasoning := coalesce(v_reasoning, '');
+    if reason is not null and trim(reason) <> '' then
+        v_new_reasoning := left(
+            v_new_reasoning || E'\n-- rejected: ' || trim(reason),
+            1000
+        );
+    end if;
+
+    update memory_review_queue
+    set status = 'rejected',
+        reviewed_at = now(),
+        reviewed_by = reviewer,
+        reasoning = v_new_reasoning
+    where id = queue_id;
+
+    return jsonb_build_object(
+        'status', 'rejected',
+        'decision', v_decision,
+        'queue_id', queue_id,
+        'rejected_by', reviewer,
+        'reason', reason
+    );
+end;
+$$;

--- a/scripts/consolidation-review.py
+++ b/scripts/consolidation-review.py
@@ -1,0 +1,499 @@
+"""Consolidation review CLI — Phase 5.1d-β (#226).
+
+Owner-review companion to `consolidation-rollback.py`. Works through
+`memory_review_queue` rows left in `status='pending'` by the weekly
+`consolidation-merge-plan.py --apply` run (i.e. below the 0.85 confidence
+gate), without SQL:
+
+  list      show pending rows (id / decision / conf / members / reasoning)
+  diff      show what would change — canonical vs member contents
+  approve   apply the stored plan (no Haiku re-call), transition to approved,
+            backfill canonical embedding on MERGE, emit event
+  reject    mark rejected (blocks re-planning forever), emit event
+
+The approve/reject paths are single-transaction RPCs
+(`approve_consolidation` / `reject_consolidation`) so concurrent CLI runs
+can't double-apply the same row. For MERGE, the canonical is written by
+the RPC with `embedding IS NULL`; this script backfills via VoyageAI
+immediately after — same contract as the auto_applied path.
+
+Usage:
+    python scripts/consolidation-review.py --list
+    python scripts/consolidation-review.py --list --limit 50
+    python scripts/consolidation-review.py <queue_id> --diff
+    python scripts/consolidation-review.py <queue_id> --approve
+    python scripts/consolidation-review.py <queue_id> --reject --reason "off-topic"
+    python scripts/consolidation-review.py ... --json   # any mode
+
+Env: SUPABASE_URL, SUPABASE_KEY, VOYAGE_API_KEY (for MERGE approve).
+.env auto-loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+try:
+    from dotenv import load_dotenv
+
+    here = Path(__file__).resolve().parent
+    for c in (here.parent / ".env", here.parent.parent / ".env"):
+        if c.exists():
+            load_dotenv(c, override=True)
+            break
+except ImportError:
+    pass
+
+import httpx
+from supabase import create_client
+
+
+VOYAGE_API_URL = "https://api.voyageai.com/v1/embeddings"
+VOYAGE_MODEL = "voyage-3-lite"
+VOYAGE_TIMEOUT = 30.0
+
+
+def _canonical_embed_text(name: str, description: str, tags: list[str], content: str) -> str:
+    """Mirror of mcp-memory/server.py:_canonical_embed_text.
+
+    Duplicated from consolidation-merge-plan.py so this script can backfill
+    approved MERGE canonicals on the same axis. Both copies mirror server.py
+    byte-for-byte (tracked in a follow-up issue if either drifts).
+    """
+    parts: list[str] = []
+    if name:
+        parts.append(name.replace("_", " "))
+    if tags:
+        parts.append("tags: " + ", ".join(tags))
+    if description:
+        parts.append(description)
+    if content:
+        parts.append(content)
+    return "\n".join(p for p in parts if p).strip()
+
+
+def embed_document(text: str, *, timeout: float = VOYAGE_TIMEOUT) -> list[float] | None:
+    """Sync VoyageAI call. Returns None on any failure (caller logs + continues)."""
+    api_key = os.environ.get("VOYAGE_API_KEY")
+    if not api_key or not text:
+        return None
+    try:
+        with httpx.Client(timeout=timeout) as http:
+            resp = http.post(
+                VOYAGE_API_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"model": VOYAGE_MODEL, "input": [text], "input_type": "document"},
+            )
+            resp.raise_for_status()
+            return resp.json()["data"][0]["embedding"]
+    except (httpx.HTTPError, KeyError, IndexError, ValueError, TypeError):
+        return None
+
+
+def _fetch_queue_row(client, queue_id: str) -> dict | None:
+    rows = (
+        client.table("memory_review_queue")
+        .select(
+            "id, decision, status, confidence, reasoning, classifier_model, "
+            "consolidation_payload, target_id, created_at, reviewed_at, "
+            "reviewed_by, applied_at"
+        )
+        .eq("id", queue_id)
+        .limit(1)
+        .execute()
+        .data
+    ) or []
+    return rows[0] if rows else None
+
+
+def list_pending(client, limit: int) -> list[dict]:
+    rows = (
+        client.table("memory_review_queue")
+        .select(
+            "id, decision, confidence, reasoning, created_at, "
+            "consolidation_payload, classifier_model"
+        )
+        .eq("status", "pending")
+        .in_("decision", ["MERGE", "SUPERSEDE_CONSOLIDATION"])
+        .order("created_at", desc=False)
+        .limit(limit)
+        .execute()
+        .data
+    ) or []
+    return rows
+
+
+def print_listing(rows: list[dict]) -> None:
+    if not rows:
+        print("No pending MERGE/SUPERSEDE_CONSOLIDATION rows.")
+        return
+    print(f"{'id':36}  {'decision':24}  {'conf':>5}  {'created':19}  members")
+    print("-" * 128)
+    for r in rows:
+        payload = r.get("consolidation_payload") or {}
+        names = payload.get("member_names") or []
+        names_str = ", ".join(names[:3]) + (f" +{len(names) - 3}" if len(names) > 3 else "")
+        created = (r.get("created_at") or "")[:19].replace("T", " ")
+        reasoning = (r.get("reasoning") or "").split("\n", 1)[0][:80]
+        print(
+            f"{r['id']:36}  {r['decision']:24}  {float(r['confidence']):5.2f}  "
+            f"{created:19}  {names_str}"
+        )
+        if reasoning:
+            print(f"{'':36}    why: {reasoning}")
+
+
+def _fetch_members(client, member_ids: list[str]) -> list[dict]:
+    if not member_ids:
+        return []
+    rows = (
+        client.table("memories")
+        .select("id, name, type, description, content, tags, created_at")
+        .in_("id", member_ids)
+        .execute()
+        .data
+    ) or []
+    order = {mid: i for i, mid in enumerate(member_ids)}
+    rows.sort(key=lambda r: order.get(r["id"], len(order)))
+    return rows
+
+
+def render_diff(row: dict, members: list[dict]) -> str:
+    payload = row.get("consolidation_payload") or {}
+    lines: list[str] = []
+    lines.append(f"Queue entry: {row['id']}")
+    lines.append(
+        f"Decision: {row['decision']}  confidence={float(row['confidence']):.2f}  "
+        f"model={row.get('classifier_model') or '?'}"
+    )
+    if row.get("reasoning"):
+        lines.append(f"Reasoning: {row['reasoning']}")
+    lines.append("")
+
+    if row["decision"] == "MERGE":
+        lines.append("--- Proposed canonical (new row) ---")
+        lines.append(f"name: {payload.get('canonical_name')}")
+        lines.append(f"type: {payload.get('canonical_type')}")
+        tags = payload.get("canonical_tags") or []
+        lines.append(f"tags: {', '.join(tags) if tags else '(none)'}")
+        if payload.get("canonical_description"):
+            lines.append(f"description: {payload['canonical_description']}")
+        lines.append("content:")
+        for ln in (payload.get("canonical_content") or "").splitlines():
+            lines.append(f"  {ln}")
+    else:  # SUPERSEDE_CONSOLIDATION
+        lines.append(
+            f"--- Canonical (winner): {row.get('target_id') or payload.get('canonical_id')} ---"
+        )
+
+    lines.append("")
+    lines.append(f"--- Members ({len(members)}) ---")
+    for m in members:
+        lines.append(
+            f"* {m['name']} ({m['type']})  id={m['id']}  created={m.get('created_at', '')[:10]}"
+        )
+        tags = m.get("tags") or []
+        if tags:
+            lines.append(f"  tags: {', '.join(tags)}")
+        if m.get("description"):
+            lines.append(f"  description: {m['description']}")
+        if m.get("content"):
+            lines.append("  content:")
+            for ln in (m.get("content") or "").splitlines():
+                lines.append(f"    {ln}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _write_event(
+    client, *, event_type: str, severity: str, title: str, payload: dict
+) -> str | None:
+    try:
+        resp = (
+            client.table("events")
+            .insert(
+                {
+                    "event_type": event_type,
+                    "severity": severity,
+                    "repo": "Osasuwu/jarvis",
+                    "source": "cli_review",
+                    "title": title,
+                    "payload": payload,
+                }
+            )
+            .execute()
+        )
+        data = resp.data or []
+        return data[0]["id"] if data else None
+    except Exception as e:
+        print(f"! event insert failed ({event_type}): {e}", file=sys.stderr)
+        return None
+
+
+def approve(client, queue_id: str, *, as_json: bool) -> int:
+    row = _fetch_queue_row(client, queue_id)
+    if not row:
+        msg = f"Queue entry {queue_id} not found"
+        print(msg, file=sys.stderr)
+        if as_json:
+            print(json.dumps({"status": "not_found", "queue_id": queue_id}))
+        return 1
+
+    if row["status"] != "pending":
+        msg = f"Queue entry {queue_id} has status={row['status']} (expected pending)"
+        print(msg, file=sys.stderr)
+        if as_json:
+            print(
+                json.dumps(
+                    {"status": "not_pending", "queue_id": queue_id, "actual_status": row["status"]}
+                )
+            )
+        return 1
+
+    try:
+        resp = client.rpc("approve_consolidation", {"queue_id": queue_id}).execute()
+        result = resp.data or {}
+    except Exception as e:
+        msg = f"approve_consolidation failed: {e}"
+        print(msg, file=sys.stderr)
+        if as_json:
+            print(json.dumps({"status": "rpc_failed", "queue_id": queue_id, "error": str(e)}))
+        return 1
+
+    canonical_id = result.get("canonical_id")
+    decision = result.get("decision")
+    embedded = None
+
+    # MERGE: backfill embedding on synthesized canonical. SUPERSEDE doesn't
+    # need a backfill — no new memory row was created.
+    if decision == "MERGE" and canonical_id:
+        payload = row.get("consolidation_payload") or {}
+        text = _canonical_embed_text(
+            payload.get("canonical_name") or "",
+            payload.get("canonical_description") or "",
+            list(payload.get("canonical_tags") or []),
+            payload.get("canonical_content") or "",
+        )
+        emb = embed_document(text)
+        if emb is not None:
+            try:
+                client.table("memories").update(
+                    {
+                        "embedding": emb,
+                        "embedding_model": VOYAGE_MODEL,
+                        "embedding_version": "v1",
+                    }
+                ).eq("id", canonical_id).execute()
+                embedded = True
+            except Exception as e:
+                print(f"! embedding backfill failed for {canonical_id}: {e}", file=sys.stderr)
+                embedded = False
+        else:
+            print(
+                f"! VoyageAI returned no embedding for {canonical_id} — canonical left with embedding=NULL",
+                file=sys.stderr,
+            )
+            embedded = False
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    event_payload = {
+        "queue_id": queue_id,
+        "decision": decision,
+        "canonical_id": canonical_id,
+        "superseded_count": result.get("superseded_count"),
+        "embedded": embedded,
+        "source_provenance": f"cli:review:{today}",
+    }
+    event_id = _write_event(
+        client,
+        event_type="consolidation_applied",
+        severity="info",
+        title=f"Consolidation approved via CLI — {decision} ({canonical_id})",
+        payload=event_payload,
+    )
+
+    out = {
+        "status": "approved",
+        "decision": decision,
+        "canonical_id": canonical_id,
+        "superseded_count": result.get("superseded_count"),
+        "embedded": embedded,
+        "queue_id": queue_id,
+        "event_id": event_id,
+    }
+    if as_json:
+        print(json.dumps(out, indent=2, default=str))
+    else:
+        print(f"Approved queue entry {queue_id}")
+        print(f"  decision:         {decision}")
+        print(f"  canonical_id:     {canonical_id}")
+        print(f"  superseded_count: {result.get('superseded_count')}")
+        print(f"  embedded:         {embedded}")
+        print(f"  event_id:         {event_id}")
+    return 0
+
+
+def reject(client, queue_id: str, *, reason: str | None, as_json: bool) -> int:
+    row = _fetch_queue_row(client, queue_id)
+    if not row:
+        print(f"Queue entry {queue_id} not found", file=sys.stderr)
+        if as_json:
+            print(json.dumps({"status": "not_found", "queue_id": queue_id}))
+        return 1
+
+    if row["status"] != "pending":
+        print(
+            f"Queue entry {queue_id} has status={row['status']} (expected pending)",
+            file=sys.stderr,
+        )
+        if as_json:
+            print(
+                json.dumps(
+                    {"status": "not_pending", "queue_id": queue_id, "actual_status": row["status"]}
+                )
+            )
+        return 1
+
+    try:
+        args: dict = {"queue_id": queue_id}
+        if reason:
+            args["reason"] = reason
+        resp = client.rpc("reject_consolidation", args).execute()
+        result = resp.data or {}
+    except Exception as e:
+        print(f"reject_consolidation failed: {e}", file=sys.stderr)
+        if as_json:
+            print(json.dumps({"status": "rpc_failed", "queue_id": queue_id, "error": str(e)}))
+        return 1
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    event_payload = {
+        "queue_id": queue_id,
+        "decision": result.get("decision"),
+        "reason": reason,
+        "source_provenance": f"cli:review:{today}",
+    }
+    event_id = _write_event(
+        client,
+        event_type="consolidation_rejected",
+        severity="info",
+        title=f"Consolidation rejected via CLI — {result.get('decision')}",
+        payload=event_payload,
+    )
+
+    out = {
+        "status": "rejected",
+        "decision": result.get("decision"),
+        "queue_id": queue_id,
+        "reason": reason,
+        "event_id": event_id,
+    }
+    if as_json:
+        print(json.dumps(out, indent=2, default=str))
+    else:
+        print(f"Rejected queue entry {queue_id}")
+        print(f"  decision: {result.get('decision')}")
+        print(f"  reason:   {reason or '(none)'}")
+        print(f"  event_id: {event_id}")
+    return 0
+
+
+def show_diff(client, queue_id: str, *, as_json: bool) -> int:
+    row = _fetch_queue_row(client, queue_id)
+    if not row:
+        print(f"Queue entry {queue_id} not found", file=sys.stderr)
+        if as_json:
+            print(json.dumps({"status": "not_found", "queue_id": queue_id}))
+        return 1
+
+    payload = row.get("consolidation_payload") or {}
+    member_ids = list(payload.get("member_ids") or [])
+    members = _fetch_members(client, member_ids)
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "queue_id": queue_id,
+                    "decision": row["decision"],
+                    "confidence": float(row["confidence"]),
+                    "status": row["status"],
+                    "reasoning": row.get("reasoning"),
+                    "canonical_project": payload.get("canonical_project"),
+                    "canonical_name": payload.get("canonical_name"),
+                    "canonical_type": payload.get("canonical_type"),
+                    "canonical_description": payload.get("canonical_description"),
+                    "canonical_content": payload.get("canonical_content"),
+                    "canonical_tags": payload.get("canonical_tags") or [],
+                    "members": members,
+                },
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        print(render_diff(row, members))
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("queue_id", nargs="?", help="memory_review_queue.id to operate on")
+    p.add_argument("--list", action="store_true", help="List pending MERGE/SUPERSEDE rows")
+    p.add_argument("--limit", type=int, default=20, help="Rows shown by --list (default 20)")
+    p.add_argument("--diff", action="store_true", help="Show canonical vs members for queue_id")
+    p.add_argument("--approve", action="store_true", help="Approve queue_id (applies the plan)")
+    p.add_argument("--reject", action="store_true", help="Reject queue_id (blocks re-planning)")
+    p.add_argument("--reason", help="Optional reason text (used with --reject)")
+    p.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    args = p.parse_args()
+
+    sb_url = os.environ.get("SUPABASE_URL")
+    sb_key = os.environ.get("SUPABASE_KEY")
+    if not sb_url or not sb_key:
+        print("SUPABASE_URL / SUPABASE_KEY missing from env", file=sys.stderr)
+        return 2
+
+    client = create_client(sb_url, sb_key)
+
+    action_flags = [args.list, args.diff, args.approve, args.reject]
+    if sum(1 for f in action_flags if f) > 1:
+        p.error("pick exactly one of --list / --diff / --approve / --reject")
+
+    if args.list:
+        rows = list_pending(client, args.limit)
+        if args.json:
+            print(json.dumps(rows, indent=2, default=str))
+        else:
+            print_listing(rows)
+        return 0
+
+    if not args.queue_id:
+        p.print_usage(sys.stderr)
+        print("error: queue_id required unless --list is passed", file=sys.stderr)
+        return 2
+
+    if args.diff:
+        return show_diff(client, args.queue_id, as_json=args.json)
+    if args.approve:
+        return approve(client, args.queue_id, as_json=args.json)
+    if args.reject:
+        return reject(client, args.queue_id, reason=args.reason, as_json=args.json)
+
+    # No action flag — default to --diff for bare queue_id.
+    return show_diff(client, args.queue_id, as_json=args.json)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
CLI companion to `consolidation-rollback.py` for working through pending queue rows without SQL. Adds two single-transaction RPCs (`approve_consolidation`, `reject_consolidation`) and a thin Python script that lists / diffs / approves / rejects `memory_review_queue` rows left in `status='pending'` by the weekly `--apply` run.

## Why
Phase 5.1b-β merged with a confidence gate at 0.85 (#222). Below-threshold plans land in the queue but there was no first-class way to review them short of hand-crafting SQL. This closes the last gap of the 5.1d sprint (milestone #22).

Closes #226

## Decisions & Alternatives
- **Two new RPCs instead of Python-side orchestration.** Approve needs SELECT FOR UPDATE + validate status + apply plan + update queue row to be one transaction. Doing it from Python would race (two concurrent CLIs could both pass the `select status='pending'` check and both call apply, producing two canonicals). Rejected.
- **`source_provenance` = `cli:review:<YYYY-MM-DD>`** on approved canonicals — audit traces can distinguish CLI-approved from `auto_applied` without grepping event history.
- **Embed backfill stays in Python.** VoyageAI access lives on the client. The RPC writes `embedding=NULL`; lifecycle filter already hides the canonical from recall until the 1–2 s it takes Python to POST to Voyage and update. Same contract as `consolidation-merge-plan.py --apply`.
- **Helper duplication.** `_canonical_embed_text` + `embed_document` are copied from `consolidation-merge-plan.py` rather than extracted to a shared module. Issue explicitly said "if churn is bounded, leave duplication" — both files already mirror `server.py` byte-for-byte, extracting would expand the diff without real benefit. Noted in a code comment; can refactor later.
- **`reject` blocks re-planning forever.** `find_consolidation_clusters` dedup excludes `rolled_back` (eligible for re-consideration) but includes `rejected` (owner said no, don't ask again). Reason text is appended to `reasoning` so `--list` surfaces why.

## Risk Assessment
- **MEDIUM**: new RPCs that mutate `memories` + `memory_review_queue` in one transaction. Classical failure mode (half-applied state) doesn't apply — the RPC is one plpgsql function, either the whole thing commits or rolls back. Concurrent approves serialize on FOR UPDATE. Reviewed during implementation.
- **LOW**: CLI is read-heavy; only `--approve` / `--reject` mutate, and both refuse on non-pending rows with a clear message.

## Testing
Migrations applied live (`phase_5_1d_beta_approve_reject_consolidation`).

End-to-end smoke test on pending row `225531c1-1d69-4d5c-b2ae-59bd261d407a` (MERGE, 3 zigzag-related members, confidence 0.85):
- `--list`: row shown with Haiku reasoning one-liner
- `--diff`: canonical body + all 3 member bodies printed top-down
- `--approve --json`: `{status: approved, decision: MERGE, canonical_id: 784d1f2f..., superseded_count: 3, embedded: true, event_id: b78875f6...}`
- Post-approve DB check: `status=approved`, `reviewed_by=cli_review`, `target_id` points at canonical, `source_provenance=cli:review:2026-04-19`, `embedding_model=voyage-3-lite`, `superseded_members=3`, `consolidates_links=3`, `events_logged=1` — all correct.
- Second `--approve` on the same row refuses: `status=approved (expected pending)`.
- `--reject` on the same row also refuses.

Separate smoke test for `--reject` on a synthetic pending row: `status=rejected`, reasoning appended with `-- rejected: smoke-test: not real`, event logged.

Lint + format pass (`ruff check`, `ruff format`).

## Files Changed
- `mcp-memory/schema.sql` — `approve_consolidation`, `reject_consolidation` plpgsql functions
- `scripts/consolidation-review.py` — CLI with `--list`/`--diff`/`--approve`/`--reject`/`--reason`/`--json`/`--limit`