### PR TITLE
feat(mcp-memory): expose memory_id in outcome_record / outcome_update (#286)

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -783,6 +783,14 @@ async def list_tools() -> list[Tool]:
                         "items": {"type": "string"},
                         "description": "Pattern tags for learning.",
                     },
+                    "memory_id": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "UUID of the primary memory that informed this outcome. "
+                            "Links the outcome into memory_calibration so confidence "
+                            "and lessons can be attributed back to the reasoning basis."
+                        ),
+                    },
                 },
                 "required": ["task_type", "task_description", "outcome_status"],
             },
@@ -813,6 +821,14 @@ async def list_tools() -> list[Tool]:
                     "verified_at": {
                         "type": "string",
                         "description": "ISO timestamp. Defaults to now() if omitted when status changes.",
+                    },
+                    "memory_id": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "UUID of the primary memory that informed this outcome. "
+                            "Pass during verification to retro-link outcomes whose "
+                            "basis became clear only after the decision played out."
+                        ),
                     },
                 },
                 "required": ["id"],
@@ -3014,6 +3030,7 @@ async def _handle_outcome_record(args: dict) -> list[TextContent]:
         "pr_merged",
         "quality_score",
         "lessons",
+        "memory_id",
     ):
         if key in args and args[key] is not None:
             row[key] = args[key]
@@ -3041,6 +3058,7 @@ async def _handle_outcome_update(args: dict) -> list[TextContent]:
         "quality_score",
         "lessons",
         "pattern_tags",
+        "memory_id",
     ):
         if key in args and args[key] is not None:
             updates[key] = args[key]

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -1494,3 +1494,105 @@ class TestRecallLifecycleFilters:
 
         for call in client.rpc.call_args_list:
             assert call.args[1].get("show_history") is True
