### PR TITLE
feat(compression): Phase 2 — session-context.py injects snapshot on compact resume (#279)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python scripts/device-info.py && echo '' && cat config/SOUL.md && echo '' && python scripts/session-context.py"
+            "command": "python scripts/device-info.py && echo '' && cat config/SOUL.md && echo ''"
+          },
+          {
+            "type": "command",
+            "command": "python scripts/session-context.py"
           }
         ]
       },
@@ -29,7 +33,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python scripts/device-info.py && echo '' && cat config/SOUL.md && echo '' && python scripts/session-context.py"
+            "command": "python scripts/device-info.py && echo '' && cat config/SOUL.md && echo ''"
+          },
+          {
+            "type": "command",
+            "command": "python scripts/session-context.py"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Thumbs.DB
 .claude/settings.local.json
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.claude/session-snapshots/
 
 # Device-specific config (auto-generated per machine)
 config/device.json

--- a/docs/design/compression-resilience.md
+++ b/docs/design/compression-resilience.md
@@ -66,6 +66,14 @@ This gives the post-compact Claude immediate access to the structured
 artefacts the LLM-summary smoothed over. Purely additive — the existing
 working-state re-injection keeps working.
 
+Settings.json caveat: the existing SessionStart hook was a single
+`&&`-chained shell command (`device-info && cat SOUL && session-context`).
+Claude Code pipes hook-input JSON to each subprocess's stdin, but in a
+shell chain only the first process in the pipeline reliably receives
+that stdin — subsequent commands see EOF. Phase 2 splits the `hooks`
+array into two entries (prelude + `session-context.py`) so each gets
+hook-input stdin from Claude Code directly. Output order is preserved.
+
 ### Phase 3 — /end reads from Supabase (issue #280)
 
 Rework `.claude/skills/end/SKILL.md` so the primary source of truth for

--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -5,6 +5,15 @@ Output is injected into Claude's context automatically by the hook.
 
 Usage (in hook):  python scripts/session-context.py
 Self-bootstraps into venv — works from any Python.
+
+Compact resume recovery (Phase 2, #279):
+When the SessionStart hook fires with source=compact, this script also
+loads the pre-compact snapshot written by `scripts/pre-compact-backup.py`
+(Supabase `session_snapshot_<session_id>` or local
+`.claude/session-snapshots/<session_id>.md`) and prepends it under
+`## Pre-Compact Recovery`. Snapshots older than
+PRE_COMPACT_FRESHNESS_MINUTES are ignored — they belong to a prior run
+that happened to reuse the same session_id.
 """
 
 import json
@@ -43,6 +52,11 @@ if sys.stderr.encoding != "utf-8":
 
 KNOWN_PROJECTS = {"jarvis", "redrobot"}
 
+# Pre-compact snapshots older than this are treated as stale. They most
+# likely belong to a different run that happened to reuse the same
+# session_id — Claude Code does reuse ids across `--resume` invocations.
+PRE_COMPACT_FRESHNESS_MINUTES = 30
+
 
 def _detect_project():
     """Return current project name if cwd basename matches a known project, else None."""
@@ -53,11 +67,131 @@ def _detect_project():
     return name if name in KNOWN_PROJECTS else None
 
 
+def _read_hook_input() -> dict:
+    """Parse SessionStart hook input from stdin.
+
+    Claude Code pipes a JSON object with session_id, transcript_path, cwd,
+    hook_event_name, and a source/matcher field when the hook fires. When
+    this script runs standalone (no pipe), stdin is a TTY and we return
+    an empty dict so the rest of main() proceeds unchanged.
+    """
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        return {}
+    if not raw or not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _is_compact_resume(hook: dict) -> bool:
+    """True when this SessionStart invocation is Claude Code resuming post-compact.
+
+    Claude Code surfaces the matcher under different keys depending on the
+    hook event (`source` for SessionStart, `matcher` for PreCompact). We
+    check both and a few synonyms to avoid version-coupling.
+    """
+    event = (hook.get("hook_event_name") or "").strip()
+    if event and event != "SessionStart":
+        return False
+    # `source` is the documented SessionStart field; `matcher` is what the
+    # Jarvis hooks.settings block uses; guard against future renames.
+    candidates = (
+        hook.get("source"),
+        hook.get("matcher"),
+        hook.get("trigger"),
+    )
+    return any(str(c).lower() == "compact" for c in candidates if c)
+
+
+def _load_snapshot_from_supabase(client, session_id: str):
+    """Return snapshot content if `session_snapshot_<session_id>` is fresh, else None."""
+    from datetime import datetime, timedelta, timezone
+    name = f"session_snapshot_{session_id}"
+    try:
+        result = (
+            client.table("memories")
+            .select("content, updated_at")
+            .eq("name", name)
+            .is_("deleted_at", "null")
+            .limit(1)
+            .execute()
+        )
+    except Exception as e:
+        print(f"[session-context] snapshot query failed: {e}", file=sys.stderr)
+        return None
+    if not result.data:
+        return None
+    row = result.data[0]
+    ts = _parse_ts(row.get("updated_at"))
+    if ts is not None:
+        age = datetime.now(timezone.utc) - ts
+        if age > timedelta(minutes=PRE_COMPACT_FRESHNESS_MINUTES):
+            return None
+    content = row.get("content")
+    return content if content else None
+
+
+def _load_snapshot_from_local(session_id: str):
+    """Return snapshot content from `.claude/session-snapshots/<session_id>.md` if fresh."""
+    from datetime import datetime, timedelta, timezone
+    path = _root / ".claude" / "session-snapshots" / f"{session_id}.md"
+    if not path.exists():
+        return None
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except Exception:
+        mtime = None
+    if mtime is not None:
+        age = datetime.now(timezone.utc) - mtime
+        if age > timedelta(minutes=PRE_COMPACT_FRESHNESS_MINUTES):
+            return None
+    try:
+        return path.read_text(encoding="utf-8") or None
+    except Exception as e:
+        print(f"[session-context] local snapshot read failed: {e}", file=sys.stderr)
+        return None
+
+
+def _format_recovery_section(snapshot: str) -> str:
+    return (
+        "## Pre-Compact Recovery\n"
+        "Compaction happened earlier in this session — pre-compact snapshot "
+        "below. Treat this as authoritative history for anything older than "
+        "the summary above.\n\n"
+        f"{snapshot}"
+    )
+
+
 def main():
+    hook_input = _read_hook_input()
+    compact_resume = _is_compact_resume(hook_input)
+    session_id = (
+        hook_input.get("session_id")
+        or hook_input.get("sessionId")
+        or ""
+    )
+
     url = os.environ.get("SUPABASE_URL")
     key = os.environ.get("SUPABASE_KEY")
     if not url or not key:
         print("[session-context] SUPABASE_URL/KEY not set", file=sys.stderr)
+        # Still try local fallback on compact resume — a disconnected dev
+        # shouldn't lose pre-compact context entirely.
+        if compact_resume and session_id:
+            snap = _load_snapshot_from_local(session_id)
+            if snap:
+                print("=" * 60)
+                print("MEMORY CONTEXT (auto-loaded — do NOT re-fetch with MCP tools)")
+                print("=" * 60)
+                print(_format_recovery_section(snap))
+                print("=" * 60)
         return
 
     try:
@@ -69,6 +203,16 @@ def main():
     project = _detect_project()
     sections = []
     touched_ids: list[str] = []
+
+    # 0. Pre-Compact Recovery — prepended before everything else on compact
+    #    resume. Supabase first, local fallback second. Freshness guarded to
+    #    avoid cross-run pollution when Claude Code reuses session_ids.
+    if compact_resume and session_id:
+        snapshot = _load_snapshot_from_supabase(client, session_id)
+        if not snapshot:
+            snapshot = _load_snapshot_from_local(session_id)
+        if snapshot:
+            sections.append(_format_recovery_section(snapshot))
 
     # 1. User memories — who is the owner (always)
     section, ids = _query_memories(client, mem_type="user", limit=2)

--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -18,6 +18,7 @@ that happened to reuse the same session_id.
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -110,16 +111,49 @@ def _is_compact_resume(hook: dict) -> bool:
     return any(str(c).lower() == "compact" for c in candidates if c)
 
 
-def _load_snapshot_from_supabase(client, session_id: str):
-    """Return snapshot content if `session_snapshot_<session_id>` is fresh, else None."""
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+
+def _safe_session_id(session_id) -> str | None:
+    """Return session_id if it matches the allowlist, else None.
+
+    session_id arrives over stdin from Claude Code. Before using it to
+    build a filesystem path or a Supabase `name` we constrain it to an
+    allowlist (alphanum + `_-`) so a malformed/hostile value can't escape
+    the snapshots directory or collide with unrelated memory rows.
+    """
+    if not isinstance(session_id, str):
+        return None
+    sid = session_id.strip()
+    if not sid or not _SESSION_ID_RE.match(sid):
+        return None
+    return sid
+
+
+def _load_snapshot_from_supabase(client, session_id: str, project: str | None = None):
+    """Return snapshot content if `session_snapshot_<session_id>` is fresh, else None.
+
+    Phase 1 upserts snapshots on `(project, name)` — two projects can share
+    a `session_id` and keep separate rows. When `project` is known, filter
+    on it to avoid picking up a sibling row. `.order(..., desc=True)` keeps
+    selection deterministic even when the filter leaves multiple rows.
+    """
     from datetime import datetime, timedelta, timezone
-    name = f"session_snapshot_{session_id}"
+    sid = _safe_session_id(session_id)
+    if not sid:
+        return None
+    name = f"session_snapshot_{sid}"
     try:
-        result = (
+        query = (
             client.table("memories")
             .select("content, updated_at")
             .eq("name", name)
             .is_("deleted_at", "null")
+        )
+        if project:
+            query = query.eq("project", project)
+        result = (
+            query.order("updated_at", desc=True)
             .limit(1)
             .execute()
         )
@@ -141,7 +175,10 @@ def _load_snapshot_from_supabase(client, session_id: str):
 def _load_snapshot_from_local(session_id: str):
     """Return snapshot content from `.claude/session-snapshots/<session_id>.md` if fresh."""
     from datetime import datetime, timedelta, timezone
-    path = _root / ".claude" / "session-snapshots" / f"{session_id}.md"
+    sid = _safe_session_id(session_id)
+    if not sid:
+        return None
+    path = _root / ".claude" / "session-snapshots" / f"{sid}.md"
     if not path.exists():
         return None
     try:
@@ -208,7 +245,7 @@ def main():
     #    resume. Supabase first, local fallback second. Freshness guarded to
     #    avoid cross-run pollution when Claude Code reuses session_ids.
     if compact_resume and session_id:
-        snapshot = _load_snapshot_from_supabase(client, session_id)
+        snapshot = _load_snapshot_from_supabase(client, session_id, project)
         if not snapshot:
             snapshot = _load_snapshot_from_local(session_id)
         if snapshot:

--- a/tests/test_session_context_recovery.py
+++ b/tests/test_session_context_recovery.py
@@ -1,0 +1,266 @@
+"""Unit tests for scripts/session-context.py pre-compact recovery (Phase 2, #279).
+
+Covers the deterministic parts that can be exercised without a live Supabase:
+  - `_read_hook_input` — stdin parsing (TTY skip, empty, invalid JSON, valid)
+  - `_is_compact_resume` — matcher detection across field-name synonyms
+  - `_load_snapshot_from_local` — local fallback + freshness
+  - `_format_recovery_section` — stable output shape
+  - `_load_snapshot_from_supabase` — freshness logic with a fake client
+
+Network-touching paths (live Supabase fetch) and end-to-end stdout rendering
+are verified manually via `/compact` on the live session; the design doc
+documents the acceptance flow.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Stub optional deps so module import succeeds on minimal CI
+# ---------------------------------------------------------------------------
+for _stub in ("dotenv", "supabase"):
+    if _stub not in sys.modules:
+        try:
+            __import__(_stub)
+        except ImportError:
+            mod = types.ModuleType(_stub)
+            if _stub == "dotenv":
+                mod.load_dotenv = lambda *a, **k: None
+            if _stub == "supabase":
+                mod.create_client = lambda *a, **k: None
+            sys.modules[_stub] = mod
+
+
+_PATH = Path(__file__).resolve().parent.parent / "scripts" / "session-context.py"
+_spec = importlib.util.spec_from_file_location("session_context", _PATH)
+sc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sc)
+
+
+# ---------------------------------------------------------------------------
+# stdin helpers
+# ---------------------------------------------------------------------------
+class _FakeStdin(io.StringIO):
+    """StringIO that lies about being a TTY — mimics a piped hook input."""
+
+    def __init__(self, payload: str = "", isatty: bool = False):
+        super().__init__(payload)
+        self._isatty = isatty
+
+    def isatty(self) -> bool:  # noqa: D401 — simple override
+        return self._isatty
+
+
+def _with_stdin(monkeypatch, payload: str, isatty: bool = False):
+    monkeypatch.setattr(sys, "stdin", _FakeStdin(payload, isatty=isatty))
+
+
+# ---------------------------------------------------------------------------
+# _read_hook_input
+# ---------------------------------------------------------------------------
+def test_read_hook_input_tty_returns_empty(monkeypatch):
+    _with_stdin(monkeypatch, "{\"session_id\": \"x\"}", isatty=True)
+    assert sc._read_hook_input() == {}
+
+
+def test_read_hook_input_empty_stdin(monkeypatch):
+    _with_stdin(monkeypatch, "", isatty=False)
+    assert sc._read_hook_input() == {}
+
+
+def test_read_hook_input_whitespace_only(monkeypatch):
+    _with_stdin(monkeypatch, "   \n  ", isatty=False)
+    assert sc._read_hook_input() == {}
+
+
+def test_read_hook_input_invalid_json(monkeypatch):
+    _with_stdin(monkeypatch, "not json", isatty=False)
+    assert sc._read_hook_input() == {}
+
+
+def test_read_hook_input_non_object_json(monkeypatch):
+    # A JSON list is syntactically valid but our contract expects an object.
+    _with_stdin(monkeypatch, "[1, 2, 3]", isatty=False)
+    assert sc._read_hook_input() == {}
+
+
+def test_read_hook_input_valid_object(monkeypatch):
+    _with_stdin(
+        monkeypatch,
+        '{"session_id": "abc", "hook_event_name": "SessionStart", "source": "compact"}',
+        isatty=False,
+    )
+    data = sc._read_hook_input()
+    assert data["session_id"] == "abc"
+    assert data["hook_event_name"] == "SessionStart"
+    assert data["source"] == "compact"
+
+
+# ---------------------------------------------------------------------------
+# _is_compact_resume
+# ---------------------------------------------------------------------------
+def test_is_compact_resume_true_for_source_compact():
+    hook = {"hook_event_name": "SessionStart", "source": "compact"}
+    assert sc._is_compact_resume(hook) is True
+
+
+def test_is_compact_resume_true_for_matcher_compact():
+    hook = {"hook_event_name": "SessionStart", "matcher": "compact"}
+    assert sc._is_compact_resume(hook) is True
+
+
+def test_is_compact_resume_case_insensitive():
+    hook = {"hook_event_name": "SessionStart", "source": "Compact"}
+    assert sc._is_compact_resume(hook) is True
+
+
+def test_is_compact_resume_false_for_startup():
+    hook = {"hook_event_name": "SessionStart", "source": "startup"}
+    assert sc._is_compact_resume(hook) is False
+
+
+def test_is_compact_resume_false_for_empty_hook():
+    # Standalone run (no hook input) must not trigger recovery.
+    assert sc._is_compact_resume({}) is False
+
+
+def test_is_compact_resume_false_for_wrong_event():
+    hook = {"hook_event_name": "PreToolUse", "matcher": "compact"}
+    assert sc._is_compact_resume(hook) is False
+
+
+def test_is_compact_resume_allows_missing_event_name():
+    # Some invocations might omit `hook_event_name` — don't reject if the
+    # matcher still clearly says compact.
+    hook = {"source": "compact"}
+    assert sc._is_compact_resume(hook) is True
+
+
+# ---------------------------------------------------------------------------
+# _load_snapshot_from_local
+# ---------------------------------------------------------------------------
+def _snapshot_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".claude" / "session-snapshots"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def test_load_snapshot_from_local_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(sc, "_root", tmp_path)
+    assert sc._load_snapshot_from_local("missing-session") is None
+
+
+def test_load_snapshot_from_local_fresh(monkeypatch, tmp_path):
+    monkeypatch.setattr(sc, "_root", tmp_path)
+    d = _snapshot_dir(tmp_path)
+    f = d / "sid.md"
+    f.write_text("# fresh snapshot", encoding="utf-8")
+    assert sc._load_snapshot_from_local("sid") == "# fresh snapshot"
+
+
+def test_load_snapshot_from_local_stale(monkeypatch, tmp_path):
+    monkeypatch.setattr(sc, "_root", tmp_path)
+    d = _snapshot_dir(tmp_path)
+    f = d / "sid.md"
+    f.write_text("# stale", encoding="utf-8")
+    # Age it well past the freshness window.
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=2)).timestamp()
+    import os as _os
+    _os.utime(f, (old_ts, old_ts))
+    assert sc._load_snapshot_from_local("sid") is None
+
+
+def test_load_snapshot_from_local_empty_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(sc, "_root", tmp_path)
+    d = _snapshot_dir(tmp_path)
+    f = d / "sid.md"
+    f.write_text("", encoding="utf-8")
+    # Empty content should not yield a recovery section.
+    assert sc._load_snapshot_from_local("sid") is None
+
+
+# ---------------------------------------------------------------------------
+# _load_snapshot_from_supabase
+# ---------------------------------------------------------------------------
+class _FakeTable:
+    def __init__(self, rows):
+        self._rows = rows
+        self._filters = []
+
+    # Chain methods — just record calls, return self.
+    def select(self, *_a, **_kw):
+        return self
+
+    def eq(self, *_a, **_kw):
+        return self
+
+    def is_(self, *_a, **_kw):
+        return self
+
+    def limit(self, *_a, **_kw):
+        return self
+
+    def execute(self):
+        result = types.SimpleNamespace(data=list(self._rows))
+        return result
+
+
+class _FakeClient:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def table(self, _name):
+        return _FakeTable(self._rows)
+
+
+def test_load_snapshot_from_supabase_fresh_row():
+    now = datetime.now(timezone.utc).isoformat()
+    client = _FakeClient([{"content": "# snap", "updated_at": now}])
+    assert sc._load_snapshot_from_supabase(client, "sid") == "# snap"
+
+
+def test_load_snapshot_from_supabase_stale_row():
+    stale = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    client = _FakeClient([{"content": "# old", "updated_at": stale}])
+    assert sc._load_snapshot_from_supabase(client, "sid") is None
+
+
+def test_load_snapshot_from_supabase_no_rows():
+    client = _FakeClient([])
+    assert sc._load_snapshot_from_supabase(client, "sid") is None
+
+
+def test_load_snapshot_from_supabase_handles_query_error(capsys):
+    class _BoomClient:
+        def table(self, _):
+            raise RuntimeError("boom")
+
+    # Must not raise — the session start hook is never blocked by this failure.
+    assert sc._load_snapshot_from_supabase(_BoomClient(), "sid") is None
+    err = capsys.readouterr().err
+    assert "snapshot query failed" in err
+
+
+def test_load_snapshot_from_supabase_no_updated_at_is_kept():
+    # If the row has no updated_at, freshness can't be verified — we
+    # optimistically include it. This matches how we wrote the snapshot
+    # (upsert always sets updated_at), but guards against schema drift.
+    client = _FakeClient([{"content": "# no ts"}])
+    assert sc._load_snapshot_from_supabase(client, "sid") == "# no ts"
+
+
+# ---------------------------------------------------------------------------
+# _format_recovery_section
+# ---------------------------------------------------------------------------
+def test_format_recovery_section_has_header_and_body():
+    out = sc._format_recovery_section("# body")
+    assert out.startswith("## Pre-Compact Recovery\n")
+    assert "# body" in out
+    assert "pre-compact snapshot" in out.lower()

