### PR TITLE
feat(memory): Phase 7.1 — lazy-index catalog in session-context

### DIFF
--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -660,17 +660,22 @@ def _load_session_context(client) -> tuple[str, dict]:
     except Exception as e:
         print(f"[context-rot] goals query failed: {e}", file=sys.stderr)
 
-    # 4. Memory catalog (Phase 7.1) — lazy-index entries (name + description +
-    #    tags) for live, in-scope memories. Mirrors scripts/session-context.py
-    #    :_query_catalog. Eval runs project-agnostic, so we scope to global
-    #    (project IS NULL) only — matches the non-project cwd session case.
+    # 4. Memory catalog (Phase 7.1) — lazy-index entries for live, in-scope
+    #    memories. Mirrors scripts/session-context.py:_query_catalog output
+    #    format (one bullet per entry, type/scope label, description truncated
+    #    to 120 chars) so the context-rot baseline reflects the shape/budget
+    #    actually injected at session start. Eval runs project-agnostic so we
+    #    scope to global (project IS NULL) — matches non-project cwd sessions.
     try:
+        now_iso = datetime.now(timezone.utc).isoformat()
         r = (
             client.table("memories")
             .select("name, description, tags, type, project")
             .is_("expired_at", "null")
             .is_("superseded_by", "null")
+            .is_("deleted_at", "null")
             .is_("project", "null")
+            .or_(f"valid_to.is.null,valid_to.gt.{now_iso}")
             .order("last_accessed_at", desc=True, nullsfirst=False)
             .limit(200)
             .execute()
@@ -681,12 +686,12 @@ def _load_session_context(client) -> tuple[str, dict]:
             tags = m.get("tags") or []
             if "always_load" in tags:
                 continue
-            pieces = [
-                m.get("name") or "",
-                m.get("description") or "",
-                " ".join(tags),
-            ]
-            parts.append(" ".join(p for p in pieces if p))
+            # Mirror _fmt_catalog_entry in session-context.py — global scope
+            # here since we filter project IS NULL.
+            desc = (m.get("description") or "").strip()
+            if len(desc) > 120:
+                desc = desc[:117] + "..."
+            parts.append(f"- {m['name']} [{m['type']}/global]: {desc}")
             counts["catalog"] = counts.get("catalog", 0) + 1
     except Exception as e:
         print(f"[context-rot] catalog query failed: {e}", file=sys.stderr)

--- a/scripts/eval-recall.py
+++ b/scripts/eval-recall.py
@@ -660,6 +660,37 @@ def _load_session_context(client) -> tuple[str, dict]:
     except Exception as e:
         print(f"[context-rot] goals query failed: {e}", file=sys.stderr)
 
+    # 4. Memory catalog (Phase 7.1) — lazy-index entries (name + description +
+    #    tags) for live, in-scope memories. Mirrors scripts/session-context.py
+    #    :_query_catalog. Eval runs project-agnostic, so we scope to global
+    #    (project IS NULL) only — matches the non-project cwd session case.
+    try:
+        r = (
+            client.table("memories")
+            .select("name, description, tags, type, project")
+            .is_("expired_at", "null")
+            .is_("superseded_by", "null")
+            .is_("project", "null")
+            .order("last_accessed_at", desc=True, nullsfirst=False)
+            .limit(200)
+            .execute()
+        )
+        for m in r.data or []:
+            if m.get("type") == "user":
+                continue
+            tags = m.get("tags") or []
+            if "always_load" in tags:
+                continue
+            pieces = [
+                m.get("name") or "",
+                m.get("description") or "",
+                " ".join(tags),
+            ]
+            parts.append(" ".join(p for p in pieces if p))
+            counts["catalog"] = counts.get("catalog", 0) + 1
+    except Exception as e:
+        print(f"[context-rot] catalog query failed: {e}", file=sys.stderr)
+
     blob = " ".join(p.strip() for p in parts if p.strip())
     chars = len(blob)
     budget = {
@@ -760,7 +791,8 @@ def print_context_rot_report(report: ContextRotReport, quiet: bool = False) -> N
               f"{report.context_budget['item_count']} items "
               f"(user={report.context_budget['user']}, "
               f"always_load={report.context_budget['always_load']}, "
-              f"goals={report.context_budget['goals']})\n")
+              f"goals={report.context_budget['goals']}, "
+              f"catalog={report.context_budget.get('catalog', 0)})\n")
 
         # Per-query table: plain rank → context rank, mark regressions/wins
         print(f"{'id':<5} {'plain':>6}  {'ctx':>6}  drank  result   query")