+
+
+# ---------------------------------------------------------------------------
+# #286: outcome_record / outcome_update must accept and persist memory_id
+# ---------------------------------------------------------------------------
+
+class TestOutcomeMemoryId:
+    """Osasuwu/jarvis#286: task_outcomes.memory_id is the FK that drives the
+    memory_calibration view. The DB column + FK + view already exist; these
+    tests pin the MCP tool layer so future refactors can't drop memory_id
+    from the insert/update payloads and silently re-empty calibration."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_client(self, monkeypatch):
+        self.client = MagicMock()
+        # Chain: client.table(...).insert(...).execute() → data=[{"id": "..."}]
+        self.tbl = MagicMock()
+        self.client.table.return_value = self.tbl
+        self.tbl.insert.return_value.execute.return_value = MagicMock(
+            data=[{"id": "outcome-uuid"}]
+        )
+        # For update: client.table(...).update(...).eq(...).execute() → data=[...]
+        self.tbl.update.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"id": "outcome-uuid"}]
+        )
+        monkeypatch.setattr(server_module, "_get_client", lambda: self.client)
+
+    @pytest.mark.asyncio
+    async def test_outcome_record_persists_memory_id(self):
+        from server import _handle_outcome_record
+
+        await _handle_outcome_record({
+            "task_type": "delegation",
+            "task_description": "test",
+            "outcome_status": "success",
+            "memory_id": "11111111-1111-1111-1111-111111111111",
+        })
+
+        insert_payload = self.tbl.insert.call_args[0][0]
+        assert insert_payload["memory_id"] == "11111111-1111-1111-1111-111111111111"
+
+    @pytest.mark.asyncio
+    async def test_outcome_record_omits_memory_id_when_absent(self):
+        """Backwards-compat: callers that don't pass memory_id still work,
+        and the key is not written as NULL (keeps existing rows' shape)."""
+        from server import _handle_outcome_record
+
+        await _handle_outcome_record({
+            "task_type": "delegation",
+            "task_description": "test",
+            "outcome_status": "success",
+        })
+
+        insert_payload = self.tbl.insert.call_args[0][0]
+        assert "memory_id" not in insert_payload
+
+    @pytest.mark.asyncio
+    async def test_outcome_record_ignores_none_memory_id(self):
+        """Explicit None is treated the same as missing — matches the
+        pattern used for every other optional field in _handle_outcome_record."""
+        from server import _handle_outcome_record
+
+        await _handle_outcome_record({
+            "task_type": "delegation",
+            "task_description": "test",
+            "outcome_status": "success",
+            "memory_id": None,
+        })
+
+        insert_payload = self.tbl.insert.call_args[0][0]
+        assert "memory_id" not in insert_payload
+
+    @pytest.mark.asyncio
+    async def test_outcome_update_persists_memory_id(self):
+        from server import _handle_outcome_update
+
+        await _handle_outcome_update({
+            "id": "outcome-uuid",
+            "memory_id": "22222222-2222-2222-2222-222222222222",
+        })
+
+        update_payload = self.tbl.update.call_args[0][0]
+        assert update_payload["memory_id"] == "22222222-2222-2222-2222-222222222222"
+
+    @pytest.mark.asyncio
+    async def test_outcome_update_retrolinks_without_status_change(self):
+        """memory_id alone is a valid update — no outcome_status flip required.
+        Covers the backfill flow: /verify already marked the row, we just now
+        discovered which memory informed it."""
+        from server import _handle_outcome_update
+
+        result = await _handle_outcome_update({
+            "id": "outcome-uuid",
+            "memory_id": "33333333-3333-3333-3333-333333333333",
+        })
+
+        update_payload = self.tbl.update.call_args[0][0]
+        assert update_payload == {"memory_id": "33333333-3333-3333-3333-333333333333"}
+        # verified_at only auto-sets when outcome_status changes off pending —
+        # memory_id-only update must not touch it.
+        assert "verified_at" not in update_payload
+        assert "updated" in result[0].text


### PR DESCRIPTION
## Summary
Exposes `memory_id` as an optional parameter on the `outcome_record` and `outcome_update` MCP tools so callers can link an outcome row to the memory that informed the decision. Unblocks the `memory_calibration` view, which already exists on the DB side but has been receiving null FKs.

## Why
Closes #286.

First issue of the [Pillar 4 Sprint: Metacognition Loop-Closure](https://github.com/Osasuwu/jarvis/milestone/26). The DB schema already had `task_outcomes.memory_id` (FK → `memories.id`) and the `memory_calibration` view joining on it, but the MCP tool layer didn't accept `memory_id` — so every `outcome_record` call landed with `NULL`, and `/reflect`'s calibration path returned "no data yet" no matter how many decisions we made. This PR wires the tool surface to the DB shape that already exists.

## Decisions & Alternatives
- **Added `memory_id` to both `outcome_record` and `outcome_update` schemas** — callers know the basis at record-time (via `record_decision`), but sometimes the link is only clear at `/verify` time. Supporting both entry points avoids forcing the backfill script (#288) to cover every case.
- **`"type": ["string", "null"]` not just `"string"`** — matches the existing style of other optional fields (`goal_slug`, `project`) so JSON schema validators on the caller side don't choke on explicit nulls.
- **No FK validation in Python** — trust DB FK constraint. Rejected doing UUID-shape validation in the handler because it duplicates what Postgres already does; if a caller passes garbage, they get a readable FK error from PostgREST.
- **No change to `outcome_list` output** — listing the linked memory inline is scope creep for a schema-exposure PR. Can be a follow-up if `/reflect` needs it.
- Rejected renaming to `informing_memory_id` — DB column is `memory_id`, the view joins on `o.memory_id = m.id`, keeping the name aligned across layers beats clarity-in-isolation.

## Risk Assessment
- **LOW**: purely additive change. Both inputSchemas get a new optional field; both handlers extend an existing optional-fields loop. Backwards-compatible — existing callers that omit `memory_id` continue to produce identical DB rows (test `test_outcome_record_omits_memory_id_when_absent` pins this).

## Testing
- `python -m pytest tests/test_memory_server.py::TestOutcomeMemoryId -x -q` — 5 passed
- `python -m pytest tests/test_memory_server.py -x -q` — 95 passed (full file, no regressions)
- Verified diff scope: only the 4 intended blocks in `server.py` and the new test class.

New test class `TestOutcomeMemoryId` covers:
- `outcome_record` persists `memory_id` → insert payload contains the UUID
- `outcome_record` omits `memory_id` when not passed → no key in payload
- `outcome_record` ignores `memory_id=None` → treats same as missing
- `outcome_update` persists `memory_id` → update payload contains the UUID
- `outcome_update` can retro-link without status change → no `verified_at` side effect

**Not provable until after merge**: the acceptance criterion `SELECT COUNT(*) FROM memory_calibration > 0` needs the running MCP server to reload with the new code. Will verify on first real `/implement` run after merge.

## Files Changed
- `mcp-memory/server.py` — 2 inputSchema additions + 2 handler loop extensions
- `tests/test_memory_server.py` — new `TestOutcomeMemoryId` class (5 tests)

## Follow-ups in sprint
- #287 — skills (`/implement`, `/delegate`, `/verify`) auto-pass `memory_id` from `record_decision` basis
- #288 — backfill existing `task_outcomes` rows from `decision_made` episodes