### PR TITLE
feat(agents): scheduler primitive -- APScheduler + Postgres jobstore (#300)

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -11,5 +11,7 @@ __all__ = [
     "event_monitor",
     "github_client",
     "ollama_client",
+    "safety",
+    "scheduler",
     "supabase_client",
 ]

--- a/agents/scheduler.py
+++ b/agents/scheduler.py
@@ -1,0 +1,263 @@
+"""Scheduler primitive for Pillar 7 persistent agents (issue #300, S2-5).
+
+Run-loop engine. Registers agent tick functions as APScheduler jobs backed
+by a Postgres jobstore (same database as LangGraph's PostgresSaver) so
+jobs persist across process restarts.
+
+Why APScheduler and not Claude Code Routines: Routines run Claude Code;
+these agents are Python/LangGraph talking to Ollama and Supabase. Routines
+can't drive them. APScheduler is in-process, Postgres-backed, crash-safe.
+
+Usage::
+
+    from agents import scheduler
+
+    handle = scheduler.build_scheduler()
+    scheduler.register_agent(
+        handle,
+        agent_id="task-dispatcher",
+        fn=dispatcher_tick,
+        interval_seconds=60,
+        jitter_seconds=10,
+    )
+    handle.scheduler.start()
+
+CLI (placeholder tick for smoke-testing before S2-3 lands)::
+
+    python -m agents.scheduler                 # tick every 60s + 10s jitter
+    python -m agents.scheduler --interval 30   # override interval
+    python -m agents.scheduler --once          # fire one tick and exit
+
+Restart semantics: each agent's job is identified by ``agent_id`` and
+registered with ``replace_existing=True`` / ``max_instances=1`` /
+``coalesce=True``. A restarted process rebuilds the same job; the
+persisted row in ``apscheduler_jobs`` is reused, no duplicate tick is
+fired, and missed ticks collapse to a single catch-up run.
+
+Co-existence with LangGraph: APScheduler writes to ``apscheduler_jobs``
+/ ``apscheduler_jobs_history``; LangGraph's PostgresSaver writes to
+``checkpoints`` / ``checkpoint_writes`` / ``checkpoint_blobs``. Disjoint
+table sets — they share the database, not the schema namespace.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import signal
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from dotenv import load_dotenv
+
+from agents.config import load_config
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL_SECONDS = 60
+DEFAULT_JITTER_SECONDS = 10
+
+
+@dataclass(frozen=True)
+class SchedulerHandle:
+    """Wraps a live scheduler and the jobstore alias used for registration.
+
+    Held by callers so they can add further jobs or shut the scheduler down.
+    Frozen — treat as a value object.
+    """
+
+    scheduler: Any  # apscheduler.schedulers.base.BaseScheduler
+    jobstore_alias: str = "default"
+
+
+def _resolve_jobstore_url(postgres_url: str) -> str:
+    """Adapt a psycopg-style URL to the SQLAlchemy driver form APScheduler wants.
+
+    LangGraph's ``PostgresSaver`` accepts plain ``postgresql://`` because psycopg
+    registers itself as the default driver. APScheduler's ``SQLAlchemyJobStore``
+    builds a SQLAlchemy engine, which in modern SA (2.x) prefers an explicit
+    driver tag. Use psycopg v3 unless the caller already specified one.
+    """
+    if postgres_url.startswith("postgresql+"):
+        return postgres_url
+    if postgres_url.startswith("postgresql://"):
+        return "postgresql+psycopg://" + postgres_url[len("postgresql://") :]
+    return postgres_url
+
+
+def build_scheduler(
+    postgres_url: str | None = None,
+    *,
+    jobstore: Any | None = None,
+) -> SchedulerHandle:
+    """Construct a ``BackgroundScheduler`` with a Postgres-backed jobstore.
+
+    Passing ``jobstore`` overrides the default SQLAlchemy one — tests inject
+    ``MemoryJobStore`` so they can run without a live Postgres.
+    """
+    from apscheduler.schedulers.background import BackgroundScheduler
+
+    if jobstore is None:
+        from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+
+        if postgres_url is None:
+            postgres_url = load_config().postgres_url
+        jobstore = SQLAlchemyJobStore(url=_resolve_jobstore_url(postgres_url))
+
+    scheduler = BackgroundScheduler(jobstores={"default": jobstore}, timezone="UTC")
+    return SchedulerHandle(scheduler=scheduler)
+
+
+def register_agent(
+    handle: SchedulerHandle,
+    *,
+    agent_id: str,
+    fn: Callable[..., Any],
+    interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+    jitter_seconds: int = DEFAULT_JITTER_SECONDS,
+) -> Any:
+    """Register ``fn`` as a recurring job keyed by ``agent_id``.
+
+    Key invariants:
+
+    - ``replace_existing=True`` — restarts reuse the persisted row, config
+      drift updates the trigger in place, no duplicate registrations.
+    - ``max_instances=1`` — no two ticks of the same agent overlap.
+    - ``coalesce=True`` — if the scheduler was asleep and 5 ticks are due,
+      run once, not five times.
+    - ``jitter`` on the trigger — two devices running the same agent don't
+      fall into lockstep with the DB.
+
+    Returns the APScheduler ``Job`` object (opaque — tests inspect it for
+    trigger shape).
+    """
+    from apscheduler.triggers.interval import IntervalTrigger
+
+    if interval_seconds <= 0:
+        raise ValueError(f"interval_seconds must be positive, got {interval_seconds}")
+    if jitter_seconds < 0:
+        raise ValueError(f"jitter_seconds must be non-negative, got {jitter_seconds}")
+
+    return handle.scheduler.add_job(
+        fn,
+        trigger=IntervalTrigger(seconds=interval_seconds, jitter=jitter_seconds or None),
+        id=agent_id,
+        name=f"agent:{agent_id}",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        jobstore=handle.jobstore_alias,
+    )
+
+
+def _placeholder_tick() -> None:
+    """Proof-of-life tick used until a real agent (S2-3 dispatcher) registers.
+
+    Lives at module scope (not a closure) so APScheduler's jobstore can
+    pickle the job reference and restore it across restarts.
+    """
+    logger.info("[scheduler] placeholder tick at %s", int(time.time()))
+
+
+def _install_signal_handlers(handle: SchedulerHandle) -> None:
+    """Drain the scheduler on SIGTERM / SIGINT where the platform supports it.
+
+    Windows: ``SIGTERM`` is exposed as a constant but ``signal.signal`` raises
+    ValueError when you try to install a handler — there's no Unix-style term
+    signal on the OS. Swallow silently; KeyboardInterrupt handling in ``run``
+    still covers Ctrl-C on both platforms.
+    """
+
+    def _handler(signum: int, frame: Any) -> None:  # noqa: ARG001
+        logger.info("[scheduler] signal %s received -- draining", signum)
+        handle.scheduler.shutdown(wait=True)
+
+    for sig_name in ("SIGTERM", "SIGINT"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            # Platform doesn't allow this signal (SIGTERM on Windows).
+            logger.debug("[scheduler] signal %s not installable on this platform", sig_name)
+
+
+def run(
+    interval_seconds: int,
+    jitter_seconds: int,
+    *,
+    once: bool = False,
+) -> int:
+    """CLI entry-point: start scheduler, register placeholder, block.
+
+    ``--once`` forces one immediate run of every registered agent and exits.
+    Useful for smoke tests that don't want to wait a full interval.
+    """
+    cfg = load_config()
+    handle = build_scheduler(cfg.postgres_url)
+    register_agent(
+        handle,
+        agent_id="scheduler-placeholder",
+        fn=_placeholder_tick,
+        interval_seconds=interval_seconds,
+        jitter_seconds=jitter_seconds,
+    )
+    _install_signal_handlers(handle)
+    handle.scheduler.start()
+
+    if once:
+        # Wake every registered job immediately, drain, exit.
+        import datetime as _dt
+
+        now = _dt.datetime.now(_dt.UTC)
+        for job in handle.scheduler.get_jobs():
+            job.modify(next_run_time=now)
+        # Give the worker thread a chance to pick up and run.
+        time.sleep(2)
+        handle.scheduler.shutdown(wait=True)
+        return 0
+
+    logger.info(
+        "[scheduler] running. interval=%ss jitter=%ss (Ctrl-C to stop)",
+        interval_seconds,
+        jitter_seconds,
+    )
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        logger.info("[scheduler] KeyboardInterrupt -- draining")
+        handle.scheduler.shutdown(wait=True)
+    return 0
+
+
+def main() -> int:
+    load_dotenv()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=DEFAULT_INTERVAL_SECONDS,
+        help=f"Seconds between ticks (default: {DEFAULT_INTERVAL_SECONDS})",
+    )
+    parser.add_argument(
+        "--jitter",
+        type=int,
+        default=DEFAULT_JITTER_SECONDS,
+        help=f"Max random seconds added per tick (default: {DEFAULT_JITTER_SECONDS})",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run registered jobs once and exit (useful for smoke tests).",
+    )
+    args = parser.parse_args()
+    return run(args.interval, args.jitter, once=args.once)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/agents/scheduler.md
+++ b/docs/agents/scheduler.md
@@ -1,0 +1,96 @@
+# Scheduler primitive
+
+Module: `agents/scheduler.py`. Ships as **S2-5** (issue #300) — the run-loop
+engine that fires persistent agents on an interval. Dispatcher (S2-3, #298)
+is the first consumer; future agents register via `register_agent()`.
+
+## Why APScheduler
+
+Claude Code Routines run Claude Code. Our agents are Python/LangGraph
+talking to Ollama + Supabase — a different process, a different runtime.
+APScheduler is in-process, uses the Postgres we already run for LangGraph
+checkpoints, and survives restart.
+
+## Usage
+
+```python
+from agents import scheduler
+
+handle = scheduler.build_scheduler()          # reads AGENTS_POSTGRES_URL
+scheduler.register_agent(
+    handle,
+    agent_id="task-dispatcher",
+    fn=dispatcher_tick,                       # plain callable, no args
+    interval_seconds=60,
+    jitter_seconds=10,
+)
+handle.scheduler.start()
+# ... main thread blocks / does other work ...
+```
+
+The returned `SchedulerHandle` is a frozen dataclass with the live
+`BackgroundScheduler` and its jobstore alias. Keep it to add more jobs
+or shut down.
+
+## CLI
+
+```bash
+python -m agents.scheduler                   # tick every 60s + jitter
+python -m agents.scheduler --interval 30     # override
+python -m agents.scheduler --once            # fire one tick and exit
+```
+
+CLI runs `_placeholder_tick` — a log-only proof-of-life. Once the
+dispatcher lands in S2-3, its entry point registers the real job
+alongside.
+
+## Restart semantics
+
+- `replace_existing=True` — a re-registered `agent_id` replaces the
+  persisted row; no duplicate.
+- `max_instances=1` — two ticks of the same agent never overlap.
+- `coalesce=True` — a backlog (scheduler was asleep N minutes) collapses
+  to one catch-up run.
+- `jitter` — avoids lockstep between devices hitting the same DB.
+
+Combined: kill the process mid-tick, restart → APScheduler reads the
+persisted job, resumes; the idempotency key from `agents/safety.py` is
+the final guard against double-dispatch.
+
+## Table co-existence with LangGraph
+
+| Owner | Table |
+|-------|-------|
+| APScheduler | `apscheduler_jobs` (plus `apscheduler_jobs_history` if enabled) |
+| LangGraph (`PostgresSaver`) | `checkpoints`, `checkpoint_writes`, `checkpoint_blobs` |
+
+Disjoint sets — they share the database, not the namespace. Smoke-test
+locally by starting `python -m agents.scheduler --once` and then
+`python -m agents.event_monitor` in any order; neither should disturb
+the other's rows.
+
+## Windows signal gotcha
+
+`SIGTERM` is exposed as a constant on Windows Python but installing a
+handler raises `ValueError` (the OS doesn't have a Unix-style term
+signal). `_install_signal_handlers` swallows that — Ctrl-C still
+triggers `KeyboardInterrupt` in `run()`.
+
+## Manual smoke test — restart recovery
+
+The kill-mid-tick/restart path needs two shells and a live Postgres.
+Can't automate inside pytest without flaky OS-specific plumbing.
+
+```bash
+# Shell 1
+python -m agents.scheduler --interval 30 --jitter 0
+# [wait for one tick logged, then Ctrl-C or kill the process]
+
+# Shell 2 — same DB, check the jobs table:
+psql "$AGENTS_POSTGRES_URL" -c 'select id, next_run_time from apscheduler_jobs;'
+# Should show scheduler-placeholder with a future next_run_time.
+
+# Shell 1 again
+python -m agents.scheduler --interval 30 --jitter 0
+# Job should resume from persisted next_run_time, not restart the interval.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ agents = [
   # but agents/github_client.py depends on it unconditionally — declare it
   # explicitly so the contract doesn't depend on a transitive.
   "httpx>=0.27",
+  # Pillar 7 Sprint 2: scheduler primitive (agents/scheduler.py, #300).
+  # APScheduler's SQLAlchemyJobStore needs SQLAlchemy; pin ranges that
+  # work with psycopg v3 (already pulled in above).
+  "apscheduler>=3.10",
+  "sqlalchemy>=2.0",
 ]
 # All runtime components
 full = [

--- a/tests/test_agents_scheduler.py
+++ b/tests/test_agents_scheduler.py
@@ -1,0 +1,294 @@
+"""Unit tests for the scheduler primitive (issue #300, S2-5).
+
+These tests use APScheduler's in-memory jobstore so they don't need a
+live Postgres. The Postgres restart-recovery path is covered by a
+manual smoke test documented in docs/agents/scheduler.md — can't
+reliably fork/kill a process from within pytest on Windows.
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+apscheduler = pytest.importorskip("apscheduler")
+
+
+@pytest.fixture()
+def memory_handle():
+    """A ``SchedulerHandle`` backed by ``MemoryJobStore`` — no Postgres required."""
+    from apscheduler.jobstores.memory import MemoryJobStore
+
+    from agents import scheduler
+
+    return scheduler.build_scheduler(jobstore=MemoryJobStore())
+
+
+# ---------------------------------------------------------------------------
+# URL resolution for the SQLAlchemy jobstore.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_jobstore_url_adds_driver_tag_when_missing() -> None:
+    from agents import scheduler
+
+    got = scheduler._resolve_jobstore_url(
+        "postgresql://jarvis:jarvis@localhost:5433/agents?sslmode=disable"
+    )
+    assert got == "postgresql+psycopg://jarvis:jarvis@localhost:5433/agents?sslmode=disable"
+
+
+def test_resolve_jobstore_url_preserves_explicit_driver() -> None:
+    from agents import scheduler
+
+    url = "postgresql+psycopg2://u:p@host/db"
+    assert scheduler._resolve_jobstore_url(url) == url
+
+
+def test_resolve_jobstore_url_passthrough_non_postgres() -> None:
+    """Sqlite URLs or anything else get returned unchanged — no surprises."""
+    from agents import scheduler
+
+    url = "sqlite:///tmp/jarvis.sqlite"
+    assert scheduler._resolve_jobstore_url(url) == url
+
+
+# ---------------------------------------------------------------------------
+# build_scheduler + SchedulerHandle basics.
+# ---------------------------------------------------------------------------
+
+
+def test_build_scheduler_returns_handle_with_injected_jobstore() -> None:
+    from apscheduler.jobstores.memory import MemoryJobStore
+
+    from agents import scheduler
+
+    store = MemoryJobStore()
+    handle = scheduler.build_scheduler(jobstore=store)
+
+    assert handle.scheduler is not None
+    assert handle.jobstore_alias == "default"
+    # The handle's scheduler should be using our injected store under the alias.
+    assert handle.scheduler._lookup_jobstore("default") is store
+
+
+def test_scheduler_handle_is_frozen_dataclass() -> None:
+    """Handle should be immutable — tests accidental mutation."""
+    from agents import scheduler
+
+    handle = scheduler.build_scheduler(jobstore=_memory_jobstore())
+    with pytest.raises(Exception):  # FrozenInstanceError is a dataclasses-specific subclass
+        handle.jobstore_alias = "other"  # type: ignore[misc]
+
+
+def _memory_jobstore():
+    from apscheduler.jobstores.memory import MemoryJobStore
+
+    return MemoryJobStore()
+
+
+# ---------------------------------------------------------------------------
+# register_agent — the core public API.
+# ---------------------------------------------------------------------------
+
+
+def test_register_agent_creates_interval_job(memory_handle) -> None:
+    from agents import scheduler
+
+    job = scheduler.register_agent(
+        memory_handle,
+        agent_id="test-agent",
+        fn=scheduler._placeholder_tick,
+        interval_seconds=30,
+        jitter_seconds=5,
+    )
+
+    assert job.id == "test-agent"
+    assert job.name == "agent:test-agent"
+    # Single-instance, coalesce, matches the restart-safe contract.
+    assert job.max_instances == 1
+    assert job.coalesce is True
+
+
+def test_register_agent_trigger_has_interval_and_jitter(memory_handle) -> None:
+    """Interval and jitter are what the trigger actually exposes."""
+    from agents import scheduler
+
+    job = scheduler.register_agent(
+        memory_handle,
+        agent_id="jitter-agent",
+        fn=scheduler._placeholder_tick,
+        interval_seconds=45,
+        jitter_seconds=7,
+    )
+
+    trigger = job.trigger
+    # IntervalTrigger stores the interval as a timedelta.
+    assert int(trigger.interval_length) == 45
+    assert trigger.jitter == 7
+
+
+def test_register_agent_jitter_zero_passed_as_none(memory_handle) -> None:
+    """jitter_seconds=0 must not register a jitter=0 (it rejects the job).
+
+    APScheduler's IntervalTrigger treats jitter=0 as 'no jitter' — we pass
+    None to make intent explicit. Verifies the `jitter_seconds or None` path.
+    """
+    from agents import scheduler
+
+    job = scheduler.register_agent(
+        memory_handle,
+        agent_id="no-jitter",
+        fn=scheduler._placeholder_tick,
+        interval_seconds=60,
+        jitter_seconds=0,
+    )
+    assert job.trigger.jitter is None
+
+
+def test_register_agent_replace_existing_is_idempotent(memory_handle) -> None:
+    """Re-registering the same ``agent_id`` replaces the previous job.
+
+    Uses ``start(paused=True)`` so the jobstore actually holds the jobs
+    (otherwise they queue into ``_pending_jobs`` and the test can't see
+    the real dedup behaviour).
+    """
+    from agents import scheduler
+
+    memory_handle.scheduler.start(paused=True)
+    try:
+        scheduler.register_agent(
+            memory_handle,
+            agent_id="dup-agent",
+            fn=scheduler._placeholder_tick,
+            interval_seconds=30,
+        )
+        # Second registration with a different interval — must succeed and
+        # update the existing job, not throw ConflictingIdError.
+        job = scheduler.register_agent(
+            memory_handle,
+            agent_id="dup-agent",
+            fn=scheduler._placeholder_tick,
+            interval_seconds=120,
+        )
+
+        assert job.id == "dup-agent"
+        assert int(job.trigger.interval_length) == 120
+        # And there is only ONE job with that id in the jobstore.
+        all_jobs = memory_handle.scheduler.get_jobs()
+        assert sum(1 for j in all_jobs if j.id == "dup-agent") == 1
+    finally:
+        memory_handle.scheduler.shutdown(wait=False)
+
+
+def test_register_agent_rejects_zero_interval(memory_handle) -> None:
+    from agents import scheduler
+
+    with pytest.raises(ValueError, match="interval_seconds must be positive"):
+        scheduler.register_agent(
+            memory_handle,
+            agent_id="zero",
+            fn=scheduler._placeholder_tick,
+            interval_seconds=0,
+        )
+
+
+def test_register_agent_rejects_negative_interval(memory_handle) -> None:
+    from agents import scheduler
+
+    with pytest.raises(ValueError, match="interval_seconds must be positive"):
+        scheduler.register_agent(
+            memory_handle,
+            agent_id="neg",
+            fn=scheduler._placeholder_tick,
+            interval_seconds=-5,
+        )
+
+
+def test_register_agent_rejects_negative_jitter(memory_handle) -> None:
+    from agents import scheduler
+
+    with pytest.raises(ValueError, match="jitter_seconds must be non-negative"):
+        scheduler.register_agent(
+            memory_handle,
+            agent_id="neg-jitter",
+            fn=scheduler._placeholder_tick,
+            interval_seconds=60,
+            jitter_seconds=-1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Job persistence contract: the registered callable must be picklable.
+# ---------------------------------------------------------------------------
+
+
+def test_placeholder_tick_is_picklable() -> None:
+    """Persistent jobstore serialises the callable. A closure here would
+    silently fail on restart — keep _placeholder_tick at module scope.
+    """
+    from agents import scheduler
+
+    blob = pickle.dumps(scheduler._placeholder_tick)
+    restored = pickle.loads(blob)
+    # Round-trip yields the same callable reference, not a copy.
+    assert restored is scheduler._placeholder_tick
+
+
+# ---------------------------------------------------------------------------
+# Signal-handler installation — must not raise on any platform.
+# ---------------------------------------------------------------------------
+
+
+def test_install_signal_handlers_is_safe_on_current_platform(memory_handle) -> None:
+    """On Windows SIGTERM install raises ValueError; on Unix it works.
+    Either way, ``_install_signal_handlers`` must not propagate the error.
+    """
+    from agents import scheduler
+
+    # Must not raise, regardless of platform.
+    scheduler._install_signal_handlers(memory_handle)
+
+
+# ---------------------------------------------------------------------------
+# CLI argparse surface — cheap sanity that --once / --interval / --jitter exist.
+# ---------------------------------------------------------------------------
+
+
+def test_main_cli_exposes_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI should accept --interval, --jitter, --once without error,
+    and forward them to ``run``. We don't actually start the scheduler.
+    """
+    from agents import scheduler
+
+    called: dict[str, object] = {}
+
+    def fake_run(interval: int, jitter: int, *, once: bool = False) -> int:
+        called["interval"] = interval
+        called["jitter"] = jitter
+        called["once"] = once
+        return 0
+
+    monkeypatch.setattr(scheduler, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["agents.scheduler", "--interval", "42", "--jitter", "3"])
+
+    rc = scheduler.main()
+    assert rc == 0
+    assert called == {"interval": 42, "jitter": 3, "once": False}
+
+
+def test_main_cli_once_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agents import scheduler
+
+    captured: dict[str, object] = {}
+
+    def fake_run(interval: int, jitter: int, *, once: bool = False) -> int:
+        captured["once"] = once
+        return 0
+
+    monkeypatch.setattr(scheduler, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["agents.scheduler", "--once"])
+
+    assert scheduler.main() == 0
+    assert captured["once"] is True


### PR DESCRIPTION
## Summary
Adds `agents/scheduler.py` — the run-loop engine for Pillar 7 persistent agents. Uses APScheduler's `BackgroundScheduler` + `SQLAlchemyJobStore` on the same Postgres that LangGraph checkpointers already live in. The dispatcher (S2-3, #298) will be the first consumer; future agents register via `register_agent()`.

## Why
Claude Code Routines can't drive these agents — Routines run Claude Code, but our agents are Python/LangGraph talking to Ollama + Supabase (different process, different runtime). APScheduler is in-process, Postgres-backed, crash-safe — reuses infra we already pay for.

Closes #300.

## Decisions & Alternatives
- **BackgroundScheduler, not AsyncIO** — matches `event_monitor.py`'s sync paradigm; LangGraph graphs compile sync-friendly `.invoke()`. Async would fork the runtime model for no gain today.
- **SQLAlchemyJobStore with psycopg v3** — `_resolve_jobstore_url` rewrites `postgresql://` → `postgresql+psycopg://`. SA 2.x needs an explicit driver tag; plain `postgresql://` picks a stale default on some systems. Alternative (keeping the plain URL) is fragile.
- **`replace_existing=True` + `max_instances=1` + `coalesce=True`** is the restart-safe contract: (1) re-registering `agent_id` replaces the row — no duplicates after restart, (2) no two ticks of the same agent overlap, (3) a long sleep collapses backlog to one catch-up run. Without all three, a crashed scheduler could resume and fire 30× back-to-back.
- **Jitter passed as `None` when zero** — APScheduler's `IntervalTrigger` rejects `jitter=0` (interprets it as "no jitter, but set it"). `jitter_seconds or None` makes intent explicit.
- **`_placeholder_tick` at module scope** — the persistent jobstore pickles the callable; a closure here would silently fail on restart with no clear error. Comment calls this out so a future refactor doesn't move it into `run()`.
- **Windows SIGTERM `try/except (ValueError, OSError)`** — `signal.SIGTERM` exists on Windows but `signal.signal(SIGTERM, _)` raises. KeyboardInterrupt still drains cleanly via `run()`'s except clause.
- **Tests use `MemoryJobStore`** — gives the full APScheduler code paths without needing live Postgres in CI. Restart recovery (the one thing MemoryJobStore can't cover) is documented as a 2-shell manual smoke test in `docs/agents/scheduler.md`. Alternative (fork/kill in pytest) would be flaky on Windows and not worth the complexity for a path that's exercised every prod run.
- **`test_register_agent_replace_existing_is_idempotent` starts the scheduler paused** — APScheduler queues jobs in `_pending_jobs` when the scheduler isn't running; `replace_existing` only dedupes on `.start()`. `start(paused=True)` flushes the queue without actually firing ticks.

## Risk Assessment
**LOW.** Pure infrastructure primitive, no behavior wired in yet — `_placeholder_tick` only logs. CLI has `--once` for smoke tests. All 16 new tests green, plus the 79-test agents suite unchanged. The only shared state is the `apscheduler_jobs` table, which is disjoint from LangGraph's `checkpoints*` tables.

## Testing
- `ruff check --fix && ruff format` — clean
- `pytest tests/test_agents_scheduler.py -v` — 16/16 pass in 0.35s
- `pytest tests/test_agents_scheduler.py tests/test_agents_safety.py tests/test_agents_smoke.py -v` — 79/79 pass in 4.00s
- Manual restart-recovery smoke test documented in `docs/agents/scheduler.md` (requires 2 shells + live Postgres; can't automate inside pytest cleanly)

Covered: URL driver rewrite (both directions + passthrough), handle immutability, trigger shape (interval/jitter/jitter-zero-as-None), idempotent re-registration, validation (zero/negative interval, negative jitter), picklability of the tick fn, signal-handler cross-platform safety, CLI flags (--interval, --jitter, --once).

## Files Changed
- `agents/scheduler.py` — the module (SchedulerHandle, build_scheduler, register_agent, _placeholder_tick, _install_signal_handlers, run, main)
- `tests/test_agents_scheduler.py` — 16 unit tests, MemoryJobStore-backed
- `docs/agents/scheduler.md` — usage, CLI, restart semantics, LangGraph co-existence table, Windows gotcha, manual smoke test
- `pyproject.toml` — `apscheduler>=3.10`, `sqlalchemy>=2.0` in `agents` extras
- `agents/__init__.py` — added `scheduler` (and `safety` from S2-1) to `__all__`

## Follow-ups
- S2-3 (#298) replaces `_placeholder_tick` with `task-dispatcher` when it lands
- Schema-drift CI gate (`.github/workflows/schema-drift-check.yml`) watches `supabase/schema.sql`, which doesn't exist — the gate silently passes today. Out of scope for this PR; filed as a follow-up in the S2-0/S2-1 thread already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)