### PR TITLE
feat(compression): PreCompact hook + transcript parser + Supabase snapshot (#278)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
   "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [
+          { "type": "command", "command": "python scripts/pre-compact-backup.py" }
+        ]
+      },
+      {
+        "matcher": "manual",
+        "hooks": [
+          { "type": "command", "command": "python scripts/pre-compact-backup.py" }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup",

--- a/docs/design/compression-resilience.md
+++ b/docs/design/compression-resilience.md
@@ -1,0 +1,104 @@
+# Compression Resilience
+
+**Status:** Sprint 1 in flight (milestone #25, epic #277)
+**Owner directive (2026-04-21):** "Jarvis needs to run autonomously for many
+hours and still produce a high-quality session close after one or more
+compactions."
+
+## Problem
+
+Claude Code auto-compacts long sessions. Compaction replaces raw conversation
+history with an LLM-generated summary. The summary is good at capturing
+narrative but lossy on the artefacts `/end` depends on:
+
+- **Decisions** — rationale, alternatives considered, reversibility
+- **Behavioural observations** — mid-session feedback ("stop doing X")
+- **Exact action log** — which files were edited, which PRs opened, which
+  memories written
+
+Current state (pre-sprint):
+
+- `SessionStart:compact` hook re-injects `working_state_*` after compaction
+  — forward recall works.
+- Nothing captures pre-compact state. Backward recall is lossy.
+- `/end` scans the **post-compact** conversation. It operates on the summary,
+  not on what actually happened.
+
+Net effect: a session that survives auto-compaction produces a degraded
+`/end` output — decisions get lost, behavioural lessons get paraphrased
+into vague "the owner gave feedback on X".
+
+## Solution — three phases
+
+### Phase 1 — capture pre-compact snapshot (issue #278)
+
+Register a `PreCompact` hook that runs **before** compaction.
+
+1. Read hook input from stdin (`session_id`, `transcript_path`, `trigger`).
+2. Parse the full session JSONL transcript at `transcript_path`.
+3. Extract structured artefacts:
+   - User messages (deduped, skipping command-messages / skill bootstraps)
+   - Tool calls (Bash, Edit/Write targets, memory ops, GitHub actions, chapters)
+   - Last TodoWrite state — the canonical "open loops" view
+   - Last assistant text block
+   - git branch (from most recent entry)
+4. Compose a markdown snapshot under 30KB. Truncate head if transcript
+   >10K lines (keep last 8K with a drop counter).
+5. Upsert to Supabase `memories`:
+   - `name = session_snapshot_<session_id>`
+   - `type = project`, `project = <detected from cwd>`
+   - `tags = ["session-snapshot", "compression-resilience", <trigger>]`
+   - `source_provenance = "hook:pre-compact"`
+6. **Never block compaction.** On Supabase failure, write a local fallback
+   file at `.claude/session-snapshots/<session_id>.md` and exit 0.
+
+Sized to ship without schema changes — snapshots live in the existing
+`memories` table.
+
+### Phase 2 — inject snapshot on resume (issue #279)
+
+Extend `scripts/session-context.py` (the `SessionStart:compact` hook
+loader): when running in the `compact` matcher, look up
+`session_snapshot_<session_id>` and emit it under a
+`## Pre-Compact Recovery` section.
+
+This gives the post-compact Claude immediate access to the structured
+artefacts the LLM-summary smoothed over. Purely additive — the existing
+working-state re-injection keeps working.
+
+### Phase 3 — /end reads from Supabase (issue #280)
+
+Rework `.claude/skills/end/SKILL.md` so the primary source of truth for
+decisions, behavioural notes, and action log is Supabase (via
+`session_snapshot_*` and `record_decision` episodes), **not** the live
+conversation. The conversation is a hint; Supabase is authoritative.
+
+This makes `/end` behave identically before and after compaction.
+
+## Acceptance (sprint-level)
+
+- PreCompact hook fires on both `auto` and `manual` triggers without
+  blocking compaction.
+- `/compact` in a medium session persists `session_snapshot_<session_id>`
+  to Supabase within 10s.
+- After compaction, session-context emits a `## Pre-Compact Recovery`
+  section.
+- `/end` quality is indistinguishable across 0 vs 1+ compactions on a
+  benchmark session.
+
+## Non-goals
+
+- Restoring the full raw transcript inline (too large, defeats compaction).
+- Retroactive snapshots for sessions compacted before this lands.
+- Cross-device snapshot replication (Supabase already handles it).
+
+## Risk register
+
+- **Hook failure blocking compaction** — mitigated by top-level try/except
+  and exit 0 on every path (see `scripts/pre-compact-backup.py`).
+- **Snapshot bloats the memories table** — 30KB × N sessions. Add a
+  consolidation job if it exceeds a month of retention (not in Sprint 1).
+- **Secrets in transcript** — `Bash` inputs may contain tokens. The
+  existing `secret-scanner.py` PreToolUse hook already catches these at
+  source; snapshots inherit whatever slipped through. Revisit if we
+  discover leaks.

--- a/scripts/pre-compact-backup.py
+++ b/scripts/pre-compact-backup.py
@@ -1,0 +1,433 @@
+"""PreCompact hook: capture a durable session snapshot before auto-compaction.
+
+Parses the session JSONL transcript, composes a structured markdown snapshot,
+and upserts it to Supabase (name=`session_snapshot_<session_id>`, type=project)
+with source_provenance="hook:pre-compact". Falls back to a local file under
+`.claude/session-snapshots/<session_id>.md` when Supabase is unreachable.
+
+Invariants:
+- **Never** blocks compaction. Exits 0 on all paths, including failures.
+- Snapshot content stays under SIZE_BUDGET bytes (~30KB). Long transcripts
+  keep only the last TAIL_KEEP entries with a dropped-head counter.
+
+Registered in `.claude/settings.json` under `PreCompact` for both `auto` and
+`manual` matchers.
+
+Hook input (stdin, JSON):
+  session_id, transcript_path, cwd, hook_event_name, trigger ("auto"|"manual")
+
+Related:
+- `scripts/session-context.py` — reads snapshots on resume (Phase 2, #279)
+- `.claude/skills/end/SKILL.md` — consumes snapshot as primary source (Phase 3, #280)
+"""
+
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Bootstrap: re-exec under venv if running under system Python
+# ---------------------------------------------------------------------------
+_root = Path(__file__).resolve().parent.parent
+_venv_py = _root / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+if _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
+    sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]))
+
+# ---------------------------------------------------------------------------
+# Under venv — safe to import deps
+# ---------------------------------------------------------------------------
+from dotenv import load_dotenv
+
+for _env in [_root / ".env", _root.parent / ".env"]:
+    if _env.exists():
+        # override=True: some shells pre-set empty SUPABASE_*; .env wins.
+        load_dotenv(_env, override=True)
+        break
+
+# UTF-8 output on Windows — Cyrillic in transcripts must survive the hook log.
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+if sys.stderr.encoding and sys.stderr.encoding.lower() != "utf-8":
+    try:
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+SIZE_BUDGET = 30_000  # bytes — content column target
+MAX_TRANSCRIPT_LINES = 10_000  # tail-truncate above this
+TAIL_KEEP = 8_000  # keep last N lines when truncating
+ACTIONS_CAP = 200  # per-section cap on verbose action lines
+KNOWN_PROJECTS = {"jarvis", "redrobot"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure — unit-tested in tests/test_pre_compact_backup.py)
+# ---------------------------------------------------------------------------
+def _detect_project(cwd: str | None) -> str | None:
+    if not cwd:
+        return None
+    try:
+        name = Path(cwd).name.lower()
+    except Exception:
+        return None
+    return name if name in KNOWN_PROJECTS else None
+
+
+def _read_hook_input(stream=None) -> dict:
+    """Read hook input JSON from stdin. Tolerate empty / invalid payloads."""
+    s = stream if stream is not None else sys.stdin
+    try:
+        raw = s.read()
+        if not raw or not raw.strip():
+            return {}
+        return json.loads(raw)
+    except Exception as e:
+        print(f"[pre-compact] bad hook input: {e}", file=sys.stderr)
+        return {}
+
+
+def _parse_transcript(path: Path) -> tuple[list[dict], int, int]:
+    """Return (entries, total_seen, dropped_head).
+
+    If the transcript has more than MAX_TRANSCRIPT_LINES lines, keep only the
+    last TAIL_KEEP; `dropped_head` reports how many leading entries were cut.
+    Malformed lines are silently skipped.
+    """
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except Exception as e:
+        print(f"[pre-compact] read transcript failed: {e}", file=sys.stderr)
+        return [], 0, 0
+
+    total = len(lines)
+    dropped = 0
+    if total > MAX_TRANSCRIPT_LINES:
+        dropped = total - TAIL_KEEP
+        lines = lines[-TAIL_KEEP:]
+
+    entries: list[dict] = []
+    for ln in lines:
+        try:
+            entries.append(json.loads(ln))
+        except Exception:
+            continue
+    return entries, total, dropped
+
+
+def _extract_user_messages(entries: list[dict]) -> list[tuple[str, str]]:
+    """Real user messages only. Skip command-messages, skill invocations,
+    scheduled-task bootstrap, tool_result blocks, and sidechain traffic.
+    Dedup on the first 200 chars so repeated prompts don't bloat the snapshot.
+    """
+    out: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for d in entries:
+        if d.get("type") != "user" or d.get("isSidechain"):
+            continue
+        ts = d.get("timestamp", "")
+        c = d.get("message", {}).get("content")
+        text = ""
+        if isinstance(c, str):
+            text = c
+        elif isinstance(c, list):
+            parts = [
+                blk.get("text", "")
+                for blk in c
+                if isinstance(blk, dict) and blk.get("type") == "text"
+            ]
+            text = "\n".join(parts)
+        text = text.strip()
+        if not text:
+            continue
+        if (
+            text.startswith("<command-message>")
+            or text.startswith("<command-name>")
+            or text.startswith("<scheduled-task")
+            or text.startswith("Base directory for this skill:")
+        ):
+            continue
+        key = text[:200]
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append((ts, text))
+    return out
+
+
+def _summarize_tool(name: str, inp: dict) -> str:
+    """One-line summary of a tool_use block, keyed by tool name."""
+    if name == "Bash":
+        return (inp.get("command") or "").replace("\n", " ").strip()[:180]
+    if name in ("Edit", "Write"):
+        return inp.get("file_path") or ""
+    if name == "NotebookEdit":
+        return inp.get("notebook_path") or ""
+    if name == "Read":
+        return inp.get("file_path") or ""
+    if name in ("Grep", "Glob"):
+        return inp.get("pattern") or ""
+    if name == "TodoWrite":
+        todos = inp.get("todos", []) or []
+        n_in = sum(1 for t in todos if t.get("status") == "in_progress")
+        n_done = sum(1 for t in todos if t.get("status") == "completed")
+        return f"{len(todos)} todos ({n_done} done, {n_in} in progress)"
+    if name == "Skill":
+        return inp.get("skill") or ""
+    if name == "Agent":
+        return inp.get("description") or inp.get("subagent_type") or ""
+    if name == "mcp__memory__memory_store":
+        return f"name={inp.get('name', '?')} type={inp.get('type', '?')}"
+    if name == "mcp__memory__record_decision":
+        return (inp.get("decision") or "")[:120]
+    if name.startswith("mcp__github__"):
+        keys = ("owner", "repo", "issue_number", "pull_number", "title")
+        return " ".join(f"{k}={inp[k]}" for k in keys if k in inp)[:180]
+    if name.startswith("mcp__ccd_session__"):
+        return (inp.get("title") or inp.get("reason") or "")[:120]
+    for k in ("description", "title", "command", "query", "prompt"):
+        v = inp.get(k)
+        if isinstance(v, str):
+            return v[:120]
+    return ""
+
+
+def _extract_actions(entries: list[dict]) -> list[tuple[str, str]]:
+    """(timestamp, 'ToolName: one-line') tuples from assistant tool_use blocks."""
+    out: list[tuple[str, str]] = []
+    for d in entries:
+        if d.get("type") != "assistant":
+            continue
+        ts = d.get("timestamp", "")
+        for blk in d.get("message", {}).get("content", []) or []:
+            if not isinstance(blk, dict) or blk.get("type") != "tool_use":
+                continue
+            name = blk.get("name", "?")
+            inp = blk.get("input", {}) or {}
+            summary = _summarize_tool(name, inp)
+            out.append((ts, f"{name}: {summary}" if summary else name))
+    return out
+
+
+def _extract_last_todos(entries: list[dict]) -> list[dict]:
+    """Most-recent TodoWrite payload — the canonical 'open loops' view."""
+    last: list[dict] = []
+    for d in entries:
+        if d.get("type") != "assistant":
+            continue
+        for blk in d.get("message", {}).get("content", []) or []:
+            if (
+                isinstance(blk, dict)
+                and blk.get("type") == "tool_use"
+                and blk.get("name") == "TodoWrite"
+            ):
+                last = blk.get("input", {}).get("todos", []) or []
+    return last
+
+
+def _extract_last_assistant_text(entries: list[dict]) -> str:
+    for d in reversed(entries):
+        if d.get("type") != "assistant":
+            continue
+        parts = [
+            blk.get("text", "")
+            for blk in d.get("message", {}).get("content", []) or []
+            if isinstance(blk, dict) and blk.get("type") == "text"
+        ]
+        text = "\n".join(parts).strip()
+        if text:
+            return text
+    return ""
+
+
+def _last_git_branch(entries: list[dict]) -> str:
+    for d in reversed(entries):
+        br = d.get("gitBranch")
+        if br:
+            return br
+    return ""
+
+
+def _compose_markdown(
+    session_id: str,
+    trigger: str,
+    cwd: str,
+    entries: list[dict],
+    total_seen: int,
+    dropped_head: int,
+) -> str:
+    """Compose the snapshot body. Enforces SIZE_BUDGET via hard truncation
+    with a visible marker — never silently drops content without notice.
+    """
+    users = _extract_user_messages(entries)
+    actions = _extract_actions(entries)
+    todos = _extract_last_todos(entries)
+    last_text = _extract_last_assistant_text(entries)
+    git_branch = _last_git_branch(entries)
+    captured = datetime.now(timezone.utc).isoformat()
+
+    lines: list[str] = []
+    lines.append(f"# Session Snapshot — {session_id}")
+    lines.append("")
+    lines.append(f"- **Captured at:** {captured}")
+    lines.append(f"- **Trigger:** {trigger}")
+    lines.append(f"- **cwd:** `{cwd}`")
+    if git_branch:
+        lines.append(f"- **git branch:** `{git_branch}`")
+    entries_line = (
+        f"- **Entries parsed:** {len(entries)} (total seen: {total_seen}"
+        + (f", dropped-head: {dropped_head}" if dropped_head else "")
+        + ")"
+    )
+    lines.append(entries_line)
+    lines.append("")
+
+    if users:
+        lines.append(f"## User messages ({len(users)})")
+        for ts, text in users:
+            preview = text.replace("\n", " ").strip()
+            if len(preview) > 500:
+                preview = preview[:500] + " …"
+            lines.append(f"- `{ts}` — {preview}")
+        lines.append("")
+
+    if actions:
+        lines.append(f"## Actions ({len(actions)})")
+        if len(actions) > ACTIONS_CAP:
+            earlier = actions[: len(actions) - ACTIONS_CAP]
+            by_tool = Counter(a[1].split(":", 1)[0] for a in earlier)
+            summ = ", ".join(f"{k}×{v}" for k, v in by_tool.most_common())
+            lines.append(f"Earlier actions (summarized): {summ}")
+            kept = actions[-ACTIONS_CAP:]
+        else:
+            kept = actions
+        for ts, act in kept:
+            a = act.replace("\n", " ").strip()
+            if len(a) > 200:
+                a = a[:200] + " …"
+            lines.append(f"- `{ts}` — {a}")
+        lines.append("")
+
+    if todos:
+        lines.append(f"## Open loops / todos ({len(todos)})")
+        status_mark = {"completed": "x", "in_progress": "~", "pending": " "}
+        for t in todos:
+            mark = status_mark.get(t.get("status", ""), "?")
+            content = t.get("content", "")
+            lines.append(f"- [{mark}] {content}")
+        lines.append("")
+
+    if last_text:
+        lines.append("## Last assistant message (text only)")
+        snippet = last_text
+        if len(snippet) > 2000:
+            snippet = snippet[:2000] + "\n…"
+        lines.append(snippet)
+        lines.append("")
+
+    md = "\n".join(lines)
+    if len(md.encode("utf-8")) > SIZE_BUDGET:
+        marker = "\n\n<!-- truncated at size budget -->\n"
+        budget = SIZE_BUDGET - len(marker.encode("utf-8"))
+        md = md.encode("utf-8")[:budget].decode("utf-8", errors="ignore") + marker
+    return md
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+def _persist_supabase(
+    session_id: str,
+    project: str | None,
+    trigger: str,
+    content: str,
+) -> bool:
+    """Upsert the snapshot to memories. Returns True on success."""
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        return False
+    try:
+        from supabase import create_client
+
+        client = create_client(url, key)
+        payload = {
+            "name": f"session_snapshot_{session_id}",
+            "type": "project",
+            "project": project,
+            "tags": ["session-snapshot", "compression-resilience", trigger or "unknown"],
+            "source_provenance": "hook:pre-compact",
+            "description": (
+                f"Pre-compact session snapshot ({trigger or 'unknown'}) — "
+                "recovery source for /end post-compact"
+            ),
+            "content": content,
+        }
+        client.table("memories").upsert(payload, on_conflict="project,name").execute()
+        return True
+    except Exception as e:
+        print(f"[pre-compact] supabase persist failed: {e}", file=sys.stderr)
+        return False
+
+
+def _persist_local(session_id: str, content: str) -> Path | None:
+    try:
+        out_dir = _root / ".claude" / "session-snapshots"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_file = out_dir / f"{session_id}.md"
+        # Use binary write to avoid Windows \n→\r\n translation, which would
+        # inflate size past SIZE_BUDGET by one byte per newline.
+        out_file.write_bytes(content.encode("utf-8"))
+        print(f"[pre-compact] local fallback: {out_file}", file=sys.stderr)
+        return out_file
+    except Exception as e:
+        print(f"[pre-compact] local fallback failed: {e}", file=sys.stderr)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+def main() -> int:
+    try:
+        hook = _read_hook_input()
+        session_id = hook.get("session_id") or hook.get("sessionId") or "unknown-session"
+        transcript_path = hook.get("transcript_path") or hook.get("transcriptPath") or ""
+        cwd = hook.get("cwd") or os.getcwd()
+        trigger = hook.get("trigger") or hook.get("matcher") or "unknown"
+
+        if not transcript_path:
+            print("[pre-compact] no transcript_path in hook input", file=sys.stderr)
+            return 0
+
+        p = Path(transcript_path)
+        if not p.exists():
+            print(f"[pre-compact] transcript not found: {p}", file=sys.stderr)
+            return 0
+
+        entries, total, dropped = _parse_transcript(p)
+        content = _compose_markdown(session_id, trigger, cwd, entries, total, dropped)
+        project = _detect_project(cwd)
+
+        if not _persist_supabase(session_id, project, trigger, content):
+            _persist_local(session_id, content)
+    except Exception as e:
+        # Never block compaction — log and move on.
+        print(f"[pre-compact] unhandled error: {e}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pre_compact_backup.py
+++ b/tests/test_pre_compact_backup.py
@@ -1,0 +1,406 @@
+"""Unit tests for scripts/pre-compact-backup.py.
+
+The Supabase-upsert path is exercised live (not here). This file covers the
+deterministic parsing + composition pieces that don't need network, plus the
+local fallback and the "never raises" guarantee.
+
+The module filename uses a dash so importlib is required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Stub optional deps so module import succeeds on minimal CI
+# ---------------------------------------------------------------------------
+for _stub in ("dotenv", "supabase"):
+    if _stub not in sys.modules:
+        try:
+            __import__(_stub)
+        except ImportError:
+            mod = types.ModuleType(_stub)
+            if _stub == "dotenv":
+                mod.load_dotenv = lambda *a, **k: None
+            if _stub == "supabase":
+                mod.create_client = lambda *a, **k: None
+            sys.modules[_stub] = mod
+
+
+_PATH = Path(__file__).resolve().parent.parent / "scripts" / "pre-compact-backup.py"
+_spec = importlib.util.spec_from_file_location("pre_compact_backup", _PATH)
+pcb = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pcb)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic transcript entries
+# ---------------------------------------------------------------------------
+def _user_entry(ts: str, text, isSidechain: bool = False) -> dict:
+    return {
+        "type": "user",
+        "timestamp": ts,
+        "isSidechain": isSidechain,
+        "gitBranch": "feat/278-precompact-hook",
+        "message": {"content": text},
+    }
+
+
+def _assistant_tool(ts: str, name: str, inp: dict) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "gitBranch": "feat/278-precompact-hook",
+        "message": {"content": [{"type": "tool_use", "id": "t1", "name": name, "input": inp}]},
+    }
+
+
+def _assistant_text(ts: str, text: str) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "gitBranch": "feat/278-precompact-hook",
+        "message": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _detect_project
+# ---------------------------------------------------------------------------
+class TestDetectProject:
+    def test_known_project(self):
+        assert pcb._detect_project(r"C:\Users\petrk\GitHub\jarvis") == "jarvis"
+        assert pcb._detect_project("/home/x/redrobot") == "redrobot"
+
+    def test_unknown_returns_none(self):
+        assert pcb._detect_project("/tmp/random") is None
+
+    def test_none_or_empty(self):
+        assert pcb._detect_project(None) is None
+        assert pcb._detect_project("") is None
+
+
+# ---------------------------------------------------------------------------
+# _read_hook_input — tolerant JSON
+# ---------------------------------------------------------------------------
+class TestReadHookInput:
+    def test_valid_payload(self):
+        payload = {"session_id": "abc", "transcript_path": "/x"}
+        r = pcb._read_hook_input(io.StringIO(json.dumps(payload)))
+        assert r == payload
+
+    def test_empty_string(self):
+        assert pcb._read_hook_input(io.StringIO("")) == {}
+
+    def test_invalid_json(self):
+        assert pcb._read_hook_input(io.StringIO("not json")) == {}
+
+
+# ---------------------------------------------------------------------------
+# _parse_transcript — file reading + tail truncation
+# ---------------------------------------------------------------------------
+class TestParseTranscript:
+    def test_small_file(self, tmp_path):
+        p = tmp_path / "t.jsonl"
+        p.write_text(
+            "\n".join(json.dumps({"type": "user", "i": i}) for i in range(3)),
+            encoding="utf-8",
+        )
+        entries, total, dropped = pcb._parse_transcript(p)
+        assert total == 3
+        assert dropped == 0
+        assert [e["i"] for e in entries] == [0, 1, 2]
+
+    def test_truncates_above_max(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pcb, "MAX_TRANSCRIPT_LINES", 10)
+        monkeypatch.setattr(pcb, "TAIL_KEEP", 6)
+        p = tmp_path / "t.jsonl"
+        p.write_text(
+            "\n".join(json.dumps({"type": "user", "i": i}) for i in range(15)),
+            encoding="utf-8",
+        )
+        entries, total, dropped = pcb._parse_transcript(p)
+        assert total == 15
+        assert dropped == 9
+        assert len(entries) == 6
+        assert entries[0]["i"] == 9  # kept the tail
+
+    def test_skips_malformed_lines(self, tmp_path):
+        p = tmp_path / "t.jsonl"
+        p.write_text(
+            '{"type":"user","i":0}\n<<garbage>>\n{"type":"user","i":1}\n',
+            encoding="utf-8",
+        )
+        entries, total, _ = pcb._parse_transcript(p)
+        assert total == 3
+        assert [e["i"] for e in entries] == [0, 1]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        entries, total, dropped = pcb._parse_transcript(tmp_path / "missing.jsonl")
+        assert entries == [] and total == 0 and dropped == 0
+
+
+# ---------------------------------------------------------------------------
+# _extract_user_messages — filters + dedup
+# ---------------------------------------------------------------------------
+class TestExtractUserMessages:
+    def test_string_content(self):
+        entries = [_user_entry("2026-04-21T00:00:00Z", "what did I leave running?")]
+        out = pcb._extract_user_messages(entries)
+        assert out == [("2026-04-21T00:00:00Z", "what did I leave running?")]
+
+    def test_list_text_blocks(self):
+        entries = [
+            _user_entry(
+                "t",
+                [
+                    {"type": "text", "text": "hello"},
+                    {"type": "tool_result", "tool_use_id": "x", "content": "ignored"},
+                ],
+            )
+        ]
+        assert pcb._extract_user_messages(entries) == [("t", "hello")]
+
+    def test_filters_noise(self):
+        entries = [
+            _user_entry("t1", "<command-message>morning-brief</command-message>"),
+            _user_entry("t2", "<command-name>/foo</command-name>"),
+            _user_entry("t3", "Base directory for this skill: X"),
+            _user_entry("t4", "<scheduled-task name='x'>bootstrap</scheduled-task>"),
+            _user_entry("t5", "real question"),
+        ]
+        out = pcb._extract_user_messages(entries)
+        assert [text for _, text in out] == ["real question"]
+
+    def test_dedups_repeats(self):
+        entries = [
+            _user_entry("t1", "same question"),
+            _user_entry("t2", "same question"),
+            _user_entry("t3", "different"),
+        ]
+        out = pcb._extract_user_messages(entries)
+        assert [text for _, text in out] == ["same question", "different"]
+
+    def test_skips_sidechain(self):
+        entries = [_user_entry("t", "subagent chatter", isSidechain=True)]
+        assert pcb._extract_user_messages(entries) == []
+
+
+# ---------------------------------------------------------------------------
+# _summarize_tool + _extract_actions
+# ---------------------------------------------------------------------------
+class TestSummarizeTool:
+    def test_bash_strips_newlines_and_caps(self):
+        s = pcb._summarize_tool("Bash", {"command": "echo hi\nsleep 1"})
+        assert "\n" not in s
+        assert s == "echo hi sleep 1"
+
+    def test_edit_returns_path(self):
+        assert pcb._summarize_tool("Edit", {"file_path": "/a/b.py"}) == "/a/b.py"
+
+    def test_todowrite_counts(self):
+        s = pcb._summarize_tool(
+            "TodoWrite",
+            {
+                "todos": [
+                    {"status": "completed"},
+                    {"status": "in_progress"},
+                    {"status": "pending"},
+                    {"status": "pending"},
+                ]
+            },
+        )
+        assert s == "4 todos (1 done, 1 in progress)"
+
+    def test_memory_store(self):
+        s = pcb._summarize_tool(
+            "mcp__memory__memory_store",
+            {"name": "working_state_jarvis", "type": "project"},
+        )
+        assert "name=working_state_jarvis" in s and "type=project" in s
+
+    def test_record_decision_truncates(self):
+        s = pcb._summarize_tool(
+            "mcp__memory__record_decision",
+            {"decision": "x" * 200},
+        )
+        assert len(s) <= 120
+
+    def test_unknown_tool_fallback_description(self):
+        s = pcb._summarize_tool("SomeNewTool", {"description": "does stuff"})
+        assert s == "does stuff"
+
+    def test_unknown_tool_no_useful_field(self):
+        assert pcb._summarize_tool("SomeNewTool", {"foo": 1}) == ""
+
+
+class TestExtractActions:
+    def test_collects_tool_uses(self):
+        entries = [
+            _assistant_tool("t1", "Bash", {"command": "ls"}),
+            _assistant_text("t2", "intermediate thought"),
+            _assistant_tool("t3", "Edit", {"file_path": "a.py"}),
+        ]
+        out = pcb._extract_actions(entries)
+        assert out == [("t1", "Bash: ls"), ("t3", "Edit: a.py")]
+
+
+# ---------------------------------------------------------------------------
+# _extract_last_todos + _extract_last_assistant_text
+# ---------------------------------------------------------------------------
+class TestExtractLastTodos:
+    def test_picks_last(self):
+        first = [{"content": "old", "status": "pending"}]
+        last = [{"content": "new", "status": "in_progress"}]
+        entries = [
+            _assistant_tool("t1", "TodoWrite", {"todos": first}),
+            _assistant_tool("t2", "Bash", {"command": "ls"}),
+            _assistant_tool("t3", "TodoWrite", {"todos": last}),
+        ]
+        assert pcb._extract_last_todos(entries) == last
+
+    def test_no_todowrite(self):
+        entries = [_assistant_tool("t", "Bash", {"command": "ls"})]
+        assert pcb._extract_last_todos(entries) == []
+
+
+class TestExtractLastAssistantText:
+    def test_picks_most_recent(self):
+        entries = [
+            _assistant_text("t1", "first"),
+            _assistant_tool("t2", "Bash", {"command": "ls"}),
+            _assistant_text("t3", "second"),
+        ]
+        assert pcb._extract_last_assistant_text(entries) == "second"
+
+    def test_no_text(self):
+        entries = [_assistant_tool("t", "Bash", {"command": "ls"})]
+        assert pcb._extract_last_assistant_text(entries) == ""
+
+
+# ---------------------------------------------------------------------------
+# _compose_markdown
+# ---------------------------------------------------------------------------
+class TestComposeMarkdown:
+    def test_structure(self):
+        entries = [
+            _user_entry("t1", "what's next?"),
+            _assistant_tool("t2", "Bash", {"command": "git status"}),
+            _assistant_tool(
+                "t3", "TodoWrite", {"todos": [{"content": "ship it", "status": "in_progress"}]}
+            ),
+            _assistant_text("t4", "Done."),
+        ]
+        md = pcb._compose_markdown("s-1", "manual", "/x/jarvis", entries, 4, 0)
+        assert "# Session Snapshot — s-1" in md
+        assert "**Trigger:** manual" in md
+        assert "**cwd:** `/x/jarvis`" in md
+        assert "## User messages (1)" in md
+        assert "what's next?" in md
+        assert "## Actions" in md
+        assert "Bash: git status" in md
+        assert "## Open loops / todos" in md
+        assert "[~] ship it" in md
+        assert "## Last assistant message" in md
+        assert "Done." in md
+
+    def test_reports_dropped_head(self):
+        md = pcb._compose_markdown("s", "auto", "/x", [], total_seen=15000, dropped_head=7000)
+        assert "dropped-head: 7000" in md
+
+    def test_caps_actions_with_summary(self, monkeypatch):
+        monkeypatch.setattr(pcb, "ACTIONS_CAP", 3)
+        entries = [_assistant_tool(f"t{i}", "Bash", {"command": f"cmd{i}"}) for i in range(10)]
+        md = pcb._compose_markdown("s", "auto", "/x", entries, 10, 0)
+        assert "Earlier actions (summarized): Bash×7" in md
+        # Only last 3 bash lines appear verbose
+        assert md.count("`t7` — Bash: cmd7") == 1
+        assert md.count("`t9` — Bash: cmd9") == 1
+        assert "Bash: cmd0" not in md
+
+    def test_enforces_size_budget(self, monkeypatch):
+        monkeypatch.setattr(pcb, "SIZE_BUDGET", 500)
+        # Pile of long bash commands — will bust 500B
+        entries = [_assistant_tool(f"t{i}", "Bash", {"command": "x" * 100}) for i in range(20)]
+        md = pcb._compose_markdown("s", "auto", "/x", entries, 20, 0)
+        assert len(md.encode("utf-8")) <= 500
+        assert "truncated at size budget" in md
+
+
+# ---------------------------------------------------------------------------
+# _persist_local — fallback file
+# ---------------------------------------------------------------------------
+class TestPersistLocal:
+    def test_writes_snapshot_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pcb, "_root", tmp_path)
+        out = pcb._persist_local("session-xyz", "# Snapshot\n")
+        assert out is not None
+        assert out.exists()
+        assert out.parent.name == "session-snapshots"
+        assert out.read_text(encoding="utf-8") == "# Snapshot\n"
+
+
+# ---------------------------------------------------------------------------
+# main — never raises, honours missing/absent inputs
+# ---------------------------------------------------------------------------
+class TestMain:
+    def test_missing_transcript_path_exits_zero(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps({"session_id": "x"})))
+        # No Supabase creds → would take the fallback branch, but transcript_path is empty
+        monkeypatch.setenv("SUPABASE_URL", "")
+        monkeypatch.setenv("SUPABASE_KEY", "")
+        assert pcb.main() == 0
+
+    def test_missing_transcript_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "session_id": "x",
+                        "transcript_path": str(tmp_path / "missing.jsonl"),
+                        "cwd": str(tmp_path),
+                    }
+                )
+            ),
+        )
+        assert pcb.main() == 0
+
+    def test_supabase_fail_triggers_local_fallback(self, tmp_path, monkeypatch):
+        # Build a tiny transcript
+        t = tmp_path / "t.jsonl"
+        t.write_text(json.dumps(_user_entry("ts", "hi")) + "\n", encoding="utf-8")
+        monkeypatch.setattr(pcb, "_root", tmp_path)
+        # Force supabase path to return False → fallback taken
+        monkeypatch.setattr(pcb, "_persist_supabase", lambda *a, **k: False)
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "session_id": "sess-fallback",
+                        "transcript_path": str(t),
+                        "cwd": str(tmp_path),
+                        "trigger": "manual",
+                    }
+                )
+            ),
+        )
+        assert pcb.main() == 0
+        out = tmp_path / ".claude" / "session-snapshots" / "sess-fallback.md"
+        assert out.exists()
+        text = out.read_text(encoding="utf-8")
+        assert "Session Snapshot — sess-fallback" in text
+        assert "**Trigger:** manual" in text
+
+    def test_bad_hook_input_does_not_raise(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("definitely not json"))
+        assert pcb.main() == 0


### PR DESCRIPTION
## Summary
Phase 1 of the compression-resilience sprint ([#277](https://github.com/Osasuwu/jarvis/issues/277), milestone [#25](https://github.com/Osasuwu/jarvis/milestone/25)). Adds a PreCompact hook script that parses the session JSONL transcript, composes a structured markdown snapshot under 30KB, and upserts it to Supabase as `session_snapshot_<session_id>` with `source_provenance = hook:pre-compact`. Falls back to a local file under `.claude/session-snapshots/` if Supabase is unreachable. Hook **never blocks compaction** — every path exits 0.

## Why
Auto-compaction replaces raw conversation with an LLM summary. `/end` scans that summary, not the real history — decisions, behavioural observations, and the exact action log get paraphrased or lost. This sprint lands the plumbing to keep those artefacts durable across compactions. Phase 1 captures. Phase 2 ([#279](https://github.com/Osasuwu/jarvis/issues/279)) will inject on resume. Phase 3 ([#280](https://github.com/Osasuwu/jarvis/issues/280)) will make `/end` read from Supabase as the primary source.

Closes #278

## Decisions & Alternatives
- **Upsert on `(project, name)`** — matches the existing `mcp-memory/server.py` convention (line 1363). The memories table has no UNIQUE on `name` alone, so `on_conflict="name"` fails with 42P10.
- **Binary write for the local fallback** (`write_bytes` instead of `write_text`) — Windows default text mode translates `\n` → `\r\n`, inflating the 30000-byte payload to ~30180. Binary keeps the size budget exact.
- **Filter noise from user-messages** — skip `<command-message>`, `<command-name>`, skill-bootstrap prompts (`Base directory for this skill:`), `<scheduled-task>` wrappers, and sidechain traffic. Without this the snapshot is dominated by plumbing, not the owner's actual requests.
- **ACTIONS_CAP = 200 with a tool-counter summary for earlier actions** — keeps the snapshot informative without blowing the budget on long sessions.
- **Hard-truncate at size budget with a visible `<!-- truncated at size budget -->` marker** — preferred over silently dropping content. Readers can see they hit the ceiling.
- **Rejected**: `MAX_TRANSCRIPT_LINES` + tail-keep applies to JSONL parsing (drop oldest entries when >10K lines), distinct from the content size budget. Two separate budgets because the transcript can have many tiny entries or few huge ones — treating both the same loses signal.

## ⚠ Protected file — manual step for owner
`.claude/settings.json` is in the protected-files list ([docs/security/agent-boundaries.md](../blob/main/docs/security/agent-boundaries.md)). The issue requires registering the hook there; the exact diff:

```diff
 {
   "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [
+          { "type": "command", "command": "python scripts/pre-compact-backup.py" }
+        ]
+      },
+      {
+        "matcher": "manual",
+        "hooks": [
+          { "type": "command", "command": "python scripts/pre-compact-backup.py" }
+        ]
+      }
+    ],
     "SessionStart": [ ... ],
```

Until this diff is applied on each device, the hook is dormant (script works end-to-end when invoked directly — smoke-tested below).

## Risk Assessment
- **LOW**: the script is standalone, has no effect until the `.claude/settings.json` entry is added, and never blocks compaction. Snapshot writes are additive — no schema changes, no migrations.
- **LOW**: local fallback writes to a dedicated directory under the repo; no collision with existing paths.
- **MEDIUM (deferred)**: snapshots may accumulate in the `memories` table over time. Revisit with a consolidation job if it becomes an issue — out of scope for Sprint 1.

## Testing
- `pytest tests/test_pre_compact_backup.py -x -q` — **36/36 passing** (0.10s)
- `ruff format` — clean
- `ruff check` — one E402 from the venv-bootstrap import pattern, consistent with `scripts/session-context.py` and `scripts/memory-recall-hook.py`
- **Manual smoke test** against a real transcript (1433 entries, 5.3MB):
  - Supabase path: upserted `session_snapshot_smoke-test-278` (30000 bytes, truncation marker present, `source_provenance=hook:pre-compact`, tags+project correct) ✓
  - Local fallback path: forced Supabase failure, got `.claude/session-snapshots/smoke-test-278.md` at exactly 30000 bytes ✓
  - `exit 0` on both paths ✓
  - Bad hook input (invalid JSON, missing transcript path) — still exits 0 ✓
- **Acceptance checklist** ([#278](https://github.com/Osasuwu/jarvis/issues/278)):
  - [x] `scripts/pre-compact-backup.py` created, self-bootstraps into venv
  - [ ] `.claude/settings.json` registers the hook — **owner to apply** (see diff above)
  - [x] Running the script manually produces a `session_snapshot_<session_id>` memory in Supabase within 10s
  - [x] Content is well-structured markdown under 30KB
  - [x] If Supabase is unreachable (simulated), local fallback file is written and script exits 0
  - [x] Bad hook input is tolerated (hook never raises)

## Files Changed
- `scripts/pre-compact-backup.py` — the hook script itself (venv bootstrap, transcript parser, markdown composer, Supabase + local persistence)
- `tests/test_pre_compact_backup.py` — 36 unit tests (dash-named module, uses importlib + stub modules for optional deps, matches `test_memory_recall_hook.py` pattern)
- `docs/design/compression-resilience.md` — sprint design doc referenced by [#277](https://github.com/Osasuwu/jarvis/issues/277) and milestone [#25](https://github.com/Osasuwu/jarvis/milestone/25); was missing from the tree

## Follow-ups
- [#279](https://github.com/Osasuwu/jarvis/issues/279) — inject snapshot on compact resume (Phase 2)
- [#280](https://github.com/Osasuwu/jarvis/issues/280) — `/end` reads from Supabase (Phase 3)