### PR TITLE
feat(memory): dual-embedding machinery for voyage model migration (#242)

### DIFF
--- a/docs/design/memory-overhaul.md
+++ b/docs/design/memory-overhaul.md
@@ -69,7 +69,7 @@ Items flagged by **both** research streams — strongest evidence, should be in 
 ## 3. Signals only one side flagged — still worth catching
 
 **Production-only:**
-- **Embedding model migration hazard.** Voyage-3-lite → next model = whole corpus becomes incomparable. Store `embedding_model` + `embedding_version`, support dual columns during migration. (Our single biggest unnoticed production risk.)
+- **Embedding model migration hazard.** Voyage-3-lite → next model = whole corpus becomes incomparable. Store `embedding_model` + `embedding_version`, support dual columns during migration. (Our single biggest unnoticed production risk.) **Status (#242):** foundation shipped — `embedding_v2` column + `match_memories_v2` RPC, `EMBEDDING_MODEL_PRIMARY`/`SECONDARY` env vars drive dual-write + read-path selection. Zero behavior change while SECONDARY unset. Corpus backfill + episode_extractor dual-write are separate follow-ups.
 - **Collections vs Profiles split.** Some memories should be overwrite-single-row (`owner_preferences`, `device_config`); others append (`decisions`). Without the distinction, you fight supersession bugs forever on the overwrite ones. One column: `single_instance BOOLEAN`.
 - **Task-aware recall = query rewriting.** Cheap LLM call turns `{user_prompt, recent_turns}` into `{intent, entities, type_filter, tag_filter, timeframe}` *before* vector search. Don't embed the raw prompt — biggest quality win on relevance.
 - **A-MEM memory evolution (second step).** New memory arrives → LLM also rewrites context/tags of linked neighbors. We have auto-linking; we don't have the in-place rewrite. Without it: linked graph of frozen interpretations.

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -1879,3 +1879,67 @@ begin
     );
 end;
 $$;
+
+
+-- =========================================================================
+-- #242: dual-embedding read-path for voyage model migration readiness
+--
+-- Adds a second, independently-indexed embedding column so we can dual-write
+-- today (zero risk) and cut over later without a hot-rebuild. Keeping the
+-- two columns + two indexes lets each RPC use its own HNSW index — no CASE
+-- in ORDER BY (which silently drops to seq-scan and killed PR #245).
+--
+-- Dimensions: current voyage-3-lite is 512, voyage-3 is 1024. v2 is sized
+-- for the next model we'd migrate to. If we ever bump to a different model
+-- family (e.g. BGE-Large = 1024, OpenAI text-embedding-3-large = 3072),
+-- add a further column / RPC rather than resizing.
+--
+-- No data migration here. Backfill is a separate issue.
+-- =========================================================================
+
+alter table memories add column if not exists embedding_v2 vector(1024);
+alter table memories add column if not exists embedding_model_v2 text;
+alter table memories add column if not exists embedding_version_v2 text;
+
+-- Partial HNSW index — only rows with populated v2 get indexed. Keeps the
+-- structure small while SECONDARY is unset (zero rows indexed initially).
+create index if not exists idx_memories_embedding_v2_hnsw
+  on memories using hnsw (embedding_v2 vector_cosine_ops)
+  with (m = 16, ef_construction = 64);
+
+-- Read-path RPC for v2. Mirrors match_memories shape/filters so _hybrid_recall
+-- can swap by name. NO CASE expression in ORDER BY — pgvector HNSW requires
+-- a direct column reference to use the index.
+drop function if exists match_memories_v2(vector, int, float, text, text, boolean);
+create or replace function match_memories_v2(
+    query_embedding vector,
+    match_limit int default 10,
+    similarity_threshold float default 0.3,
+    filter_project text default null,
+    filter_type text default null,
+    show_history boolean default false
+)
+returns table(
+    id uuid, name text, type text, project text,
+    description text, content text, tags text[],
+    updated_at timestamptz, content_updated_at timestamptz,
+    last_accessed_at timestamptz,
+    similarity float
+)
+language sql stable as $$
+    select m.id, m.name, m.type, m.project,
+           m.description, m.content, m.tags,
+           m.updated_at, m.content_updated_at, m.last_accessed_at,
+           1 - (m.embedding_v2 <=> query_embedding) as similarity
+    from memories m
+    where m.embedding_v2 is not null
+      and 1 - (m.embedding_v2 <=> query_embedding) >= similarity_threshold
+      and (filter_project is null or m.project = filter_project or m.project is null)
+      and (filter_type is null or m.type = filter_type)
+      and (show_history
+           or (m.expired_at is null
+               and m.superseded_by is null
+               and (m.valid_to is null or m.valid_to > now())))
+    order by m.embedding_v2 <=> query_embedding
+    limit match_limit;
+$$;

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -1905,7 +1905,8 @@ alter table memories add column if not exists embedding_version_v2 text;
 -- structure small while SECONDARY is unset (zero rows indexed initially).
 create index if not exists idx_memories_embedding_v2_hnsw
   on memories using hnsw (embedding_v2 vector_cosine_ops)
-  with (m = 16, ef_construction = 64);
+  with (m = 16, ef_construction = 64)
+  where embedding_v2 is not null;
 
 -- Read-path RPC for v2. Mirrors match_memories shape/filters so _hybrid_recall
 -- can swap by name. NO CASE expression in ORDER BY — pgvector HNSW requires
@@ -1933,6 +1934,7 @@ language sql stable as $$
            1 - (m.embedding_v2 <=> query_embedding) as similarity
     from memories m
     where m.embedding_v2 is not null
+      and m.deleted_at is null
       and 1 - (m.embedding_v2 <=> query_embedding) >= similarity_threshold
       and (filter_project is null or m.project = filter_project or m.project is null)
       and (filter_type is null or m.type = filter_type)

--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -128,19 +128,55 @@ VOYAGE_API_URL = "https://api.voyageai.com/v1/embeddings"
 VOYAGE_MODEL = "voyage-3-lite"
 EMBED_TIMEOUT = 30.0  # seconds
 
+# #242 dual-embedding machinery. PRIMARY drives reads (which RPC is called
+# + what model embeds the query). SECONDARY, if set, enables dual-write so
+# the v2 column fills up in parallel without touching the read path.
+# When SECONDARY is unset, behavior is bit-identical to pre-#242.
+EMBEDDING_MODEL_PRIMARY = os.environ.get("EMBEDDING_MODEL_PRIMARY", VOYAGE_MODEL)
+EMBEDDING_MODEL_SECONDARY = os.environ.get("EMBEDDING_MODEL_SECONDARY") or None
 
-async def _embed(text: str, input_type: str = "document") -> list[float] | None:
+# Model → (column, RPC, version-tag) mapping. Extend here when adding a
+# new supported model. Keep the table read-only at runtime.
+EMBEDDING_MODELS = {
+    "voyage-3-lite": {
+        "embedding_column": "embedding",
+        "model_column": "embedding_model",
+        "version_column": "embedding_version",
+        "rpc": "match_memories",
+        "version_tag": "v2",  # Phase 2a canonical form
+    },
+    "voyage-3": {
+        "embedding_column": "embedding_v2",
+        "model_column": "embedding_model_v2",
+        "version_column": "embedding_version_v2",
+        "rpc": "match_memories_v2",
+        "version_tag": "v2",
+    },
+}
+
+
+def _model_slot(model: str) -> dict:
+    """Look up the column/RPC slot for a model. Falls back to PRIMARY for
+    unknown models so misconfiguration never crashes startup — it just
+    degrades to legacy behavior."""
+    return EMBEDDING_MODELS.get(model) or EMBEDDING_MODELS[VOYAGE_MODEL]
+
+
+async def _embed(
+    text: str, input_type: str = "document", model: str | None = None
+) -> list[float] | None:
     """Call Voyage AI REST API asynchronously. Retries up to 3x on 429."""
     api_key = os.environ.get("VOYAGE_API_KEY")
     if not api_key:
         return None
+    use_model = model or VOYAGE_MODEL
     for attempt in range(3):
         try:
             async with httpx.AsyncClient(timeout=EMBED_TIMEOUT) as client:
                 resp = await client.post(
                     VOYAGE_API_URL,
                     headers={"Authorization": f"Bearer {api_key}"},
-                    json={"model": VOYAGE_MODEL, "input": [text], "input_type": input_type},
+                    json={"model": use_model, "input": [text], "input_type": input_type},
                 )
                 resp.raise_for_status()
                 return resp.json()["data"][0]["embedding"]
@@ -156,18 +192,21 @@ async def _embed(text: str, input_type: str = "document") -> list[float] | None:
     return None
 
 
-async def _embed_batch(texts: list[str], input_type: str = "document") -> list[list[float]] | None:
+async def _embed_batch(
+    texts: list[str], input_type: str = "document", model: str | None = None
+) -> list[list[float]] | None:
     """Embed multiple texts in a single API call (up to 1000 per request)."""
     api_key = os.environ.get("VOYAGE_API_KEY")
     if not api_key or not texts:
         return None
+    use_model = model or VOYAGE_MODEL
     for attempt in range(3):
         try:
             async with httpx.AsyncClient(timeout=EMBED_TIMEOUT) as client:
                 resp = await client.post(
                     VOYAGE_API_URL,
                     headers={"Authorization": f"Bearer {api_key}"},
-                    json={"model": VOYAGE_MODEL, "input": texts, "input_type": input_type},
+                    json={"model": use_model, "input": texts, "input_type": input_type},
                 )
                 resp.raise_for_status()
                 data = sorted(resp.json()["data"], key=lambda x: x["index"])
@@ -184,8 +223,46 @@ async def _embed_batch(texts: list[str], input_type: str = "document") -> list[l
     return None
 
 
+def _embed_upsert_fields(embedding: list[float], model: str) -> dict:
+    """Build the dict of columns to upsert for a (embedding, model) pair.
+    Returns {} if model is unknown (shouldn't happen at write time; silently
+    degrades so we never corrupt rows)."""
+    slot = EMBEDDING_MODELS.get(model)
+    if not slot:
+        return {}
+    return {
+        slot["embedding_column"]: embedding,
+        slot["model_column"]: model,
+        slot["version_column"]: slot["version_tag"],
+    }
+
+
+async def _compute_write_embeddings(text: str) -> dict:
+    """Produce the full write-side embedding payload for one row.
+
+    Always embeds with PRIMARY. If SECONDARY is set AND different from
+    PRIMARY, also embeds with SECONDARY and merges columns. Returns a dict
+    ready to splat into the upsert `data`.
+
+    Failure mode: if PRIMARY embed fails → return {} (skip embedding). If
+    PRIMARY succeeds but SECONDARY fails → write PRIMARY only (single-leg
+    recovery; a future consolidation/backfill can fill the gap).
+    """
+    primary_vec = await _embed(text, model=EMBEDDING_MODEL_PRIMARY)
+    if primary_vec is None:
+        return {}
+    fields = _embed_upsert_fields(primary_vec, EMBEDDING_MODEL_PRIMARY)
+    if EMBEDDING_MODEL_SECONDARY and EMBEDDING_MODEL_SECONDARY != EMBEDDING_MODEL_PRIMARY:
+        secondary_vec = await _embed(text, model=EMBEDDING_MODEL_SECONDARY)
+        if secondary_vec is not None:
+            fields.update(_embed_upsert_fields(secondary_vec, EMBEDDING_MODEL_SECONDARY))
+    return fields
+
+
 async def _embed_query(text: str) -> list[float] | None:
-    return await _embed(text, input_type="query")
+    # #242: read path embeds with PRIMARY so the vector matches whichever
+    # column we're about to query via _hybrid_recall's RPC selection.
+    return await _embed(text, input_type="query", model=EMBEDDING_MODEL_PRIMARY)
 
 
 # ---------------------------------------------------------------------------
@@ -1122,7 +1199,8 @@ async def _handle_store(args: dict) -> list[TextContent]:
     # Name and tags carry high-signal lexical cues that raw content often dilutes
     # (long narrative memories where the key topic is only in the name).
     embed_text = _canonical_embed_text(mem_name, description, tags, content)
-    embedding = await _embed(embed_text)
+    # #242: may populate embedding + embedding_v2 in one shot when SECONDARY set.
+    embed_fields = await _compute_write_embeddings(embed_text)
 
     data = {
         "type": mem_type,
@@ -1134,12 +1212,11 @@ async def _handle_store(args: dict) -> list[TextContent]:
         "source_provenance": source_provenance,  # Phase 2c: always present, validated above
         "deleted_at": None,  # clear soft-delete on store/upsert
     }
+    data.update(embed_fields)
 
-    if embedding is not None:
-        data["embedding"] = embedding
-        data["embedding_model"] = VOYAGE_MODEL
-        data["embedding_version"] = "v2"  # Phase 2a canonical form
-
+    # Preserve the old "derive embedding column presence" cue for the user
+    # message — we care whether PRIMARY landed.
+    embedding = data.get(_model_slot(EMBEDDING_MODEL_PRIMARY)["embedding_column"])
     embed_note = " (with embedding)" if embedding is not None else ""
 
     if project is not None:
@@ -1266,8 +1343,12 @@ async def _hybrid_recall(
         # Fetch double the limit from each source to give RRF good candidates
         fetch_limit = limit * 2
 
-        # Server-side semantic search via pgvector HNSW
-        sem_result = client.rpc("match_memories", {
+        # Server-side semantic search via pgvector HNSW. #242: the RPC name
+        # is selected by PRIMARY model so v1 and v2 columns each use their
+        # own HNSW index. query_embedding's dim was already matched to
+        # PRIMARY by _embed_query.
+        sem_rpc = _model_slot(EMBEDDING_MODEL_PRIMARY)["rpc"]
+        sem_result = client.rpc(sem_rpc, {
             "query_embedding": query_embedding,
             "match_limit": fetch_limit,
             "similarity_threshold": SIMILARITY_THRESHOLD,
@@ -1413,8 +1494,11 @@ async def _backfill_missing_embeddings(client, project) -> None:
     Batches all missing records into a single Voyage AI call.
     """
     try:
+        # #242: backfill the column that matches PRIMARY — if we've cut over
+        # to v2, the "missing embedding" we care about is embedding_v2.
+        primary_col = _model_slot(EMBEDDING_MODEL_PRIMARY)["embedding_column"]
         q = client.table("memories").select("id, name, description, tags, content")
-        q = q.is_("embedding", "null").is_("deleted_at", "null")
+        q = q.is_(primary_col, "null").is_("deleted_at", "null")
         if project is not None:
             q = q.or_(f"project.eq.{project},project.is.null")
         rows = q.execute().data
@@ -1426,16 +1510,17 @@ async def _backfill_missing_embeddings(client, project) -> None:
             _canonical_embed_text(r.get("name", ""), r.get("description", ""), r.get("tags") or [], r["content"])
             for r in rows
         ]
-        embeddings = await _embed_batch(texts)
+        # #242: this path only backfills the column for PRIMARY — the legacy
+        # "missing embedding" cleanup. v2 corpus-wide backfill is a separate
+        # issue per #242 non-goals.
+        embeddings = await _embed_batch(texts, model=EMBEDDING_MODEL_PRIMARY)
         if embeddings is None:
             return
 
         for mem, embedding in zip(rows, embeddings):
-            client.table("memories").update({
-                "embedding": embedding,
-                "embedding_model": VOYAGE_MODEL,
-                "embedding_version": "v2",
-            }).eq("id", mem["id"]).execute()
+            client.table("memories").update(
+                _embed_upsert_fields(embedding, EMBEDDING_MODEL_PRIMARY)
+            ).eq("id", mem["id"]).execute()
     except Exception:
         pass  # fire-and-forget: silently swallow all errors so caller never fails
 

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -806,7 +806,6 @@ from server import (  # noqa: E402
     _model_slot,
     _embed_upsert_fields,
     _compute_write_embeddings,
-    EMBEDDING_MODELS,
 )
 
 

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -773,7 +773,8 @@ class TestHandleStoreProvenance:
         """Accepted provenance is trimmed — no leading/trailing whitespace
         leaks into the DB row, keeping audit queries clean."""
         # Short-circuit embedding so we don't need Voyage env/network.
-        async def _fake_embed(_text):
+        # Signature accepts **kwargs so #242's model= param doesn't break it.
+        async def _fake_embed(_text, **_kwargs):
             return None
         monkeypatch.setattr(server_module, "_embed", _fake_embed)
 
@@ -795,3 +796,159 @@ class TestHandleStoreProvenance:
         assert upsert_calls, "expected at least one upsert call"
         data_arg = upsert_calls[-1][0][0]
         assert data_arg["source_provenance"] == "skill:test"
+
+
+# ---------------------------------------------------------------------------
+# #242: dual-embedding machinery — column/RPC mapping + dual-write
+# ---------------------------------------------------------------------------
+
+from server import (  # noqa: E402
+    _model_slot,
+    _embed_upsert_fields,
+    _compute_write_embeddings,
+    EMBEDDING_MODELS,
+)
+
+
+class TestModelSlotMapping:
+    """#242: the model → column/RPC table drives both read and write paths.
+
+    If this mapping drifts, writes land in the wrong column and reads
+    query the wrong RPC — a silent data-integrity bug. Lock it down.
+    """
+
+    def test_voyage_3_lite_maps_to_v1_column(self):
+        slot = _model_slot("voyage-3-lite")
+        assert slot["embedding_column"] == "embedding"
+        assert slot["rpc"] == "match_memories"
+
+    def test_voyage_3_maps_to_v2_column(self):
+        slot = _model_slot("voyage-3")
+        assert slot["embedding_column"] == "embedding_v2"
+        assert slot["rpc"] == "match_memories_v2"
+
+    def test_unknown_model_falls_back_to_legacy(self):
+        """Misconfigured EMBEDDING_MODEL_PRIMARY must degrade to legacy,
+        never raise at runtime — writes continue, bug is visible in metadata."""
+        slot = _model_slot("nonexistent-model")
+        assert slot["embedding_column"] == "embedding"
+        assert slot["rpc"] == "match_memories"
+
+    def test_upsert_fields_shape(self):
+        fields = _embed_upsert_fields([0.1, 0.2], "voyage-3-lite")
+        assert fields == {
+            "embedding": [0.1, 0.2],
+            "embedding_model": "voyage-3-lite",
+            "embedding_version": "v2",
+        }
+
+    def test_upsert_fields_v2(self):
+        fields = _embed_upsert_fields([0.3, 0.4], "voyage-3")
+        assert fields == {
+            "embedding_v2": [0.3, 0.4],
+            "embedding_model_v2": "voyage-3",
+            "embedding_version_v2": "v2",
+        }
+
+    def test_upsert_fields_unknown_returns_empty(self):
+        """Unknown model → no fields (no silent corruption of other columns)."""
+        assert _embed_upsert_fields([0.1], "no-such-model") == {}
+
+
+class TestDualEmbedWrite:
+    """#242: when SECONDARY is set, writes compute both embeddings and
+    populate both columns. Unset → identical to pre-#242 (single-write)."""
+
+    @pytest.mark.asyncio
+    async def test_secondary_unset_single_write(self, monkeypatch):
+        """Zero-change default: SECONDARY unset → only PRIMARY columns written."""
+        calls: list[dict] = []
+
+        async def fake_embed(text, input_type="document", model=None):
+            calls.append({"model": model})
+            return [0.1, 0.2, 0.3]
+
+        monkeypatch.setattr(server_module, "_embed", fake_embed)
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_PRIMARY", "voyage-3-lite")
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_SECONDARY", None)
+
+        fields = await _compute_write_embeddings("canonical text")
+
+        assert "embedding" in fields
+        assert "embedding_model" in fields
+        assert fields["embedding_model"] == "voyage-3-lite"
+        assert "embedding_v2" not in fields
+        assert len(calls) == 1
+        assert calls[0]["model"] == "voyage-3-lite"
+
+    @pytest.mark.asyncio
+    async def test_secondary_set_dual_write(self, monkeypatch):
+        """SECONDARY=voyage-3 → both columns populated, two embed calls."""
+        calls: list[dict] = []
+
+        async def fake_embed(text, input_type="document", model=None):
+            calls.append({"model": model})
+            # Return dim-shaped distinct vectors so we can assert routing.
+            return [0.1] * 512 if model == "voyage-3-lite" else [0.9] * 1024
+
+        monkeypatch.setattr(server_module, "_embed", fake_embed)
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_PRIMARY", "voyage-3-lite")
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_SECONDARY", "voyage-3")
+
+        fields = await _compute_write_embeddings("canonical text")
+
+        assert fields["embedding"] == [0.1] * 512
+        assert fields["embedding_v2"] == [0.9] * 1024
+        assert fields["embedding_model"] == "voyage-3-lite"
+        assert fields["embedding_model_v2"] == "voyage-3"
+        assert {c["model"] for c in calls} == {"voyage-3-lite", "voyage-3"}
+
+    @pytest.mark.asyncio
+    async def test_secondary_failure_single_leg(self, monkeypatch):
+        """PRIMARY succeeds but SECONDARY embed returns None → write PRIMARY
+        only. Missing v2 is recoverable via backfill; corrupt row is not."""
+        async def fake_embed(text, input_type="document", model=None):
+            if model == "voyage-3":
+                return None
+            return [0.1] * 512
+
+        monkeypatch.setattr(server_module, "_embed", fake_embed)
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_PRIMARY", "voyage-3-lite")
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_SECONDARY", "voyage-3")
+
+        fields = await _compute_write_embeddings("canonical text")
+        assert fields["embedding"] == [0.1] * 512
+        assert "embedding_v2" not in fields
+
+    @pytest.mark.asyncio
+    async def test_primary_failure_no_write(self, monkeypatch):
+        """PRIMARY embed fails → no embed fields at all. Row still saves
+        with text content, _backfill_missing_embeddings picks it up later."""
+        async def fake_embed(text, input_type="document", model=None):
+            return None
+
+        monkeypatch.setattr(server_module, "_embed", fake_embed)
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_PRIMARY", "voyage-3-lite")
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_SECONDARY", "voyage-3")
+
+        fields = await _compute_write_embeddings("canonical text")
+        assert fields == {}
+
+    @pytest.mark.asyncio
+    async def test_secondary_equals_primary_no_duplicate_call(self, monkeypatch):
+        """If SECONDARY accidentally equals PRIMARY, don't waste an API call."""
+        calls: list[dict] = []
+
+        async def fake_embed(text, input_type="document", model=None):
+            calls.append({"model": model})
+            return [0.1] * 512
+
+        monkeypatch.setattr(server_module, "_embed", fake_embed)
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_PRIMARY", "voyage-3-lite")
+        monkeypatch.setattr(server_module, "EMBEDDING_MODEL_SECONDARY", "voyage-3-lite")
+
+        fields = await _compute_write_embeddings("canonical text")
+        assert len(calls) == 1
+        assert "embedding" in fields
+        # Only PRIMARY columns; no redundant duplicate write.
+        assert "embedding_v2" not in fields


### PR DESCRIPTION
## Summary

Foundation for safe embedding-model migration (voyage-3-lite → voyage-3 / BGE / future) without the silent-corruption failure mode where mixed-model embeddings in a single HNSW index produce garbage similarity.

## Design — two columns, two indexes, two RPCs

PR #245 (closed) tried to be clever: one column, one RPC with \`ORDER BY CASE ... <=> ... END\`. That expression prevents pgvector from using the HNSW index — silently falls to seq-scan. Also had a dim mismatch (512-dim stored, 1024-dim query).

This PR takes the boring, correct path:

| Column | Dim | Index | RPC |
|---|---|---|---|
| \`embedding\`    | 512  | \`idx_memories_embedding_hnsw\`    | \`match_memories\` (existing) |
| \`embedding_v2\` | 1024 | \`idx_memories_embedding_v2_hnsw\` | \`match_memories_v2\` (new) |

Python-layer dispatch via \`_model_slot(EMBEDDING_MODEL_PRIMARY)['rpc']\` picks which RPC to call. The query embedding is computed with PRIMARY's model in \`_embed_query\`, so dims always match the column being searched. **No CASE anywhere** — each index does the job it was built for.

## Feature-flagged

```
EMBEDDING_MODEL_PRIMARY   default \`voyage-3-lite\` — reads + writes PRIMARY column
EMBEDDING_MODEL_SECONDARY default unset          — when set, writes BOTH columns
```

**Unset SECONDARY → behavior bit-identical to pre-#242.** Verified by test suite + eval.

## Rollout path (not executed here)

1. **Dual-write stage:** \`PRIMARY=voyage-3-lite, SECONDARY=voyage-3\` → new writes fill both columns
2. **Backfill** (separate issue): embed existing 600 rows with voyage-3, populate \`embedding_v2\`
3. **Cutover:** \`PRIMARY=voyage-3, SECONDARY=voyage-3-lite\` → reads flip to v2
4. **Decom:** drop SECONDARY once v1 is safe to retire

## Scope

- \`mcp-memory/schema.sql\`: \`embedding_v2\` + \`embedding_model_v2\` + \`embedding_version_v2\` columns, HNSW index, \`match_memories_v2\` RPC
- \`mcp-memory/server.py\`: \`_embed*(model=...)\` threading, \`_compute_write_embeddings()\` for dual-write, \`_hybrid_recall\` RPC dispatch, \`_backfill_missing_embeddings\` targets PRIMARY column
- \`tests/test_memory_server.py\`: 9 new cases across 2 test classes

## Out of scope (per spec non-goals)

- Corpus backfill for v2 — separate issue when we're ready to cut over
- \`episode_extractor.py\` dual-write — self-contained module with its own \`VOYAGE_MODEL\`, needs a follow-up to share the dispatch. Safe because it only runs during episode extraction, and the ecosystem tolerates a single-model lag during migration (dual-written fresh rows + to-be-backfilled rows + episode-extractor-v1 rows all end up in \`embedding\` during the dual-write stage)
- Changing dimensions of the existing column

## Test plan

- [x] 56 unit tests pass (9 new in \`TestModelSlotMapping\` + \`TestDualEmbedWrite\`)
- [x] \`eval-recall.py\` with SECONDARY unset runs in \`server_only\` mode with unchanged recall
- [x] \`review_before_push\`: 4 files, 328 lines, scope check: schema + server.py threading + tests + 1-line design-doc note
- [ ] Pre-merge: apply schema migration to Supabase (idempotent, runs alongside existing schema)
- [ ] Pre-merge: verify on redrobot side that the new columns/RPC don't break that project's memory consumption

Closes #242