### PR TITLE
feat(backfill): link historical task_outcomes to memories via decision episodes (#288)

### DIFF
--- a/scripts/backfill-outcome-memories.py
+++ b/scripts/backfill-outcome-memories.py
@@ -1,0 +1,271 @@
+"""Backfill task_outcomes.memory_id from decision_made episodes (#288).
+
+Every /implement run emits a decision_made episode whose payload carries
+`memories_used` — the names of the memories the decision was based on.
+The `task_outcomes.memory_id` FK then joins outcome rows back to those
+memories so the `memory_calibration` view can score calibration per
+memory. The FK column exists on the DB, but until #286 the MCP tool
+schema didn't accept it — so every historical outcome has memory_id=NULL.
+
+This script recovers the link retroactively.
+
+## Join strategy
+
+1. Read every `episodes` row where `kind='decision_made'` and
+   `payload.memories_used` is non-empty.
+2. Extract `#N` references from `payload.decision`. Keep only episodes
+   that mention **exactly one** `#N` — multi-issue decisions (sprint
+   planners, batch triages) are too ambiguous to attribute.
+3. Map N -> (primary_memory_name, episode_id). When multiple episodes
+   reference the same N, the most-recent one wins.
+4. For each `task_outcomes` row with `memory_id IS NULL`, extract the
+   issue # from `issue_url` and the PR # from `pr_url`. Either match
+   against N is accepted (decisions sometimes quote PR #, sometimes
+   issue #).
+5. Resolve the memory name to `memories.id` — most-recently-updated
+   live row wins if multiple memories share a name.
+6. Update task_outcomes.memory_id, guarded by `memory_id IS NULL` at
+   write time (true idempotency even under concurrent writes).
+
+## Spec drift note
+
+Issue body says "events table" and "payload contains pr_url" — both
+wrong against the live DB. Decisions actually live in `episodes`
+(kind='decision_made'), payload holds `decision` text + `memories_used`
+(list of names, not UUIDs). This script matches the live shape.
+
+## Usage
+
+    python scripts/backfill-outcome-memories.py           # dry-run (default)
+    python scripts/backfill-outcome-memories.py --apply   # persist updates
+
+Environment: SUPABASE_URL, SUPABASE_KEY (or SUPABASE_SERVICE_KEY — either
+works; the service key gets more privilege but isn't required for this
+update path since PostgREST allows the owner role to update task_outcomes).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+try:
+    from dotenv import load_dotenv
+
+    for _env_path in [_HERE.parent / ".env", _HERE.parent.parent / ".env"]:
+        if _env_path.exists():
+            load_dotenv(_env_path, override=True)
+            break
+except ImportError:
+    pass
+
+
+_ISSUE_URL_RE = re.compile(r"/issues/(\d+)")
+_PR_URL_RE = re.compile(r"/pull/(\d+)")
+_HASH_RE = re.compile(r"#(\d+)")
+
+
+def _parse_issue_number(url: str | None) -> int | None:
+    if not url:
+        return None
+    m = _ISSUE_URL_RE.search(url)
+    return int(m.group(1)) if m else None
+
+
+def _parse_pr_number(url: str | None) -> int | None:
+    if not url:
+        return None
+    m = _PR_URL_RE.search(url)
+    return int(m.group(1)) if m else None
+
+
+def _extract_single_hash(text: str | None) -> int | None:
+    """Return the single `#N` in text, or None if zero or multiple."""
+    if not text:
+        return None
+    hits = _HASH_RE.findall(text)
+    if len(hits) != 1:
+        return None
+    return int(hits[0])
+
+
+def _client():
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        print("ERROR: SUPABASE_URL / SUPABASE_KEY (or SUPABASE_SERVICE_KEY) unset", file=sys.stderr)
+        sys.exit(1)
+    from supabase import create_client
+
+    return create_client(url, key)
+
+
+def _build_hash_to_memory_index(client) -> dict[int, tuple[str, str, str]]:
+    """Map `#N` -> (primary_memory_name, episode_id, decision_preview).
+
+    Scans `episodes` oldest-first so the most-recent decision for each N
+    overwrites earlier ones in the dict.
+    """
+    result = (
+        client.table("episodes")
+        .select("id, payload, created_at")
+        .eq("kind", "decision_made")
+        .order("created_at", desc=False)
+        .execute()
+    )
+
+    idx: dict[int, tuple[str, str, str]] = {}
+    for ep in result.data or []:
+        payload = ep.get("payload") or {}
+        memories_used = payload.get("memories_used") or []
+        if not memories_used:
+            continue
+        n = _extract_single_hash(payload.get("decision", ""))
+        if n is None:
+            continue
+        primary_name = memories_used[0]
+        if not isinstance(primary_name, str) or not primary_name:
+            continue
+        preview = (payload.get("decision") or "")[:80]
+        idx[n] = (primary_name, ep["id"], preview)
+    return idx
+
+
+def _resolve_memory_name(client, name: str) -> str | None:
+    """Resolve memories.name -> id, preferring the most recently updated live row."""
+    result = (
+        client.table("memories")
+        .select("id, updated_at")
+        .eq("name", name)
+        .is_("deleted_at", "null")
+        .order("updated_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    if result.data:
+        return result.data[0]["id"]
+    return None
+
+
+def _fetch_null_outcomes(client) -> list[dict]:
+    result = (
+        client.table("task_outcomes")
+        .select("id, task_description, issue_url, pr_url, created_at")
+        .is_("memory_id", "null")
+        .order("created_at", desc=True)
+        .execute()
+    )
+    return result.data or []
+
+
+def backfill(apply: bool) -> int:
+    client = _client()
+
+    index = _build_hash_to_memory_index(client)
+    print(f"Indexed {len(index)} issue/PR # -> memory links from decision_made episodes.")
+    for n, (name, ep_id, preview) in sorted(index.items()):
+        print(f"  #{n} -> {name!r}  (episode {ep_id[:8]}, decision: {preview!r})")
+
+    candidates = _fetch_null_outcomes(client)
+    print(f"\nFound {len(candidates)} task_outcomes with memory_id=NULL.")
+
+    linked: list[tuple[str, str, int, str, str]] = []
+    skipped_no_url = 0
+    skipped_no_decision = 0
+    unresolved: set[str] = set()
+
+    # Cache memory-name -> id to avoid hammering the memories table.
+    name_cache: dict[str, str | None] = {}
+
+    for oc in candidates:
+        issue_n = _parse_issue_number(oc.get("issue_url"))
+        pr_n = _parse_pr_number(oc.get("pr_url"))
+        if issue_n is None and pr_n is None:
+            skipped_no_url += 1
+            continue
+
+        match = None
+        for n in (issue_n, pr_n):
+            if n is not None and n in index:
+                match = index[n]
+                matched_n = n
+                break
+        if match is None:
+            skipped_no_decision += 1
+            continue
+
+        primary_name, _ep_id, _preview = match
+        if primary_name not in name_cache:
+            name_cache[primary_name] = _resolve_memory_name(client, primary_name)
+        memory_id = name_cache[primary_name]
+        if memory_id is None:
+            unresolved.add(primary_name)
+            continue
+
+        desc = (oc.get("task_description") or "")[:60]
+        linked.append((oc["id"], memory_id, matched_n, primary_name, desc))
+
+    total = len(candidates)
+    print(
+        f"\n=== Plan: {len(linked)} linkable, "
+        f"{skipped_no_url} missing issue/PR url, "
+        f"{skipped_no_decision} no matching decision, "
+        f"{len(unresolved)} memory names unresolved "
+        f"(of {total} candidates) ===\n"
+    )
+    for out_id, mem_id, n, name, desc in linked:
+        print(f"  #{n}  outcome {out_id[:8]} -> memory {mem_id[:8]} ({name})  | {desc}")
+    if unresolved:
+        print(f"\nUnresolved memory names (renamed/deleted?): {sorted(unresolved)}")
+
+    if not apply:
+        print("\n(dry-run — default — no changes made; rerun with --apply to persist)")
+        return 0
+
+    if not linked:
+        print("\nNothing to apply.")
+        return 0
+
+    print("\n--apply — writing updates...")
+    applied = 0
+    for out_id, mem_id, n, name, _desc in linked:
+        # Guard with `memory_id IS NULL` at write time — true idempotency
+        # even if the script races with a concurrent /implement writing
+        # memory_id via outcome_record.
+        result = (
+            client.table("task_outcomes")
+            .update({"memory_id": mem_id})
+            .eq("id", out_id)
+            .is_("memory_id", "null")
+            .execute()
+        )
+        if result.data:
+            applied += 1
+            print(f"  [OK]   #{n} outcome {out_id[:8]} -> memory {mem_id[:8]} ({name})")
+        else:
+            print(f"  [SKIP] outcome {out_id[:8]} — already linked or vanished")
+
+    print(f"\nApplied {applied}/{len(linked)} updates.")
+    return 0 if applied == len(linked) else 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill task_outcomes.memory_id from decision_made episodes."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write updates. Default is dry-run.",
+    )
+    args = parser.parse_args()
+    return backfill(apply=args.apply)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill_outcome_memories.py
+++ b/tests/test_backfill_outcome_memories.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/backfill-outcome-memories.py (#288).
+
+Covers the pure-function helpers. DB-interaction paths
+(_build_hash_to_memory_index, _resolve_memory_name, backfill) are exercised
+manually via `python scripts/backfill-outcome-memories.py` against the
+live Supabase project — see the PR description for the dry-run output.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+# Script has a hyphen in the filename so import it via importlib.
+_spec = importlib.util.spec_from_file_location(
+    "backfill_outcome_memories",
+    Path(__file__).parent.parent / "scripts" / "backfill-outcome-memories.py",
+)
+backfill = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(backfill)
+
+
+class TestParseIssueNumber:
+    def test_github_issue_url(self):
+        assert backfill._parse_issue_number("https://github.com/Osasuwu/jarvis/issues/286") == 286
+
+    def test_github_pr_url_returns_none(self):
+        """PR URLs must not be treated as issue URLs."""
+        assert backfill._parse_issue_number("https://github.com/Osasuwu/jarvis/pull/290") is None
+
+    def test_none_input(self):
+        assert backfill._parse_issue_number(None) is None
+
+    def test_empty_string(self):
+        assert backfill._parse_issue_number("") is None
+
+    def test_malformed_url(self):
+        assert backfill._parse_issue_number("not a url") is None
+
+
+class TestParsePrNumber:
+    def test_github_pr_url(self):
+        assert backfill._parse_pr_number("https://github.com/Osasuwu/jarvis/pull/290") == 290
+
+    def test_github_issue_url_returns_none(self):
+        assert backfill._parse_pr_number("https://github.com/Osasuwu/jarvis/issues/286") is None
+
+    def test_none_input(self):
+        assert backfill._parse_pr_number(None) is None
+
+
+class TestExtractSingleHash:
+    """Only decisions mentioning exactly ONE #N qualify for attribution.
+    Multi-issue decisions (sprint planners, batch triages) are too ambiguous."""
+
+    def test_single_hash_returns_int(self):
+        assert backfill._extract_single_hash("Implement #286: add memory_id") == 286
+
+    def test_pr_hash_style_also_matches(self):
+        """Decision might reference #N as PR number, not just issue."""
+        assert (
+            backfill._extract_single_hash(
+                "Address Copilot review on PR #285 with client-side filter"
+            )
+            == 285
+        )
+
+    def test_zero_hashes_returns_none(self):
+        assert backfill._extract_single_hash("Refactor memory server for clarity") is None
+
+    def test_multiple_hashes_returns_none(self):
+        """Sprint-opening decisions with 5 issues must NOT attribute to any one."""
+        text = (
+            "Open Pillar 4 Sprint 'Metacognition Loop-Closure' with 5 issues: "
+            "#286, #287, #288, #237, #289."
+        )
+        assert backfill._extract_single_hash(text) is None
+
+    def test_two_hashes_returns_none(self):
+        """Even two #N references are too ambiguous — pick neither."""
+        assert backfill._extract_single_hash("Fix #42 then revisit #43") is None
+
+    def test_none_input(self):
+        assert backfill._extract_single_hash(None) is None
+
+    def test_empty_string(self):
+        assert backfill._extract_single_hash("") is None
+
+    def test_hash_inside_word_still_matches(self):
+        """Regex is `#(\\d+)` — will catch `foo#286bar` too. Accept that as
+        a known false-positive edge case; real decision text doesn't do this."""
+        assert backfill._extract_single_hash("foo#286bar") == 286


### PR DESCRIPTION
## Summary
Adds `scripts/backfill-outcome-memories.py` to recover `task_outcomes.memory_id` for historical rows. Joins `decision_made` episodes → task outcomes via the `#N` issue/PR reference, then resolves the memory name to its id. Default dry-run; `--apply` persists. Idempotent under concurrent writes (guarded by `WHERE memory_id IS NULL` at update time).

## Why
Closes #288. Until #286 the `outcome_record` tool didn't accept `memory_id`, so every historical outcome has `memory_id=NULL`. The `memory_calibration` view is empty as a result. This script populates the link retroactively so Pillar 4's calibration feedback loop starts producing data.

## Decisions & Alternatives

- **Match strategy: single `#N` mentions only.** Sprint-opening decisions reference 5 issues in one string — attributing their memories_used to any one of those issues would be arbitrary. Chose to skip multi-hash decisions entirely. Covered by `test_multiple_hashes_returns_none`.
- **Most-recent decision wins per `#N`.** If the same issue is mentioned across multiple decisions over time (e.g. initial claim, then a follow-up clarification), the later one reflects the final basis. Scan order is oldest-first so the most-recent overwrites in the dict.
- **Primary memory = first in `memories_used`.** The list order is authored by `record_decision`; first entry is conventionally the dominant basis. For deeper multi-memory attribution the view-layer is the right place, not this script.
- **Match against issue `#` OR PR `#`.** Outcomes have both `issue_url` and `pr_url`; decisions usually cite one or the other, sometimes whichever surfaced first. Accept either.
- **Alternative rejected — writing a SQL migration instead.** Keeping this as a Python one-shot means idempotent re-runs, observable output, and dry-run by default. A migration would make the backfill silent and harder to verify.

## Spec drift (important)

Issue body says the decisions live in `events` table and `memories_used` contains UUIDs. Live DB shows otherwise:
- Decisions are in `episodes` (kind=`decision_made`) — `events` is for ci_failure / pr_merged / memory_recall
- `memories_used` contains memory **names** (strings), not UUIDs

Script matches the live shape. Noted in the docstring under "Spec drift note" so future readers don't rewrite based on the original spec.

## Risk Assessment
- **LOW**: new file only, does not touch `mcp-memory/server.py` or any protected file. Default dry-run; only `--apply` mutates. Writes guarded by `memory_id IS NULL` so concurrent `/implement` outcomes can't be clobbered.

## Testing
- `pytest tests/test_backfill_outcome_memories.py -q` → 16 passed
- `ruff check` + `ruff format` clean
- **Live end-to-end verification** on Supabase project `svwrzttdkxeselkpxfgm`:
  - Dry-run plan: 6 linkable, 22 missing issue/PR url, 27 no matching decision, 0 unresolved
  - `--apply`: 6/6 updates succeeded
  - Re-run plans 0 (idempotent confirmed)
  - `SELECT COUNT(*) FROM memory_calibration` went from 0 → 2 rows (view filters by project/status — not this script's concern)

## Files Changed
- `scripts/backfill-outcome-memories.py` — the backfill tool, helpers are small pure functions
- `tests/test_backfill_outcome_memories.py` — 16 tests for `_parse_issue_number`, `_parse_pr_number`, `_extract_single_hash`. DB-touching functions (`_build_hash_to_memory_index`, `_resolve_memory_name`, `backfill`) are exercised via the live dry-run above.