### PR TITLE
feat(agents): Claude Max usage probe -- false-safe budget gate for dispatcher (#297)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,11 @@ OLLAMA_MODEL=qwen3:4b
 # Local Postgres for LangGraph checkpoints (see docker-compose.agents.yml).
 # dev-only credentials — swap when self-hosted PG comes online.
 AGENTS_POSTGRES_URL=postgresql://jarvis:jarvis@localhost:5433/agents?sslmode=disable
+
+# ── Pillar 7 Sprint 2 — task-dispatcher budget probe (see docs/agents/usage_probe.md) ──
+# Dispatcher counts successful dispatches in a rolling window and pauses when
+# headroom is near zero. Defaults are conservative; tune as we learn real usage.
+CLAUDE_USAGE_WINDOW_HOURS=5
+CLAUDE_USAGE_BUDGET=100
+CLAUDE_USAGE_NEAR_EXHAUSTION_PERCENT=15
+CLAUDE_USAGE_CACHE_TTL_SECONDS=300

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -14,4 +14,5 @@ __all__ = [
     "safety",
     "scheduler",
     "supabase_client",
+    "usage_probe",
 ]

--- a/agents/usage_probe.py
+++ b/agents/usage_probe.py
@@ -1,0 +1,286 @@
+"""Claude Max usage probe for Pillar 7 Sprint 2 (issue #297, S2-2).
+
+Dispatcher (S2-3, #298) calls :func:`read_usage` before dispatching a task.
+If ``reading.near_exhaustion`` is True, the dispatch is paused (the task
+stays in ``task_queue`` for the next tick). Every probe failure is
+*conservative false-safe* — we return a reading with ``near_exhaustion=True``
+rather than raising, so a broken probe never causes a flood of dispatches.
+
+Probe source
+============
+
+Claude Max does not expose a live-quota API to end users. This module
+counts *successful* task-dispatcher audit rows since the current window
+started. That's the authoritative record of "how much budget this
+jurisdiction has consumed". If we later get a real API, swap
+:class:`StaticBudgetProbe` for a new implementation — dispatcher only
+depends on the :class:`UsageProbe` Protocol.
+
+Configuration
+=============
+
+All knobs live in env vars with conservative defaults:
+
+- ``CLAUDE_USAGE_WINDOW_HOURS``          — rolling window size (default 5h)
+- ``CLAUDE_USAGE_BUDGET``                — dispatches allowed per window (default 100)
+- ``CLAUDE_USAGE_NEAR_EXHAUSTION_PERCENT`` — headroom threshold (default 15)
+- ``CLAUDE_USAGE_CACHE_TTL_SECONDS``     — probe cache TTL (default 300)
+
+Cache
+=====
+
+:class:`CachedProbe` memoizes the reading for ``ttl_seconds`` in process
+memory. Dispatcher runs in a single long-lived APScheduler process, so
+cross-process cache (Supabase) adds complexity without benefit. A restart
+invalidates the cache; the first tick after restart re-probes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_WINDOW_HOURS = 5
+DEFAULT_BUDGET = 100
+DEFAULT_NEAR_EXHAUSTION_PERCENT = 15
+DEFAULT_CACHE_TTL_SECONDS = 300
+
+DISPATCHER_AGENT_ID = "task-dispatcher"
+DISPATCH_ACTION = "dispatch"
+
+
+@dataclass(frozen=True)
+class UsageReading:
+    """Snapshot of dispatcher's budget headroom in the current window.
+
+    Dispatcher's gate is ``not reading.near_exhaustion``. The other fields
+    are surfaced for audit and dashboards.
+    """
+
+    limit_window: timedelta
+    used: int
+    total: int
+    reset_at: datetime
+    near_exhaustion: bool
+
+    @property
+    def headroom_ratio(self) -> float:
+        """Fraction of budget remaining — 0.0 means exhausted, 1.0 means empty.
+
+        Returns 0.0 if ``total`` is zero or negative, matching the false-safe
+        contract: ``total=0`` is also what :func:`_false_safe_reading` produces.
+        """
+        if self.total <= 0:
+            return 0.0
+        return max(0.0, (self.total - self.used) / self.total)
+
+
+class UsageProbeError(RuntimeError):
+    """Raised by concrete probes when a reading cannot be produced."""
+
+
+class UsageProbe(Protocol):
+    """Anything that produces a :class:`UsageReading`."""
+
+    def read(self) -> UsageReading: ...
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "[usage_probe] %s is not an int (%r) -- using default %s", name, raw, default
+        )
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Concrete probe: static budget + audit_log count
+# ---------------------------------------------------------------------------
+
+
+class StaticBudgetProbe:
+    """Reading = (budget, count of successful dispatcher audit rows since window start).
+
+    ``supabase`` may be a module (``agents.supabase_client``) exposing
+    ``get_client()`` or a pre-built client. ``None`` means "no external source"
+    — the probe reports ``used=0`` so tests can exercise headroom math
+    without a live DB.
+    """
+
+    def __init__(
+        self,
+        *,
+        supabase: Any | None = None,
+        window: timedelta | None = None,
+        total: int | None = None,
+        near_exhaustion_percent: int | None = None,
+    ) -> None:
+        self._supabase = supabase
+        self._window = window or timedelta(
+            hours=_env_int("CLAUDE_USAGE_WINDOW_HOURS", DEFAULT_WINDOW_HOURS)
+        )
+        self._total = (
+            total if total is not None else _env_int("CLAUDE_USAGE_BUDGET", DEFAULT_BUDGET)
+        )
+        self._pct = (
+            near_exhaustion_percent
+            if near_exhaustion_percent is not None
+            else _env_int("CLAUDE_USAGE_NEAR_EXHAUSTION_PERCENT", DEFAULT_NEAR_EXHAUSTION_PERCENT)
+        )
+
+    def read(self) -> UsageReading:
+        now = _now_utc()
+        window_start = now - self._window
+        # reset_at is an upper bound on "budget refills in at most this long".
+        # Claude Max 5-hour windows aren't aligned to a public clock pivot,
+        # so "now + window" is the most honest answer we can give without an
+        # API. Dispatcher only uses near_exhaustion; reset_at is informational.
+        reset_at = now + self._window
+        used = self._count_dispatches_since(window_start)
+        used_capped = min(used, self._total) if self._total > 0 else used
+        total = max(self._total, 0)
+        if total == 0:
+            near = True
+        else:
+            headroom_pct = 100 - int(used_capped * 100 / total)
+            near = headroom_pct <= self._pct
+        return UsageReading(
+            limit_window=self._window,
+            used=used_capped,
+            total=total,
+            reset_at=reset_at,
+            near_exhaustion=near,
+        )
+
+    def _count_dispatches_since(self, window_start: datetime) -> int:
+        """Count successful task-dispatcher audit rows since ``window_start``.
+
+        Raises :class:`UsageProbeError` on backend failure so the outer
+        :func:`read_usage` wrapper can convert it to a false-safe reading.
+        """
+        if self._supabase is None:
+            return 0
+        try:
+            client = (
+                self._supabase.get_client()
+                if hasattr(self._supabase, "get_client")
+                else self._supabase
+            )
+            resp = (
+                client.table("audit_log")
+                .select("id", count="exact")
+                .eq("agent_id", DISPATCHER_AGENT_ID)
+                .eq("action", DISPATCH_ACTION)
+                .eq("outcome", "success")
+                .gte("created_at", window_start.isoformat())
+                .execute()
+            )
+            return int(getattr(resp, "count", 0) or 0)
+        except Exception as exc:  # noqa: BLE001 — wrap any backend failure
+            raise UsageProbeError(f"audit_log dispatch count failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Cache decorator
+# ---------------------------------------------------------------------------
+
+
+class CachedProbe:
+    """Memoize ``inner.read()`` for ``ttl_seconds`` using a monotonic clock.
+
+    ``invalidate()`` drops the cached value — dispatcher can call it after a
+    confirmed dispatch that shifts headroom materially.
+    """
+
+    def __init__(
+        self,
+        inner: UsageProbe,
+        *,
+        ttl_seconds: int | None = None,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._inner = inner
+        self._ttl = (
+            ttl_seconds
+            if ttl_seconds is not None
+            else _env_int("CLAUDE_USAGE_CACHE_TTL_SECONDS", DEFAULT_CACHE_TTL_SECONDS)
+        )
+        self._now = now
+        self._cached: UsageReading | None = None
+        self._cached_at: float | None = None
+
+    def read(self) -> UsageReading:
+        now = self._now()
+        if (
+            self._cached is not None
+            and self._cached_at is not None
+            and now - self._cached_at < self._ttl
+        ):
+            return self._cached
+        reading = self._inner.read()
+        self._cached = reading
+        self._cached_at = now
+        return reading
+
+    def invalidate(self) -> None:
+        self._cached = None
+        self._cached_at = None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def read_usage(probe: UsageProbe | None = None) -> UsageReading:
+    """Dispatcher-safe wrapper: never raises, never dispatches on failure.
+
+    A probe exception is logged and replaced with
+    :func:`_false_safe_reading` — ``near_exhaustion=True`` so the
+    dispatcher pauses until the probe recovers.
+    """
+    if probe is None:
+        from agents import supabase_client
+
+        probe = CachedProbe(StaticBudgetProbe(supabase=supabase_client))
+    try:
+        return probe.read()
+    except Exception as exc:  # noqa: BLE001 — false-safe contract
+        logger.warning(
+            "[usage_probe] probe failed -- returning false-safe reading (near_exhaustion=True): %s",
+            exc,
+        )
+        return _false_safe_reading()
+
+
+def _false_safe_reading() -> UsageReading:
+    """Reading that tells the dispatcher *do not dispatch*."""
+    return UsageReading(
+        limit_window=timedelta(hours=_env_int("CLAUDE_USAGE_WINDOW_HOURS", DEFAULT_WINDOW_HOURS)),
+        used=0,
+        total=0,
+        reset_at=_now_utc(),
+        near_exhaustion=True,
+    )

--- a/docs/agents/usage_probe.md
+++ b/docs/agents/usage_probe.md
@@ -1,0 +1,111 @@
+# Claude Max usage probe
+
+Module: `agents/usage_probe.py`. Ships as **S2-2** (issue #297) — the
+lightweight budget gate the task-dispatcher (S2-3, #298) consults before
+every live dispatch.
+
+## Why a probe, not a live API
+
+Claude Max has no public per-user quota endpoint. The dispatcher still
+needs a "do I have headroom?" answer every tick. The probe gives one
+authoritative answer: **count the dispatcher's own successful dispatches
+in a rolling window**. That's exactly the budget this jurisdiction
+consumes, and we already write one audit row per dispatch (S2-0 safety
+gate). If Anthropic exposes a real API later, swap the probe
+implementation — dispatcher only depends on the `UsageProbe` Protocol.
+
+## Usage
+
+```python
+from agents.usage_probe import read_usage
+
+reading = read_usage()        # builds default StaticBudgetProbe + cache
+if reading.near_exhaustion:
+    return  # dispatcher pauses this tick
+```
+
+`read_usage` **never raises**. A probe failure is logged and replaced with
+a reading that has `near_exhaustion=True` — conservative false-safe, per
+the issue's acceptance criteria.
+
+## Configuration
+
+All knobs are env vars:
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `CLAUDE_USAGE_WINDOW_HOURS` | `5` | Rolling window matching Claude Max's 5-hour quota |
+| `CLAUDE_USAGE_BUDGET` | `100` | Dispatches allowed per window (tune as we learn) |
+| `CLAUDE_USAGE_NEAR_EXHAUSTION_PERCENT` | `15` | Flip `near_exhaustion` when ≤ this much headroom remains |
+| `CLAUDE_USAGE_CACHE_TTL_SECONDS` | `300` | In-process cache TTL (re-probe at most once per 5 min) |
+
+Bad values (non-int) fall back to the default with a warning log — never
+a crash.
+
+## Cache semantics
+
+`CachedProbe` memoizes the reading in process memory for the TTL. The
+dispatcher runs as one long-lived APScheduler process, so cross-process
+cache (Supabase) would add complexity without benefit:
+
+- First tick after process start → fresh probe.
+- Subsequent ticks within TTL → cached reading.
+- TTL expiry → re-probe.
+- `probe.invalidate()` → force next read (dispatcher can call this after
+  a confirmed dispatch that materially shifts headroom).
+
+A restart simply re-probes — no stale cache leaks across process lifetimes.
+
+## Reading shape
+
+```python
+@dataclass(frozen=True)
+class UsageReading:
+    limit_window: timedelta   # e.g. 5h
+    used: int                 # successful dispatches since window_start
+    total: int                # CLAUDE_USAGE_BUDGET at probe time
+    reset_at: datetime        # upper bound on next refill
+    near_exhaustion: bool     # dispatcher gate
+```
+
+`reset_at = now + limit_window` because Claude Max windows aren't aligned
+to a public clock pivot. Dispatcher only gates on `near_exhaustion`; the
+other fields are for dashboards and audit.
+
+## Source data
+
+`StaticBudgetProbe` counts rows in `audit_log` where:
+
+- `agent_id = 'task-dispatcher'`
+- `action = 'dispatch'`
+- `outcome = 'success'`
+- `created_at >= now - window`
+
+The count is capped at `total` — an over-count (shouldn't happen, but be
+resilient) still produces a sane reading with `near_exhaustion=True`.
+
+## Failure modes
+
+| Failure | Outcome |
+|---------|---------|
+| Supabase unreachable | `UsageProbeError` → `read_usage` returns false-safe reading (`near_exhaustion=True`, `total=0`) |
+| Env var is a typo (e.g. `"abc"`) | Warning logged, default used |
+| `supabase=None` (no client wired) | `used=0` returned — tests exercise headroom math without a live DB |
+
+## Smoke test
+
+```python
+from unittest.mock import MagicMock
+from agents.usage_probe import StaticBudgetProbe
+
+mock = MagicMock()
+mock.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.gte.return_value.execute.return_value.count = 90
+
+probe = StaticBudgetProbe(supabase=mock, total=100, near_exhaustion_percent=15)
+reading = probe.read()
+assert reading.used == 90
+assert reading.near_exhaustion is True  # 10% headroom <= 15% threshold
+```
+
+Full unit suite (`tests/test_agents_usage_probe.py`) uses a hand-rolled
+stub client and fake clock — no live DB or real time passing required.

--- a/tests/test_agents_usage_probe.py
+++ b/tests/test_agents_usage_probe.py
@@ -1,0 +1,354 @@
+"""Unit tests for the Claude Max usage probe (issue #297, S2-2).
+
+Uses a stub Supabase client + a fake clock so these tests run in-process
+without a live DB or real time passing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from agents import usage_probe
+from agents.usage_probe import (
+    CachedProbe,
+    StaticBudgetProbe,
+    UsageProbe,
+    UsageProbeError,
+    UsageReading,
+    _false_safe_reading,
+    read_usage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: stub supabase query chain + fake probe.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResponse:
+    count: int
+
+
+class _FakeQuery:
+    """Records the method chain so tests can assert filter shape."""
+
+    def __init__(self, count: int, recorder: dict[str, Any]) -> None:
+        self._count = count
+        self._recorder = recorder
+
+    def select(self, *args: Any, **kwargs: Any) -> "_FakeQuery":
+        self._recorder["select_kwargs"] = kwargs
+        return self
+
+    def eq(self, col: str, val: Any) -> "_FakeQuery":
+        self._recorder.setdefault("eq", []).append((col, val))
+        return self
+
+    def gte(self, col: str, val: Any) -> "_FakeQuery":
+        self._recorder.setdefault("gte", []).append((col, val))
+        return self
+
+    def execute(self) -> _FakeResponse:
+        return _FakeResponse(count=self._count)
+
+
+class _FakeClient:
+    def __init__(self, count: int) -> None:
+        self.count = count
+        self.recorder: dict[str, Any] = {}
+
+    def table(self, name: str) -> _FakeQuery:
+        self.recorder["table"] = name
+        return _FakeQuery(self.count, self.recorder)
+
+
+class _ExplodingClient:
+    def table(self, name: str) -> Any:
+        raise RuntimeError("simulated backend failure")
+
+
+class _StubProbe:
+    """Deterministic probe for testing the cache and wrapper."""
+
+    def __init__(self, reading: UsageReading) -> None:
+        self.reading = reading
+        self.calls = 0
+
+    def read(self) -> UsageReading:
+        self.calls += 1
+        return self.reading
+
+
+class _FlakyProbe:
+    def read(self) -> UsageReading:
+        raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# UsageReading.headroom_ratio
+# ---------------------------------------------------------------------------
+
+
+def test_headroom_ratio_full() -> None:
+    r = UsageReading(
+        limit_window=timedelta(hours=5),
+        used=0,
+        total=100,
+        reset_at=usage_probe._now_utc(),
+        near_exhaustion=False,
+    )
+    assert r.headroom_ratio == 1.0
+
+
+def test_headroom_ratio_half() -> None:
+    r = UsageReading(
+        limit_window=timedelta(hours=5),
+        used=50,
+        total=100,
+        reset_at=usage_probe._now_utc(),
+        near_exhaustion=False,
+    )
+    assert r.headroom_ratio == 0.5
+
+
+def test_headroom_ratio_zero_total_returns_zero() -> None:
+    """False-safe reading uses total=0 — headroom must be 0, not a ZeroDivisionError."""
+    r = _false_safe_reading()
+    assert r.headroom_ratio == 0.0
+
+
+def test_headroom_ratio_clamped_to_zero_when_overused() -> None:
+    r = UsageReading(
+        limit_window=timedelta(hours=5),
+        used=150,
+        total=100,
+        reset_at=usage_probe._now_utc(),
+        near_exhaustion=True,
+    )
+    assert r.headroom_ratio == 0.0
+
+
+# ---------------------------------------------------------------------------
+# StaticBudgetProbe — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_probe_without_supabase_reports_zero_used() -> None:
+    probe = StaticBudgetProbe(supabase=None, total=100, near_exhaustion_percent=15)
+    reading = probe.read()
+    assert reading.used == 0
+    assert reading.total == 100
+    assert reading.near_exhaustion is False
+    assert reading.limit_window == timedelta(hours=5)
+
+
+def test_probe_counts_dispatcher_audit_rows() -> None:
+    client = _FakeClient(count=42)
+    probe = StaticBudgetProbe(supabase=client, total=100, near_exhaustion_percent=15)
+    reading = probe.read()
+    assert reading.used == 42
+    assert reading.total == 100
+    # Near-exhaustion triggers at <=15% headroom → used=42 leaves 58% headroom.
+    assert reading.near_exhaustion is False
+    # The filter chain must have scoped to task-dispatcher / dispatch / success.
+    eqs = dict(client.recorder["eq"])
+    assert eqs["agent_id"] == "task-dispatcher"
+    assert eqs["action"] == "dispatch"
+    assert eqs["outcome"] == "success"
+    # And filtered by window_start in created_at.
+    gtes = dict(client.recorder["gte"])
+    assert "created_at" in gtes
+
+
+def test_probe_near_exhaustion_flips_at_threshold() -> None:
+    """85 used / 100 total = 15% headroom → near_exhaustion at <=15%."""
+    client = _FakeClient(count=85)
+    probe = StaticBudgetProbe(supabase=client, total=100, near_exhaustion_percent=15)
+    reading = probe.read()
+    assert reading.used == 85
+    assert reading.near_exhaustion is True
+
+
+def test_probe_not_near_exhaustion_just_below_threshold() -> None:
+    """84 used / 100 total = 16% headroom → NOT near_exhaustion at <=15%."""
+    client = _FakeClient(count=84)
+    probe = StaticBudgetProbe(supabase=client, total=100, near_exhaustion_percent=15)
+    reading = probe.read()
+    assert reading.near_exhaustion is False
+
+
+def test_probe_used_capped_at_total() -> None:
+    """Over-use in the window (shouldn't happen, but be resilient) caps at total."""
+    client = _FakeClient(count=200)
+    probe = StaticBudgetProbe(supabase=client, total=100, near_exhaustion_percent=15)
+    reading = probe.read()
+    assert reading.used == 100
+    assert reading.near_exhaustion is True
+
+
+def test_probe_threshold_is_configurable() -> None:
+    """Setting threshold to 50% should flip near_exhaustion at 50 used / 100."""
+    client = _FakeClient(count=50)
+    probe = StaticBudgetProbe(supabase=client, total=100, near_exhaustion_percent=50)
+    reading = probe.read()
+    assert reading.near_exhaustion is True
+
+
+def test_probe_accepts_module_with_get_client() -> None:
+    """supabase-module shape (agents.supabase_client) vs already-built client."""
+    client = _FakeClient(count=7)
+
+    class _Module:
+        @staticmethod
+        def get_client() -> _FakeClient:
+            return client
+
+    probe = StaticBudgetProbe(supabase=_Module(), total=100)
+    reading = probe.read()
+    assert reading.used == 7
+
+
+def test_probe_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLAUDE_USAGE_WINDOW_HOURS", "2")
+    monkeypatch.setenv("CLAUDE_USAGE_BUDGET", "50")
+    monkeypatch.setenv("CLAUDE_USAGE_NEAR_EXHAUSTION_PERCENT", "25")
+    probe = StaticBudgetProbe(supabase=None)
+    reading = probe.read()
+    assert reading.limit_window == timedelta(hours=2)
+    assert reading.total == 50
+
+
+def test_probe_env_var_bad_int_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Typo in env var → warn + use default, not crash."""
+    monkeypatch.setenv("CLAUDE_USAGE_BUDGET", "not-an-int")
+    with caplog.at_level("WARNING"):
+        probe = StaticBudgetProbe(supabase=None)
+    reading = probe.read()
+    assert reading.total == 100  # DEFAULT_BUDGET
+    assert any("CLAUDE_USAGE_BUDGET" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# StaticBudgetProbe — failure path
+# ---------------------------------------------------------------------------
+
+
+def test_probe_wraps_backend_errors_in_usage_probe_error() -> None:
+    probe = StaticBudgetProbe(supabase=_ExplodingClient(), total=100)
+    with pytest.raises(UsageProbeError, match="audit_log dispatch count failed"):
+        probe.read()
+
+
+# ---------------------------------------------------------------------------
+# CachedProbe — TTL behaviour
+# ---------------------------------------------------------------------------
+
+
+def _reading(used: int = 10, total: int = 100, near: bool = False) -> UsageReading:
+    return UsageReading(
+        limit_window=timedelta(hours=5),
+        used=used,
+        total=total,
+        reset_at=usage_probe._now_utc(),
+        near_exhaustion=near,
+    )
+
+
+def test_cached_probe_returns_cached_within_ttl() -> None:
+    clock = [1000.0]
+    inner = _StubProbe(_reading(used=10))
+    cached = CachedProbe(inner, ttl_seconds=300, now=lambda: clock[0])
+
+    first = cached.read()
+    clock[0] += 299  # just inside TTL
+    second = cached.read()
+
+    assert first is second  # same object, from cache
+    assert inner.calls == 1
+
+
+def test_cached_probe_re_reads_after_ttl_expires() -> None:
+    clock = [1000.0]
+    inner = _StubProbe(_reading(used=10))
+    cached = CachedProbe(inner, ttl_seconds=300, now=lambda: clock[0])
+
+    cached.read()
+    clock[0] += 301  # just past TTL
+    cached.read()
+
+    assert inner.calls == 2
+
+
+def test_cached_probe_invalidate_forces_next_read() -> None:
+    clock = [1000.0]
+    inner = _StubProbe(_reading(used=10))
+    cached = CachedProbe(inner, ttl_seconds=300, now=lambda: clock[0])
+
+    cached.read()
+    cached.invalidate()
+    cached.read()
+
+    assert inner.calls == 2
+
+
+def test_cached_probe_ttl_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLAUDE_USAGE_CACHE_TTL_SECONDS", "7")
+    clock = [1000.0]
+    inner = _StubProbe(_reading(used=10))
+    cached = CachedProbe(inner, now=lambda: clock[0])
+
+    cached.read()
+    clock[0] += 8  # past the 7s env-specified TTL
+    cached.read()
+
+    assert inner.calls == 2
+
+
+# ---------------------------------------------------------------------------
+# read_usage — false-safe contract
+# ---------------------------------------------------------------------------
+
+
+def test_read_usage_returns_probe_reading_on_success() -> None:
+    inner_reading = _reading(used=10, total=100, near=False)
+    probe = _StubProbe(inner_reading)
+    reading = read_usage(probe)
+    assert reading is inner_reading
+
+
+def test_read_usage_returns_false_safe_on_probe_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A flaky probe must NOT propagate — dispatcher must never crash on probe error."""
+    with caplog.at_level("WARNING"):
+        reading = read_usage(_FlakyProbe())
+    assert reading.near_exhaustion is True
+    assert reading.total == 0
+    assert reading.headroom_ratio == 0.0
+    # User-facing warning must name the module and the failure.
+    assert any("probe failed" in rec.message for rec in caplog.records)
+
+
+def test_false_safe_reading_says_do_not_dispatch() -> None:
+    r = _false_safe_reading()
+    assert r.near_exhaustion is True
+    assert r.used == 0
+    assert r.total == 0
+
+
+# ---------------------------------------------------------------------------
+# UsageProbe protocol surface — _StubProbe must satisfy it structurally.
+# ---------------------------------------------------------------------------
+
+
+def test_stub_probe_satisfies_protocol() -> None:
+    """Sanity: any class with a .read() returning UsageReading is a UsageProbe."""
+    stub: UsageProbe = _StubProbe(_reading())
+    assert isinstance(stub.read(), UsageReading)


### PR DESCRIPTION
## Summary
Adds `agents/usage_probe.py` — the lightweight budget gate that task-dispatcher (S2-3, #298) will consult before every live dispatch. Probe counts the dispatcher's own successful audit rows in a rolling window; no Claude Max API dependency; false-safe on failure.

## Why
Dispatcher needs a \"do I have headroom?\" answer every tick. Claude Max has no public per-user quota endpoint, but `audit_log` already records one row per dispatch (from the S2-0 safety gate) — that's the authoritative record of \"how much budget this jurisdiction has consumed\". Counting those rows is the most honest answer we can give without an API.

Closes #297.

## Decisions & Alternatives
- **`StaticBudgetProbe` over log-scraping or live API** — audit_log counts are already wired through the safety gate; adding a second source would duplicate state. If Anthropic ships a real quota API, swap the implementation — dispatcher only depends on the `UsageProbe` Protocol.
- **In-process `CachedProbe`, not Supabase-persisted cache** — dispatcher runs as one long-lived APScheduler process. Cross-process cache (Supabase table) would add a failure mode (what if the cache row is stale?) without benefit. Restart simply re-probes on first tick. TTL default 300s means at most 12 probes/hour even if dispatcher ticks every second.
- **False-safe on failure (`near_exhaustion=True`)** per issue's acceptance criteria. A broken probe must NEVER cause a dispatch flood — the alternative (propagating the exception) would crash dispatcher's tick, and a silently-retried tick would hit the same broken probe. False-safe converts \"backend down\" into \"pause dispatching until it comes back\".
- **Count `action='dispatch'` + `outcome='success'`, not `task_queue.status='dispatched'`** — status can flip on escalation or completion; audit rows are immutable. Audit is the authoritative past-tense record of \"what happened\", status is current-tense.
- **`reset_at = now + window`** — Claude Max 5-hour windows aren't aligned to a public clock pivot, so there's no honest exact answer. Dispatcher only uses `near_exhaustion`; `reset_at` is informational for dashboards.
- **Env vars with conservative defaults + bad-value tolerance** — `CLAUDE_USAGE_BUDGET=\"not-an-int\"` logs a warning and uses the default, not a crash. Better to gate conservatively than refuse to start.
- **Defensive cap: `min(used, total)`** — an over-count (shouldn't happen, but audit rows are append-only) still produces a sane reading with `near_exhaustion=True`.

## Risk Assessment
**LOW.** Pure infrastructure primitive. Nothing consumes the probe yet — dispatcher (#298) is the first caller. `read_usage()` never raises, so wiring it into dispatcher later is safe even if the probe is misconfigured. All 22 new tests green; full 101-test agents suite unchanged.

## Testing
- `ruff check --fix && ruff format` — clean
- `pytest tests/test_agents_usage_probe.py -v` — 22/22 pass in 0.10s
- `pytest tests/test_agents_usage_probe.py tests/test_agents_scheduler.py tests/test_agents_safety.py tests/test_agents_smoke.py -q` — 101/101 pass in 1.91s

Coverage: headroom math (zero/half/full/overused/zero-total edge), StaticBudgetProbe happy paths (with + without Supabase + module-style `get_client`), threshold configurability, over-count capping, env var overrides, bad env value fallback, backend failure wrapping, CachedProbe TTL (within/past TTL, env-specified TTL, invalidation), read_usage false-safe contract (success path + flaky-probe path + false-safe reading shape), Protocol structural compliance.

## Files Changed
- `agents/usage_probe.py` — `UsageReading` dataclass, `UsageProbe` Protocol, `StaticBudgetProbe`, `CachedProbe`, `read_usage()`, `_false_safe_reading()`
- `tests/test_agents_usage_probe.py` — 22 unit tests with stub client + fake clock
- `docs/agents/usage_probe.md` — usage, config table, cache semantics, failure modes, smoke test
- `agents/__init__.py` — `usage_probe` added to `__all__`
- `.env.example` — four `CLAUDE_USAGE_*` knobs documented with defaults

## Follow-ups
- S2-3 (#298) dispatcher wires `if read_usage().near_exhaustion: return` into its tick
- S2-4 (#299) escalation: limit-near-exhaustion is one of the escalation triggers that writes to `events`; probe is the input, S2-4 the reaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)