### PR TITLE
feat(skills): /implement, /delegate, /verify pass memory_id to outcome_record (#287)

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -173,6 +173,8 @@ One `outcome_record` per issue (delegated or inline). Distinguish:
 - Subagent: `pattern_tags: ["delegation", "subagent", "<area>"]`
 - Inline: `pattern_tags: ["delegation", "inline", "<area>"]`
 
+**Also pass `memory_id`** — the primary informing memory id from the per-task `record_decision` episode. Rule: `memory_id = memories_used[0]` (first = dominant basis). For batch-level inline work, use the inline task's own decision_made memories_used; for subagent work, the subagent's record_decision episode is the source. If `memories_used` was empty at decision time, omit `memory_id`.
+
 In `lessons`, note anything non-obvious: subagent misread the issue, scope drift, worktree contamination, etc. These make future delegation decisions smarter.
 
 ### 9. Post-merge cleanup

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -156,11 +156,14 @@ outcome_record(
   project: "<repo name>",
   issue_url: "<issue URL>",
   pr_url: "<PR URL if created>",
+  memory_id: "<primary informing memory id>",   # see rule below
   tests_passed: true/false,
   lessons: "<anything non-obvious learned>",
   pattern_tags: ["delegation", "inline", "<area>"]
 )
 ```
+
+**Rule — primary informing memory**: pass `memory_id = memories_used[0]` from the `record_decision` call at §3.5 (first element is the dominant basis). If `memories_used` was empty, omit `memory_id`. Never pass multiple — the FK is a single UUID and `memory_calibration` joins on one memory per outcome; richer attribution belongs at the view layer, not the row.
 
 **Always record**, even on failure — failed outcomes are the most valuable for learning.
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -59,9 +59,12 @@ outcome_update(
   outcome_status="<new_status>",
   pr_merged=<true/false>,
   tests_passed=<true/false>,
+  memory_id="<primary informing memory id>",   # enrich if still unset — see rule
   lessons="<brief result if any>"
 )
 ```
+
+**Enrich `memory_id` if the outcome row has it NULL**: look up the linked `decision_made` episode (same issue/PR) and pass `memory_id = payload.memories_used[0]`. Rule — primary informing memory = first entry (dominant basis). If the outcome already has `memory_id`, leave it alone; `/verify` is not where you rewrite attribution. If no decision episode references this issue, omit — the backfill script (`scripts/backfill-outcome-memories.py`) can handle historical rows in bulk.
 
 `verified_at` is set automatically when status changes from pending.
 


### PR DESCRIPTION
## Summary
Docs-only change to three skill SKILL.md files so that every future `outcome_record` / `outcome_update` call propagates `memory_id` — the primary informing memory captured at `record_decision` time. Rule: `memory_id = memories_used[0]` (first element = dominant basis).

## Why
Closes #287. Second issue of the Pillar 4 metacognition sprint (milestone #26).
- #286 opened the schema pipe (MCP tools now accept `memory_id`).
- #288 backfilled historical rows via a one-shot script.
- #287 (this PR) ensures every **future** run populates the link at source, so `memory_calibration` keeps growing instead of freezing at the backfill snapshot.

## Decisions & Alternatives

- **Primary memory = first entry of `memories_used`.** Matches the convention already in use when composing `record_decision` calls — the list is authored first-is-dominant. The FK is a single UUID, not an array; richer multi-memory attribution belongs at the view layer, not the row. Documented as an explicit rule in each skill so it doesn't drift.
- **`/verify` enriches only when the row is NULL.** It's an update path, not a rewrite path — if a prior run already attributed the outcome, don't second-guess it. Bulk historical repair belongs in the `backfill-outcome-memories.py` one-shot (added in #288), not here.
- **Alternative rejected — runtime auto-extraction in the server.** Could have had `outcome_record` pull the last `decision_made` episode for the caller and auto-inject `memory_id`. Rejected: more coupling, less observability, and the skill already composes the call site — cheapest fix is explicit.
- **Alternative rejected — pass the full `memories_used` list.** The FK column is a single UUID per the existing schema (#286). Expanding to array is a bigger design question for a later sprint (multi-memory calibration).

## Risk Assessment
- **LOW**: docs-only, no server or test changes. Skills are instructions the model reads; behavior change takes effect on next /implement/delegate/verify run. If docs are subtly wrong, next session will notice and correct — no production impact.

## Testing
- No runtime code touched → no unit tests to run.
- Verified via `git diff --stat`: 3 files, 8 insertions, no protected-file modifications.
- End-to-end verification deferred to the next /implement run: the outcome row it creates should have `memory_id IS NOT NULL` in Supabase.

## Files Changed
- `.claude/skills/implement/SKILL.md` — §6 outcome_record template + primary-memory rule.
- `.claude/skills/delegate/SKILL.md` — §8 outcome_record guidance for both subagent and inline tasks.
- `.claude/skills/verify/SKILL.md` — §3 outcome_update template with NULL-only enrichment rule.