### PR TITLE
feat(schema): task_queue dispatcher input surface (#296)

### DIFF
--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2253,3 +2253,85 @@ language sql stable as $$
     order by deduped.link_strength desc
     limit 10;
 $$;
+
+
+-- =========================================================================
+-- Pillar 7 Sprint 2: task_queue — dispatcher input surface (issue #296, S2-1)
+--
+-- Owner inserts approved tasks; the task-dispatcher agent (S2-3) scans
+-- status='pending' and transitions rows through the FSM below, logging
+-- each transition to audit_log via the safety gate (agents/safety.py).
+--
+-- FSM transitions (enforced in the dispatcher; DB check guards the enum):
+--   pending    -> dispatched | escalated | rejected
+--   dispatched -> done | escalated
+--   escalated  -> pending      (owner re-approves)
+--   done       -> (terminal)
+--   rejected   -> (terminal)
+--
+-- Drift detection uses `approved_scope_hash` + `scope_files`: if the repo
+-- state at dispatch time disagrees with the approval-time hash/globs, the
+-- dispatcher flips the row to `escalated` instead of firing.
+-- =========================================================================
+
+create table if not exists task_queue (
+  id uuid primary key default gen_random_uuid(),
+
+  -- Intent
+  goal text not null,
+  scope_files text[] not null default '{}',
+
+  -- Approval (inputs for drift detection + auto-dispatch gating)
+  approved_at timestamptz not null default now(),
+  approved_by text not null,
+  approved_scope_hash text not null,
+  auto_dispatch boolean not null default false,
+
+  -- Lifecycle
+  status text not null default 'pending'
+    check (status in ('pending', 'dispatched', 'done', 'escalated', 'rejected')),
+  dispatched_at timestamptz,
+  completed_at timestamptz,
+  escalated_reason text,
+
+  -- Dedup. Matches the safety-gate idempotency_key shape (sha256 hex, 64
+  -- chars). Unique so a retrying dispatcher cannot double-enqueue.
+  idempotency_key text not null unique,
+
+  -- Timestamps
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Dispatcher scan: oldest approved pending first. Also covers 'dispatched'
+-- so a restarted dispatcher can find in-flight rows to reconcile.
+create index if not exists idx_task_queue_pending_scan
+  on task_queue(status, approved_at)
+  where status in ('pending', 'dispatched');
+
+-- Dedicated updated_at trigger. The memories-shared update_updated_at()
+-- references last_accessed_at/fts/project_key -- columns task_queue does
+-- not have, so reusing it would error at runtime.
+create or replace function update_task_queue_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists task_queue_updated_at on task_queue;
+create trigger task_queue_updated_at
+  before update on task_queue
+  for each row execute function update_task_queue_updated_at();
+
+-- RLS -- matches the Pillar 7 convention (allow-all under service/anon
+-- key; app-layer gatekeeping is the safety gate + dispatcher). Hardening
+-- to per-role policies is its own sweep.
+alter table task_queue enable row level security;
+
+create policy "Allow all for authenticated" on task_queue
+  for all using (true) with check (true);
+
+create policy "Allow all for anon" on task_queue
+  for all to anon using (true) with check (true);

--- a/supabase/migrations/20260422134442_create_task_queue.sql
+++ b/supabase/migrations/20260422134442_create_task_queue.sql
@@ -1,0 +1,72 @@
+-- Pillar 7 Sprint 2: task_queue (issue #296, S2-1)
+-- Dispatcher input surface. Paired with mcp-memory/schema.sql.
+-- CI gate (#289) requires a migration file whenever schema.sql changes.
+
+-- FSM transitions (enforced in the dispatcher; DB check guards the enum):
+--   pending    -> dispatched | escalated | rejected
+--   dispatched -> done | escalated
+--   escalated  -> pending      (owner re-approves)
+--   done       -> (terminal)
+--   rejected   -> (terminal)
+
+create table if not exists task_queue (
+  id uuid primary key default gen_random_uuid(),
+
+  -- Intent
+  goal text not null,
+  scope_files text[] not null default '{}',
+
+  -- Approval (inputs for drift detection + auto-dispatch gating)
+  approved_at timestamptz not null default now(),
+  approved_by text not null,
+  approved_scope_hash text not null,
+  auto_dispatch boolean not null default false,
+
+  -- Lifecycle
+  status text not null default 'pending'
+    check (status in ('pending', 'dispatched', 'done', 'escalated', 'rejected')),
+  dispatched_at timestamptz,
+  completed_at timestamptz,
+  escalated_reason text,
+
+  -- Dedup. Matches the safety-gate idempotency_key shape (sha256 hex, 64
+  -- chars). Unique so a retrying dispatcher cannot double-enqueue.
+  idempotency_key text not null unique,
+
+  -- Timestamps
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Dispatcher scan: oldest approved pending first. Also covers 'dispatched'
+-- so a restarted dispatcher can find in-flight rows to reconcile.
+create index if not exists idx_task_queue_pending_scan
+  on task_queue(status, approved_at)
+  where status in ('pending', 'dispatched');
+
+-- Dedicated updated_at trigger. The memories-shared update_updated_at()
+-- references last_accessed_at/fts/project_key -- columns task_queue does
+-- not have, so reusing it would error at runtime.
+create or replace function update_task_queue_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists task_queue_updated_at on task_queue;
+create trigger task_queue_updated_at
+  before update on task_queue
+  for each row execute function update_task_queue_updated_at();
+
+-- RLS -- matches the Pillar 7 convention (allow-all under service/anon
+-- key; app-layer gatekeeping is the safety gate + dispatcher). Hardening
+-- to per-role policies is its own sweep.
+alter table task_queue enable row level security;
+
+create policy "Allow all for authenticated" on task_queue
+  for all using (true) with check (true);
+
+create policy "Allow all for anon" on task_queue
+  for all to anon using (true) with check (true);


### PR DESCRIPTION
## Summary

S2-1: adds the `task_queue` table — the dispatcher's input surface for Pillar 7 Sprint 2. Owner inserts approved tasks; the dispatcher agent (S2-3, #298) will scan `status='pending'`, evaluate drift/limits, and transition rows through a five-state FSM.

Changes:
- `mcp-memory/schema.sql` +82 lines — canonical table docs at the bottom of the file.
- `supabase/migrations/20260422134442_create_task_queue.sql` +72 lines — paired migration per #289 convention.
- Migration applied live (version `20260422134442`) and smoke-tested against production.

## Why

Without a persistent, idempotent, auditable queue, the dispatcher has no input. Every Sprint 2 sub-issue downstream of S2-1 depends on this shape being stable.

Closes #296. Part of epic #184, sprint milestone #21.

## Decisions & Alternatives

- **`idempotency_key` is UNIQUE NOT NULL** — app-level dedup is strictly weaker than a DB constraint; the dispatcher needs to retry blind without checking first. Key shape matches `agents/safety.py` sha256-hex (64 chars).
- **Dedicated `update_task_queue_updated_at()` trigger function** — the shared `update_updated_at()` on `memories` references `last_accessed_at`, `fts`, `project_key` — columns this table doesn't have; reusing would crash on first UPDATE. Goals table already set the per-table-trigger precedent.
- **Partial index `(status, approved_at) WHERE status IN ('pending','dispatched')`** — dispatcher scans these two states; terminal rows (done/rejected) stay indexable for history but don't inflate the hot scan.
- **Scope covered: `dispatched` in the partial index** — restart recovery: a crashed dispatcher must find in-flight rows to reconcile.
- **RLS: allow-all under auth + anon** — matches Pillar 7 convention; hardening to per-role policies is its own sweep, not in-scope here.
- **Rejected: GIN index on `scope_files`** — issue body said "defer if not required"; dispatcher's query shape is `(status, approved_at)`, no `scope_files @>` pattern today.
- **Rejected: FSM transition constraints at DB level** — enforced in dispatcher (S2-3). DB guards the enum; application owns the transitions. Standard tradeoff — keeps DDL reviewable.

## Risk Assessment

- **LOW**. Strictly additive: new table, new function, new trigger. No existing table/column modified. No data migration. `CREATE ... IF NOT EXISTS` everywhere — migration is idempotent and re-run-safe.
- Cross-project impact: jarvis Supabase is shared with redrobot. `task_queue` is a new public-schema table; no name collision (verified `select table_name from information_schema.tables where table_name='task_queue'` returned empty before apply). No redrobot code references `task_queue`.

## Testing

Applied migration via `mcp__supabase__apply_migration` against live `svwrzttdkxeselkpxfgm`. Smoke tests (all via `execute_sql`, all passed):

1. **Insert + defaults** — row inserted; `status='pending'`, `auto_dispatch=false`, `scope_files` array stored correctly, `approved_at/created_at/updated_at` auto-set.
2. **UPDATE bumps `updated_at`** — verified `updated_at > created_at` after status change.
3. **Status check constraint** — inserting `status='frobnicated'` rejected with `check_violation` (PASS).
4. **Unique idempotency_key** — duplicate insert rejected with `unique_violation` (PASS).
5. **Cleanup** — `DELETE FROM task_queue WHERE goal='smoke-test #296'`; final count = 0.

No Python code changed → no ruff/pytest needed for this PR.

## Files Changed

- `mcp-memory/schema.sql` — appended the Sprint 2 section with the full DDL for reviewers who read the canonical schema file.
- `supabase/migrations/20260422134442_create_task_queue.sql` — the executed DDL, version-matched to the live migration registered in Supabase.

## Follow-ups (not in this PR)

- Drift between `mcp-memory/schema.sql` (de-facto canonical, 2337 lines) and `supabase/schema.sql` (watched by CI #289, does not exist) — the schema-drift gate never fires today. Worth tracking as its own issue; not S2-1 scope.
- S2-3 (#298) implements the FSM transitions; until it lands, `task_queue` rows should not be dispatched — agents that enqueue (none today) must set `auto_dispatch=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)