### PR TITLE
ci: block PRs that modify schema.sql without a paired migration (#289)

### DIFF
--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -1,0 +1,53 @@
+name: Schema Drift Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    paths:
+      - 'supabase/schema.sql'
+      - 'supabase/migrations/**'
+
+jobs:
+  require-paired-migration:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number, per_page: 100,
+            });
+
+            const schemaChanged = files.some(f =>
+              f.filename === 'supabase/schema.sql' &&
+              (f.status === 'modified' || f.status === 'added' || f.status === 'changed')
+            );
+
+            if (!schemaChanged) {
+              core.info('supabase/schema.sql unchanged — skipping drift check.');
+              return;
+            }
+
+            const migrationAdded = files.some(f =>
+              f.filename.startsWith('supabase/migrations/') &&
+              f.status === 'added'
+            );
+
+            if (!migrationAdded) {
+              core.setFailed(
+                'supabase/schema.sql changed without a paired migration file.\n' +
+                'schema.sql is aspirational documentation — it does not execute against the live DB.\n' +
+                'Apply the change via `mcp supabase apply_migration` and commit the new\n' +
+                'supabase/migrations/<timestamp>_<name>.sql file in the same PR.\n' +
+                'See incident: #284 (recall soft-delete filter) — schema.sql edit without migration\n' +
+                'caused memory_recall to silently return soft-deleted rows in production.'
+              );
+              return;
+            }
+
+            core.info('schema.sql change is paired with a new migration file — OK.');


### PR DESCRIPTION
## Summary
Adds `.github/workflows/schema-drift-check.yml` — a GH Actions workflow that fails any PR modifying `supabase/schema.sql` without also adding a new `supabase/migrations/<timestamp>_<name>.sql` file. Path-filtered trigger so it runs only on relevant PRs.

## Why
Closes #289. Fourth issue of the Pillar 4 metacognition sprint.

`supabase/schema.sql` is aspirational documentation — it does not execute against the live DB. Editing it without a paired migration creates silent drift: code assumes a column/function exists, production doesn't have it, things break at runtime with no signal at PR time.

Incident that motivated this: **#284**. The recall soft-delete filter was added to `schema.sql` in the original Phase 2c PR, but no migration file was paired. Live DB never got `WHERE deleted_at IS NULL` on `match_memories` / `keyword_search_memories` / `get_linked_memories`, so `memory_recall` returned soft-deleted rows. Fixed retroactively via migration `recall_soft_delete_filter_fix_284`. This check would have blocked the original PR.

The metacognition loop (Pillar 4) depends on schema integrity — if `memory_calibration` view silently disappears from the live DB because someone edited schema.sql without migrating, the entire pillar collapses with no signal. CI catches it at PR time.

## Decisions & Alternatives

- **Check for `status: 'added'` on migrations, not 'modified'.** A legitimate schema change always appends a NEW timestamped migration — editing a past migration is itself a drift smell (once applied, migrations are immutable). Requiring 'added' enforces the append-only convention.
- **Path-filtered trigger.** The workflow skips entirely unless the PR touches `schema.sql` or `supabase/migrations/**` — no wasted CI minutes on frontend / unrelated PRs.
- **Error message points at #284 by reference.** The fix instruction is concrete (`mcp supabase apply_migration`), and the historical incident gives reviewers context for why the check exists rather than appearing arbitrary.
- **Alternative rejected — comments-only exception for schema.sql.** Issue body flagged it as "low priority, optional"; skipped for v1. Comments edits to schema.sql are rare, and the false positive cost (one unnecessary migration with a no-op body) is small. Can soften later if it bites.
- **Alternative rejected — `git diff` bash parsing.** `pulls.listFiles` with `status` field is the structured, paginated, api-stable way. Shell diff parsing would be brittle (rename/delete handling, large diffs).

## Risk Assessment
- **LOW-MEDIUM**: new workflow only, does not modify any runtime code or server. Path filter prevents it from running on unrelated PRs. Worst case (false positive): developer gets a clear error pointing at the fix. Worst case (false negative — fails to catch a real drift): same status quo as today.

## Testing
- YAML syntax validated locally (`python -c "import yaml; yaml.safe_load(...)"`)
- **Post-merge verification plan**: the next PR that happens to touch `supabase/schema.sql` will exercise the check. If none arrive soon, can open a deliberate throwaway PR as a smoke test. Not doing that now to avoid merge noise on a sprint-heavy branch.

## Files Changed
- `.github/workflows/schema-drift-check.yml` — new workflow, 53 lines. Path-filtered trigger, github-script action, pulls.listFiles via Octokit, explicit error message referencing the motivating incident.