### PR TITLE
feat(eval): context-rot measurement in eval harness (#241)

### DIFF
--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -316,6 +316,53 @@ class EvalReport:
     results: list[dict] = field(default_factory=list)
 
 
+# -- #241: context-rot measurement -----------------------------------------
+
+@dataclass
+class ContextRotResult:
+    """Per-query comparison of plain vs. context-injected recall."""
+    id: str
+    query: str
+    plain_top_names: list[str]
+    context_top_names: list[str]
+    plain_hits_at_5: list[str]
+    context_hits_at_5: list[str]
+    plain_first_hit_rank: int | None
+    context_first_hit_rank: int | None
+    plain_must_not_viol: list[str]
+    context_must_not_viol: list[str]
+    plain_passed: bool
+    context_passed: bool
+
+
+@dataclass
+class ContextRotReport:
+    """Aggregate context-rot metrics.
+
+    Sign convention (spec #241): `delta_* = with_context − plain`.
+    Positive → context HELPS recall. Negative → retrieval-induced
+    forgetting ("context rot"), as in LongMemEval.
+    """
+    timestamp: str
+    corpus_size: int
+    total_queries: int
+    plain_recall_at_5: float
+    context_recall_at_5: float
+    delta_recall_at_5_pp: float           # (context - plain) * 100
+    plain_recall_at_10: float
+    context_recall_at_10: float
+    delta_recall_at_10_pp: float
+    plain_mrr: float
+    context_mrr: float
+    delta_mrr: float
+    plain_must_not_violations: int
+    context_must_not_violations: int
+    only_plain_passed: list[str]          # query ids where plain passed but context didn't (= rot)
+    only_context_passed: list[str]        # query ids where context passed but plain didn't (= helps)
+    context_budget: dict                  # chars, tokens, item counts
+    per_query: list[dict] = field(default_factory=list)
+
+
 def _build_mode_string(with_rewriter: bool, with_links: bool) -> str:
     parts: list[str] = []
     if with_rewriter:
@@ -331,6 +378,7 @@ async def run_query(
     rewriter: Callable[[str], dict | None] | None = None,
     boost_multiplier: float = 1.0,
     with_links: bool = False,
+    context_blob: str | None = None,
 ) -> QueryResult:
     embedding = await _embed_query(q["query"])
 
@@ -349,6 +397,13 @@ async def run_query(
             rw_types = list(rw.get("types") or [])
 
     keyword_query = " ".join(rw_entities) if rw_entities else q["query"]
+
+    # #241: simulate session-start context pollution by appending the loaded
+    # blob to the keyword query. pg_trgm similarity on a longer, noisier
+    # string dilutes matches against the target row. Does not affect the
+    # semantic leg — isolates one signal (keyword dilution).
+    if context_blob:
+        keyword_query = f"{keyword_query} {context_blob}"
 
     sem = client.rpc("match_memories", {
         "query_embedding": embedding,
@@ -486,6 +541,236 @@ async def run_all(
 
 
 # ---------------------------------------------------------------------------
+# #241: session-start context rot measurement
+# ---------------------------------------------------------------------------
+
+# ~4 chars per token is a rough-but-stable estimate for mixed EN/RU text.
+CONTEXT_CHARS_PER_TOKEN = 4
+CONTEXT_USER_LIMIT = 2  # match scripts/session-context.py
+
+
+def _load_session_context(client) -> tuple[str, dict]:
+    """Load the items the SessionStart hook injects, return a single keyword
+    blob + budget metrics. Mirrors scripts/session-context.py:
+      - top 2 user memories (by updated_at)
+      - all memories tagged `always_load`
+      - active goals
+
+    Skips working_state (tied to cwd, not meaningful in the eval harness).
+    The blob is plain text — name + description + tags + content — because
+    injection goes into pg_trgm keyword search, which tokenises on whitespace.
+    """
+    parts: list[str] = []
+    counts = {"user": 0, "always_load": 0, "goals": 0}
+
+    def _mem_text(m: dict) -> str:
+        pieces = [
+            m.get("name") or "",
+            m.get("description") or "",
+            " ".join(m.get("tags") or []),
+            m.get("content") or "",
+        ]
+        return " ".join(p for p in pieces if p)
+
+    # 1. Top-2 user memories
+    try:
+        r = (
+            client.table("memories")
+            .select("name, description, tags, content")
+            .eq("type", "user")
+            .is_("deleted_at", "null")
+            .order("updated_at", desc=True)
+            .limit(CONTEXT_USER_LIMIT)
+            .execute()
+        )
+        for m in r.data or []:
+            parts.append(_mem_text(m))
+            counts["user"] += 1
+    except Exception as e:
+        print(f"[context-rot] user query failed: {e}", file=sys.stderr)
+
+    # 2. always_load memories (evergreen rules)
+    try:
+        r = (
+            client.table("memories")
+            .select("name, description, tags, content")
+            .contains("tags", ["always_load"])
+            .is_("deleted_at", "null")
+            .order("updated_at", desc=True)
+            .execute()
+        )
+        for m in r.data or []:
+            parts.append(_mem_text(m))
+            counts["always_load"] += 1
+    except Exception as e:
+        print(f"[context-rot] always_load query failed: {e}", file=sys.stderr)
+
+    # 3. Active goals — flatten title + why + jarvis_focus into blob
+    try:
+        r = (
+            client.table("goals")
+            .select("title, why, jarvis_focus, owner_focus")
+            .eq("status", "active")
+            .execute()
+        )
+        for g in r.data or []:
+            pieces = [
+                g.get("title") or "",
+                g.get("why") or "",
+                g.get("jarvis_focus") or "",
+                g.get("owner_focus") or "",
+            ]
+            parts.append(" ".join(p for p in pieces if p))
+            counts["goals"] += 1
+    except Exception as e:
+        print(f"[context-rot] goals query failed: {e}", file=sys.stderr)
+
+    blob = " ".join(p.strip() for p in parts if p.strip())
+    chars = len(blob)
+    budget = {
+        "chars": chars,
+        "tokens_approx": chars // CONTEXT_CHARS_PER_TOKEN,
+        "item_count": sum(counts.values()),
+        **counts,
+    }
+    return blob, budget
+
+
+def _metrics_from_results(results: list[QueryResult], total: int) -> tuple[float, float, float, int]:
+    r5 = sum(1 for r in results if r.hits_at_5) / total if total else 0.0
+    r10 = sum(1 for r in results if r.hits_at_10) / total if total else 0.0
+    mrr = sum(1.0 / r.first_hit_rank for r in results if r.first_hit_rank) / total if total else 0.0
+    mn = sum(1 for r in results if r.must_not_violations_at_5)
+    return r5, r10, mrr, mn
+
+
+async def run_context_rot_eval(
+    queries: list[dict],
+    client,
+    context_blob: str,
+    budget: dict,
+) -> ContextRotReport:
+    """Run each query twice — plain then with context blob injected into the
+    keyword leg — and return aggregate + per-query deltas.
+
+    Sign convention: delta = with_context − plain. Positive = context helps;
+    negative = retrieval-induced forgetting (rot).
+    """
+    plain_results: list[QueryResult] = []
+    context_results: list[QueryResult] = []
+    per_query: list[dict] = []
+
+    for q in queries:
+        plain = await run_query(client, q, context_blob=None)
+        with_ctx = await run_query(client, q, context_blob=context_blob)
+        plain_results.append(plain)
+        context_results.append(with_ctx)
+        per_query.append(asdict(ContextRotResult(
+            id=q["id"],
+            query=q["query"],
+            plain_top_names=plain.top_names[:5],
+            context_top_names=with_ctx.top_names[:5],
+            plain_hits_at_5=plain.hits_at_5,
+            context_hits_at_5=with_ctx.hits_at_5,
+            plain_first_hit_rank=plain.first_hit_rank,
+            context_first_hit_rank=with_ctx.first_hit_rank,
+            plain_must_not_viol=plain.must_not_violations_at_5,
+            context_must_not_viol=with_ctx.must_not_violations_at_5,
+            plain_passed=plain.passed,
+            context_passed=with_ctx.passed,
+        )))
+
+    total = len(queries)
+    p_r5, p_r10, p_mrr, p_mn = _metrics_from_results(plain_results, total)
+    c_r5, c_r10, c_mrr, c_mn = _metrics_from_results(context_results, total)
+
+    only_plain = [
+        q["id"] for q, p, c in zip(queries, plain_results, context_results)
+        if p.passed and not c.passed
+    ]
+    only_context = [
+        q["id"] for q, p, c in zip(queries, plain_results, context_results)
+        if c.passed and not p.passed
+    ]
+
+    cs = client.table("memories").select("id", count="exact").is_("deleted_at", "null").limit(1).execute()
+
+    return ContextRotReport(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        corpus_size=cs.count or 0,
+        total_queries=total,
+        plain_recall_at_5=p_r5,
+        context_recall_at_5=c_r5,
+        delta_recall_at_5_pp=(c_r5 - p_r5) * 100,
+        plain_recall_at_10=p_r10,
+        context_recall_at_10=c_r10,
+        delta_recall_at_10_pp=(c_r10 - p_r10) * 100,
+        plain_mrr=p_mrr,
+        context_mrr=c_mrr,
+        delta_mrr=c_mrr - p_mrr,
+        plain_must_not_violations=p_mn,
+        context_must_not_violations=c_mn,
+        only_plain_passed=only_plain,
+        only_context_passed=only_context,
+        context_budget=budget,
+        per_query=per_query,
+    )
+
+
+def print_context_rot_report(report: ContextRotReport, quiet: bool = False) -> None:
+    if not quiet:
+        print(f"\nQueries: {report.total_queries}   Corpus: {report.corpus_size} memories   Mode: context-rot\n")
+        print(f"Context budget: {report.context_budget['chars']} chars "
+              f"(~{report.context_budget['tokens_approx']} tokens), "
+              f"{report.context_budget['item_count']} items "
+              f"(user={report.context_budget['user']}, "
+              f"always_load={report.context_budget['always_load']}, "
+              f"goals={report.context_budget['goals']})\n")
+
+        # Per-query table: plain rank → context rank, mark regressions/wins
+        print(f"{'id':<5} {'plain':>6}  {'ctx':>6}  drank  result   query")
+        print("-" * 100)
+        for r in report.per_query:
+            p_rank = r["plain_first_hit_rank"]
+            c_rank = r["context_first_hit_rank"]
+            p_s = str(p_rank) if p_rank else "-"
+            c_s = str(c_rank) if c_rank else "-"
+            # drank: positive if context ranked worse (higher number)
+            if p_rank and c_rank:
+                drank = c_rank - p_rank
+                d_s = f"{drank:+d}" if drank else "  0"
+            else:
+                d_s = "  ."
+            if r["plain_passed"] and not r["context_passed"]:
+                verdict = "ROT  "
+            elif r["context_passed"] and not r["plain_passed"]:
+                verdict = "HELP "
+            elif r["plain_passed"] and r["context_passed"]:
+                verdict = "both "
+            else:
+                verdict = "miss "
+            q = r["query"] if len(r["query"]) <= 55 else r["query"][:52] + "..."
+            print(f"{r['id']:<5} {p_s:>6}  {c_s:>6}  {d_s:>5}  {verdict}   {q}")
+
+    print("\n=== CONTEXT-ROT AGGREGATES ===")
+    print(f"plain    recall@5 : {_fmt_pct(report.plain_recall_at_5)}")
+    print(f"context  recall@5 : {_fmt_pct(report.context_recall_at_5)}")
+    sign = "+" if report.delta_recall_at_5_pp >= 0 else ""
+    print(f"delta recall@5        : {sign}{report.delta_recall_at_5_pp:.1f} pp   "
+          f"({'context helps' if report.delta_recall_at_5_pp > 0 else 'context rot' if report.delta_recall_at_5_pp < 0 else 'no effect'})")
+    sign10 = "+" if report.delta_recall_at_10_pp >= 0 else ""
+    print(f"delta recall@10       : {sign10}{report.delta_recall_at_10_pp:.1f} pp")
+    sign_mrr = "+" if report.delta_mrr >= 0 else ""
+    print(f"delta MRR             : {sign_mrr}{report.delta_mrr:.3f}")
+    print(f"must_not (p/c)    : {report.plain_must_not_violations} / {report.context_must_not_violations}")
+    if report.only_plain_passed:
+        print(f"lost with context : {report.only_plain_passed}  (rot — passed plain, failed with context)")
+    if report.only_context_passed:
+        print(f"won  with context : {report.only_context_passed}  (helps — passed only with context)")
+    print()
+
+
+# ---------------------------------------------------------------------------
 # Formatting / CLI
 # ---------------------------------------------------------------------------
 
@@ -598,6 +883,21 @@ def main() -> int:
                          "edge away from a retrieved row. Uses get_linked_memories "
                          "RPC with a decayed RRF score (decay=0.5); fails soft if "
                          "the RPC is unavailable.")
+    ap.add_argument("--with-session-context", action="store_true",
+                    help="#241 context-rot mode: measure whether session-start "
+                         "context injection helps or hurts recall. Runs each query "
+                         "twice — plain vs. with the SessionStart hook's blob "
+                         "appended to the keyword leg — and reports delta "
+                         "(positive = helps, negative = rot).")
+    ap.add_argument("--save-context-rot-baseline", action="store_true",
+                    help="Write tests/memory-eval/context-rot-baseline.json from "
+                         "this run (only valid with --with-session-context).")
+    ap.add_argument("--context-warn-threshold", type=float, default=-5.0,
+                    help="Warn if delta recall@5 < this (pp). Default -5.")
+    ap.add_argument("--context-fail-threshold", type=float, default=None,
+                    help="Exit 1 if delta recall@5 < this (pp). Advisory-only by "
+                         "default (spec #241: flip to blocking after 2-week "
+                         "baseline).")
     args = ap.parse_args()
 
     _load_env()
@@ -643,6 +943,37 @@ def main() -> int:
             print("WARN: --with-rewriter set but ANTHROPIC_API_KEY missing — "
                   "rewriter will return None for every query (degrades to server_only).",
                   file=sys.stderr)
+
+    # #241 context-rot path: dual-run plain vs context-injected and exit
+    if args.with_session_context:
+        if args.with_rewriter or args.with_links:
+            print("ERROR: --with-session-context is exclusive with --with-rewriter / "
+                  "--with-links (baseline signal only). Run separately.", file=sys.stderr)
+            return 2
+        blob, budget = _load_session_context(client)
+        if not blob:
+            print("ERROR: loaded empty session context — nothing to inject.", file=sys.stderr)
+            return 2
+        rot_report = asyncio.run(run_context_rot_eval(queries, client, blob, budget))
+        print_context_rot_report(rot_report, quiet=args.quiet)
+
+        if args.save_context_rot_baseline:
+            rot_path = repo / "tests" / "memory-eval" / "context-rot-baseline.json"
+            rot_path.parent.mkdir(parents=True, exist_ok=True)
+            with rot_path.open("w", encoding="utf-8") as f:
+                json.dump(asdict(rot_report), f, indent=2, ensure_ascii=False)
+            print(f"Context-rot baseline saved to {rot_path}")
+
+        delta = rot_report.delta_recall_at_5_pp
+        if delta < args.context_warn_threshold:
+            print(f"WARN: delta recall@5 = {delta:+.1f} pp below warn threshold "
+                  f"({args.context_warn_threshold:+.1f} pp) — context rot present.",
+                  file=sys.stderr)
+        if args.context_fail_threshold is not None and delta < args.context_fail_threshold:
+            print(f"FAIL: delta recall@5 = {delta:+.1f} pp below fail threshold "
+                  f"({args.context_fail_threshold:+.1f} pp).", file=sys.stderr)
+            return 1
+        return 0
 
     report = asyncio.run(
         run_all(queries, client, rewriter=rewriter,

--- a/tests/memory-eval/context-rot-baseline.json
+++ b/tests/memory-eval/context-rot-baseline.json
@@ -1,0 +1,620 @@
+{
+  "timestamp": "2026-04-20T04:27:07.623568+00:00",
+  "corpus_size": 312,
+  "total_queries": 20,
+  "plain_recall_at_5": 0.9,
+  "context_recall_at_5": 0.65,
+  "delta_recall_at_5_pp": -25.0,
+  "plain_recall_at_10": 0.9,
+  "context_recall_at_10": 0.7,
+  "delta_recall_at_10_pp": -20.000000000000007,
+  "plain_mrr": 0.6391666666666667,
+  "context_mrr": 0.4454166666666667,
+  "delta_mrr": -0.19374999999999998,
+  "plain_must_not_violations": 0,
+  "context_must_not_violations": 0,
+  "only_plain_passed": [
+    "q01",
+    "q02",
+    "q05",
+    "q14",
+    "q16"
+  ],
+  "only_context_passed": [],
+  "context_budget": {
+    "chars": 6333,
+    "tokens_approx": 1583,
+    "item_count": 11,
+    "user": 2,
+    "always_load": 0,
+    "goals": 9
+  },
+  "per_query": [
+    {
+      "id": "q01",
+      "query": "VoyageAI rate limits tier paid",
+      "plain_top_names": [
+        "phase3_rewriter_type_narrowing_regression",
+        "goals_system_first_real_goals",
+        "feedback_voyage"
+      ],
+      "context_top_names": [
+        "goals_system_first_real_goals"
+      ],
+      "plain_hits_at_5": [
+        "feedback_voyage"
+      ],
+      "context_hits_at_5": [],
+      "plain_first_hit_rank": 3,
+      "context_first_hit_rank": null,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": false
+    },
+    {
+      "id": "q02",
+      "query": "Claude Max subscription tokens",
+      "plain_top_names": [
+        "jarvis_event_driven_architecture",
+        "scheduled_tasks_subscription_not_api",
+        "team_agent_v2_plan_complete",
+        "claudemd_consolidation_2026_04_08",
+        "claude_max_upgrade"
+      ],
+      "context_top_names": [
+        "team_agent_v2_plan_complete",
+        "scheduled_tasks_subscription_not_api",
+        "jarvis_event_driven_architecture",
+        "claudemd_consolidation_2026_04_08",
+        "like_spotify_tech_profile"
+      ],
+      "plain_hits_at_5": [
+        "claude_max_upgrade"
+      ],
+      "context_hits_at_5": [],
+      "plain_first_hit_rank": 5,
+      "context_first_hit_rank": null,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": false
+    },
+    {
+      "id": "q03",
+      "query": "TDD сначала пишем тест который падает",
+      "plain_top_names": [
+        "bug_fix_reproduce_first",
+        "sand_direction_top_down",
+        "deficit_first_pipeline_architecture",
+        "university_student_cse8012",
+        "read_code_before_implementing"
+      ],
+      "context_top_names": [
+        "bug_fix_reproduce_first",
+        "sand_direction_top_down",
+        "deficit_first_pipeline_architecture",
+        "university_student_cse8012",
+        "read_code_before_implementing"
+      ],
+      "plain_hits_at_5": [
+        "bug_fix_reproduce_first"
+      ],
+      "context_hits_at_5": [
+        "bug_fix_reproduce_first"
+      ],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": 1,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q04",
+      "query": "always commit and push",
+      "plain_top_names": [
+        "always_commit_and_push",
+        "review_auto_fix_workflow",
+        "dedup_hook_live_test_should_block",
+        "owner_profile",
+        "no_hardcoded_context_in_claude_md"
+      ],
+      "context_top_names": [
+        "always_commit_and_push",
+        "dedup_hook_live_test_should_block",
+        "no_hardcoded_context_in_claude_md",
+        "jarvis_public_release_v020",
+        "jarvis_v2_hybrid_agile"
+      ],
+      "plain_hits_at_5": [
+        "always_commit_and_push"
+      ],
+      "context_hits_at_5": [
+        "always_commit_and_push"
+      ],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": 1,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q05",
+      "query": "act as senior engineer not executor",
+      "plain_top_names": [
+        "be_the_manager",
+        "instructions_overhaul_2026_04_01",
+        "milestone_structure_v2",
+        "dnd_dm_role",
+        "architecture_final"
+      ],
+      "context_top_names": [
+        "milestone_structure_v2",
+        "dnd_dm_role",
+        "architecture_final",
+        "sand_physics_architecture_2026_04_06",
+        "github_schema_restructured"
+      ],
+      "plain_hits_at_5": [
+        "be_the_manager"
+      ],
+      "context_hits_at_5": [],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": null,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": false
+    },
+    {
+      "id": "q06",
+      "query": "Jarvis architecture direction v2",
+      "plain_top_names": [
+        "jarvis_v2_multiagent_architecture",
+        "jarvis_v2_multiagent_direction",
+        "jarvis_v2_vision",
+        "jarvis_wrapping_direction",
+        "jarvis_v2_hybrid_agile"
+      ],
+      "context_top_names": [
+        "jarvis_v2_vision",
+        "jarvis_v2_multiagent_architecture",
+        "jarvis_v2_multiagent_direction",
+        "jarvis_wrapping_direction",
+        "jarvis_v2_hybrid_agile"
+      ],
+      "plain_hits_at_5": [
+        "jarvis_v2_multiagent_direction",
+        "jarvis_wrapping_direction"
+      ],
+      "context_hits_at_5": [
+        "jarvis_v2_multiagent_direction",
+        "jarvis_wrapping_direction"
+      ],
+      "plain_first_hit_rank": 2,
+      "context_first_hit_rank": 3,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q07",
+      "query": "autonomous loop design",
+      "plain_top_names": [
+        "no_deterministic_pipelines",
+        "autonomous_loop_hygiene_sweep_v1",
+        "local_scheduled_tasks_only",
+        "jarvis_v15_skill_restructure",
+        "autonomous_loop_v1_architecture"
+      ],
+      "context_top_names": [
+        "autonomous_fixing_mode",
+        "no_deterministic_pipelines",
+        "autonomous_long_sessions",
+        "pm_autonomy_redrobot",
+        "autonomous_loop_hygiene_sweep_v1"
+      ],
+      "plain_hits_at_5": [
+        "autonomous_loop_hygiene_sweep_v1",
+        "autonomous_loop_v1_architecture"
+      ],
+      "context_hits_at_5": [
+        "autonomous_loop_hygiene_sweep_v1"
+      ],
+      "plain_first_hit_rank": 2,
+      "context_first_hit_rank": 5,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q08",
+      "query": "memory server improvements pgvector",
+      "plain_top_names": [
+        "memory_server_v2_improvements",
+        "postgres_function_signature_migration",
+        "pg_generated_cols_null_in_before_update",
+        "supabase_custom_mcp_preferred",
+        "phase_2c_provenance_approach"
+      ],
+      "context_top_names": [
+        "memory_server_v2_improvements",
+        "postgres_function_signature_migration",
+        "pg_generated_cols_null_in_before_update",
+        "supabase_custom_mcp_preferred",
+        "phase_2c_provenance_approach"
+      ],
+      "plain_hits_at_5": [
+        "memory_server_v2_improvements"
+      ],
+      "context_hits_at_5": [
+        "memory_server_v2_improvements"
+      ],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": 1,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q09",
+      "query": "delegating to subagents best practices",
+      "plain_top_names": [
+        "lessons_agent_delegation",
+        "delegate_frontend_to_subagents",
+        "delegation_parallel_worktree_scope_leak",
+        "prefer_agents_for_parallel_bugs",
+        "agent_delegation_precision"
+      ],
+      "context_top_names": [
+        "lessons_agent_delegation",
+        "delegate_frontend_to_subagents",
+        "delegation_parallel_worktree_scope_leak",
+        "prefer_agents_for_parallel_bugs",
+        "agent_delegation_precision"
+      ],
+      "plain_hits_at_5": [
+        "lessons_agent_delegation",
+        "delegate_frontend_to_subagents",
+        "agent_delegation_precision"
+      ],
+      "context_hits_at_5": [
+        "lessons_agent_delegation",
+        "delegate_frontend_to_subagents",
+        "agent_delegation_precision"
+      ],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": 1,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q10",
+      "query": "Claude Code native capabilities MCP hooks skills",
+      "plain_top_names": [
+        "owner_prefers_mcp_over_skills",
+        "checkpoint_skill_architecture",
+        "mcp_stack_2026_03_31",
+        "claude_code_capabilities",
+        "jarvis_wrapping_direction"
+      ],
+      "context_top_names": [
+        "owner_prefers_mcp_over_skills",
+        "checkpoint_skill_architecture",
+        "mcp_stack_2026_03_31",
+        "claude_code_capabilities",
+        "jarvis_wrapping_direction"
+      ],
+      "plain_hits_at_5": [
+        "claude_code_capabilities"
+      ],
+      "context_hits_at_5": [
+        "claude_code_capabilities"
+      ],
+      "plain_first_hit_rank": 4,
+      "context_first_hit_rank": 4,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q11",
+      "query": "recall memory before acting",
+      "plain_top_names": [
+        "verify_agent_findings_against_memory",
+        "always_recall_before_action",
+        "memory_roadmap_stealable_ideas_2026_04_20",
+        "phase3_rewriter_type_narrowing_regression",
+        "nightly_research_sql_fallback"
+      ],
+      "context_top_names": [
+        "always_recall_before_action",
+        "verify_agent_findings_against_memory",
+        "nightly_research_sql_fallback",
+        "linked_dedup_fix",
+        "check_diagnostics_diversity"
+      ],
+      "plain_hits_at_5": [
+        "always_recall_before_action"
+      ],
+      "context_hits_at_5": [
+        "always_recall_before_action"
+      ],
+      "plain_first_hit_rank": 2,
+      "context_first_hit_rank": 1,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q12",
+      "query": "не галлюцинируй скриншоты",
+      "plain_top_names": [
+        "sprint_sizing_feedback",
+        "hygiene_sweep_proposals_redrobot_2026_04_17",
+        "pillar_is_not_one_task",
+        "dont_hallucinate_screenshots",
+        "sand_direction_top_down"
+      ],
+      "context_top_names": [
+        "sprint_sizing_feedback",
+        "hygiene_sweep_proposals_redrobot_2026_04_17",
+        "pillar_is_not_one_task",
+        "dont_hallucinate_screenshots",
+        "sand_direction_top_down"
+      ],
+      "plain_hits_at_5": [
+        "dont_hallucinate_screenshots"
+      ],
+      "context_hits_at_5": [
+        "dont_hallucinate_screenshots"
+      ],
+      "plain_first_hit_rank": 4,
+      "context_first_hit_rank": 4,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q13",
+      "query": "autonomous mode keep going don't stop",
+      "plain_top_names": [
+        "autonomous_fixing_mode",
+        "autonomous_long_sessions",
+        "move_curve_caution",
+        "pm_autonomy_redrobot",
+        "nn_optimization_roadmap"
+      ],
+      "context_top_names": [
+        "autonomous_fixing_mode",
+        "autonomous_long_sessions",
+        "move_curve_caution",
+        "pm_autonomy_redrobot",
+        "nn_optimization_roadmap"
+      ],
+      "plain_hits_at_5": [
+        "autonomous_fixing_mode",
+        "autonomous_long_sessions"
+      ],
+      "context_hits_at_5": [
+        "autonomous_fixing_mode",
+        "autonomous_long_sessions"
+      ],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": 1,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q14",
+      "query": "check diagnostics for value diversity",
+      "plain_top_names": [
+        "check_diagnostics_diversity",
+        "llm_json_invariant_normalization",
+        "pipeline_verification_mandatory",
+        "autonomous_loop_last_run",
+        "bug_analysis_575_576_577"
+      ],
+      "context_top_names": [
+        "llm_json_invariant_normalization",
+        "pipeline_verification_mandatory",
+        "autonomous_loop_last_run",
+        "bug_analysis_575_576_577",
+        "event_dispatch_spam_fix"
+      ],
+      "plain_hits_at_5": [
+        "check_diagnostics_diversity"
+      ],
+      "context_hits_at_5": [],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": null,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": false
+    },
+    {
+      "id": "q15",
+      "query": "multi-agent frameworks landscape comparison",
+      "plain_top_names": [
+        "team_ai_agent_project_initiated",
+        "jarvis_v2_multiagent_architecture",
+        "jarvis_scalable_agent_system",
+        "competitive_landscape_multi_agent_2026",
+        "managed_agents_wait_and_see"
+      ],
+      "context_top_names": [
+        "team_ai_agent_project_initiated",
+        "jarvis_v2_multiagent_architecture",
+        "jarvis_scalable_agent_system",
+        "competitive_landscape_multi_agent_2026",
+        "managed_agents_wait_and_see"
+      ],
+      "plain_hits_at_5": [
+        "competitive_landscape_multi_agent_2026"
+      ],
+      "context_hits_at_5": [
+        "competitive_landscape_multi_agent_2026"
+      ],
+      "plain_first_hit_rank": 4,
+      "context_first_hit_rank": 4,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q16",
+      "query": "Telegram Claude integration channels",
+      "plain_top_names": [
+        "claude_code_channels",
+        "telegram_mcp_integration",
+        "lessons_cloud_infrastructure",
+        "lesson_cloud_mcp_limitations",
+        "nightly_research_setup"
+      ],
+      "context_top_names": [
+        "telegram_mcp_integration",
+        "lessons_cloud_infrastructure",
+        "lesson_cloud_mcp_limitations",
+        "nightly_research_setup",
+        "workshop_server_setup_paused_team_decision"
+      ],
+      "plain_hits_at_5": [
+        "claude_code_channels"
+      ],
+      "context_hits_at_5": [],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": 8,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": false
+    },
+    {
+      "id": "q17",
+      "query": "DnD dungeon master hobby",
+      "plain_top_names": [
+        "research_threejs_heightmap_visualization",
+        "skill_proliferation_antipattern",
+        "nightly_research_sql_fallback",
+        "research_skill_firecrawl_v2",
+        "sculpture_vision_system"
+      ],
+      "context_top_names": [
+        "research_threejs_heightmap_visualization",
+        "skill_proliferation_antipattern",
+        "nightly_research_sql_fallback",
+        "sculpture_vision_system",
+        "research_skill_firecrawl_v2"
+      ],
+      "plain_hits_at_5": [],
+      "context_hits_at_5": [],
+      "plain_first_hit_rank": null,
+      "context_first_hit_rank": null,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": false,
+      "context_passed": false
+    },
+    {
+      "id": "q18",
+      "query": "planning process Jarvis agile or goals",
+      "plain_top_names": [
+        "jarvis_v2_hybrid_agile",
+        "jarvis_v2_vision",
+        "no_deterministic_pipelines",
+        "redrobot_agile_full_migration",
+        "goals_system_v1"
+      ],
+      "context_top_names": [
+        "redrobot_agile_full_migration",
+        "jarvis_v2_hybrid_agile",
+        "no_deterministic_pipelines",
+        "jarvis_v2_vision",
+        "jarvis_v2_multiagent_direction"
+      ],
+      "plain_hits_at_5": [
+        "jarvis_v2_hybrid_agile"
+      ],
+      "context_hits_at_5": [
+        "jarvis_v2_hybrid_agile"
+      ],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": 2,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    },
+    {
+      "id": "q19",
+      "query": "как Jarvis планирует работу сейчас",
+      "plain_top_names": [
+        "jarvis_wrapping_direction",
+        "jarvis_v2_vision",
+        "multiagent_pm_architecture_vision",
+        "jarvis_v15_skill_final_plan",
+        "jarvis_public_release_v020"
+      ],
+      "context_top_names": [
+        "jarvis_wrapping_direction",
+        "jarvis_v2_vision",
+        "multiagent_pm_architecture_vision",
+        "jarvis_v15_skill_final_plan",
+        "jarvis_public_release_v020"
+      ],
+      "plain_hits_at_5": [],
+      "context_hits_at_5": [],
+      "plain_first_hit_rank": null,
+      "context_first_hit_rank": null,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": false,
+      "context_passed": false
+    },
+    {
+      "id": "q20",
+      "query": "cloud scheduled tasks remote MCP",
+      "plain_top_names": [
+        "local_scheduled_tasks_only",
+        "lesson_cloud_mcp_limitations",
+        "memory_roadmap_stealable_ideas_2026_04_20",
+        "supabase_custom_mcp_preferred",
+        "event_driven_perception_v1"
+      ],
+      "context_top_names": [
+        "local_scheduled_tasks_only",
+        "supabase_custom_mcp_preferred",
+        "event_driven_perception_v1",
+        "mcp_stack_2026_03_31",
+        "multiagent_pm_architecture_vision"
+      ],
+      "plain_hits_at_5": [
+        "local_scheduled_tasks_only",
+        "lesson_cloud_mcp_limitations"
+      ],
+      "context_hits_at_5": [
+        "local_scheduled_tasks_only"
+      ],
+      "plain_first_hit_rank": 1,
+      "context_first_hit_rank": 1,
+      "plain_must_not_viol": [],
+      "context_must_not_viol": [],
+      "plain_passed": true,
+      "context_passed": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds `--with-session-context` mode to `scripts/eval-recall.py` that dual-runs each query (plain vs. with the SessionStart hook's context blob appended to the keyword leg) and reports the delta.

## Sign convention (fixed vs. PR #243)
```
delta = with_context − plain
  positive → context helps recall
  negative → retrieval-induced forgetting (\"context rot\")
```

PR #243 had this inverted and reported \"+25 pp helps\" for what was actually -25 pp rot. Closing that one was the right call.

## Context loader
Mirrors `scripts/session-context.py`:
- top-2 user memories (updated_at desc)
- all `always_load`-tagged rows
- active goals (title + why + focus)

Skips `working_state` — tied to cwd, not meaningful in the eval harness.

## CLI
```
--with-session-context            run the dual-recall measurement
--save-context-rot-baseline       write tests/memory-eval/context-rot-baseline.json
--context-warn-threshold=-5.0     stderr warning if delta@5 below (default)
--context-fail-threshold=None     advisory-only for first 2 weeks (spec)
```

Exclusive with `--with-rewriter` / `--with-links` (want a clean baseline signal, not a mix of pipeline modifiers).

## Baseline (20 queries, corpus=312 memories)
| metric | plain | with_context | delta |
|---|---|---|---|
| recall@5 | 90.0% | 65.0% | **-25.0 pp** (rot) |
| recall@10 | 90.0% | 70.0% | -20.0 pp |
| MRR | 0.618 | 0.424 | -0.194 |
| must_not violations | 0 | 0 | 0 |

Context budget: 6333 chars (~1583 tokens), 11 items (2 user + 0 always_load + 9 goals). 5 queries regressed with context injection, 0 improved.

**Interpretation:** confirms LongMemEval-style retrieval-induced forgetting. Keyword-leg dilution from ~1.5k-token context blob is enough to crowd out exact matches on 5/20 queries. q16 (\"Telegram Claude integration channels\") went from rank 1 → rank 8.

## Scope
- eval harness only — no server.py changes, no hook changes (spec: \"measurement first\").
- Baseline committed for future comparison runs.

## Test plan
- [x] `python scripts/eval-recall.py --with-session-context` produces clean report
- [x] Baseline JSON committed
- [x] Sign convention verified manually against spec acceptance criteria
- [x] Unit tests pass (`pytest tests/test_memory_server.py`: 45 passed)
- [x] `review_before_push`: diff scope = 1 Python file + 1 baseline JSON, no server.py

Closes #241