--- a/tests/test_session_context_recovery.py
+++ b/tests/test_session_context_recovery.py
@@ -190,24 +190,33 @@ def test_load_snapshot_from_local_empty_file(monkeypatch, tmp_path):
 # _load_snapshot_from_supabase
 # ---------------------------------------------------------------------------
 class _FakeTable:
-    def __init__(self, rows):
+    def __init__(self, rows, call_log=None):
         self._rows = rows
-        self._filters = []
+        self._call_log = call_log if call_log is not None else []
 
     # Chain methods — just record calls, return self.
-    def select(self, *_a, **_kw):
+    def select(self, *a, **kw):
+        self._call_log.append(("select", a, kw))
         return self
 
-    def eq(self, *_a, **_kw):
+    def eq(self, *a, **kw):
+        self._call_log.append(("eq", a, kw))
         return self
 
-    def is_(self, *_a, **_kw):
+    def is_(self, *a, **kw):
+        self._call_log.append(("is_", a, kw))
         return self
 
-    def limit(self, *_a, **_kw):
+    def order(self, *a, **kw):
+        self._call_log.append(("order", a, kw))
+        return self
+
+    def limit(self, *a, **kw):
+        self._call_log.append(("limit", a, kw))
         return self
 
     def execute(self):
+        self._call_log.append(("execute", (), {}))
         result = types.SimpleNamespace(data=list(self._rows))
         return result
 
