### PR TITLE
feat(memory): brief mode for memory_recall + auto-inject hook (#265)

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -1665,7 +1665,9 @@ async def _hybrid_recall(
         merged = _rrf_merge(semantic_rows, keyword_rows, limit)
 
         if not merged:
-            return [], await _keyword_recall(client, query_text, project, mem_type, limit)
+            return [], await _keyword_recall(
+                client, query_text, project, mem_type, limit, brief
+            )
 
         # Phase 1 polish (#240): match_memories RPC doesn't project confidence.
         # Enrich merged rows before scoring so entrenchment multiplier has data.
@@ -1762,7 +1764,9 @@ async def _hybrid_recall(
         raise
     except Exception:
         # RPC not available (e.g. migration not applied) — fall back to keyword
-        return [], await _keyword_recall(client, query_text, project, mem_type, limit)
+        return [], await _keyword_recall(
+            client, query_text, project, mem_type, limit, brief
+        )
 
 
 def _rrf_merge(
@@ -1798,12 +1802,18 @@ def _rrf_merge(
 async def _keyword_recall(
     client, query_text: str, project, mem_type, limit: int, brief: bool = False
 ) -> list[TextContent]:
-    """ILIKE keyword search (fallback when semantic unavailable)."""
-    q = (
-        client.table("memories")
-        .select("name, type, project, description, content, tags, updated_at")
-        .is_("deleted_at", "null")
+    """ILIKE keyword search (fallback when semantic unavailable).
+
+    In brief mode we skip the `content` column — it's never rendered and
+    would bloat the fallback payload, which is hit precisely when the fast
+    path failed and we're already on a slower code path.
+    """
+    cols = (
+        "name, type, project, description, tags, updated_at"
+        if brief
+        else "name, type, project, description, content, tags, updated_at"
     )
+    q = client.table("memories").select(cols).is_("deleted_at", "null")
 
     if project is not None:
         q = q.or_(f"project.eq.{project},project.is.null")
@@ -1882,17 +1892,27 @@ def _format_memories(
                 link_str += f" ({mem['link_strength']:.2f})"
         proj = mem.get("project") or "global"
         if brief:
-            # Score provenance: rrf > similarity > rank. Only one field is set
-            # on any given row (see _rrf_merge / _keyword_recall).
+            # `_temporal_score` (set by _apply_temporal_scoring) is the actual
+            # sort key after rrf × recency × access × entrenchment. Show it
+            # first so the displayed value matches the displayed order.
+            # Retrieval provenance (rrf/sim/rank) follows as secondary signal
+            # — useful for debugging why a row surfaced at all.
+            temporal = mem.get("_temporal_score")
             rrf = mem.get("_rrf_score")
             sim = mem.get("similarity")
             rank = mem.get("rank")
+            base_parts = []
             if rrf is not None:
-                score_str = f" (rrf {rrf:.3f})"
+                base_parts.append(f"rrf {rrf:.3f}")
             elif isinstance(sim, (int, float)):
-                score_str = f" (sim {sim:.2f})"
+                base_parts.append(f"sim {sim:.2f}")
             elif isinstance(rank, (int, float)):
-                score_str = f" (rank {rank:.2f})"
+                base_parts.append(f"rank {rank:.2f}")
+            if isinstance(temporal, (int, float)):
+                lead = f"score {temporal:.3f}"
+                score_str = f" ({lead}; {base_parts[0]})" if base_parts else f" ({lead})"
+            elif base_parts:
+                score_str = f" ({base_parts[0]})"
             else:
                 score_str = ""
             desc = (mem.get("description") or "").strip()

--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -584,6 +584,16 @@ async def list_tools() -> list[Tool]:
                         ),
                         "default": False,
                     },
+                    "brief": {
+                        "type": "boolean",
+                        "description": (
+                            "When true, omit full content — return only name, "
+                            "type, project, tags, description, and score. Use to "
+                            "preview what's relevant before committing prompt "
+                            "budget; call memory_get for full content on hits."
+                        ),
+                        "default": False,
+                    },
                 },
             },
         ),
@@ -1564,6 +1574,7 @@ async def _handle_recall(args: dict) -> list[TextContent]:
 
     include_links = args.get("include_links", False)
     show_history = args.get("show_history", False)
+    brief = args.get("brief", False)
 
     # Hybrid search: combine semantic + keyword results via RRF + temporal scoring
     if query_text:
@@ -1578,6 +1589,7 @@ async def _handle_recall(args: dict) -> list[TextContent]:
                 limit,
                 include_links,
                 show_history,
+                brief,
             )
             # Track reads (fire-and-forget)
             ids = [r["id"] for r in rows if r.get("id")]
@@ -1586,7 +1598,7 @@ async def _handle_recall(args: dict) -> list[TextContent]:
             return results
 
     # Fallback: keyword-only search
-    results = await _keyword_recall(client, query_text, project, mem_type, limit)
+    results = await _keyword_recall(client, query_text, project, mem_type, limit, brief)
 
     # Lazily backfill embeddings for records missing them (fire-and-forget)
     if os.environ.get("VOYAGE_API_KEY"):
@@ -1604,6 +1616,7 @@ async def _hybrid_recall(
     limit: int,
     include_links: bool = False,
     show_history: bool = False,
+    brief: bool = False,
 ) -> tuple[list[dict], list[TextContent]]:
     """Hybrid search: server-side pgvector semantic + pg_trgm keyword, merged via RRF.
 
@@ -1677,10 +1690,12 @@ async def _hybrid_recall(
                 )
             )
 
-        formatted = _format_memories(merged)
+        formatted = _format_memories(merged, brief=brief)
         search_type = "hybrid+temporal" if keyword_rows else "semantic+temporal"
-        text = f"Found {len(merged)} memories ({search_type} search):\n\n" + "\n---\n".join(
-            formatted
+        mode_tag = ", brief" if brief else ""
+        text = (
+            f"Found {len(merged)} memories ({search_type} search{mode_tag}):\n\n"
+            + ("\n".join(formatted) if brief else "\n---\n".join(formatted))
         )
 
         # Track known unknowns: if top similarity < 0.45, log as a potential gap
@@ -1709,10 +1724,12 @@ async def _hybrid_recall(
                             seen_linked.add(rid)
                             unique_linked.append(r)
                     if unique_linked:
-                        link_formatted = _format_memories(unique_linked, link_info=True)
+                        link_formatted = _format_memories(
+                            unique_linked, link_info=True, brief=brief
+                        )
                         text += (
                             f"\n\n### Linked memories ({len(unique_linked)}):\n\n"
-                            + "\n---\n".join(link_formatted)
+                            + ("\n".join(link_formatted) if brief else "\n---\n".join(link_formatted))
                         )
 
         # Phase 5 metacognition: emit memory_recall event for FOK batch processing (#250).
@@ -1779,7 +1796,7 @@ def _rrf_merge(
 
 
 async def _keyword_recall(
-    client, query_text: str, project, mem_type, limit: int
+    client, query_text: str, project, mem_type, limit: int, brief: bool = False
 ) -> list[TextContent]:
     """ILIKE keyword search (fallback when semantic unavailable)."""
     q = (
@@ -1805,12 +1822,13 @@ async def _keyword_recall(
     if not result.data:
         return [TextContent(type="text", text="No memories found.")]
 
-    formatted = _format_memories(result.data)
+    formatted = _format_memories(result.data, brief=brief)
+    mode_tag = ", brief" if brief else ""
     return [
         TextContent(
             type="text",
-            text=f"Found {len(result.data)} memories (keyword search):\n\n"
-            + "\n---\n".join(formatted),
+            text=f"Found {len(result.data)} memories (keyword search{mode_tag}):\n\n"
+            + ("\n".join(formatted) if brief else "\n---\n".join(formatted)),
         )
     ]
 
@@ -1840,7 +1858,20 @@ async def _emit_recall_event(client, payload: dict) -> None:
         pass
 
 
-def _format_memories(memories: list[dict], link_info: bool = False) -> list[str]:
+def _format_memories(
+    memories: list[dict], link_info: bool = False, brief: bool = False
+) -> list[str]:
+    """Format memory rows for display.
+
+    brief=False (default): full markdown block with header + description +
+    updated_at + content. Suited to a Jarvis-driven targeted recall where the
+    whole memory needs to land in the prompt.
+
+    brief=True: single-line `- name [type/project] (score): description`.
+    Suited to bulk/auto injection (UserPromptSubmit hook) where the agent
+    should preview what's relevant and pull full content via memory_get on
+    hits it actually wants. Content-free, so it can't rot long answers.
+    """
     formatted = []
     for mem in memories:
         tags_str = f" [{', '.join(mem.get('tags', []))}]" if mem.get("tags") else ""
@@ -1849,12 +1880,32 @@ def _format_memories(memories: list[dict], link_info: bool = False) -> list[str]
             link_str = f" ← {mem['link_type']}"
             if mem.get("link_strength"):
                 link_str += f" ({mem['link_strength']:.2f})"
-        formatted.append(
-            f"## {mem['name']} ({mem['type']}, {mem.get('project') or 'global'}){tags_str}{link_str}\n"
-            f"*{mem.get('description', '')}*\n"
-            f"Updated: {mem.get('updated_at', '?')}\n\n"
-            f"{mem['content']}\n"
-        )
+        proj = mem.get("project") or "global"
+        if brief:
+            # Score provenance: rrf > similarity > rank. Only one field is set
+            # on any given row (see _rrf_merge / _keyword_recall).
+            rrf = mem.get("_rrf_score")
+            sim = mem.get("similarity")
+            rank = mem.get("rank")
+            if rrf is not None:
+                score_str = f" (rrf {rrf:.3f})"
+            elif isinstance(sim, (int, float)):
+                score_str = f" (sim {sim:.2f})"
+            elif isinstance(rank, (int, float)):
+                score_str = f" (rank {rank:.2f})"
+            else:
+                score_str = ""
+            desc = (mem.get("description") or "").strip()
+            formatted.append(
+                f"- {mem['name']} [{mem['type']}/{proj}]{tags_str}{score_str}{link_str}: {desc}"
+            )
+        else:
+            formatted.append(
+                f"## {mem['name']} ({mem['type']}, {proj}){tags_str}{link_str}\n"
+                f"*{mem.get('description', '')}*\n"
+                f"Updated: {mem.get('updated_at', '?')}\n\n"
+                f"{mem['content']}\n"
+            )
     return formatted
 
 

--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -320,11 +320,13 @@ def _score_str(m: dict) -> str:
 def format_memory_brief(m: dict) -> str:
     """One-line preview for bulk auto-injection (Phase 7.2).
 
-    Format: `- name [type/project] [tags] (score): description`. Matches the
-    session-start catalog layout (scripts/session-context.py::_fmt_catalog_entry)
-    but adds the per-query score so the agent can distinguish hybrid-ranked
-    hits from the recency-sorted inventory. No content body — agent pulls
-    via memory_get on anything that looks worth reading.
+    Format: `- name [type/project] [tags] (score): description`. Similar in
+    spirit to the session-start catalog layout
+    (scripts/session-context.py::_fmt_catalog_entry) — this hook block adds
+    the per-query score so the agent can distinguish hybrid-ranked hits
+    from the recency-sorted inventory, and always emits an explicit
+    `type/project` scope (the catalog omits project for the current one).
+    No content body — agent pulls via memory_get on anything worth reading.
     """
     tags = m.get("tags") or []
     tags_str = f" [{', '.join(tags)}]" if tags else ""

--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -16,9 +16,16 @@ technical identifiers) — the kind of tokens that match memories by
 keyword but not semantically.
 
 Types ∈ {feedback, decision, reference}. Scope: current project (cwd
-basename) + global. Capped at ~40K chars (~10K tokens, ~5% of 200K
-context). `user` + `project` are already loaded at session start by
-scripts/session-context.py and excluded here to avoid duplication.
+basename) + global. `user` + `project` are already loaded at session
+start by scripts/session-context.py and excluded here to avoid
+duplication.
+
+Phase 7.2: by default emits **brief** entries (one line per hit —
+name + type/project + tags + score + description). The agent previews
+what's relevant and calls memory_get(name=...) on anything worth
+reading, instead of every UserPromptSubmit paying ~40KB of full
+content. Legacy full mode still available via BRIEF_MODE=False for
+debugging.
 
 Touches accessed memories via RPC so the ACT-R access-frequency boost
 applies. Semantic failure falls back to keyword-only search (still using
@@ -65,7 +72,14 @@ SIMILARITY_THRESHOLD = 0.30  # calibrated 2026-04-17: real user prompts hit 0.35
 # top-similarity on voyage-3-lite/512 with conversational queries. 0.30 catches
 # clearly-relevant matches without firing on unrelated memories (which sit <0.25).
 # server.py default SIMILARITY_THRESHOLD is also 0.25 for the same reason.
-CHAR_BUDGET = 40_000         # ~10K tokens, ~5% of 200K window
+# Phase 7.2 default: brief-mode one-line entries instead of full content. Jarvis
+# sees the inventory relevant to the prompt and fetches content via memory_get
+# on hits it actually wants. Reduces per-turn rot since we no longer dump
+# 5-10 full bodies into every UserPromptSubmit.
+BRIEF_MODE = True
+CHAR_BUDGET_FULL = 40_000    # ~10K tokens, ~5% of 200K window (legacy path)
+CHAR_BUDGET_BRIEF = 12_000   # ~3K tokens — ~60 brief entries at ~200 chars each
+CHAR_BUDGET = CHAR_BUDGET_BRIEF if BRIEF_MODE else CHAR_BUDGET_FULL
 FETCH_LIMIT = 50             # pull wide per signal, cap by budget in Python
 # Types loaded per-prompt. Excluded:
 #   'user'    — loaded at session start (scripts/session-context.py top-2)
@@ -276,38 +290,56 @@ def detect_project(cwd: str) -> str | None:
     return name if name in KNOWN_PROJECTS else None
 
 
-def format_memory(m: dict) -> str:
-    tags = m.get("tags") or []
-    tags_str = f" [{', '.join(tags)}]" if tags else ""
-    # Signal-accurate score display. rrf_merge only sets _rrf_score on
-    # rows hit by both signals, so single-signal hits fall through to
-    # their native field (similarity for semantic, rank for keyword/FTS).
-    # _sort_score is set only on single-signal rows that were type-boosted
-    # — without it, the displayed sim/rank would contradict the actual
-    # ranking (the boost changed the sort key, not the native score).
-    # _link_score is set on rows pulled in by 1-hop BFS that weren't in
-    # the direct RRF result — surfaces link provenance to the reader.
+def _score_str(m: dict) -> str:
+    """Render the ranking signal visible to the reader.
+
+    Shared between `format_memory` (full) and `format_memory_brief`. The
+    priority mirrors rrf_merge's field invariants: _rrf_score is set only on
+    dual-signal rows; _sort_score only on boosted single-signal rows;
+    _link_score only on rows pulled in by 1-hop BFS. Falling through to
+    native similarity/rank keeps the displayed score truthful.
+    """
     rrf = m.get("_rrf_score")
     sort_score = m.get("_sort_score")
     link_score = m.get(LINK_SCORE_FIELD)
     sim = m.get("similarity")
     rank = m.get("rank")
     if rrf is not None:
-        score_str = f" (rrf {rrf:.3f})"
-    elif sort_score is not None:
-        score_str = f" (boost {sort_score:.3f})"
-    elif link_score is not None:
-        score_str = f" (link {link_score:.3f})"
-    elif sim is not None:
-        score_str = f" (sim {sim:.2f})"
-    elif rank is not None:
-        score_str = f" (rank {rank:.2f})"
-    else:
-        score_str = ""
+        return f" (rrf {rrf:.3f})"
+    if sort_score is not None:
+        return f" (boost {sort_score:.3f})"
+    if link_score is not None:
+        return f" (link {link_score:.3f})"
+    if sim is not None:
+        return f" (sim {sim:.2f})"
+    if rank is not None:
+        return f" (rank {rank:.2f})"
+    return ""
+
+
+def format_memory_brief(m: dict) -> str:
+    """One-line preview for bulk auto-injection (Phase 7.2).
+
+    Format: `- name [type/project] [tags] (score): description`. Matches the
+    session-start catalog layout (scripts/session-context.py::_fmt_catalog_entry)
+    but adds the per-query score so the agent can distinguish hybrid-ranked
+    hits from the recency-sorted inventory. No content body — agent pulls
+    via memory_get on anything that looks worth reading.
+    """
+    tags = m.get("tags") or []
+    tags_str = f" [{', '.join(tags)}]" if tags else ""
+    proj = m.get("project") or "global"
+    desc = (m.get("description") or "").strip()
+    return f"- {m['name']} [{m['type']}/{proj}]{tags_str}{_score_str(m)}: {desc}"
+
+
+def format_memory(m: dict) -> str:
+    tags = m.get("tags") or []
+    tags_str = f" [{', '.join(tags)}]" if tags else ""
     proj = m.get("project") or "global"
     desc = m.get("description") or ""
     content = m.get("content") or ""
-    header = f"## {m['name']} ({m['type']}, {proj}){tags_str}{score_str}"
+    header = f"## {m['name']} ({m['type']}, {proj}){tags_str}{_score_str(m)}"
     body = f"*{desc}*\n\n{content}" if desc else content
     return f"{header}\n{body}"
 
@@ -626,13 +658,28 @@ def main():
             bits.append(f"boost: {', '.join(sorted(boost_types))}")
         if bits:
             rewriter_note = f" — rewriter: {'; '.join(bits)}"
-    header = f"# Memories on topic{scope}\n\nHybrid recall ({signal}){rewriter_note}:\n\n"
+    mode_tag = ", brief" if BRIEF_MODE else ""
+    hint = (
+        "\n\n(Brief mode — names + descriptions only. "
+        "Use memory_get(name=...) to fetch full content for any hit worth reading.)"
+        if BRIEF_MODE
+        else ""
+    )
+    header = (
+        f"# Memories on topic{scope}\n\n"
+        f"Hybrid recall ({signal}{mode_tag}){rewriter_note}:{hint}\n\n"
+    )
     parts = [header]
     total = len(header)
     included_ids = []
 
+    # Full mode separates bodies with `---`; brief mode is one line per entry,
+    # so a single newline is enough and keeps the injected block compact.
+    separator = "\n" if BRIEF_MODE else "\n\n---\n\n"
+    formatter = format_memory_brief if BRIEF_MODE else format_memory
+
     for row in rows:
-        block = format_memory(row) + "\n\n---\n\n"
+        block = formatter(row) + separator
         if total + len(block) > CHAR_BUDGET:
             break
         parts.append(block)
@@ -644,8 +691,8 @@ def main():
         silent_exit()
 
     # Trim trailing separator
-    if parts[-1].endswith("---\n\n"):
-        parts[-1] = parts[-1][: -len("---\n\n")]
+    if parts[-1].endswith(separator):
+        parts[-1] = parts[-1][: -len(separator)]
 
     # Touch accessed memories (fire-and-forget; failures ignored)
     try:

--- a/tests/test_memory_recall_hook.py
+++ b/tests/test_memory_recall_hook.py
@@ -333,6 +333,85 @@ class TestFormatMemory:
 
 
 # ---------------------------------------------------------------------------
+# format_memory_brief — one-line bulk-injection layout (Phase 7.2)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMemoryBrief:
+    def test_basic_shape(self):
+        m = {
+            "name": "memory_foo",
+            "type": "feedback",
+            "project": "jarvis",
+            "description": "short description",
+            "similarity": 0.42,
+            "content": "NEVER_RENDERED",
+        }
+        out = mrh.format_memory_brief(m)
+        assert out == "- memory_foo [feedback/jarvis] (sim 0.42): short description"
+
+    def test_global_scope_and_tags(self):
+        m = {
+            "name": "g",
+            "type": "decision",
+            "project": None,
+            "tags": ["a", "b"],
+            "description": "d",
+            "_rrf_score": 0.033,
+        }
+        out = mrh.format_memory_brief(m)
+        assert out == "- g [decision/global] [a, b] (rrf 0.033): d"
+
+    def test_score_precedence_rrf_over_similarity(self):
+        # Same precedence as format_memory — _rrf_score wins so dual-signal
+        # hits never display a stale similarity.
+        m = {"name": "n", "type": "decision", "_rrf_score": 0.42, "similarity": 0.8, "description": "x"}
+        out = mrh.format_memory_brief(m)
+        assert "rrf 0.420" in out
+        assert "sim" not in out
+
+    def test_link_score_surfaces(self):
+        m = {
+            "name": "n", "type": "decision", "_link_score": 0.006,
+            "description": "via-link",
+        }
+        out = mrh.format_memory_brief(m)
+        assert "link 0.006" in out
+
+    def test_missing_description_renders_empty_suffix(self):
+        # Migration-target memories have empty descriptions — brief still
+        # emits them (they carry a name worth seeing), just with nothing
+        # after the colon. Asserted so future polish (e.g. strip trailing
+        # `: `) is a conscious choice, not accidental.
+        m = {"name": "bare", "type": "decision", "project": "jarvis", "similarity": 0.5}
+        out = mrh.format_memory_brief(m)
+        assert out == "- bare [decision/jarvis] (sim 0.50): "
+
+    def test_no_score_fields(self):
+        m = {"name": "n", "type": "reference", "description": "d"}
+        out = mrh.format_memory_brief(m)
+        assert out == "- n [reference/global]: d"
+
+
+# ---------------------------------------------------------------------------
+# main()-level branching for BRIEF_MODE — we don't exec main(), just assert
+# the constants expose the two budgets and that BRIEF_MODE is on by default
+# ---------------------------------------------------------------------------
+
+
+class TestBriefModeConstants:
+    def test_brief_mode_on_by_default(self):
+        assert mrh.BRIEF_MODE is True
+
+    def test_brief_budget_smaller_than_full(self):
+        assert mrh.CHAR_BUDGET_BRIEF < mrh.CHAR_BUDGET_FULL
+        # And CHAR_BUDGET reflects the active mode.
+        expected = mrh.CHAR_BUDGET_BRIEF if mrh.BRIEF_MODE else mrh.CHAR_BUDGET_FULL
+        assert mrh.CHAR_BUDGET == expected
+
+
+
+# ---------------------------------------------------------------------------
 # _score_linked_rows — pure scorer for 1-hop BFS neighbors
 # ---------------------------------------------------------------------------
 

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -370,6 +370,75 @@ class TestFormatMemories:
         result = _format_memories(mems)
         assert len(result) == 5
 
+    # Brief mode — Phase 7.2. One-line rows so bulk/auto-injection sites
+    # don't pay full-content budget.
+
+    def test_brief_basic_layout(self):
+        mem = {
+            "name": "foo",
+            "type": "feedback",
+            "project": "jarvis",
+            "tags": ["a", "b"],
+            "description": "hello world",
+            "similarity": 0.42,
+            "content": "MUST_NOT_APPEAR",
+        }
+        result = _format_memories([mem], brief=True)
+        assert result == ["- foo [feedback/jarvis] [a, b] (sim 0.42): hello world"]
+        assert "MUST_NOT_APPEAR" not in result[0]
+
+    def test_brief_global_scope(self):
+        mem = {"name": "g", "type": "user", "project": None, "description": "d"}
+        result = _format_memories([mem], brief=True)
+        assert result[0] == "- g [user/global]: d"
+
+    def test_brief_temporal_score_leads_when_present(self):
+        # `_temporal_score` is what drives actual ordering after
+        # _apply_temporal_scoring. It must appear first so the shown score
+        # matches the displayed rank; the retrieval signal (rrf/sim) trails
+        # as provenance.
+        mem = {
+            "name": "t",
+            "type": "decision",
+            "project": "jarvis",
+            "description": "x",
+            "_temporal_score": 0.0456,
+            "_rrf_score": 0.0333,
+        }
+        result = _format_memories([mem], brief=True)
+        assert "(score 0.046; rrf 0.033)" in result[0]
+
+    def test_brief_rrf_wins_over_similarity(self):
+        mem = {
+            "name": "r", "type": "decision", "description": "x",
+            "_rrf_score": 0.05, "similarity": 0.9,
+        }
+        result = _format_memories([mem], brief=True)
+        assert "rrf 0.050" in result[0]
+        assert "sim" not in result[0]
+
+    def test_brief_link_info(self):
+        mem = {
+            "name": "l", "type": "decision", "project": "jarvis",
+            "description": "d", "similarity": 0.5,
+            "link_type": "related", "link_strength": 0.75,
+        }
+        result = _format_memories([mem], link_info=True, brief=True)
+        assert "← related (0.75)" in result[0]
+        assert result[0].startswith("- l [decision/jarvis]")
+
+    def test_brief_no_score_fields(self):
+        mem = {"name": "n", "type": "reference", "project": None, "description": "d"}
+        result = _format_memories([mem], brief=True)
+        assert result[0] == "- n [reference/global]: d"
+
+    def test_brief_empty_description(self):
+        # Migration-target memories carry empty descriptions — brief still
+        # surfaces the name (no crash, trailing `: ` is intentional).
+        mem = {"name": "bare", "type": "decision", "project": "jarvis"}
+        result = _format_memories([mem], brief=True)
+        assert result[0] == "- bare [decision/jarvis]: "
+
 
 # ---------------------------------------------------------------------------
 # _create_auto_links (async, mocked Supabase)


### PR DESCRIPTION
## Summary

Phase 7.2 of Memory #262. Content-free display for bulk recall surfaces — stops the UserPromptSubmit hook from dumping ~40KB of full content on every turn.

## Changes

**mcp-memory/server.py**
- `memory_recall` gains `brief: bool = false` param. When true, `_format_memories` emits `- name [type/project] [tags] (score): desc` instead of full `## header\n*desc*\nUpdated: ...\n<content>` blocks.
- Threaded through `_handle_recall → _hybrid_recall / _keyword_recall`. Link-expansion output honors the same flag.

**scripts/memory-recall-hook.py**
- `BRIEF_MODE = True` by default. UserPromptSubmit injects brief one-liners; agent pulls full content via `memory_get(name=...)` on hits worth reading.
- `CHAR_BUDGET` drops 40K → 12K in brief mode (still covers ~60 entries). Shared `_score_str()` between `format_memory` and new `format_memory_brief`.
- Header gets a one-line hint telling the agent how to fetch.

## Why not just shrink the budget?

Full content of 5-10 recalled memories is still rot fuel even at 20K — and most of it is irrelevant to the current prompt (dominant failure mode: Haiku rewriter fires on any keyword, surface unrelated decisions from 6 months ago). Brief mode lets Jarvis see the inventory relevant to the query and fetch only on real hits. Same signal, fraction of the cost.

## Verification

- `python scripts/eval-recall.py --with-rewriter --with-session-context --save-context-rot-baseline` — delta recall@5 unchanged at −25pp, which is expected: 7.2 targets per-turn hook injection, not session-start. Context-rot eval doesn't exercise the hook.
- Smoke-test: `echo '{"prompt":"...","cwd":"..."}' | python scripts/memory-recall-hook.py` — output is well-formed brief list; ~4KB for 45 hits vs. ~40KB before.
- `python -c "import ast; ast.parse(...)"` passes for both files.

## Test plan

- [ ] MCP server: smoke-test `memory_recall(query=..., brief=true)` returns content-free blocks; `brief=false` (default) unchanged.
- [ ] Hook: verify `# Memories on topic` block in a fresh session shows brief entries with the fetch-hint preamble.
- [ ] Regression: run `/status` + a normal coding prompt — confirm no tooling relies on full content being auto-injected.

Closes #265. Part of #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)