### PR TITLE
feat(self-improve): known-unknowns + calibration as ideation seeds (#253)

### DIFF
--- a/.claude/skills/self-improve/SKILL.md
+++ b/.claude/skills/self-improve/SKILL.md
@@ -46,13 +46,30 @@ Sources of ideas:
 - Unacted research findings
 - Missing capabilities observed in recent sessions
 - Opportunities from new Claude Code / MCP features
+- **Known-unknowns** (`known_unknowns` table → repeated recall gaps) — queries Jarvis has been asked but couldn't answer from memory
 - **Poor-calibration types** (`memory_calibration_summary` → types with Brier > 0.25) — systemic over/underconfidence is signal worth investigating
 
-Before ideating, pull calibration gaps as candidate seeds:
+#### Metacognition seeds
+
+Before ideating, pull both metacognition signals as candidate seeds. Run in parallel; both may return empty (skill must still work — just skip the section).
+
+**1. Known-unknowns** — retrieval gaps with highest recurrence:
+```sql
+SELECT query, hit_count, last_seen_at
+FROM known_unknowns
+WHERE status='open'
+ORDER BY hit_count DESC, last_seen_at DESC
+LIMIT 5
+```
+Run via `execute_sql` (works in cloud + local). A query with `hit_count >= 3` is a strong seed: "asked N times, still no answer" → candidate for a research run, a new memory, or a capability gap.
+
+**2. Calibration gaps** — types where confidence diverges from outcome:
 ```
 mcp__memory__memory_calibration_summary(project="jarvis")
 ```
-Types flagged `overconfident` often point at a concrete pattern (e.g. "decision memories relying on unverified research") that can be fixed by a feedback rule, a hook, or a schema tweak.
+Types flagged `overconfident` (Brier > 0.25, avg_predicted > avg_actual) often point at a concrete pattern (e.g. "decision memories relying on unverified research") that can be fixed by a feedback rule, a hook, or a schema tweak.
+
+Render both under a **Ideation seeds (metacognition)** subsection in the output. Each seed becomes a candidate idea scored in the table below alongside health-check findings and friction patterns. If both sources return empty, omit the subsection (don't render empty headings).
 
 If no strong ideas: fall back to health check findings for code improvements.
 
@@ -103,6 +120,17 @@ gh pr create --title "self-improve: <description>" --body "..."
 
 ### Health check
 - <key findings, or "Clean">
+
+### Ideation seeds (metacognition)
+<omit entire subsection if both sources empty>
+
+**Known-unknowns** (top open, by hit_count):
+| Query | Hits | Last seen |
+|-------|------|-----------|
+| ... | N | YYYY-MM-DD |
+
+**Calibration gaps** (Brier > 0.25, n >= 20):
+- `<type>` — Brier X.XX, overconfident/underconfident (avg_pred Y vs avg_actual Z)
 
 ### Ideas (scored)
 | Idea | Impact | Effort | Risk |


### PR DESCRIPTION
## Summary
Extend \`/self-improve\` Step 3 (Ideate) to pull two new ideation seeds from the metacognition infrastructure shipped in this sprint: open known-unknowns (repeated retrieval gaps) and poor-calibration types (Brier > 0.25). Both sources render under a new **Ideation seeds (metacognition)** subsection in the output.

## Why
Metacognition without a feedback loop is just logging. The loop closes when gaps drive new investigation: \"asked about X 5 times and don't know it → research X\" / \"decision memories have Brier 0.4 → investigate overconfidence.\" This was the last open issue in milestone #23; merging it closes Pillar 4 Phase 5.

Closes #253

## Decisions & Alternatives
- **Extended existing Step 3 rather than adding a new step** — Step 3 already had partial calibration integration (pre-existing lines 49-55); known-unknowns is a sibling source, not a separate phase. Keeps the skill coherent.
- **Mirrored the exact SQL used by \`/status\`** for known-unknowns (\`ORDER BY hit_count DESC, last_seen_at DESC LIMIT 5\`). Rejected a custom variant — two skills reading the same signal should do so identically so the surfaces agree.
- **Graceful empty behavior, explicit** — spec says \"omit entire subsection if both sources empty.\" Rejected rendering empty headings (noise on a fresh corpus). Rejected failing on empty (would break the skill on day 0 of a new project).
- **\`execute_sql\` for known-unknowns** (not a custom MCP tool) — works both locally and in cloud scheduled runs, no new plumbing.

## Risk Assessment
- **LOW**: docs-only change to a skill definition file. No code, no schema, no hooks. Owner can eyeball the diff.

## Testing
- \`git diff main --stat\` → only \`.claude/skills/self-improve/SKILL.md\` touched (scope-fit clean)
- Skill will exercise next \`/self-improve\` invocation; acceptance criterion \"manual run shows new seeds on current corpus\" is inherently a post-merge check since the skill runs on the next invocation
- Empty-table path documented in prose (\"If both sources return empty, omit the subsection\")

## Files Changed
- \`.claude/skills/self-improve/SKILL.md\` — Step 3 gains Metacognition seeds subsection + sources bullet for known-unknowns; Output template gains Ideation seeds section

## Side note
While running the \`/delegate\` pipeline's Step 3.5 (record_decision), the MCP tool returned \`Error: name '_handle_record_decision' is not defined\`. The tool was shipped in #254 but the handler wasn't wired. Flagged as a follow-up task; out of scope for #253.