--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -100,6 +100,16 @@ def main():
     if goal_section:
         sections.append(goal_section)
 
+    # 5. Memory catalog — lazy awareness (Phase 7.1). One-line inventory of
+    #    live memories (name + type + scope + short description) so Jarvis
+    #    knows what exists and can pull full content on demand via memory_get
+    #    / memory_recall. Replaces the old recency-based feedback/decision
+    #    dumps — those rot recall (see tests/memory-eval/context-rot-baseline.json).
+    section, ids = _query_catalog(client, project)
+    if section:
+        sections.append("## Memory Catalog\n" + section)
+        touched_ids.extend(ids)
+
     # Bump last_accessed_at for every memory we just loaded. Phase 1 drives the
     # access-frequency boost in temporal scoring off this column, so
     # session-start loads should count as access. The content_updated_at /
@@ -165,6 +175,88 @@ def _query_always_load(client):
     except Exception as e:
         print(f"[session-context] always_load query failed: {e}", file=sys.stderr)
     return None, []
+
+
+def _query_catalog(client, project):
+    """Compact one-line catalog of live memories — lazy awareness (Phase 7.1).
+
+    Returns (formatted_text, ids). Sorted by last_accessed_at desc so recently
+    touched entries surface first. Filters to live memories (not expired, not
+    superseded, valid_to in future or null) scoped to current project or
+    global (project IS NULL).
+
+    Excludes entries already rendered in other sections:
+      - type=user (User Profile)
+      - 'always_load' in tags (Always-Load Rules)
+      - name=working_state_<project> (Working State)
+    """
+    try:
+        query = (
+            client.table("memories")
+            .select("id, name, type, project, description, tags, last_accessed_at, valid_to")
+            .is_("expired_at", "null")
+            .is_("superseded_by", "null")
+        )
+        if project:
+            query = query.or_(f"project.eq.{project},project.is.null")
+        else:
+            query = query.is_("project", "null")
+        result = (
+            query.order("last_accessed_at", desc=True, nullsfirst=False)
+            .limit(200)
+            .execute()
+        )
+    except Exception as e:
+        print(f"[session-context] catalog query failed: {e}", file=sys.stderr)
+        return None, []
+
+    if not result.data:
+        return None, []
+
+    working_state_name = f"working_state_{project}" if project else None
+    now_iso = None  # lazy init
+    entries = []
+    ids = []
+    for m in result.data:
+        if m["type"] == "user":
+            continue
+        tags = m.get("tags") or []
+        if "always_load" in tags:
+            continue
+        if working_state_name and m["name"] == working_state_name:
+            continue
+        # valid_to filter — Postgres already excluded rows we don't want, but
+        # the OR clause above is project-level; valid_to still needs a
+        # client-side check since we didn't add it to the server filter.
+        vt = m.get("valid_to")
+        if vt:
+            if now_iso is None:
+                from datetime import datetime, timezone
+                now_iso = datetime.now(timezone.utc).isoformat()
+            if vt <= now_iso:
+                continue
+        entries.append(_fmt_catalog_entry(m, project))
+        if m.get("id"):
+            ids.append(m["id"])
+
+    if not entries:
+        return None, []
+    return "\n".join(entries), ids
+
+
+def _fmt_catalog_entry(m, current_project):
+    """One-line catalog entry: `- <name> [<type>/<scope>]: <description>`."""
+    p = m.get("project")
+    if p is None:
+        scope = f"{m['type']}/global"
+    elif p == current_project:
+        scope = m["type"]
+    else:
+        scope = f"{m['type']}/{p}"
+    desc = (m.get("description") or "").strip()
+    if len(desc) > 120:
+        desc = desc[:117] + "..."
+    return f"- {m['name']} [{scope}]: {desc}"
 
 
 def _touch_accessed(client, ids):

--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -105,10 +105,13 @@ def main():
     #    knows what exists and can pull full content on demand via memory_get
     #    / memory_recall. Replaces the old recency-based feedback/decision
     #    dumps — those rot recall (see tests/memory-eval/context-rot-baseline.json).
