### PR TITLE
feat(memory): confidence multiplier in retrieval scoring (#240)

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -231,6 +231,7 @@ TEMPORAL_HALF_LIVES = {
 DEFAULT_HALF_LIFE = 30
 ACCESS_BOOST_MAX = 0.3
 ACCESS_HALF_LIFE = 14
+CONFIDENCE_FLOOR = 0.5  # Multiplier floor: score * (floor + (1-floor) * confidence)
 LINK_SIM_THRESHOLD = 0.60
 # Phase 2b: classifier replaces the bare similarity gate. We still keep a
 # threshold, but it now decides *when to ask the classifier*, not whether to
@@ -1728,7 +1729,14 @@ def _apply_temporal_scoring(rows: list[dict]) -> list[dict]:
         # Access frequency boost (1..1+ACCESS_BOOST_MAX)
         access = 1.0 + ACCESS_BOOST_MAX * math.exp(-0.693 * days_since_access / ACCESS_HALF_LIFE)
 
-        row["_temporal_score"] = rrf * recency * access
+        # Confidence multiplier: NULL treated as 1.0, else floor + (1-floor) * confidence
+        confidence = row.get("confidence")
+        if confidence is None:
+            confidence_mult = 1.0
+        else:
+            confidence_mult = CONFIDENCE_FLOOR + (1.0 - CONFIDENCE_FLOOR) * confidence
+
+        row["_temporal_score"] = rrf * recency * access * confidence_mult
 
     rows.sort(key=lambda r: r.get("_temporal_score", 0), reverse=True)
     return rows

--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -56,6 +56,7 @@ TEMPORAL_HALF_LIVES = {
 DEFAULT_HALF_LIFE = 30
 ACCESS_BOOST_MAX = 0.3
 ACCESS_HALF_LIFE = 14
+CONFIDENCE_FLOOR = 0.5  # Multiplier floor: score * (floor + (1-floor) * confidence)
 
 VOYAGE_URL = "https://api.voyageai.com/v1/embeddings"
 VOYAGE_MODEL = "voyage-3-lite"
@@ -270,7 +271,15 @@ def _apply_temporal_scoring(rows: list[dict]) -> list[dict]:
 
         recency = math.exp(-0.693 * days_since_update / half_life)
         access = 1.0 + ACCESS_BOOST_MAX * math.exp(-0.693 * days_since_access / ACCESS_HALF_LIFE)
-        row["_temporal_score"] = rrf * recency * access
+
+        # Confidence multiplier: NULL treated as 1.0, else floor + (1-floor) * confidence
+        confidence = row.get("confidence")
+        if confidence is None:
+            confidence_mult = 1.0
+        else:
+            confidence_mult = CONFIDENCE_FLOOR + (1.0 - CONFIDENCE_FLOOR) * confidence
+
+        row["_temporal_score"] = rrf * recency * access * confidence_mult
 
     rows.sort(key=lambda r: r.get("_temporal_score", 0), reverse=True)
     return rows

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -251,6 +251,42 @@ class TestTemporalScoring:
         scores = [r["_temporal_score"] for r in result]
         assert scores == sorted(scores, reverse=True)
 
+    def test_confidence_multiplier(self):
+        """Confidence gates ranking: score * (0.5 + 0.5 * confidence)."""
+        # Use exact same timestamp to ensure only confidence differs
+        now = datetime.now(timezone.utc)
+        updated = (now - timedelta(days=5)).isoformat()
+        high_conf = {
+            "type": "decision",
+            "updated_at": updated,
+            "last_accessed_at": None,
+            "_rrf_score": 0.5,
+            "confidence": 1.0,
+        }
+        low_conf = {
+            "type": "decision",
+            "updated_at": updated,
+            "last_accessed_at": None,
+            "_rrf_score": 0.5,
+            "confidence": 0.5,
+        }
+        result = _apply_temporal_scoring([low_conf, high_conf])
+        # Result is sorted descending: high_conf should be first (higher score)
+        assert result[0]["confidence"] == 1.0
+        assert result[1]["confidence"] == 0.5
+        # Expected score ratio: high=score*1.0, low=score*0.75 → ratio 1.0/0.75≈1.333
+        ratio = result[0]["_temporal_score"] / result[1]["_temporal_score"]
+        assert abs(ratio - (1.0 / 0.75)) < 1e-2
+
+    def test_confidence_null_defaults_to_1(self):
+        """NULL confidence → 1.0 (legacy memories don't regress)."""
+        no_conf = self._make_row(days_ago=5, rrf=0.5)
+        # no_conf doesn't set "confidence", so it's None
+        assert no_conf.get("confidence") is None
+        result = _apply_temporal_scoring([no_conf])
+        # Score should NOT be gated by confidence multiplier
+        assert result[0]["_temporal_score"] > 0
+
 
 # ---------------------------------------------------------------------------
 # _format_memories


### PR DESCRIPTION
## Summary
Fold `memories.confidence` into final retrieval score via `score * (0.5 + 0.5 * confidence)`. NULL confidence treated as 1.0 so legacy memories don't regress. Mirrors the change in `scripts/eval-recall.py` for measurable deltas.

## Why
Phase 0 added the column, Phase 2b's Haiku classifier writes it — but recall ignored it. Research synthesis ([design doc §2c, §2f](docs/design/memory-overhaul.md)) flags this as an ACT-R / Gärdenfors entrenchment-ordering gap.

Closes #240

## Decisions & Alternatives
- **Chose `0.5 + 0.5*conf` (soft floor 0.5)** — confidence=0 still scores at half, not zero. Rejected hard multiply (`score * conf`) as too aggressive: it would bury any memory the classifier marked confidence=0.2.
- `CONFIDENCE_FLOOR = 0.5` exposed as a tunable constant in both server.py and eval-recall.py. If the floor needs retuning later, edit both (eval mirrors server intentionally).

## Risk Assessment
- **MEDIUM**: scoring change in `mcp-memory/server.py`. Eval-gated; baseline diff attached below.

## Testing
- `pytest tests/test_memory_server.py -x -q` → 10 TestTemporalScoring tests pass incl. 2 new
- `python scripts/eval-recall.py --diff baseline`:
  - **recall@5**: 85.0% → **90.0%** (+5.0 pp)
  - **recall@10**: 90.0% → 90.0% (no change)
  - **MRR**: 0.663 → 0.643 (-0.020)
  - **must_not violations**: 0 → 0 (maintained)
  - Net: net-positive on recall@5 with neutral must_not, small MRR dip (low-confidence items drop in rank, which is the point).
- Baseline NOT refreshed — leave that to owner after review.

## Files Changed
- `mcp-memory/server.py` — `CONFIDENCE_FLOOR` constant + `_apply_temporal_scoring` folds confidence
- `scripts/eval-recall.py` — mirror constant + same scoring in the duplicated pipeline
- `tests/test_memory_server.py` — `test_confidence_multiplier` + `test_confidence_null_defaults_to_1`