### PR TITLE
fix(autonomous-loop): add source_provenance to all memory_store examples

### DIFF
--- a/.claude/skills/autonomous-loop/SKILL.md
+++ b/.claude/skills/autonomous-loop/SKILL.md
@@ -74,7 +74,7 @@ Generate candidates:
 
 **Write-action permissions (enforced here):**
 - Repos under `Osasuwu/*` → all Low/Medium actions execute normally.
-- Repos under any other owner (e.g. `SergazyNarynov/redrobot`) → **flag-only**: record the finding in memory (`type=project, name=hygiene_sweep_proposals_<repo>_<date>`) and surface it in the output, but never execute the action. Owner acts manually or flips the repo to an owned org.
+- Repos under any other owner (e.g. `SergazyNarynov/redrobot`) → **flag-only**: record the finding in memory (`type=project, name=hygiene_sweep_proposals_<repo>_<date>, source_provenance="skill:autonomous-loop"`) and surface it in the output, but never execute the action. Owner acts manually or flips the repo to an owned org.
 
 **Dedup per-finding:** before closing a milestone / creating a retroactive one, check `outcome_list(task_type='autonomous', pattern_tags=['hygiene'])` for matching description from last 3 days. Skip if same finding already actioned.
 
@@ -129,12 +129,12 @@ Execute each independently:
 - Create GitHub issue: `gh issue create --repo <R> --title "..." --body "..."`
   - **Epics** (`--label epic`) MUST use the `.github/ISSUE_TEMPLATE/epic.yml` structure: body requires `### Children` heading with `- [ ]` checkbox items, else `Issue Checks` CI fails. No `Parent: #NNN` — epics use milestones, not parent links.
   - **Tasks/bugs**: link parent via GitHub sub-issue relationship or `Parent: #NNN` at top of body.
-- Memory operations: `memory_store(...)`, `goal_update(...)`
+- Memory operations: `memory_store(..., source_provenance="skill:autonomous-loop")`, `goal_update(...)`
 - Tag or label work: `gh issue edit`, `gh pr edit`
 - Triage events: `events_mark_processed(...)`
-- Memory consolidation: run `find_consolidation_clusters()` via `execute_sql`, for each cluster: read all memories, merge content into one authoritative memory via `memory_store`, archive originals via `archive_memories(ids)`
+- Memory consolidation: run `find_consolidation_clusters()` via `execute_sql`, for each cluster: read all memories, merge content into one authoritative memory via `memory_store(..., source_provenance="skill:autonomous-loop")`, archive originals via `archive_memories(ids)`
 - **Hygiene: close orphan milestone** (only on `Osasuwu/*` repos): `gh api repos/<R>/milestones/<N> -X PATCH -F state=closed` — for each milestone with `state=open && open_issues==0`.
-- **Hygiene: flag epic missing Children heading**: record proposal via `memory_store(type="project", name="hygiene_epic_<N>_needs_children", ...)`. Don't auto-rewrite bodies.
+- **Hygiene: flag epic missing Children heading**: record proposal via `memory_store(type="project", name="hygiene_epic_<N>_needs_children", ..., source_provenance="skill:autonomous-loop")`. Don't auto-rewrite bodies.
 
 ### Medium-risk (at most 1)
 Execute after Low-risk batch completes:
@@ -146,7 +146,7 @@ Execute after Low-risk batch completes:
 
 ### High-risk (proposals only)
 Never execute — save to memory:
-- Record: `memory_store(type="project", name="autonomous_proposals", ...)`
+- Record: `memory_store(type="project", name="autonomous_proposals", ..., source_provenance="skill:autonomous-loop")`
 - Output proposal text to user
 
 ## Step 7 — Record Outcomes


### PR DESCRIPTION
## Summary

- All `memory_store(...)` shorthand examples in `autonomous-loop/SKILL.md` now explicitly show `source_provenance="skill:autonomous-loop"`
- Covers: inline memory ops, memory consolidation, hygiene flag-only proposals, high-risk proposal recording, and the Step 2a flag-only description
- The dedup-marker code block at Step 7 already had `source_provenance` — this PR makes all other call sites consistent

## Root cause (for context)

Phase 2c (#198) added `source_provenance NOT NULL` to the memories table and validation in `server.py`. The server also shows the right Phase 2c readable error when provenance is missing. However:

1. The MCP server process is loaded at Claude Code startup — if started before Phase 2c was committed, it runs stale code and leaks the Postgres `NOT NULL` violation instead of the readable boundary error
2. The inline SKILL.md shorthands used `...` notation that didn't make `source_provenance` visible, so the autonomous loop omitted it

## Activation

After merging, **restart Claude Code** to reload the MCP server with the Phase 2c code. The validation boundary error (not Postgres) will then guide any remaining callers that still miss the parameter.

## Test plan

- [ ] After Claude Code restart, run autonomous loop manually — verify `memory_store` calls succeed (dedup marker written) or return the Phase 2c readable error (not the Postgres one)
- [ ] Verify `autonomous_loop_last_run` memory updates correctly on next run

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)