### PR TITLE
fix(memory): parse pgvector JSON strings before cosine sim (#268)

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -1440,7 +1440,7 @@ async def _handle_store(args: dict) -> list[TextContent]:
                     .execute()
                 )
                 for gap in open_gaps.data or []:
-                    gap_emb = gap.get("query_embedding")
+                    gap_emb = _parse_pgvector(gap.get("query_embedding"))
                     if gap_emb and embedding and _cosine_sim(embedding, gap_emb) > 0.7:
                         client.table("known_unknowns").update(
                             {
@@ -1465,6 +1465,27 @@ SIMILARITY_THRESHOLD = 0.25  # minimum cosine similarity to include in results
 
 GAP_THRESHOLD = 0.45  # known-unknowns: log gaps when top_similarity < this
 GAP_DEDUP_SIM = 0.9
+
+
+def _parse_pgvector(v: list[float] | str | None) -> list[float] | None:
+    """Normalize a pgvector value returned by supabase-py.
+
+    PostgREST returns vector columns as JSON-encoded strings
+    (e.g. ``"[0.1,0.2,...]"``), not Python lists. Callers that pass the raw
+    value into `_cosine_sim` hit the len-mismatch guard and silently score 0.
+    Return a float list, or None if the value is missing / unparseable.
+    """
+    if v is None:
+        return None
+    if isinstance(v, list):
+        return v
+    if isinstance(v, str):
+        try:
+            parsed = json.loads(v)
+        except (ValueError, TypeError):
+            return None
+        return parsed if isinstance(parsed, list) else None
+    return None
 
 
 def _cosine_sim(a: list[float], b: list[float]) -> float:
@@ -1532,7 +1553,7 @@ def _upsert_known_unknown(
         best_match = None
         best_sim = GAP_DEDUP_SIM
         for gap in open_gaps.data or []:
-            gap_emb = gap.get("query_embedding")
+            gap_emb = _parse_pgvector(gap.get("query_embedding"))
             if gap_emb:
                 sim = _cosine_sim(query_embedding, gap_emb)
                 if sim > best_sim:
@@ -2384,7 +2405,7 @@ async def _upsert_known_unknown(
         # Include hit_count in the select so the increment is correct.
         open_unknowns = client.table("known_unknowns").select("id, query_embedding, hit_count").eq("status", "open").execute()
         for row in open_unknowns.data or []:
-            stored_embedding = row.get("query_embedding")
+            stored_embedding = _parse_pgvector(row.get("query_embedding"))
             if stored_embedding and _cosine_sim(query_embedding, stored_embedding) > 0.9:
                 # Semantic match: increment hit_count
                 client.table("known_unknowns").update({
@@ -2414,7 +2435,7 @@ async def _resolve_known_unknowns(client, memory_embedding: list[float], memory_
         open_unknowns = client.table("known_unknowns").select("id, query_embedding").eq("status", "open").execute()
         now = datetime.now(timezone.utc).isoformat()
         for row in open_unknowns.data or []:
-            stored_embedding = row.get("query_embedding")
+            stored_embedding = _parse_pgvector(row.get("query_embedding"))
             if stored_embedding and _cosine_sim(memory_embedding, stored_embedding) > 0.7:
                 client.table("known_unknowns").update({
                     "status": "resolved",

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -5,6 +5,7 @@ Covers Memory 2.0 core: temporal scoring, RRF merge, formatting, auto-linking.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 import types
@@ -1069,7 +1070,12 @@ class TestDualEmbedWrite:
 # Known unknowns — retrieval gaps + unsatisfied queries (#249)
 # =========================================================================
 
-from server import _cosine_sim, _upsert_known_unknown, _resolve_known_unknowns
+from server import (
+    _cosine_sim,
+    _parse_pgvector,
+    _upsert_known_unknown,
+    _resolve_known_unknowns,
+)
 
 
 class TestCosineSim:
@@ -1104,6 +1110,49 @@ class TestCosineSim:
         # Dim mismatch must not silently truncate via zip — returns 0.0.
         assert _cosine_sim([1.0, 0.0, 0.0], [1.0, 0.0]) == 0.0
         assert _cosine_sim([1.0] * 512, [1.0] * 1024) == 0.0
+
+
+class TestParsePgvector:
+    """supabase-py returns pgvector columns as JSON strings, not lists.
+
+    Regression guard for the known-unknowns dedup/resolution bug where raw
+    string embeddings hit the `_cosine_sim` length-mismatch guard and
+    silently scored 0.
+    """
+
+    def test_list_passes_through(self):
+        v = [0.1, 0.2, 0.3]
+        assert _parse_pgvector(v) is v
+
+    def test_none_returns_none(self):
+        assert _parse_pgvector(None) is None
+
+    def test_json_string_parses_to_list(self):
+        parsed = _parse_pgvector("[0.1, 0.2, 0.3]")
+        assert parsed == [0.1, 0.2, 0.3]
+
+    def test_malformed_string_returns_none(self):
+        assert _parse_pgvector("not-json") is None
+        assert _parse_pgvector("[0.1, 0.2,") is None
+
+    def test_non_list_json_returns_none(self):
+        # A valid JSON number or object is not a vector — reject.
+        assert _parse_pgvector("42") is None
+        assert _parse_pgvector('{"x": 1}') is None
+
+    def test_unsupported_type_returns_none(self):
+        assert _parse_pgvector(42) is None  # type: ignore[arg-type]
+
+    def test_string_embedding_yields_nonzero_similarity(self):
+        """Core regression: feed a JSON-string embedding through the parser,
+        then _cosine_sim against an identical list must score ~1.0. Before
+        the fix, len("[0.1,...]") != len([0.1,...]) → guard returned 0.0."""
+        vec = [0.1] * 512
+        stored_as_string = json.dumps(vec)  # what supabase-py actually returns
+        parsed = _parse_pgvector(stored_as_string)
+        assert parsed is not None
+        assert len(parsed) == 512
+        assert _cosine_sim(vec, parsed) == pytest.approx(1.0)
 
 
 class TestKnownUnknowns:


### PR DESCRIPTION
## Summary

Parse pgvector values returned by supabase-py (JSON-encoded strings) into Python lists before feeding them to `_cosine_sim`. Without this, the length-mismatch guard inside `_cosine_sim` silently scored 0 and both semantic dedup + semantic resolution of `known_unknowns` never fired.

Closes #268.
Refs #185 (Pillar 4 Memory overhaul, Phase 5 known-unknowns).

## Why

PostgREST returns `vector(N)` columns as JSON strings like `"[-0.08,0.12,...]"`, not lists. Verified from a live hook session:

```python
client.table("known_unknowns").select("id, query_embedding").limit(2).execute()
# row.get("query_embedding") → type=str, len≈6200, head="[-0.08,..."
```

Effect before the fix:
- Semantic dedup on `_upsert_known_unknown` never triggered → duplicate open gaps
- Semantic resolution on `_resolve_known_unknowns` never triggered → resolved gaps stayed open
- No exception, no log: the `_cosine_sim` short-circuit returned 0.0 because a string's `len()` is its char count, not its vector dim

## Decisions & Alternatives

- **One helper, four call sites.** Owner flagged two sites; I found two more of the same pattern in duplicate code paths (lines 1444 and 1537). Fixing only half would leave the bug active — same root cause, same table, same `_cosine_sim` contract. The helper adds negligible overhead.
- **Named `_parse_pgvector`** (not `_parse_embedding`) to match an unpushed helper the owner is already writing in `scripts/memory-recall-hook.py`. Consistent naming > local preference.
- **Did not deduplicate** the two copies of `_cosine_sim` / `_upsert_known_unknown` / `_resolve_known_unknowns` that live in the file. That's a separate cleanup; bundling it would balloon the diff and risk behavioral changes. Flagged in the commit message.
- **Did not run `ruff format`** because it would churn ~40 unrelated lines. My additions are already format-clean.

## Risk Assessment

- **LOW**: behavior-preserving when the DB returns a list (existing tests cover this). Helper is pure, no side effects, best-effort paths stay best-effort.
- Worst-case new failure mode: `_parse_pgvector` returns `None` on unexpected input → call site's `if stored_embedding` guard short-circuits, matching pre-fix behavior. No regression.

## Testing

- `pytest tests/test_memory_server.py -q` → **84 passed**
- New `TestParsePgvector` class (7 tests): list passthrough, None, JSON-string parse, malformed string, non-list JSON, unsupported type, and the core regression — JSON-string embedding round-trips through the parser and scores ≈ 1.0 against an identical list.
- Ruff: no new errors (9 pre-existing baseline errors untouched).

## Files Changed

- `mcp-memory/server.py` — new `_parse_pgvector` helper + 4 call-site patches
- `tests/test_memory_server.py` — `json` import, extended `server` import, `TestParsePgvector` class