-    section, ids = _query_catalog(client, project)
+    #    NOTE: catalog ids are NOT added to touched_ids. Showing a memory in
+    #    the session-start index is not a read; bumping last_accessed_at here
+    #    would create a feedback loop (catalog is sorted by last_accessed_at)
+    #    and distort temporal scoring for genuine recall/read events.
+    section, _catalog_ids = _query_catalog(client, project)
     if section:
         sections.append("## Memory Catalog\n" + section)
-        touched_ids.extend(ids)
 
     # Bump last_accessed_at for every memory we just loaded. Phase 1 drives the
     # access-frequency boost in temporal scoring off this column, so
@@ -182,20 +185,27 @@ def _query_catalog(client, project):
 
     Returns (formatted_text, ids). Sorted by last_accessed_at desc so recently
     touched entries surface first. Filters to live memories (not expired, not
-    superseded, valid_to in future or null) scoped to current project or
-    global (project IS NULL).
+    superseded, not soft-deleted, valid_to in future or null) scoped to
+    current project or global (project IS NULL).
 
     Excludes entries already rendered in other sections:
       - type=user (User Profile)
       - 'always_load' in tags (Always-Load Rules)
       - name=working_state_<project> (Working State)
+
+    valid_to is filtered client-side with aware-datetime parsing because the
+    project scoping already uses one .or_() clause (PostgREST allows only one
+    `or=` parameter per query).
     """
+    from datetime import datetime, timezone
+    now_utc = datetime.now(timezone.utc)
     try:
         query = (
             client.table("memories")
             .select("id, name, type, project, description, tags, last_accessed_at, valid_to")
             .is_("expired_at", "null")
             .is_("superseded_by", "null")
+            .is_("deleted_at", "null")
         )
         if project:
             query = query.or_(f"project.eq.{project},project.is.null")
@@ -214,7 +224,6 @@ def _query_catalog(client, project):
         return None, []
 
     working_state_name = f"working_state_{project}" if project else None
-    now_iso = None  # lazy init
     entries = []
     ids = []
     for m in result.data:
@@ -225,16 +234,9 @@ def _query_catalog(client, project):
             continue
         if working_state_name and m["name"] == working_state_name:
             continue
-        # valid_to filter — Postgres already excluded rows we don't want, but
-        # the OR clause above is project-level; valid_to still needs a
-        # client-side check since we didn't add it to the server filter.
-        vt = m.get("valid_to")
-        if vt:
-            if now_iso is None:
-                from datetime import datetime, timezone
-                now_iso = datetime.now(timezone.utc).isoformat()
-            if vt <= now_iso:
-                continue
+        vt = _parse_ts(m.get("valid_to"))
+        if vt and vt <= now_utc:
+            continue
         entries.append(_fmt_catalog_entry(m, project))
         if m.get("id"):
             ids.append(m["id"])
@@ -242,6 +244,21 @@ def _query_catalog(client, project):
     if not entries:
         return None, []
     return "\n".join(entries), ids
+
+
+def _parse_ts(val):
+    """Parse Supabase timestamp (ISO str or datetime) to aware UTC datetime, or None."""
+    from datetime import datetime, timezone
+    if val is None:
+        return None
+    if isinstance(val, datetime):
+        return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+    if isinstance(val, str):
+        try:
+            return datetime.fromisoformat(val.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
 
 
 def _fmt_catalog_entry(m, current_project):

--- a/tests/memory-eval/context-rot-baseline.json
+++ b/tests/memory-eval/context-rot-baseline.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-04-20T16:06:16.600389+00:00",
+  "timestamp": "2026-04-20T17:57:10.655417+00:00",
   "corpus_size": 323,
   "total_queries": 20,
   "plain_recall_at_5": 0.9,
@@ -8,9 +8,9 @@
   "plain_recall_at_10": 0.9,
   "context_recall_at_10": 0.7,
   "delta_recall_at_10_pp": -20.000000000000007,
-  "plain_mrr": 0.5808333333333333,
+  "plain_mrr": 0.5891666666666666,
   "context_mrr": 0.4197222222222222,
-  "delta_mrr": -0.1611111111111111,
+  "delta_mrr": -0.1694444444444444,
   "plain_must_not_violations": 0,
   "context_must_not_violations": 0,
   "only_plain_passed": [
@@ -22,13 +22,13 @@
   ],
   "only_context_passed": [],
   "context_budget": {
-    "chars": 15041,
-    "tokens_approx": 3760,
-    "item_count": 65,
+    "chars": 14141,
+    "tokens_approx": 3535,
+    "item_count": 64,
     "user": 2,
     "always_load": 0,
     "goals": 9,
-    "catalog": 54
+    "catalog": 53
   },
   "per_query": [
     {
@@ -423,8 +423,8 @@
       "query": "check diagnostics for value diversity",
       "plain_top_names": [
         "check_pr_scope_fit_at_open_time",
-        "__e2e_test_provenance_bad__",
         "check_diagnostics_diversity",
+        "__e2e_test_provenance_bad__",
         "llm_json_invariant_normalization",
         "pipeline_verification_mandatory"
       ],
@@ -439,7 +439,7 @@
         "check_diagnostics_diversity"
       ],
       "context_hits_at_5": [],
-      "plain_first_hit_rank": 3,
+      "plain_first_hit_rank": 2,
       "context_first_hit_rank": null,
       "plain_must_not_viol": [],
       "context_must_not_viol": [],
@@ -568,14 +568,14 @@
         "jarvis_v2_vision",
         "multiagent_pm_architecture_vision",
         "jarvis_v15_skill_final_plan",
-        "no_jarvis_in_team_docs"
+        "jarvis_public_release_v020"
       ],
       "context_top_names": [
         "jarvis_wrapping_direction",
         "jarvis_v2_vision",
         "multiagent_pm_architecture_vision",
         "jarvis_v15_skill_final_plan",
-        "no_jarvis_in_team_docs"
+        "jarvis_public_release_v020"
       ],
       "plain_hits_at_5": [],
       "context_hits_at_5": [],
@@ -594,7 +594,7 @@
         "lesson_cloud_mcp_limitations",
         "supabase_custom_mcp_preferred",
         "event_driven_perception_v1",
-        "memory_roadmap_stealable_ideas_2026_04_20"
+        "mcp_stack_2026_03_31"
       ],
       "context_top_names": [
         "local_scheduled_tasks_only",

--- a/tests/memory-eval/context-rot-baseline.json
+++ b/tests/memory-eval/context-rot-baseline.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-04-20T04:27:07.623568+00:00",
-  "corpus_size": 312,
+  "timestamp": "2026-04-20T16:06:16.600389+00:00",
+  "corpus_size": 323,
   "total_queries": 20,
   "plain_recall_at_5": 0.9,
   "context_recall_at_5": 0.65,
@@ -8,9 +8,9 @@
   "plain_recall_at_10": 0.9,
   "context_recall_at_10": 0.7,
   "delta_recall_at_10_pp": -20.000000000000007,
-  "plain_mrr": 0.6391666666666667,
-  "context_mrr": 0.4454166666666667,
-  "delta_mrr": -0.19374999999999998,
+  "plain_mrr": 0.5808333333333333,
+  "context_mrr": 0.4197222222222222,
+  "delta_mrr": -0.1611111111111111,
   "plain_must_not_violations": 0,
   "context_must_not_violations": 0,
   "only_plain_passed": [
@@ -22,12 +22,13 @@
   ],
   "only_context_passed": [],
   "context_budget": {
-    "chars": 6333,
-    "tokens_approx": 1583,
-    "item_count": 11,
+    "chars": 15041,
+    "tokens_approx": 3760,
+    "item_count": 65,
     "user": 2,
     "always_load": 0,
-    "goals": 9
+    "goals": 9,
+    "catalog": 54
   },
   "per_query": [
     {
@@ -84,18 +85,18 @@
       "id": "q03",
       "query": "TDD сначала пишем тест который падает",
       "plain_top_names": [
+        "deficit_first_pipeline_architecture",
         "bug_fix_reproduce_first",
         "sand_direction_top_down",
-        "deficit_first_pipeline_architecture",
-        "university_student_cse8012",
-        "read_code_before_implementing"
+        "__e2e_test_provenance_bad__",
+        "university_student_cse8012"
       ],
       "context_top_names": [
+        "deficit_first_pipeline_architecture",
         "bug_fix_reproduce_first",
         "sand_direction_top_down",
-        "deficit_first_pipeline_architecture",
-        "university_student_cse8012",
-        "read_code_before_implementing"
+        "__e2e_test_provenance_bad__",
+        "university_student_cse8012"
       ],
       "plain_hits_at_5": [
         "bug_fix_reproduce_first"
@@ -103,8 +104,8 @@
       "context_hits_at_5": [
         "bug_fix_reproduce_first"
       ],
-      "plain_first_hit_rank": 1,
-      "context_first_hit_rank": 1,
+      "plain_first_hit_rank": 2,
+      "context_first_hit_rank": 2,
       "plain_must_not_viol": [],
       "context_must_not_viol": [],
       "plain_passed": true,
@@ -115,17 +116,17 @@
       "query": "always commit and push",
       "plain_top_names": [
         "always_commit_and_push",
+        "schema_sql_requires_paired_migration",
         "review_auto_fix_workflow",
         "dedup_hook_live_test_should_block",
-        "owner_profile",
-        "no_hardcoded_context_in_claude_md"
+        "parallel_delegate_worktree_isolation_failed_2026_04_20"
       ],
       "context_top_names": [
         "always_commit_and_push",
         "dedup_hook_live_test_should_block",
         "no_hardcoded_context_in_claude_md",
         "jarvis_public_release_v020",
-        "jarvis_v2_hybrid_agile"
+        "working_state_jarvis"
       ],
       "plain_hits_at_5": [
         "always_commit_and_push"
@@ -145,17 +146,17 @@
       "query": "act as senior engineer not executor",
       "plain_top_names": [
         "be_the_manager",
+        "architecture_final",
         "instructions_overhaul_2026_04_01",
         "milestone_structure_v2",
-        "dnd_dm_role",
-        "architecture_final"
+        "dnd_dm_role"
       ],
       "context_top_names": [
+        "architecture_final",
         "milestone_structure_v2",
         "dnd_dm_role",
-        "architecture_final",
-        "sand_physics_architecture_2026_04_06",
-        "github_schema_restructured"
+        "metacognition_sprint_plan_2026_04_20",
+        "sand_physics_architecture_2026_04_06"
       ],
       "plain_hits_at_5": [
         "be_the_manager"
@@ -179,8 +180,8 @@
         "jarvis_v2_hybrid_agile"
       ],
       "context_top_names": [
-        "jarvis_v2_vision",
         "jarvis_v2_multiagent_architecture",
+        "jarvis_v2_vision",
         "jarvis_v2_multiagent_direction",
         "jarvis_wrapping_direction",
         "jarvis_v2_hybrid_agile"
@@ -238,15 +239,15 @@
         "memory_server_v2_improvements",
         "postgres_function_signature_migration",
         "pg_generated_cols_null_in_before_update",
-        "supabase_custom_mcp_preferred",
-        "phase_2c_provenance_approach"
+        "schema_sql_requires_paired_migration",
+        "supabase_custom_mcp_preferred"
       ],
       "context_top_names": [
         "memory_server_v2_improvements",
         "postgres_function_signature_migration",
         "pg_generated_cols_null_in_before_update",
-        "supabase_custom_mcp_preferred",
-        "phase_2c_provenance_approach"
+        "schema_sql_requires_paired_migration",
+        "supabase_custom_mcp_preferred"
       ],
       "plain_hits_at_5": [
         "memory_server_v2_improvements"
@@ -268,15 +269,15 @@
         "lessons_agent_delegation",
         "delegate_frontend_to_subagents",
         "delegation_parallel_worktree_scope_leak",
-        "prefer_agents_for_parallel_bugs",
-        "agent_delegation_precision"
+        "agent_delegation_precision",
+        "prefer_agents_for_parallel_bugs"
       ],
       "context_top_names": [
         "lessons_agent_delegation",
         "delegate_frontend_to_subagents",
         "delegation_parallel_worktree_scope_leak",
-        "prefer_agents_for_parallel_bugs",
-        "agent_delegation_precision"
+        "agent_delegation_precision",
+        "prefer_agents_for_parallel_bugs"
       ],
       "plain_hits_at_5": [
         "lessons_agent_delegation",
@@ -331,15 +332,15 @@
       "plain_top_names": [
         "verify_agent_findings_against_memory",
         "always_recall_before_action",
-        "memory_roadmap_stealable_ideas_2026_04_20",
         "phase3_rewriter_type_narrowing_regression",
+        "linked_dedup_fix",
         "nightly_research_sql_fallback"
       ],
       "context_top_names": [
         "always_recall_before_action",
         "verify_agent_findings_against_memory",
-        "nightly_research_sql_fallback",
         "linked_dedup_fix",
+        "nightly_research_sql_fallback",
         "check_diagnostics_diversity"
       ],
       "plain_hits_at_5": [
@@ -421,24 +422,24 @@
       "id": "q14",
       "query": "check diagnostics for value diversity",
       "plain_top_names": [
+        "check_pr_scope_fit_at_open_time",
+        "__e2e_test_provenance_bad__",
         "check_diagnostics_diversity",
         "llm_json_invariant_normalization",
-        "pipeline_verification_mandatory",
-        "autonomous_loop_last_run",
-        "bug_analysis_575_576_577"
+        "pipeline_verification_mandatory"
       ],
       "context_top_names": [
+        "check_pr_scope_fit_at_open_time",
+        "__e2e_test_provenance_bad__",
         "llm_json_invariant_normalization",
         "pipeline_verification_mandatory",
-        "autonomous_loop_last_run",
-        "bug_analysis_575_576_577",
-        "event_dispatch_spam_fix"
+        "parallel_delegate_worktree_isolation_failed_2026_04_20"
       ],
       "plain_hits_at_5": [
         "check_diagnostics_diversity"
       ],
       "context_hits_at_5": [],
-      "plain_first_hit_rank": 1,
+      "plain_first_hit_rank": 3,
       "context_first_hit_rank": null,
       "plain_must_not_viol": [],
       "context_must_not_viol": [],
@@ -449,15 +450,15 @@
       "id": "q15",
       "query": "multi-agent frameworks landscape comparison",
       "plain_top_names": [
-        "team_ai_agent_project_initiated",
         "jarvis_v2_multiagent_architecture",
+        "team_ai_agent_project_initiated",
         "jarvis_scalable_agent_system",
         "competitive_landscape_multi_agent_2026",
         "managed_agents_wait_and_see"
       ],
       "context_top_names": [
-        "team_ai_agent_project_initiated",
         "jarvis_v2_multiagent_architecture",
+        "team_ai_agent_project_initiated",
         "jarvis_scalable_agent_system",
         "competitive_landscape_multi_agent_2026",
         "managed_agents_wait_and_see"
@@ -497,7 +498,7 @@
       ],
       "context_hits_at_5": [],
       "plain_first_hit_rank": 1,
-      "context_first_hit_rank": 8,
+      "context_first_hit_rank": 9,
       "plain_must_not_viol": [],
       "context_must_not_viol": [],
       "plain_passed": true,
@@ -507,18 +508,18 @@
       "id": "q17",
       "query": "DnD dungeon master hobby",
       "plain_top_names": [
-        "research_threejs_heightmap_visualization",
         "skill_proliferation_antipattern",
+        "research_threejs_heightmap_visualization",
         "nightly_research_sql_fallback",
         "research_skill_firecrawl_v2",
-        "sculpture_vision_system"
+        "proactive_goal_tracking"
       ],
       "context_top_names": [
-        "research_threejs_heightmap_visualization",
         "skill_proliferation_antipattern",
+        "research_threejs_heightmap_visualization",
         "nightly_research_sql_fallback",
-        "sculpture_vision_system",
-        "research_skill_firecrawl_v2"
+        "research_skill_firecrawl_v2",
+        "proactive_goal_tracking"
       ],
       "plain_hits_at_5": [],
       "context_hits_at_5": [],
@@ -536,8 +537,8 @@
         "jarvis_v2_hybrid_agile",
         "jarvis_v2_vision",
         "no_deterministic_pipelines",
-        "redrobot_agile_full_migration",
-        "goals_system_v1"
+        "goals_system_v1",
+        "redrobot_agile_full_migration"
       ],
       "context_top_names": [
         "redrobot_agile_full_migration",
@@ -567,14 +568,14 @@
         "jarvis_v2_vision",
         "multiagent_pm_architecture_vision",
         "jarvis_v15_skill_final_plan",
-        "jarvis_public_release_v020"
+        "no_jarvis_in_team_docs"
       ],
       "context_top_names": [
         "jarvis_wrapping_direction",
         "jarvis_v2_vision",
         "multiagent_pm_architecture_vision",
         "jarvis_v15_skill_final_plan",
-        "jarvis_public_release_v020"
+        "no_jarvis_in_team_docs"
       ],
       "plain_hits_at_5": [],
       "context_hits_at_5": [],
@@ -591,9 +592,9 @@
       "plain_top_names": [
         "local_scheduled_tasks_only",
         "lesson_cloud_mcp_limitations",
-        "memory_roadmap_stealable_ideas_2026_04_20",
         "supabase_custom_mcp_preferred",
-        "event_driven_perception_v1"
+        "event_driven_perception_v1",
+        "memory_roadmap_stealable_ideas_2026_04_20"
       ],
       "context_top_names": [
         "local_scheduled_tasks_only",


### PR DESCRIPTION
## Summary

- Adds a **Memory Catalog** section to `scripts/session-context.py` — one-line inventory of every live memory in scope (current project + global). Gives Jarvis awareness of what exists so it can pull full content on demand via `memory_get` / `memory_recall`, instead of recall'ing blind.
- Mirrors the catalog in `scripts/eval-recall.py:_load_session_context` so context-rot measurement stays symmetric.
- Refreshes `tests/memory-eval/context-rot-baseline.json` with the new context shape.

## Why

After v0.4.0 ship, `context-rot-baseline.json` showed -25pp recall@5 rot at the bare minimum session-start config (user + always_load + goals, 1583 tokens). LongMemEval's signal confirmed: more context in the prompt hurts recall. But going lighter is not the answer either — Jarvis had no awareness of what lives in memory and searched blind.

Owner decision (memory `next_memory_direction_token_fine_tuning`): lazy index over aggressive pruning. Show a catalog (name + description + type + scope), let the model decide when to fetch content.

## Design

**Catalog section format** — one line per memory:
```
- <name> [<type>/<scope>]: <description-truncated-120>
```

Scope label:
- current project → omitted (implicit)
- `null` → `/global`
- other project → `/<project>`

**Filters:**
- Live: `expired_at IS NULL AND superseded_by IS NULL AND deleted_at IS NULL AND (valid_to IS NULL OR valid_to > now())`
- Scope: `project = <current> OR project IS NULL` (non-project cwd → global only)
- Exclude already-rendered: `type=user`, `'always_load' IN tags`, `name=working_state_<project>`

**Sort:** `last_accessed_at DESC NULLS LAST` — recently touched first.

**Cap:** 200 rows (server-side), additional filters may reduce further.

**Does NOT bump last_accessed_at** — showing a memory in the session-start index is not a read; touching them here would create a feedback loop (catalog is sorted by last_accessed_at) and distort temporal scoring for genuine recall/read events.

## Measurement

Context-rot harness with the new catalog:

| metric | prior baseline | this PR | delta |
|---|---|---|---|
| plain recall@5 | 90.0% | 90.0% | 0 |
| **context recall@5** | **65.0%** | **65.0%** | **0** |
| delta recall@5 | -25.0 pp | -25.0 pp | 0 |
| delta MRR | -0.194 | -0.169 | +0.025 |
| context_budget chars | 6333 | ~15000 | +8700 |
| items | 11 | ~65 (user=2, goals=9, catalog=~54) | +54 |

**Honest read:** rot was -25pp and stays -25pp — catalog did not worsen retrieval. The MRR improvement is noise-adjacent. The value delivered by this PR is **awareness**, not a rot reduction; rot reduction lands in 7.2 (brief mode on `memory_recall`) and 7.3 (known-unknowns + calibration gating). Non-rot eval unchanged (recall@5 = 90%, MRR 0.581).

## Review feedback addressed

- Added `deleted_at IS NULL` filter to catalog queries in both files
- Aware-datetime parsing for `valid_to` (Supabase returns str or datetime, str can have Z suffix); eval-recall pushes it server-side via `or_()` since no other or-clause competes there
- Mirrored session-context.py catalog format in eval-recall.py blob (bullets + [type/scope] + 120-char description truncation)
- Removed `touched_ids.extend(catalog_ids)` — catalog exposure should not bump last_accessed_at (feedback loop)

## Test plan

- [x] Smoke-test `python scripts/session-context.py` — catalog section renders
- [x] `python scripts/eval-recall.py --with-session-context --save-context-rot-baseline` — saved refreshed baseline
- [x] `python scripts/eval-recall.py --quiet` — non-rot recall@5 = 90% (no regression)
- [ ] Manual smoke: new Claude Code session → catalog appears under `## Memory Catalog`

Closes #263. Part of Phase 7 anchor #262 / milestone #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)