### PR TITLE
feat(agents): safety gate module — S2-0 foundation (#295)

### DIFF
--- a/agents/safety.py
+++ b/agents/safety.py
@@ -1,0 +1,469 @@
+"""Action-agent safety gate — S2-0 foundation (issue #295).
+
+Every action agent in Pillar 7 Sprint 2+ that mutates external state
+(GitHub, Supabase beyond Sprint-1 allowlist, filesystem) must route
+its side effect through this module. Three responsibilities:
+
+1. ``classify(tool_name, action, target, area=...)`` → ``Tier`` per
+   ``action_agent_safety_gate_model_v1`` (see memory of the same
+   name). Tier 0 = auto-allowed, Tier 1 = owner-approve queue, Tier 2
+   = blocked outright.
+2. ``idempotency_key(agent_id, action, target, scope_hash=...)`` →
+   deterministic sha256 key so re-running an agent with the same
+   inputs does not re-fire the action.
+3. ``gate(..., fn=..., dry_run=...)`` → run ``fn`` only if Tier 0 and
+   not dry-run; audit every classification/attempt via
+   ``supabase_client.audit`` (best-effort).
+
+The tiered whitelist/blocklist here mirrors the model memory exactly.
+When the owner moves an action between tiers, update this module and
+the memory in the same change.
+
+``action_queue`` enqueueing for Tier 1 lives in S2-1 (``task_queue``
+migration). Until that ships, ``gate()`` records Tier 1 attempts via
+audit but does not persist to a dedicated queue; ``GateOutcome.queued``
+still flips so callers can react.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Callable, Iterable, TypeVar
+
+from agents import supabase_client
+
+log = logging.getLogger(__name__)
+
+
+class Tier(IntEnum):
+    """Safety tier per ``action_agent_safety_gate_model_v1``."""
+
+    AUTO = 0
+    OWNER_QUEUE = 1
+    BLOCKED = 2
+
+
+# ---------------------------------------------------------------------------
+# Tier 0 whitelist (auto-allowed)
+# ---------------------------------------------------------------------------
+
+# Narrow GitHub labels per model memory. ``priority:critical`` intentionally
+# absent — big claims need a human.
+_TIER0_GITHUB_LABELS: frozenset[str] = frozenset(
+    {
+        "priority:high",
+        "priority:medium",
+        "priority:low",
+        "needs-research",
+        "needs-triage",
+        "status:ready",
+    }
+)
+
+# area:* labels follow the same namespace-prefix rule (any area:* is Tier 0).
+_TIER0_GITHUB_LABEL_PREFIXES: tuple[str, ...] = ("area:",)
+
+# Supabase tables Sprint 1 already allows writing to. Tables outside this set
+# are Tier 1 by default. Explicit ``action`` values prevent an UPDATE-all
+# sneaking through under the same table name.
+_TIER0_SUPABASE = {
+    "events": {"insert", "append"},
+    "audit_log": {"insert"},
+    "goals": {"progress_append", "update_progress"},
+}
+
+# Memory store is Tier 0 only when tagged as auto-generated (dry-run flagging,
+# not authoritative memory).
+_TIER0_MEMORY_TAGS: frozenset[str] = frozenset({"auto-generated"})
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 blocklist (never allowed)
+# ---------------------------------------------------------------------------
+
+# File patterns anywhere in the target string trip Tier 2 regardless of
+# tool. ``.env`` catches ``.env``, ``.env.local``, etc. ``.claude/`` covers
+# skills/settings/hooks per `claude_dir_edits_need_manual_confirm`.
+_TIER2_FILE_PATTERNS: tuple[str, ...] = (".env", ".claude/")
+
+# Destructive verbs. Match is exact action-string equality (not substring) to
+# avoid false positives like ``delete_comment_draft``.
+_TIER2_ACTIONS: frozenset[str] = frozenset(
+    {
+        "delete",
+        "destroy",
+        "drop",
+        "truncate",
+        "force_push",
+        "impersonate",
+        "send_as_owner",
+    }
+)
+
+# Tool-name substrings that signal impersonation / owner-send paths. Matched
+# case-insensitively. Hard rule per `no_sending_from_owner_name`.
+_TIER2_TOOL_NAME_SUBSTRINGS: tuple[str, ...] = (
+    "impersonate",
+    "send_as_owner",
+)
+
+# Areas that are wholesale Tier 2 until explicitly re-tiered.
+_TIER2_AREAS: frozenset[str] = frozenset({"messaging"})
+
+# Single-repo scope for Sprint 2. Extend only when we have audit proof it
+# works (per model memory).
+DEFAULT_ALLOWED_REPO = "Osasuwu/jarvis"
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def classify(
+    tool_name: str,
+    action: str,
+    target: str | None = None,
+    *,
+    area: str | None = None,
+    tags: Iterable[str] | None = None,
+    allowed_repo: str = DEFAULT_ALLOWED_REPO,
+) -> Tier:
+    """Classify an attempted action into a safety tier.
+
+    ``area`` is a coarse category — ``"github"``, ``"supabase"``,
+    ``"filesystem"``, ``"memory"``, ``"messaging"`` — used by the
+    classifier to choose the right allowlist. Unknown area → Tier 1.
+
+    Resolution order:
+
+    1. Tier 2 (blocked) — takes precedence; an unsafe pattern overrides
+       any matching allowlist.
+    2. Tier 0 (allowed) — explicit positive match against the narrow
+       whitelist for the area.
+    3. Tier 1 (owner queue) — default.
+    """
+    if _is_blocked(tool_name, action, target, area=area, allowed_repo=allowed_repo):
+        return Tier.BLOCKED
+    if _is_tier0(tool_name, action, target, area=area, tags=tags):
+        return Tier.AUTO
+    return Tier.OWNER_QUEUE
+
+
+def _is_blocked(
+    tool_name: str,
+    action: str,
+    target: str | None,
+    *,
+    area: str | None,
+    allowed_repo: str,
+) -> bool:
+    if area in _TIER2_AREAS:
+        return True
+    if action in _TIER2_ACTIONS:
+        return True
+    lowered_tool = (tool_name or "").lower()
+    for needle in _TIER2_TOOL_NAME_SUBSTRINGS:
+        if needle in lowered_tool:
+            return True
+    if target:
+        # Normalise path separators so Windows targets hit the same rules.
+        normalised = target.replace("\\", "/")
+        for pattern in _TIER2_FILE_PATTERNS:
+            if pattern in normalised:
+                return True
+    if area == "github" and target:
+        repo = _github_repo_of(target)
+        if repo and repo != allowed_repo:
+            return True
+    return False
+
+
+def _is_tier0(
+    tool_name: str,
+    action: str,
+    target: str | None,
+    *,
+    area: str | None,
+    tags: Iterable[str] | None,
+) -> bool:
+    if area == "github" and action == "add_label":
+        if not target:
+            return False
+        if target in _TIER0_GITHUB_LABELS:
+            return True
+        return any(target.startswith(prefix) for prefix in _TIER0_GITHUB_LABEL_PREFIXES)
+    if area == "supabase":
+        allowed_actions = _TIER0_SUPABASE.get(target or "")
+        if allowed_actions and action in allowed_actions:
+            return True
+    if area == "memory" and action == "store":
+        tagset = set(tags or ())
+        if tagset & _TIER0_MEMORY_TAGS:
+            return True
+    return False
+
+
+def _github_repo_of(target: str) -> str | None:
+    """Extract ``owner/repo`` prefix from a GitHub target string.
+
+    Accepts shapes like ``owner/repo#123``, ``owner/repo/path/to/file``,
+    or a bare ``owner/repo``. Returns ``None`` if the shape doesn't
+    resemble a repo reference (e.g. a label string like ``priority:high``
+    — those aren't repo-scoped and should not trip cross-repo checks).
+    """
+    if "/" not in target:
+        return None
+    # A label ``area:backend`` contains ``:``, never ``/``, so the guard
+    # above rejects it. Repo refs always have a slash between owner and
+    # repo segments.
+    head, _, _ = target.partition("#")
+    parts = head.split("/", 2)
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def idempotency_key(
+    agent_id: str,
+    action: str,
+    target: str | None = None,
+    scope_hash: str | None = None,
+) -> str:
+    """Deterministic sha256 over the action inputs.
+
+    Same ``(agent_id, action, target, scope_hash)`` → same key. Callers
+    store the key on the action row (audit, action queue, or queue_row)
+    and skip a live-run if the key already exists.
+
+    ``scope_hash`` changes with repo state (``approved_scope_hash`` on
+    ``task_queue``); feeding it in means post-drift re-attempts produce
+    a different key — no silent coalescing with the pre-drift attempt.
+    """
+    raw = "|".join([agent_id or "", action or "", target or "", scope_hash or ""])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+
+class GateError(RuntimeError):
+    """Raised when a Tier 2 action is attempted through ``gate``."""
+
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+@dataclass(frozen=True)
+class GateOutcome:
+    """Result of a ``gate`` call.
+
+    - ``tier`` — classification that decided the outcome.
+    - ``fired`` — ``fn`` actually ran (Tier 0, not dry-run).
+    - ``queued`` — classified as Tier 1; caller should enqueue (when
+      ``task_queue`` ships in S2-1, the gate itself will enqueue).
+    - ``dry_run`` — caller passed ``dry_run=True`` and no mutation was
+      attempted.
+    - ``idempotency_key`` — key recorded on the audit row; callers can
+      dedupe on re-run.
+    """
+
+    tier: Tier
+    fired: bool
+    queued: bool
+    dry_run: bool
+    idempotency_key: str
+
+
+def gate(
+    *,
+    agent_id: str,
+    tool_name: str,
+    action: str,
+    target: str | None = None,
+    area: str | None = None,
+    tags: Iterable[str] | None = None,
+    scope_hash: str | None = None,
+    dry_run: bool = False,
+    fn: Callable[[], object] | None = None,
+    allowed_repo: str = DEFAULT_ALLOWED_REPO,
+) -> GateOutcome:
+    """Run ``fn`` under the safety gate.
+
+    Behaviour matrix:
+
+    +----------+------------+------------------------------------------+
+    | tier     | dry_run    | behaviour                                |
+    +==========+============+==========================================+
+    | BLOCKED  | *          | audit, raise :class:`GateError`          |
+    +----------+------------+------------------------------------------+
+    | OWNER_Q  | *          | audit (outcome=queued / dry_run_queued), |
+    |          |            | return queued=True, do NOT call fn       |
+    +----------+------------+------------------------------------------+
+    | AUTO     | True       | audit (outcome=dry_run), do NOT call fn  |
+    +----------+------------+------------------------------------------+
+    | AUTO     | False      | call fn, audit with outcome=success |    |
+    |          |            | ``failure:<ExceptionType>``              |
+    +----------+------------+------------------------------------------+
+
+    Audit is best-effort; a logging backend outage never blocks the
+    action or obscures a genuine ``fn`` exception.
+    """
+    tier = classify(tool_name, action, target, area=area, tags=tags, allowed_repo=allowed_repo)
+    key = idempotency_key(agent_id, action, target, scope_hash)
+
+    if tier == Tier.BLOCKED:
+        _audit_best_effort(
+            agent_id=agent_id,
+            tool_name=tool_name,
+            action=action,
+            target=target,
+            tier=tier,
+            outcome="blocked",
+            idempotency_key=key,
+        )
+        raise GateError(
+            f"Tier 2 action blocked: tool={tool_name!r} action={action!r} target={target!r}"
+        )
+
+    if tier == Tier.OWNER_QUEUE:
+        _audit_best_effort(
+            agent_id=agent_id,
+            tool_name=tool_name,
+            action=action,
+            target=target,
+            tier=tier,
+            outcome="dry_run_queued" if dry_run else "queued",
+            idempotency_key=key,
+        )
+        return GateOutcome(
+            tier=tier, fired=False, queued=True, dry_run=dry_run, idempotency_key=key
+        )
+
+    # Tier.AUTO
+    if dry_run:
+        _audit_best_effort(
+            agent_id=agent_id,
+            tool_name=tool_name,
+            action=action,
+            target=target,
+            tier=tier,
+            outcome="dry_run",
+            idempotency_key=key,
+        )
+        return GateOutcome(tier=tier, fired=False, queued=False, dry_run=True, idempotency_key=key)
+
+    if fn is None:
+        # Classification-only use: caller wants the tier decision and the
+        # audit trail but has no side effect to perform here.
+        _audit_best_effort(
+            agent_id=agent_id,
+            tool_name=tool_name,
+            action=action,
+            target=target,
+            tier=tier,
+            outcome="classified",
+            idempotency_key=key,
+        )
+        return GateOutcome(tier=tier, fired=False, queued=False, dry_run=False, idempotency_key=key)
+
+    try:
+        fn()
+    except Exception as exc:
+        _audit_best_effort(
+            agent_id=agent_id,
+            tool_name=tool_name,
+            action=action,
+            target=target,
+            tier=tier,
+            outcome=f"failure:{type(exc).__name__}",
+            idempotency_key=key,
+            error=str(exc),
+        )
+        raise
+    _audit_best_effort(
+        agent_id=agent_id,
+        tool_name=tool_name,
+        action=action,
+        target=target,
+        tier=tier,
+        outcome="success",
+        idempotency_key=key,
+    )
+    return GateOutcome(tier=tier, fired=True, queued=False, dry_run=False, idempotency_key=key)
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+def audit(
+    *,
+    agent_id: str,
+    tool_name: str,
+    action: str,
+    target: str | None = None,
+    tier: Tier = Tier.AUTO,
+    outcome: str = "success",
+    idempotency_key: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Standalone best-effort audit helper.
+
+    Use when the caller has already classified/executed independently
+    (e.g. legacy code paths, tests) and just needs to emit the audit
+    row with tier + idempotency key in ``details``. ``gate()`` already
+    calls this; callers that use ``gate`` should not also call ``audit``
+    for the same event or the row count will double.
+    """
+    _audit_best_effort(
+        agent_id=agent_id,
+        tool_name=tool_name,
+        action=action,
+        target=target,
+        tier=tier,
+        outcome=outcome,
+        idempotency_key=idempotency_key or "",
+        error=error,
+    )
+
+
+def _audit_best_effort(
+    *,
+    agent_id: str,
+    tool_name: str,
+    action: str,
+    target: str | None,
+    tier: Tier,
+    outcome: str,
+    idempotency_key: str,
+    error: str | None = None,
+) -> None:
+    details: dict[str, object] = {
+        "tier": int(tier),
+        "idempotency_key": idempotency_key,
+    }
+    if error is not None:
+        details["error"] = error
+    try:
+        supabase_client.audit(
+            agent_id=agent_id,
+            tool_name=tool_name,
+            action=action,
+            target=target,
+            details=details,
+            outcome=outcome,
+        )
+    except Exception as exc:  # noqa: BLE001 — audit must never raise
+        log.debug("safety audit swallowed exception: %s", exc)

--- a/docs/agents/safety.md
+++ b/docs/agents/safety.md
@@ -1,0 +1,99 @@
+# Action-agent safety gate
+
+Module: `agents/safety.py`. Ships as **S2-0** (issue #295), the foundation
+every Pillar 7 Sprint 2+ action agent must route its mutations through.
+Model memory: `action_agent_safety_gate_model_v1`.
+
+## Three tiers
+
+| Tier | Meaning | Examples |
+|------|---------|----------|
+| `0 AUTO` | Fires without owner involvement. | `priority:{high,medium,low}`, `area:*`, `needs-research`, `needs-triage`, `status:ready` labels. Insert into `events` / `audit_log`. `goals.progress` append. Memory store with tag `auto-generated`. |
+| `1 OWNER_QUEUE` | Default. Gate refuses to fire and flags `queued=True`. | New issue comments, closing issues, merging PRs, `priority:critical`, `pillar:*` labels, any write to a table not on the Sprint-1 whitelist. |
+| `2 BLOCKED` | Never runs. `gate()` raises `GateError`. | `.env*`, `.claude/*`, destructive verbs (`delete`, `drop`, `force_push`), impersonation / `send_as_owner`, cross-repo writes, the whole `messaging` area. |
+
+Tier 2 wins over Tier 0 when both match — safety bias is deny-first.
+
+## Typical use
+
+```python
+from agents import safety
+
+outcome = safety.gate(
+    agent_id="langgraph-dispatcher",
+    tool_name="gh_labels",
+    action="add_label",
+    target="priority:high",
+    area="github",
+    scope_hash=approved_scope_hash,
+    dry_run=False,
+    fn=lambda: github_client.add_label(issue=42, label="priority:high"),
+)
+```
+
+What the gate does for you:
+
+1. Classifies `(tool_name, action, target, area)` into a tier.
+2. Computes a deterministic `idempotency_key` via sha256 over
+   `agent_id | action | target | scope_hash`.
+3. Decides: fire `fn` (Tier 0, live-run), skip `fn` and flag
+   `queued=True` (Tier 1), or raise `GateError` (Tier 2).
+4. Emits one `audit_log` row per attempt — best-effort, never raises.
+   The row carries `tier` and `idempotency_key` in `details`.
+
+The returned `GateOutcome` has `tier`, `fired`, `queued`, `dry_run`,
+`idempotency_key`. Keep the key on your queue / outcome row so re-runs
+are no-ops.
+
+## Classification-only
+
+If you just want a tier decision and an audit row without running code,
+omit `fn`:
+
+```python
+outcome = safety.gate(
+    agent_id="langgraph-dispatcher",
+    tool_name="gh_labels",
+    action="add_label",
+    target="priority:high",
+    area="github",
+)
+# outcome.tier is Tier.AUTO; audit row outcome="classified"
+```
+
+## Dry-run
+
+Pass `dry_run=True` when piloting a new action type. `fn` never runs;
+the audit row shows `outcome="dry_run"` (Tier 0) or
+`"dry_run_queued"` (Tier 1); Tier 2 still raises.
+
+## Standalone audit
+
+`safety.audit(...)` writes a single audit row without going through the
+gate. Useful for legacy paths that classify+execute on their own. Do
+**not** call it in addition to `gate()` for the same event — you'll
+double-count.
+
+## Adding a new action type
+
+1. Classify before writing code. Where does it land: Tier 0, 1, or 2?
+2. If Tier 0 / Tier 2, update both `agents/safety.py` **and**
+   `action_agent_safety_gate_model_v1` memory in the same change — the
+   two must stay in lockstep.
+3. Add a unit test in `tests/test_agents_safety.py` covering the new
+   match. Every tier-boundary assertion is the spec.
+
+## Changing tiers
+
+Owner-driven moves only. If the owner says "stop asking about X,
+auto-apply it" → move the action to Tier 0 and narrow the rule as much
+as possible. If "this was too aggressive" → move to Tier 1. Each move
+is a decision memory with the reason. Never expand Tier 0 silently.
+
+## Relation to `task_queue` / `action_queue`
+
+Tier 1 `queued=True` currently means "audited as queued"; the actual
+enqueue to a dedicated queue table lands in S2-1 (#296) when
+`task_queue` ships. Until then, the dispatcher and other agents can
+rely on the audit row + `queued` flag; no agent should fire a Tier 1
+action today.

--- a/tests/test_agents_safety.py
+++ b/tests/test_agents_safety.py
@@ -1,0 +1,415 @@
+"""Unit tests for ``agents.safety`` — S2-0 safety gate module (issue #295).
+
+Semantics pinned here mirror ``action_agent_safety_gate_model_v1``:
+
+1. Tier 0 = narrow whitelist (specific GitHub labels, Sprint-1 Supabase
+   tables, memory with ``auto-generated`` tag).
+2. Tier 2 = blocked outright (``.env*``, ``.claude/*``, destructive
+   actions, impersonation, cross-repo, messaging area).
+3. Tier 1 = everything else (owner queue).
+4. Idempotency keys are deterministic and change with ``scope_hash``.
+5. ``gate()`` audits every classification even when it refuses to fire.
+6. Audit is best-effort — backend failure never raises from safety.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agents import safety
+
+
+# ---------------------------------------------------------------------------
+# classify — Tier 0 whitelist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "priority:high",
+        "priority:medium",
+        "priority:low",
+        "needs-research",
+        "needs-triage",
+        "status:ready",
+    ],
+)
+def test_tier0_github_labels_on_whitelist(label: str) -> None:
+    assert safety.classify("gh", "add_label", label, area="github") == safety.Tier.AUTO
+
+
+def test_tier0_github_area_prefix() -> None:
+    # area:* labels follow a prefix rule, not an exact-match list.
+    assert safety.classify("gh", "add_label", "area:core-agent", area="github") == safety.Tier.AUTO
+    assert (
+        safety.classify("gh", "add_label", "area:infrastructure", area="github") == safety.Tier.AUTO
+    )
+
+
+@pytest.mark.parametrize(
+    "table,action",
+    [
+        ("events", "insert"),
+        ("events", "append"),
+        ("audit_log", "insert"),
+        ("goals", "progress_append"),
+        ("goals", "update_progress"),
+    ],
+)
+def test_tier0_supabase_sprint1_whitelist(table: str, action: str) -> None:
+    assert safety.classify("sb", action, table, area="supabase") == safety.Tier.AUTO
+
+
+def test_tier0_memory_store_requires_auto_generated_tag() -> None:
+    tagged = safety.classify("mem", "store", "some_memory", area="memory", tags=["auto-generated"])
+    untagged = safety.classify("mem", "store", "some_memory", area="memory", tags=["decision"])
+    assert tagged == safety.Tier.AUTO
+    assert untagged == safety.Tier.OWNER_QUEUE
+
+
+# ---------------------------------------------------------------------------
+# classify — Tier 2 blocklist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        ".env",
+        ".env.local",
+        "config/.env.production",
+        ".claude/settings.json",
+        "src/.claude/skills/my_skill.md",
+    ],
+)
+def test_tier2_protected_file_patterns(target: str) -> None:
+    assert safety.classify("fs", "write", target, area="filesystem") == safety.Tier.BLOCKED
+
+
+def test_tier2_protected_paths_normalise_windows_separators() -> None:
+    # A Windows-style path still must hit the blocklist.
+    assert (
+        safety.classify("fs", "write", r"C:\repo\.claude\settings.json", area="filesystem")
+        == safety.Tier.BLOCKED
+    )
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["delete", "destroy", "drop", "truncate", "force_push", "impersonate", "send_as_owner"],
+)
+def test_tier2_destructive_actions(action: str) -> None:
+    assert safety.classify("anything", action, "any_target") == safety.Tier.BLOCKED
+
+
+@pytest.mark.parametrize("tool_name", ["send_as_owner", "tg_impersonate_user", "EMAIL_IMPERSONATE"])
+def test_tier2_tool_name_impersonation_substrings(tool_name: str) -> None:
+    assert safety.classify(tool_name, "send", "anyone") == safety.Tier.BLOCKED
+
+
+def test_tier2_messaging_area_blocked_wholesale() -> None:
+    # Hard rule per no_sending_from_owner_name — messaging tools are not
+    # available to agents until the digital-twin pillar ships.
+    assert (
+        safety.classify("tg_bot", "send_message", "chat-42", area="messaging")
+        == safety.Tier.BLOCKED
+    )
+
+
+def test_tier2_cross_repo_write_blocked() -> None:
+    # Writing to a repo outside the allowed scope is Tier 2.
+    assert (
+        safety.classify("gh", "comment", "OtherUser/otherrepo#10", area="github")
+        == safety.Tier.BLOCKED
+    )
+
+
+def test_tier2_same_repo_write_not_blocked_by_cross_repo_rule() -> None:
+    # A non-whitelisted action on the allowed repo should fall back to
+    # Tier 1 (owner queue), not Tier 2.
+    assert (
+        safety.classify("gh", "comment", "Osasuwu/jarvis#10", area="github")
+        == safety.Tier.OWNER_QUEUE
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify — Tier 2 wins over Tier 0
+# ---------------------------------------------------------------------------
+
+
+def test_tier2_wins_over_tier0_when_both_match() -> None:
+    # Constructed clash: ``delete`` is Tier 2; even with a whitelisted
+    # label target the action verb must dominate. Safety bias: deny-first.
+    assert safety.classify("gh", "delete", "priority:low", area="github") == safety.Tier.BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# classify — Tier 1 default
+# ---------------------------------------------------------------------------
+
+
+def test_tier1_default_for_unknown_area() -> None:
+    assert safety.classify("unknown_tool", "do_thing", "somewhere") == safety.Tier.OWNER_QUEUE
+
+
+def test_tier1_github_label_outside_whitelist() -> None:
+    # ``priority:critical`` is intentionally NOT on the whitelist.
+    assert (
+        safety.classify("gh", "add_label", "priority:critical", area="github")
+        == safety.Tier.OWNER_QUEUE
+    )
+
+
+def test_tier1_supabase_table_outside_whitelist() -> None:
+    # ``memories`` insert is not Tier 0 — agents should not silently mint
+    # authoritative memory without owner review.
+    assert safety.classify("sb", "insert", "memories", area="supabase") == safety.Tier.OWNER_QUEUE
+
+
+# ---------------------------------------------------------------------------
+# idempotency_key
+# ---------------------------------------------------------------------------
+
+
+def test_idempotency_key_is_deterministic() -> None:
+    k1 = safety.idempotency_key("agent-a", "label", "target-x")
+    k2 = safety.idempotency_key("agent-a", "label", "target-x")
+    assert k1 == k2
+
+
+def test_idempotency_key_changes_with_scope_hash() -> None:
+    k_no_scope = safety.idempotency_key("agent-a", "label", "target-x")
+    k_with_scope = safety.idempotency_key("agent-a", "label", "target-x", scope_hash="sha-1")
+    k_other_scope = safety.idempotency_key("agent-a", "label", "target-x", scope_hash="sha-2")
+    assert k_no_scope != k_with_scope
+    assert k_with_scope != k_other_scope
+
+
+def test_idempotency_key_sensitive_to_every_input() -> None:
+    base = safety.idempotency_key("a", "x", "t", "s")
+    assert base != safety.idempotency_key("b", "x", "t", "s")
+    assert base != safety.idempotency_key("a", "y", "t", "s")
+    assert base != safety.idempotency_key("a", "x", "u", "s")
+    assert base != safety.idempotency_key("a", "x", "t", "r")
+
+
+def test_idempotency_key_is_hex_sha256() -> None:
+    key = safety.idempotency_key("a", "x")
+    assert len(key) == 64
+    int(key, 16)  # raises if not hex
+
+
+# ---------------------------------------------------------------------------
+# gate() — audit capture helper
+# ---------------------------------------------------------------------------
+
+
+class _AuditSpy:
+    """Replace ``supabase_client.audit`` to capture calls without a backend."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.raise_with: Exception | None = None
+
+    def __call__(self, **kwargs: Any) -> None:
+        if self.raise_with is not None:
+            raise self.raise_with
+        self.calls.append(kwargs)
+
+
+@pytest.fixture
+def audit_spy(monkeypatch: pytest.MonkeyPatch) -> _AuditSpy:
+    spy = _AuditSpy()
+    monkeypatch.setattr("agents.safety.supabase_client.audit", spy)
+    return spy
+
+
+# ---------------------------------------------------------------------------
+# gate() — Tier 2 raises + audits
+# ---------------------------------------------------------------------------
+
+
+def test_gate_tier2_raises_gate_error(audit_spy: _AuditSpy) -> None:
+    calls: list[str] = []
+
+    def fn() -> None:
+        calls.append("fired")
+
+    with pytest.raises(safety.GateError):
+        safety.gate(
+            agent_id="test-agent",
+            tool_name="fs",
+            action="delete",
+            target="some.txt",
+            area="filesystem",
+            fn=fn,
+        )
+
+    assert calls == []  # fn must not run
+    assert len(audit_spy.calls) == 1
+    row = audit_spy.calls[0]
+    assert row["outcome"] == "blocked"
+    assert row["details"]["tier"] == int(safety.Tier.BLOCKED)
+    assert len(row["details"]["idempotency_key"]) == 64
+
+
+# ---------------------------------------------------------------------------
+# gate() — Tier 1 queues, no fn call
+# ---------------------------------------------------------------------------
+
+
+def test_gate_tier1_queues_and_skips_fn(audit_spy: _AuditSpy) -> None:
+    calls: list[str] = []
+
+    result = safety.gate(
+        agent_id="test-agent",
+        tool_name="gh",
+        action="comment",
+        target="Osasuwu/jarvis#42",
+        area="github",
+        fn=lambda: calls.append("fired"),
+    )
+
+    assert calls == []
+    assert result.tier == safety.Tier.OWNER_QUEUE
+    assert result.queued is True
+    assert result.fired is False
+    assert audit_spy.calls[-1]["outcome"] == "queued"
+
+
+def test_gate_tier1_dry_run_marks_outcome_dry_run_queued(audit_spy: _AuditSpy) -> None:
+    safety.gate(
+        agent_id="test-agent",
+        tool_name="gh",
+        action="comment",
+        target="Osasuwu/jarvis#42",
+        area="github",
+        dry_run=True,
+    )
+    assert audit_spy.calls[-1]["outcome"] == "dry_run_queued"
+
+
+# ---------------------------------------------------------------------------
+# gate() — Tier 0 dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_gate_tier0_dry_run_skips_fn_and_audits_dry_run(audit_spy: _AuditSpy) -> None:
+    calls: list[str] = []
+
+    result = safety.gate(
+        agent_id="test-agent",
+        tool_name="gh",
+        action="add_label",
+        target="priority:high",
+        area="github",
+        dry_run=True,
+        fn=lambda: calls.append("fired"),
+    )
+
+    assert calls == []
+    assert result.tier == safety.Tier.AUTO
+    assert result.fired is False
+    assert result.dry_run is True
+    assert audit_spy.calls[-1]["outcome"] == "dry_run"
+    assert audit_spy.calls[-1]["details"]["tier"] == int(safety.Tier.AUTO)
+
+
+# ---------------------------------------------------------------------------
+# gate() — Tier 0 live happy path
+# ---------------------------------------------------------------------------
+
+
+def test_gate_tier0_live_runs_fn_and_audits_success(audit_spy: _AuditSpy) -> None:
+    calls: list[str] = []
+
+    result = safety.gate(
+        agent_id="test-agent",
+        tool_name="gh",
+        action="add_label",
+        target="priority:high",
+        area="github",
+        fn=lambda: calls.append("fired"),
+    )
+
+    assert calls == ["fired"]
+    assert result.fired is True
+    assert result.tier == safety.Tier.AUTO
+    assert audit_spy.calls[-1]["outcome"] == "success"
+
+
+def test_gate_tier0_fn_none_records_classified(audit_spy: _AuditSpy) -> None:
+    # When the caller only wants classification + audit, not a side
+    # effect, gate still audits with an explicit outcome.
+    result = safety.gate(
+        agent_id="test-agent",
+        tool_name="gh",
+        action="add_label",
+        target="priority:high",
+        area="github",
+    )
+    assert result.fired is False
+    assert audit_spy.calls[-1]["outcome"] == "classified"
+
+
+# ---------------------------------------------------------------------------
+# gate() — Tier 0 live failure reraises + audits
+# ---------------------------------------------------------------------------
+
+
+def test_gate_tier0_failure_audits_and_reraises(audit_spy: _AuditSpy) -> None:
+    def boom() -> None:
+        raise ValueError("kaboom")
+
+    with pytest.raises(ValueError, match="kaboom"):
+        safety.gate(
+            agent_id="test-agent",
+            tool_name="gh",
+            action="add_label",
+            target="priority:high",
+            area="github",
+            fn=boom,
+        )
+
+    row = audit_spy.calls[-1]
+    assert row["outcome"] == "failure:ValueError"
+    assert row["details"]["error"] == "kaboom"
+
+
+# ---------------------------------------------------------------------------
+# Audit is best-effort
+# ---------------------------------------------------------------------------
+
+
+def test_audit_swallows_backend_errors(
+    audit_spy: _AuditSpy, caplog: pytest.LogCaptureFixture
+) -> None:
+    audit_spy.raise_with = RuntimeError("supabase down")
+    # Should not raise, and fn-less classification should still return
+    # its outcome so agents can carry on.
+    result = safety.gate(
+        agent_id="test-agent",
+        tool_name="gh",
+        action="add_label",
+        target="priority:high",
+        area="github",
+    )
+    assert result.tier == safety.Tier.AUTO
+
+
+def test_audit_standalone_helper_best_effort(audit_spy: _AuditSpy) -> None:
+    audit_spy.raise_with = RuntimeError("supabase down")
+    # Must not raise.
+    safety.audit(
+        agent_id="test-agent",
+        tool_name="gh",
+        action="add_label",
+        target="priority:high",
+        tier=safety.Tier.AUTO,
+        outcome="success",
+        idempotency_key="abc",
+    )


### PR DESCRIPTION
## Summary

Adds `agents/safety.py` — the single tier-classifier / idempotency / gate / audit layer every Pillar 7 Sprint 2+ action agent must route its mutations through. Foundation ships **before** the dispatcher and other action agents, per the sprint plan in #184.

## Why

Pillar 7 Sprint 2 introduces agents that mutate external state (not just observe). The owner rejected "all owner-approved at start" — volume would overwhelm him. A tiered allowlist/blocklist is the design (see memory `action_agent_safety_gate_model_v1`). This PR encodes that model in code.

Closes #295. Parent epic: #184.

## Decisions & Alternatives

- **Reuse `supabase_client.audit()` instead of a new audit writer.** Rejected: duplicating the audit path — two code paths drift over time, Sprint 1 already has a tested best-effort writer, safety only needs to stamp `tier` + `idempotency_key` into `details`.
- **Classification-only use is supported** (`fn=None`). Rejected: forcing every caller to pass a closure — some callers only want a tier decision for their own branch logic, and we still want the audit row.
- **Tier 2 checked before Tier 0.** Deny-first: an action that matches both an unsafe pattern (e.g. `delete`) and a "safe" target (e.g. `priority:low`) must lose. Documented via `test_tier2_wins_over_tier0_when_both_match`.
- **`action_queue` enqueue wiring deferred.** S2-0 issue explicitly out-of-scopes it (ships in S2-1 via `task_queue` migration — #296). Current gate sets `queued=True` on Tier 1 and audits `outcome="queued"`; the dispatcher (S2-3, #298) will be the first consumer that cares.
- **Filesystem targets normalised to `/`.** Windows paths still hit the `.claude/*` and `.env*` rules without needing duplicate patterns.

## Risk Assessment

- **LOW**: new file, no existing code modified, no new runtime dependencies. Pure stdlib (hashlib, enum, dataclasses, logging) + existing `agents.supabase_client` import. Not wired into any agent yet — can't affect production until dispatcher starts calling it.
- All 49 new unit tests green. Pre-existing `tests/test_agents_smoke.py` and `tests/test_agents_supabase_bridge.py` unchanged and still green.

## Testing

```
ruff check agents/safety.py tests/test_agents_safety.py
ruff format agents/safety.py tests/test_agents_safety.py
pytest tests/test_agents_smoke.py tests/test_agents_supabase_bridge.py tests/test_agents_safety.py -x -q
  78 passed
```

Coverage focus:
- Every Tier 0 whitelist entry hits (labels, prefix rule for `area:*`, five Sprint-1 Supabase table/action pairs, memory `auto-generated` tag).
- Every Tier 2 blocklist class hits (`.env*`, `.claude/*`, Windows paths, seven destructive verbs, impersonation substrings, messaging area, cross-repo).
- Tier 2-beats-Tier-0 clash.
- Tier 1 fallback (unknown area, `priority:critical` outside whitelist, non-whitelisted Supabase table).
- `idempotency_key` deterministic + sensitive to every input.
- `gate()` behaviour for Tier 2 (raises + audits), Tier 1 (queues + skips fn), Tier 0 dry-run (skips fn + audits), Tier 0 live success (fires + audits), Tier 0 live failure (audits + reraises), Tier 0 classify-only (no fn).
- Audit best-effort: backend exception never propagates.

## Files Changed

- `agents/safety.py` — new module, the whole scope of S2-0.
- `tests/test_agents_safety.py` — 49 unit tests pinning classifier + gate + audit semantics.
- `docs/agents/safety.md` — README snippet for agent authors: three tiers, typical use, dry-run, standalone audit, tier-change policy.

## Follow-ups (not in this PR)

- S2-1 (#296) `task_queue` schema — will let Tier 1 attempts actually enqueue for owner approval.
- S2-3 (#298) dispatcher agent — first real caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>