@@ -215,9 +224,10 @@ class _FakeTable:
 class _FakeClient:
     def __init__(self, rows):
         self._rows = rows
+        self.call_log = []
 
     def table(self, _name):
-        return _FakeTable(self._rows)
+        return _FakeTable(self._rows, self.call_log)
 
 
 def test_load_snapshot_from_supabase_fresh_row():
@@ -254,6 +264,103 @@ def test_load_snapshot_from_supabase_no_updated_at_is_kept():
     # (upsert always sets updated_at), but guards against schema drift.
     client = _FakeClient([{"content": "# no ts"}])
     assert sc._load_snapshot_from_supabase(client, "sid") == "# no ts"
+
+
+def test_load_snapshot_from_supabase_with_project_filters_and_orders():
+    # Copilot review fix: with project known, ensure we apply eq(project=...)
+    # and order by updated_at desc before limit.
+    now = datetime.now(timezone.utc).isoformat()
+    client = _FakeClient([{"content": "# snap", "updated_at": now}])
+    assert sc._load_snapshot_from_supabase(client, "sid", "jarvis") == "# snap"
+
+    ops = client.call_log
+    # name filter is there …
+    assert ("eq", ("name", "session_snapshot_sid"), {}) in ops
+    # deleted_at is_null is there …
+    assert ("is_", ("deleted_at", "null"), {}) in ops
+    # project filter is applied when supplied …
+    assert ("eq", ("project", "jarvis"), {}) in ops
+    # order is applied before limit
+    order_idx = next(i for i, op in enumerate(ops) if op[0] == "order")
+    limit_idx = next(i for i, op in enumerate(ops) if op[0] == "limit")
+    assert order_idx < limit_idx
+    order_op = ops[order_idx]
+    assert order_op[1][0] == "updated_at"
+    assert order_op[2].get("desc") is True
+
+
+def test_load_snapshot_from_supabase_without_project_skips_project_filter():
+    now = datetime.now(timezone.utc).isoformat()
+    client = _FakeClient([{"content": "# snap", "updated_at": now}])
+    assert sc._load_snapshot_from_supabase(client, "sid") == "# snap"
+
+    ops = client.call_log
+    # Only the name eq, no project eq.
+    eq_calls = [op for op in ops if op[0] == "eq"]
+    assert ("eq", ("name", "session_snapshot_sid"), {}) in eq_calls
+    assert all(op[1][:1] != ("project",) for op in eq_calls)
+
+
+def test_load_snapshot_from_supabase_rejects_bad_session_id():
+    # Copilot review fix: session_id goes into the Supabase `name` — sanitize
+    # before use so a hostile value can't widen the query.
+    client = _FakeClient([{"content": "anything", "updated_at": datetime.now(timezone.utc).isoformat()}])
+    assert sc._load_snapshot_from_supabase(client, "../escape") is None
+    # Supabase must not be queried at all for a rejected id.
+    assert client.call_log == []
+
+
+# ---------------------------------------------------------------------------
+# _safe_session_id — path-traversal / injection guard
+# ---------------------------------------------------------------------------
+def test_safe_session_id_accepts_typical_uuid():
+    assert sc._safe_session_id("d47e5fb3-4609-4af1-a271-88a29004c7b3") == "d47e5fb3-4609-4af1-a271-88a29004c7b3"
+
+
+def test_safe_session_id_accepts_alnum_and_underscore():
+    assert sc._safe_session_id("abc_123-XYZ") == "abc_123-XYZ"
+
+
+def test_safe_session_id_trims_surrounding_whitespace():
+    assert sc._safe_session_id("  sid  ") == "sid"
+
+
+def test_safe_session_id_rejects_path_traversal():
+    assert sc._safe_session_id("../../etc/passwd") is None
+
+
+def test_safe_session_id_rejects_path_separators():
+    assert sc._safe_session_id("a/b") is None
+    assert sc._safe_session_id("a\\b") is None
+
+
+def test_safe_session_id_rejects_empty_and_non_str():
+    assert sc._safe_session_id("") is None
+    assert sc._safe_session_id("   ") is None
+    assert sc._safe_session_id(None) is None
+    assert sc._safe_session_id(123) is None
+
+
+def test_safe_session_id_rejects_overlong():
+    # Over 128 chars — keep the allowlist tight.
+    assert sc._safe_session_id("a" * 129) is None
+
+
+def test_safe_session_id_rejects_special_chars():
+    assert sc._safe_session_id("a b") is None
+    assert sc._safe_session_id("a;b") is None
+    assert sc._safe_session_id("a$b") is None
+
+
+# Path-traversal must also be rejected by the local loader, not only the
+# sanitizer — this is the end-to-end guarantee.
+def test_load_snapshot_from_local_rejects_path_traversal(monkeypatch, tmp_path):
+    monkeypatch.setattr(sc, "_root", tmp_path)
+    # Seed a file *outside* the snapshots directory that an attacker might
+    # try to reach with `../` — confirm we refuse to read it.
+    outside = tmp_path / "secrets.md"
+    outside.write_text("# sensitive", encoding="utf-8")
+    assert sc._load_snapshot_from_local("../secrets") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 2 of the compression-resilience sprint (milestone #25, epic #277).

- `scripts/session-context.py` now parses the SessionStart hook input on stdin. When the `compact` matcher fires, it pulls `session_snapshot_<session_id>` from Supabase (Phase 1 source) and prepends a `## Pre-Compact Recovery` section so post-compact Claude sees the structured pre-compact record alongside the LLM summary.
- Supabase-unreachable path falls back to the local `.claude/session-snapshots/<session_id>.md` file that Phase 1 already writes on Supabase failure.
- Stale snapshots (>30 min) are rejected — Claude Code reuses session_ids across `--resume`, so age-gating prevents a prior run's snapshot from leaking into a new session that reuses the id.
- Standalone invocation (TTY stdin, no pipe) bypasses the new path entirely — no regression for the `startup` matcher or manual invocation.

## Why the settings.json edit

The existing SessionStart hook was one `&&`-chained shell command. Claude Code pipes hook input JSON to each subprocess's stdin, but in a shell chain only the first process reliably receives it — later commands see EOF. Split the `hooks` array into two entries (prelude + `session-context.py`) so `session-context.py` gets stdin directly. Output order is preserved.

## Test plan

- [x] `pytest tests/test_session_context_recovery.py` — 23 new unit tests (stdin parsing, matcher detection, freshness guards, output shape) all pass.
- [x] Full suite: `pytest tests/` — 549 passed, 3 skipped, no regression.
- [x] Manual smoke: seeded fresh `session_snapshot_phase2-smoke`, piped `{"session_id": "phase2-smoke", "hook_event_name": "SessionStart", "source": "compact"}` into `scripts/session-context.py` → `## Pre-Compact Recovery` appears first, followed by the usual User Profile / Working State / Active Goals / Catalog sections.
- [x] Negative check: same pipe with `"source": "startup"` → recovery section is NOT emitted.
- [ ] End-to-end `/compact` on a live session + `/end` post-compact — to be verified after merge, tracked in Phase 3 (#280) and the sprint-level acceptance in #277.

Closes #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)