### PR TITLE
fix(memory): _handle_record_decision unreachable at runtime (#260)

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -3151,19 +3151,6 @@ async def _handle_credential_check_expiry(args: dict) -> list[TextContent]:
     return [TextContent(type="text", text="\n".join(lines))]
 
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-
-async def main():
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, server.create_initialization_options())
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
-
 async def _handle_record_decision(args: dict) -> list[TextContent]:
     """Insert a 'decision_made' episode with structured payload (#252).
 
@@ -3224,3 +3211,17 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
         eid = result.data[0].get("id", "?")
         return [TextContent(type="text", text=f"Decision recorded: episode {eid}")]
     return [TextContent(type="text", text="Failed to record decision.")]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_record_decision.py
+++ b/tests/test_record_decision.py
@@ -154,6 +154,39 @@ class TestRecordDecisionInsert:
         assert "boom" in result[0].text
 
 
+def test_handler_defined_before_main_entry():
+    """Regression guard: _handle_record_decision must live ABOVE the
+    `if __name__ == "__main__"` block in server.py.
+
+    When the module runs as main, Python enters `asyncio.run(main())` and
+    blocks — any def after that point never gets bound to the module
+    namespace. Tests don't catch this (they import server as a module,
+    so __main__ never fires), but the dispatcher at runtime hits a
+    NameError. This test parses the source and asserts the line ordering
+    so we never ship the bug again.
+    """
+    server_path = Path(__file__).resolve().parents[1] / "mcp-memory" / "server.py"
+    src = server_path.read_text(encoding="utf-8").splitlines()
+
+    handler_line = next(
+        (i for i, line in enumerate(src, start=1)
+         if line.startswith("async def _handle_record_decision")),
+        None,
+    )
+    main_guard_line = next(
+        (i for i, line in enumerate(src, start=1)
+         if line.startswith('if __name__ == "__main__"')),
+        None,
+    )
+    assert handler_line is not None, "_handle_record_decision def not found in server.py"
+    assert main_guard_line is not None, 'if __name__ == "__main__" not found in server.py'
+    assert handler_line < main_guard_line, (
+        f"_handle_record_decision defined at line {handler_line} is AFTER "
+        f'`if __name__ == "__main__"` at line {main_guard_line} — the def '
+        "will never be bound at runtime. Move it above the main entry."
+    )
+
+
 def test_decision_made_in_schema_check_constraint():
     """Regression guard: schema.sql must include 'decision_made' in episodes.kind CHECK.
 


### PR DESCRIPTION
## Summary
Move the \`_handle_record_decision\` handler above the \`if __name__ == \"__main__\": asyncio.run(main())\` block in \`mcp-memory/server.py\`. Add a source-text regression guard.

## Why
Handler was defined at line 3167, *after* \`asyncio.run(main())\` on line 3165. Python blocks inside the event loop and never evaluates lines that follow, so the function is not bound at runtime. Dispatcher hits NameError when \`record_decision\` is called.

Caught live during the metacognition DB recovery session (same day as #259). Tests passed against the bug because pytest imports the module and never executes \`__main__\`.

Closes #260

## Decisions & Alternatives
- **Move the def, don't refactor the dispatcher.** Minimal change. Rejected a larger cleanup (e.g., extracting all \`_handle_*\` functions into a separate module) — orthogonal to the bug and expands blast radius.
- **Regression guard as a source-text check.** Parses \`server.py\`, finds the def line, finds the \`__main__\` guard line, asserts ordering. Rejected a runtime check (e.g., subprocess-spawning the server and pinging it) — heavier, flakier, no extra signal.
- **Kept existing 9 tests unchanged.** They assert handler behavior correctly; they just don't exercise the load path. The new 10th test covers the load path.

## Risk Assessment
- **LOW**: pure reordering in a protected file. No logic change. 104/104 relevant tests pass (including the new regression guard). Handler body is byte-identical to pre-fix.

Note on protected-file rule: \`mcp-memory/server.py\` is in the CLAUDE.md protected list; owner explicitly approved in-session edits for this bug given the release urgency.

## Testing
- \`python -m pytest tests/test_record_decision.py -q\` → 10 passed (9 original + 1 new regression guard)
- \`python -m pytest tests/test_memory_server.py tests/test_record_decision.py tests/test_memory_calibration.py tests/test_fok_batch.py -q\` → 104 passed
- \`python -c \"import ast; ast.parse(open('mcp-memory/server.py', encoding='utf-8').read())\"\` → syntax OK
- Live smoke-test pending: MCP server in current session still runs old code; new Claude Code session will pick up the fix and can invoke \`record_decision\` end-to-end.

## Files Changed
- \`mcp-memory/server.py\` — move \`async def _handle_record_decision\` block from end-of-file to above the \`# Main\` header. Body unchanged.
- \`tests/test_record_decision.py\` — add \`test_handler_defined_before_main_entry\` regression guard.