### PR TITLE
feat(agents): dispatcher escalation triggers (#299)

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -8,6 +8,7 @@ See docs/agents/ for setup and operational notes.
 
 __all__ = [
     "config",
+    "escalation",
     "event_monitor",
     "github_client",
     "ollama_client",

--- a/agents/escalation.py
+++ b/agents/escalation.py
@@ -1,0 +1,367 @@
+"""Escalation triggers for the task dispatcher (issue #299, S2-4).
+
+Dispatcher (S2-3, #298) calls the check functions here before dispatching
+a ``task_queue`` row. If any trigger fires, :func:`escalate` moves the
+row to ``escalated`` state and writes an `events` row with
+``severity=HIGH`` so the owner sees it in the normal event-monitor path
+(Sprint 1) or via `/status`.
+
+Five triggers — split into pure checks (no DB writes, trivially testable)
+and one DB-writing :func:`escalate` helper. Dispatcher wires them
+together.
+
+1. **Stale approval** — approval sat too long; re-approve before running.
+2. **Scope drift** — files in ``scope_files`` changed after approval;
+   the approval isn't valid for the current state.
+3. **Limit near-exhaustion** — :mod:`agents.usage_probe` says budget is
+   low; pause rather than burn the last tokens on auto-dispatch.
+4. **Cross-task conflict** — another ``dispatched`` row touches overlapping
+   ``scope_files``; avoid interleaved edits.
+5. **Pattern repeat** — >3 successful dispatches of the same ``goal`` in
+   a row; guards against a runaway loop.
+
+Thresholds are module-level constants so tuning is a one-line change.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from typing import Any
+
+from agents import supabase_client
+from agents.usage_probe import UsageReading
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tunable thresholds. Change here and the rule changes everywhere.
+# ---------------------------------------------------------------------------
+
+STALE_APPROVAL_MAX_DAYS = 7
+PATTERN_REPEAT_THRESHOLD = 3
+
+DISPATCHER_AGENT_ID = "task-dispatcher"
+ESCALATION_EVENT_TYPE = "dispatcher_escalation"
+ESCALATION_SEVERITY = "high"
+
+
+class Trigger(str, Enum):
+    """Reason an escalation fired. Becomes the ``trigger`` payload field."""
+
+    STALE_APPROVAL = "stale_approval"
+    SCOPE_DRIFT = "scope_drift"
+    LIMIT_NEAR_EXHAUSTION = "limit_near_exhaustion"
+    CROSS_TASK_CONFLICT = "cross_task_conflict"
+    PATTERN_REPEAT = "pattern_repeat"
+
+
+@dataclass(frozen=True)
+class EscalationCheck:
+    """Outcome of a single trigger check.
+
+    ``context`` is free-form dict captured for the event payload so the
+    owner can reason about *why* without re-running the check. Keep it
+    small and JSON-safe — it round-trips through Supabase jsonb.
+    """
+
+    should_escalate: bool
+    trigger: Trigger | None = None
+    context: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def no_action(cls) -> "EscalationCheck":
+        return cls(should_escalate=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def _parse_timestamptz(value: Any) -> datetime | None:
+    """Parse Supabase's timestamptz value (str or datetime) — ``None`` on fail.
+
+    Supabase-py sometimes returns ISO strings, sometimes parsed datetimes,
+    depending on client version and column config. Handle both; unknown
+    shapes return None so callers decide how to degrade (we treat "can't
+    parse" as "don't escalate — no evidence").
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        try:
+            # fromisoformat handles "2026-04-22T12:34:56+00:00" and "...Z" in 3.11+.
+            normalized = value.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(normalized)
+            return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+        except ValueError:
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Pure checks — no DB writes, safe to run against synthetic rows in tests.
+# ---------------------------------------------------------------------------
+
+
+def check_stale_approval(
+    row: dict[str, Any],
+    *,
+    max_age_days: int = STALE_APPROVAL_MAX_DAYS,
+    now: datetime | None = None,
+) -> EscalationCheck:
+    """Escalate if ``now - approved_at > max_age_days``."""
+    approved_at = _parse_timestamptz(row.get("approved_at"))
+    if approved_at is None:
+        return EscalationCheck.no_action()
+    current = now or _now_utc()
+    age = current - approved_at
+    if age > timedelta(days=max_age_days):
+        return EscalationCheck(
+            should_escalate=True,
+            trigger=Trigger.STALE_APPROVAL,
+            context={
+                "approved_at": approved_at.isoformat(),
+                "age_days": age.days,
+                "max_age_days": max_age_days,
+            },
+        )
+    return EscalationCheck.no_action()
+
+
+def check_scope_drift(
+    row: dict[str, Any],
+    *,
+    current_scope_hash: str | Callable[[Iterable[str]], str],
+) -> EscalationCheck:
+    """Escalate if ``current_scope_hash != row['approved_scope_hash']``.
+
+    ``current_scope_hash`` can be a precomputed string or a callable that
+    takes ``scope_files`` and returns the hash (the hashing function lives
+    in S2-3 dispatcher; this module stays transport-agnostic).
+    """
+    approved_hash = row.get("approved_scope_hash")
+    if not approved_hash:
+        # No baseline to drift from — a row without an approved hash
+        # shouldn't have reached dispatch anyway. Caller's bug, not ours.
+        return EscalationCheck.no_action()
+    if callable(current_scope_hash):
+        scope_files = row.get("scope_files") or []
+        try:
+            current = current_scope_hash(scope_files)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[escalation] scope hash function raised -- treating as drift: %s", exc)
+            return EscalationCheck(
+                should_escalate=True,
+                trigger=Trigger.SCOPE_DRIFT,
+                context={"error": f"{type(exc).__name__}: {exc}"},
+            )
+    else:
+        current = current_scope_hash
+    if current != approved_hash:
+        return EscalationCheck(
+            should_escalate=True,
+            trigger=Trigger.SCOPE_DRIFT,
+            context={"approved_scope_hash": approved_hash, "current_scope_hash": current},
+        )
+    return EscalationCheck.no_action()
+
+
+def check_limit_near_exhaustion(reading: UsageReading) -> EscalationCheck:
+    """Escalate when the usage probe reports budget near-exhaustion."""
+    if reading.near_exhaustion:
+        return EscalationCheck(
+            should_escalate=True,
+            trigger=Trigger.LIMIT_NEAR_EXHAUSTION,
+            context={
+                "used": reading.used,
+                "total": reading.total,
+                "headroom_ratio": reading.headroom_ratio,
+            },
+        )
+    return EscalationCheck.no_action()
+
+
+def check_cross_task_conflict(
+    row: dict[str, Any],
+    *,
+    active_dispatched_rows: Iterable[dict[str, Any]],
+) -> EscalationCheck:
+    """Escalate if another dispatched row's ``scope_files`` overlaps this one.
+
+    ``active_dispatched_rows`` comes from the dispatcher's scan — the rows
+    with ``status='dispatched'`` that aren't this one. Dispatcher's
+    responsibility to exclude the current row; we don't check ids here.
+    """
+    own_files = set(row.get("scope_files") or [])
+    if not own_files:
+        return EscalationCheck.no_action()
+    own_id = row.get("id")
+    for other in active_dispatched_rows:
+        if other.get("id") == own_id:
+            # Defensive: dispatcher should've excluded us, but a safety net
+            # costs one comparison and prevents a row flagging itself.
+            continue
+        other_files = set(other.get("scope_files") or [])
+        overlap = own_files & other_files
+        if overlap:
+            return EscalationCheck(
+                should_escalate=True,
+                trigger=Trigger.CROSS_TASK_CONFLICT,
+                context={
+                    "conflicting_task_id": str(other.get("id")),
+                    "overlapping_files": sorted(overlap),
+                },
+            )
+    return EscalationCheck.no_action()
+
+
+def check_pattern_repeat(
+    row: dict[str, Any],
+    *,
+    recent_successful_dispatches: Iterable[dict[str, Any]],
+    threshold: int = PATTERN_REPEAT_THRESHOLD,
+) -> EscalationCheck:
+    """Escalate when the same ``goal`` appears > ``threshold`` times consecutively.
+
+    ``recent_successful_dispatches`` should be ordered newest-first
+    (standard Supabase ``order('dispatched_at', desc=True)``). We count the
+    run of matching goals from the most recent entry; a different goal
+    anywhere in the run resets the count.
+    """
+    goal = row.get("goal")
+    if not goal:
+        return EscalationCheck.no_action()
+    run_length = 0
+    for past in recent_successful_dispatches:
+        if past.get("goal") == goal:
+            run_length += 1
+        else:
+            break
+    if run_length > threshold:
+        return EscalationCheck(
+            should_escalate=True,
+            trigger=Trigger.PATTERN_REPEAT,
+            context={
+                "goal": goal,
+                "recent_matching_dispatches": run_length,
+                "threshold": threshold,
+            },
+        )
+    return EscalationCheck.no_action()
+
+
+# ---------------------------------------------------------------------------
+# Aggregator — dispatcher's single entry point.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EscalationContext:
+    """Bundle of context every check needs — keeps dispatcher's call site terse.
+
+    ``current_scope_hash`` mirrors :func:`check_scope_drift` — precomputed
+    string or callable. ``usage_reading`` is the cached probe reading for
+    this tick.
+    """
+
+    current_scope_hash: str | Callable[[Iterable[str]], str]
+    usage_reading: UsageReading
+    active_dispatched_rows: Iterable[dict[str, Any]] = field(default_factory=tuple)
+    recent_successful_dispatches: Iterable[dict[str, Any]] = field(default_factory=tuple)
+
+
+def check_all(row: dict[str, Any], ctx: EscalationContext) -> EscalationCheck:
+    """Run every trigger; return the first that fires, or ``no_action``.
+
+    Order: stale approval → scope drift → limit near-exhaustion →
+    cross-task conflict → pattern repeat. First-match is intentional —
+    the reason surfaced to the owner should be the one the owner can act
+    on first (re-approve, fix the conflict, wait for budget).
+    """
+    for check in (
+        lambda: check_stale_approval(row),
+        lambda: check_scope_drift(row, current_scope_hash=ctx.current_scope_hash),
+        lambda: check_limit_near_exhaustion(ctx.usage_reading),
+        lambda: check_cross_task_conflict(row, active_dispatched_rows=ctx.active_dispatched_rows),
+        lambda: check_pattern_repeat(
+            row, recent_successful_dispatches=ctx.recent_successful_dispatches
+        ),
+    ):
+        result = check()
+        if result.should_escalate:
+            return result
+    return EscalationCheck.no_action()
+
+
+# ---------------------------------------------------------------------------
+# DB side-effect: write event + flip row status.
+# ---------------------------------------------------------------------------
+
+
+def escalate(
+    row: dict[str, Any],
+    check: EscalationCheck,
+    *,
+    client: Any | None = None,
+    config: Any | None = None,
+) -> dict[str, Any]:
+    """Persist an escalation: write `events` row + flip `task_queue.status`.
+
+    Returns the inserted event row. Raises if the check didn't actually
+    flag an escalation — easier to catch misuse than to silently skip.
+    """
+    if not check.should_escalate or check.trigger is None:
+        raise ValueError("escalate() called on a non-escalating check")
+
+    cli = client or supabase_client.get_client(config)
+    queue_id = row.get("id")
+    reason = f"{check.trigger.value}: {check.context}"
+
+    # Event first — dispatcher writes this in tier-0 territory (events is
+    # on the Sprint-1 allowlist). Queue update is tier-0 too (status flip
+    # within approved rows).
+    event_payload = {
+        "queue_id": str(queue_id) if queue_id is not None else None,
+        "trigger": check.trigger.value,
+        "context": check.context,
+    }
+    event_row = (
+        cli.table("events")
+        .insert(
+            {
+                "event_type": ESCALATION_EVENT_TYPE,
+                "severity": ESCALATION_SEVERITY,
+                "repo": "Osasuwu/jarvis",
+                "source": DISPATCHER_AGENT_ID,
+                "title": f"Dispatcher escalated task {queue_id}: {check.trigger.value}",
+                "payload": event_payload,
+            }
+        )
+        .execute()
+    )
+    event_data = (event_row.data or [{}])[0]
+
+    # Queue status update — only if we know the id. An unidentifiable row
+    # means the caller constructed it by hand; the event still carries the
+    # signal, so don't fail the whole escalation on a missing id.
+    if queue_id is not None:
+        (
+            cli.table("task_queue")
+            .update({"status": "escalated", "escalated_reason": reason})
+            .eq("id", queue_id)
+            .execute()
+        )
+
+    return event_data

--- a/docs/agents/escalation.md
+++ b/docs/agents/escalation.md
@@ -1,0 +1,94 @@
+# Dispatcher escalation triggers
+
+Module: `agents/escalation.py`. Ships as **S2-4** (issue #299) — the
+guardrails dispatcher (S2-3, #298) calls before every live dispatch. If
+any trigger fires, the `task_queue` row flips to `escalated` and an
+`events` row (`severity=high`) tells the owner.
+
+## Triggers
+
+| Trigger | Fires when | Context payload |
+|---------|------------|-----------------|
+| `stale_approval` | `now - approved_at > 7 days` | `approved_at`, `age_days`, `max_age_days` |
+| `scope_drift` | `current_scope_hash != approved_scope_hash` | both hashes (or error if hasher raised) |
+| `limit_near_exhaustion` | usage probe reports `near_exhaustion=True` | `used`, `total`, `headroom_ratio` |
+| `cross_task_conflict` | another `dispatched` row overlaps our `scope_files` | `conflicting_task_id`, `overlapping_files` |
+| `pattern_repeat` | same `goal` appears >3 times in the most-recent dispatches | `goal`, `recent_matching_dispatches`, `threshold` |
+
+Thresholds are module-level constants (`STALE_APPROVAL_MAX_DAYS`,
+`PATTERN_REPEAT_THRESHOLD`) — change the constant, change the rule
+everywhere.
+
+## Design
+
+Pure checks (no DB writes) + one DB-writing `escalate()`:
+
+```python
+from agents.escalation import check_all, escalate, EscalationContext
+
+ctx = EscalationContext(
+    current_scope_hash=hash_current_files,         # callable or precomputed str
+    usage_reading=usage_probe.read_usage(),
+    active_dispatched_rows=other_dispatched,       # excludes `row`
+    recent_successful_dispatches=recent_newest_first,
+)
+
+check = check_all(row, ctx)
+if check.should_escalate:
+    escalate(row, check)           # writes events + flips task_queue.status
+    return                         # dispatcher skips this tick's dispatch
+```
+
+`check_all` runs triggers in this priority order:
+
+1. **Stale approval** — owner needs to re-approve, cheapest fix.
+2. **Scope drift** — files changed, approval is stale in a different way.
+3. **Limit near-exhaustion** — wait for budget, no config change needed.
+4. **Cross-task conflict** — another task is already touching these files.
+5. **Pattern repeat** — probable loop; owner should inspect the queue.
+
+First-match wins — surfacing five simultaneous reasons would drown the
+owner in noise. If multiple fire, the earliest-fixable one shows up in
+the event.
+
+## `escalate()` side effect
+
+Two writes, best-effort:
+
+1. Insert into `events`:
+   - `event_type = "dispatcher_escalation"`
+   - `severity = "high"`
+   - `source = "task-dispatcher"`
+   - `payload = {queue_id, trigger, context}`
+   - `title = "Dispatcher escalated task <id>: <trigger>"`
+
+2. Update `task_queue`:
+   - `status = "escalated"`
+   - `escalated_reason = "<trigger>: <context dict>"`
+
+A row without an `id` (only really happens in hand-built test rows) still
+emits the event; the queue update is skipped rather than failing.
+
+## Testing
+
+`tests/test_agents_escalation.py` — 33 unit tests. Pure checks use
+dict rows + fake clock; `escalate()` uses a stub Supabase client that
+records insert/update shape.
+
+No live DB required.
+
+## Failure modes
+
+| Failure | Outcome |
+|---------|---------|
+| Bad timestamp in `approved_at` | Check returns `no_action` (no evidence to escalate from) |
+| Hasher callable raises | Treat as drift and escalate (evidence points to "something wrong with scope") |
+| `approved_scope_hash` empty | No baseline to drift from → `no_action` |
+| `escalate()` called on `EscalationCheck.no_action()` | `ValueError` — catch misuse early |
+
+## Wired-up dependencies
+
+- `agents.usage_probe.UsageReading` — `check_limit_near_exhaustion` consumes.
+- `agents.supabase_client.get_client` — `escalate()` uses when `client` is not injected.
+- `task_queue` schema (S2-1) — the row shape and the `status`/`escalated_reason` columns.
+- `events` table (Sprint 1 allowlist) — dispatcher is authorized to insert.

--- a/tests/test_agents_escalation.py
+++ b/tests/test_agents_escalation.py
@@ -1,0 +1,492 @@
+"""Unit tests for dispatcher escalation triggers (issue #299, S2-4).
+
+Pure-check tests use hand-rolled dict rows; DB-write tests use a stub
+Supabase client that records the insert/update call shape. No live DB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from agents.escalation import (
+    DISPATCHER_AGENT_ID,
+    ESCALATION_EVENT_TYPE,
+    ESCALATION_SEVERITY,
+    PATTERN_REPEAT_THRESHOLD,
+    STALE_APPROVAL_MAX_DAYS,
+    EscalationCheck,
+    EscalationContext,
+    Trigger,
+    check_all,
+    check_cross_task_conflict,
+    check_limit_near_exhaustion,
+    check_pattern_repeat,
+    check_scope_drift,
+    check_stale_approval,
+    escalate,
+)
+from agents.usage_probe import UsageReading
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+
+
+def _queue_row(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "goal": "refactor: split usage_probe tests",
+        "scope_files": ["tests/test_agents_usage_probe.py"],
+        "approved_at": _now().isoformat(),
+        "approved_by": "owner",
+        "approved_scope_hash": "abc123",
+        "auto_dispatch": True,
+        "status": "pending",
+        "idempotency_key": "deadbeef",
+    }
+    base.update(overrides)
+    return base
+
+
+def _reading(near: bool, used: int = 20, total: int = 100) -> UsageReading:
+    return UsageReading(
+        limit_window=timedelta(hours=5),
+        used=used,
+        total=total,
+        reset_at=_now(),
+        near_exhaustion=near,
+    )
+
+
+# ---------------------------------------------------------------------------
+# check_stale_approval
+# ---------------------------------------------------------------------------
+
+
+def test_stale_approval_fresh_does_not_escalate() -> None:
+    row = _queue_row(approved_at=(_now() - timedelta(days=1)).isoformat())
+    result = check_stale_approval(row, now=_now())
+    assert result.should_escalate is False
+
+
+def test_stale_approval_exact_threshold_does_not_escalate() -> None:
+    """Strictly >max_age_days escalates; == does not (conservative, honors owner's approval)."""
+    row = _queue_row(approved_at=(_now() - timedelta(days=STALE_APPROVAL_MAX_DAYS)).isoformat())
+    result = check_stale_approval(row, now=_now())
+    assert result.should_escalate is False
+
+
+def test_stale_approval_past_threshold_escalates() -> None:
+    row = _queue_row(approved_at=(_now() - timedelta(days=STALE_APPROVAL_MAX_DAYS + 1)).isoformat())
+    result = check_stale_approval(row, now=_now())
+    assert result.should_escalate is True
+    assert result.trigger == Trigger.STALE_APPROVAL
+    assert result.context["age_days"] == STALE_APPROVAL_MAX_DAYS + 1
+    assert result.context["max_age_days"] == STALE_APPROVAL_MAX_DAYS
+
+
+def test_stale_approval_missing_approved_at_does_not_escalate() -> None:
+    """No evidence to escalate from — don't fabricate one."""
+    row = _queue_row()
+    row.pop("approved_at")
+    result = check_stale_approval(row, now=_now())
+    assert result.should_escalate is False
+
+
+def test_stale_approval_accepts_datetime_value() -> None:
+    """Supabase sometimes returns already-parsed datetimes."""
+    row = _queue_row(approved_at=_now() - timedelta(days=STALE_APPROVAL_MAX_DAYS + 1))
+    result = check_stale_approval(row, now=_now())
+    assert result.should_escalate is True
+
+
+def test_stale_approval_bad_timestamp_does_not_escalate() -> None:
+    row = _queue_row(approved_at="not-a-date")
+    result = check_stale_approval(row, now=_now())
+    assert result.should_escalate is False
+
+
+def test_stale_approval_z_suffix_parses() -> None:
+    """ISO string with 'Z' suffix (old-style UTC) must parse on 3.11+."""
+    row = _queue_row(
+        approved_at=(_now() - timedelta(days=STALE_APPROVAL_MAX_DAYS + 1))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    result = check_stale_approval(row, now=_now())
+    assert result.should_escalate is True
+
+
+def test_stale_approval_max_age_days_is_configurable() -> None:
+    row = _queue_row(approved_at=(_now() - timedelta(days=2)).isoformat())
+    result = check_stale_approval(row, max_age_days=1, now=_now())
+    assert result.should_escalate is True
+    assert result.context["max_age_days"] == 1
+
+
+# ---------------------------------------------------------------------------
+# check_scope_drift
+# ---------------------------------------------------------------------------
+
+
+def test_scope_drift_same_hash_does_not_escalate() -> None:
+    row = _queue_row(approved_scope_hash="abc123")
+    result = check_scope_drift(row, current_scope_hash="abc123")
+    assert result.should_escalate is False
+
+
+def test_scope_drift_different_hash_escalates() -> None:
+    row = _queue_row(approved_scope_hash="abc123")
+    result = check_scope_drift(row, current_scope_hash="zzz999")
+    assert result.should_escalate is True
+    assert result.trigger == Trigger.SCOPE_DRIFT
+    assert result.context == {"approved_scope_hash": "abc123", "current_scope_hash": "zzz999"}
+
+
+def test_scope_drift_callable_hasher_is_invoked_with_scope_files() -> None:
+    row = _queue_row(approved_scope_hash="abc123", scope_files=["a.py", "b.py"])
+    seen: list[list[str]] = []
+
+    def hasher(files: Any) -> str:
+        seen.append(list(files))
+        return "abc123"  # same -> no drift
+
+    result = check_scope_drift(row, current_scope_hash=hasher)
+    assert result.should_escalate is False
+    assert seen == [["a.py", "b.py"]]
+
+
+def test_scope_drift_hasher_exception_escalates_safely() -> None:
+    """A broken hasher should escalate (treat as drift) rather than blowing up."""
+    row = _queue_row(approved_scope_hash="abc123")
+
+    def hasher(_files: Any) -> str:
+        raise IOError("file vanished mid-scan")
+
+    result = check_scope_drift(row, current_scope_hash=hasher)
+    assert result.should_escalate is True
+    assert result.trigger == Trigger.SCOPE_DRIFT
+    assert "file vanished mid-scan" in result.context["error"]
+
+
+def test_scope_drift_missing_approved_hash_does_not_escalate() -> None:
+    row = _queue_row(approved_scope_hash="")
+    result = check_scope_drift(row, current_scope_hash="zzz")
+    assert result.should_escalate is False
+
+
+# ---------------------------------------------------------------------------
+# check_limit_near_exhaustion
+# ---------------------------------------------------------------------------
+
+
+def test_limit_escalates_when_probe_reports_near_exhaustion() -> None:
+    result = check_limit_near_exhaustion(_reading(near=True, used=90, total=100))
+    assert result.should_escalate is True
+    assert result.trigger == Trigger.LIMIT_NEAR_EXHAUSTION
+    assert result.context["used"] == 90
+    assert result.context["total"] == 100
+    assert 0.0 <= result.context["headroom_ratio"] <= 1.0
+
+
+def test_limit_does_not_escalate_when_probe_reports_headroom() -> None:
+    result = check_limit_near_exhaustion(_reading(near=False, used=10, total=100))
+    assert result.should_escalate is False
+
+
+# ---------------------------------------------------------------------------
+# check_cross_task_conflict
+# ---------------------------------------------------------------------------
+
+
+def test_cross_task_conflict_overlap_escalates() -> None:
+    row = _queue_row(id="me", scope_files=["a.py", "b.py"])
+    others = [
+        {"id": "other", "scope_files": ["b.py", "c.py"]},
+    ]
+    result = check_cross_task_conflict(row, active_dispatched_rows=others)
+    assert result.should_escalate is True
+    assert result.trigger == Trigger.CROSS_TASK_CONFLICT
+    assert result.context["conflicting_task_id"] == "other"
+    assert result.context["overlapping_files"] == ["b.py"]
+
+
+def test_cross_task_conflict_disjoint_does_not_escalate() -> None:
+    row = _queue_row(id="me", scope_files=["a.py"])
+    others = [{"id": "other", "scope_files": ["x.py"]}]
+    result = check_cross_task_conflict(row, active_dispatched_rows=others)
+    assert result.should_escalate is False
+
+
+def test_cross_task_conflict_same_id_is_ignored() -> None:
+    """Defensive: even if dispatcher forgot to exclude this row, we do."""
+    row = _queue_row(id="me", scope_files=["a.py"])
+    result = check_cross_task_conflict(
+        row, active_dispatched_rows=[{"id": "me", "scope_files": ["a.py"]}]
+    )
+    assert result.should_escalate is False
+
+
+def test_cross_task_conflict_empty_scope_does_not_escalate() -> None:
+    row = _queue_row(id="me", scope_files=[])
+    others = [{"id": "other", "scope_files": ["a.py"]}]
+    result = check_cross_task_conflict(row, active_dispatched_rows=others)
+    assert result.should_escalate is False
+
+
+def test_cross_task_conflict_first_overlap_wins() -> None:
+    """Stability: we report the first conflicting peer, not all of them."""
+    row = _queue_row(id="me", scope_files=["a.py"])
+    others = [
+        {"id": "peer1", "scope_files": ["a.py"]},
+        {"id": "peer2", "scope_files": ["a.py"]},
+    ]
+    result = check_cross_task_conflict(row, active_dispatched_rows=others)
+    assert result.context["conflicting_task_id"] == "peer1"
+
+
+# ---------------------------------------------------------------------------
+# check_pattern_repeat
+# ---------------------------------------------------------------------------
+
+
+def test_pattern_repeat_escalates_above_threshold() -> None:
+    row = _queue_row(goal="auto-label cleanup")
+    recent = [{"goal": "auto-label cleanup"}] * (PATTERN_REPEAT_THRESHOLD + 1)
+    result = check_pattern_repeat(row, recent_successful_dispatches=recent)
+    assert result.should_escalate is True
+    assert result.trigger == Trigger.PATTERN_REPEAT
+    assert result.context["recent_matching_dispatches"] == PATTERN_REPEAT_THRESHOLD + 1
+    assert result.context["threshold"] == PATTERN_REPEAT_THRESHOLD
+
+
+def test_pattern_repeat_at_threshold_does_not_escalate() -> None:
+    """Issue says '> 3', so exactly 3 should pass."""
+    row = _queue_row(goal="x")
+    recent = [{"goal": "x"}] * PATTERN_REPEAT_THRESHOLD
+    result = check_pattern_repeat(row, recent_successful_dispatches=recent)
+    assert result.should_escalate is False
+
+
+def test_pattern_repeat_different_goal_resets_run() -> None:
+    """A different goal anywhere in the newest-first list breaks the run."""
+    row = _queue_row(goal="x")
+    recent = [
+        {"goal": "x"},
+        {"goal": "x"},
+        {"goal": "different"},
+        {"goal": "x"},
+        {"goal": "x"},
+    ]
+    result = check_pattern_repeat(row, recent_successful_dispatches=recent)
+    assert result.should_escalate is False
+
+
+def test_pattern_repeat_missing_goal_does_not_escalate() -> None:
+    row = _queue_row()
+    row.pop("goal")
+    result = check_pattern_repeat(row, recent_successful_dispatches=[{"goal": "whatever"}] * 10)
+    assert result.should_escalate is False
+
+
+def test_pattern_repeat_custom_threshold() -> None:
+    row = _queue_row(goal="x")
+    result = check_pattern_repeat(
+        row, recent_successful_dispatches=[{"goal": "x"}, {"goal": "x"}], threshold=1
+    )
+    assert result.should_escalate is True
+
+
+# ---------------------------------------------------------------------------
+# check_all — aggregator
+# ---------------------------------------------------------------------------
+
+
+def test_check_all_returns_first_match_in_priority_order() -> None:
+    """Stale approval is first; if both stale and scope drift fire, stale wins."""
+    row = _queue_row(
+        approved_at=(_now() - timedelta(days=STALE_APPROVAL_MAX_DAYS + 1)).isoformat(),
+        approved_scope_hash="abc",
+    )
+    ctx = EscalationContext(
+        current_scope_hash="different",  # drift would also fire
+        usage_reading=_reading(near=False),
+    )
+    result = check_all(row, ctx)
+    assert result.trigger == Trigger.STALE_APPROVAL
+
+
+def test_check_all_no_triggers_returns_no_action() -> None:
+    row = _queue_row()
+    ctx = EscalationContext(
+        current_scope_hash=row["approved_scope_hash"],
+        usage_reading=_reading(near=False),
+    )
+    result = check_all(row, ctx)
+    assert result.should_escalate is False
+
+
+def test_check_all_runs_later_checks_when_earlier_pass() -> None:
+    row = _queue_row()
+    ctx = EscalationContext(
+        current_scope_hash=row["approved_scope_hash"],  # no drift
+        usage_reading=_reading(near=True, used=90, total=100),  # limit fires
+    )
+    result = check_all(row, ctx)
+    assert result.trigger == Trigger.LIMIT_NEAR_EXHAUSTION
+
+
+# ---------------------------------------------------------------------------
+# escalate() — DB side effect via stub client.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubResponse:
+    data: list[dict[str, Any]]
+
+
+class _StubUpdateQuery:
+    def __init__(self, table: "_StubTable") -> None:
+        self._table = table
+        self._update: dict[str, Any] = {}
+
+    def update(self, payload: dict[str, Any]) -> "_StubUpdateQuery":
+        self._update = payload
+        return self
+
+    def eq(self, col: str, val: Any) -> "_StubUpdateQuery":
+        self._table.calls.append(
+            ("update", self._table.name, {"match": {col: val}, "set": self._update})
+        )
+        return self
+
+    def execute(self) -> _StubResponse:
+        return _StubResponse(data=[self._update])
+
+
+class _StubInsertQuery:
+    def __init__(self, table: "_StubTable", payload: dict[str, Any]) -> None:
+        self._table = table
+        self._payload = payload
+
+    def execute(self) -> _StubResponse:
+        stored = {**self._payload, "id": f"{self._table.name}-evt-1"}
+        self._table.calls.append(("insert", self._table.name, self._payload))
+        return _StubResponse(data=[stored])
+
+
+class _StubTable:
+    def __init__(self, name: str, calls: list[Any]) -> None:
+        self.name = name
+        self.calls = calls
+
+    def insert(self, payload: dict[str, Any]) -> _StubInsertQuery:
+        return _StubInsertQuery(self, payload)
+
+    def update(self, payload: dict[str, Any]) -> _StubUpdateQuery:
+        q = _StubUpdateQuery(self)
+        return q.update(payload)
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def table(self, name: str) -> _StubTable:
+        return _StubTable(name, self.calls)
+
+
+def test_escalate_writes_event_with_expected_shape() -> None:
+    client = _StubClient()
+    row = _queue_row(id="11111111-1111-1111-1111-111111111111", goal="cleanup")
+    check = EscalationCheck(
+        should_escalate=True,
+        trigger=Trigger.STALE_APPROVAL,
+        context={"age_days": 9, "max_age_days": 7},
+    )
+    result = escalate(row, check, client=client)
+    insert_calls = [c for c in client.calls if c[0] == "insert"]
+    assert len(insert_calls) == 1
+    _, table, payload = insert_calls[0]
+    assert table == "events"
+    assert payload["event_type"] == ESCALATION_EVENT_TYPE
+    assert payload["severity"] == ESCALATION_SEVERITY
+    assert payload["source"] == DISPATCHER_AGENT_ID
+    assert payload["payload"]["queue_id"] == row["id"]
+    assert payload["payload"]["trigger"] == Trigger.STALE_APPROVAL.value
+    assert payload["payload"]["context"] == check.context
+    # Title should carry both id and trigger for quick scanning.
+    assert row["id"] in payload["title"]
+    assert Trigger.STALE_APPROVAL.value in payload["title"]
+    # And the returned event should have the stubbed id.
+    assert "id" in result
+
+
+def test_escalate_updates_queue_row_to_escalated() -> None:
+    client = _StubClient()
+    row = _queue_row(id="11111111-1111-1111-1111-111111111111")
+    check = EscalationCheck(
+        should_escalate=True,
+        trigger=Trigger.SCOPE_DRIFT,
+        context={"approved_scope_hash": "a", "current_scope_hash": "b"},
+    )
+    escalate(row, check, client=client)
+    update_calls = [c for c in client.calls if c[0] == "update"]
+    assert len(update_calls) == 1
+    _, table, payload = update_calls[0]
+    assert table == "task_queue"
+    assert payload["match"] == {"id": row["id"]}
+    assert payload["set"]["status"] == "escalated"
+    assert "scope_drift" in payload["set"]["escalated_reason"]
+
+
+def test_escalate_rejects_non_escalating_check() -> None:
+    client = _StubClient()
+    row = _queue_row()
+    with pytest.raises(ValueError, match="non-escalating"):
+        escalate(row, EscalationCheck.no_action(), client=client)
+
+
+def test_escalate_without_id_skips_queue_update_but_writes_event() -> None:
+    """An id-less row (hand-built in a test, hypothetically) still records the event."""
+    client = _StubClient()
+    row = _queue_row()
+    row.pop("id")
+    check = EscalationCheck(
+        should_escalate=True,
+        trigger=Trigger.LIMIT_NEAR_EXHAUSTION,
+        context={"used": 90},
+    )
+    escalate(row, check, client=client)
+    inserts = [c for c in client.calls if c[0] == "insert"]
+    updates = [c for c in client.calls if c[0] == "update"]
+    assert len(inserts) == 1
+    assert len(updates) == 0
+    assert inserts[0][2]["payload"]["queue_id"] is None
+
+
+def test_escalate_context_round_trips_to_payload() -> None:
+    """Nested dict context should survive into the events.payload jsonb."""
+    client = _StubClient()
+    row = _queue_row(id="x")
+    context = {
+        "conflicting_task_id": "peer",
+        "overlapping_files": ["a.py", "b.py"],
+        "nested": {"k": 1},
+    }
+    check = EscalationCheck(
+        should_escalate=True, trigger=Trigger.CROSS_TASK_CONFLICT, context=context
+    )
+    escalate(row, check, client=client)
+    insert = [c for c in client.calls if c[0] == "insert"][0]
+    assert insert[2]["payload"]["context"] == context


### PR DESCRIPTION
## Summary
Adds `agents/escalation.py` — the five guardrails dispatcher (S2-3, #298) calls before every live dispatch. Pure check functions (no DB) + one `escalate()` helper that writes the `events` row and flips `task_queue.status` to `escalated`. Integrates cleanly with S2-2 usage probe (#297).

## Why
Dispatcher must not blindly dispatch. Stale approvals, file-scope drift, exhausted budget, cross-task conflicts, and runaway patterns are the five failure modes the owner named in epic #184. Each one needs a deterministic check and a visible escalation event so the owner can intervene.

Closes #299.

## Decisions & Alternatives
- **Pure checks + DB-writing `escalate()`** — every check takes a dict row + context and returns `EscalationCheck`. Rejected: a single monolithic \"check and escalate\" that did everything. The split means tests can exercise each trigger with a synthetic row and no DB, which is what the issue's \"unit test with a synthetic queue row\" acceptance criterion asked for.
- **First-match wins, not all-matches** — surfacing five simultaneous reasons would drown the owner. Priority order is: stale → drift → limit → conflict → pattern. That order reflects what the owner can fix first (re-approve is cheapest, pattern-repeat needs investigation).
- **Scope-drift hasher is pluggable (str *or* callable)** — the actual hashing of current file state lives in dispatcher (S2-3); escalation stays transport-agnostic. A precomputed str works for tests; a callable works for dispatcher's tick-time computation.
- **Broken hasher → treat as drift** — if we can't hash the files, we have no evidence the scope is *still valid*. Escalate rather than silently dispatching against an un-hashable state.
- **Module-level constants for thresholds** (`STALE_APPROVAL_MAX_DAYS=7`, `PATTERN_REPEAT_THRESHOLD=3`) — per the issue's explicit requirement. Tune in one line.
- **Pattern-repeat counts a *run* from newest-first**, not a total — a different goal in the history breaks the run. Rationale: a runaway loop is \"the same thing over and over right now\", not \"appears 4 times this year\".
- **Cross-task conflict self-exclusion** — dispatcher should pre-filter, but we double-check `id == own_id` anyway. One comparison, prevents a row from flagging itself if dispatcher's query ever regresses.
- **Timezone-aware timestamp parsing with `Z` suffix support** — Supabase returns `...Z` sometimes, `...+00:00` other times. `datetime.fromisoformat` on 3.11+ handles both after a cheap `.replace('Z', '+00:00')`. Bad values return `None` → check returns `no_action` (no evidence, no escalation).
- **`escalate()` requires a positive check** — `ValueError` on `should_escalate=False`. Misuse is louder than silent skip; this catches dispatcher bugs like \"forgot the if\".
- **Id-less row still emits the event** — only really a test construction thing, but the event is more useful than a hard failure.

## Risk Assessment
**LOW.** Pure primitive. No callers yet — dispatcher (#298) is the first. `escalate()` writes to `events` (Sprint-1 allowlist) and `task_queue` (status-only flip, not destructive). Checks are side-effect-free. 33 new tests cover every trigger, every edge case (missing fields, bad timestamps, threshold boundaries, id-less rows, nested context round-trip).

## Testing
- `ruff check --fix && ruff format` — clean
- `pytest tests/test_agents_escalation.py -v` — 33/33 pass in 0.14s
- `pytest tests/test_agents_escalation.py tests/test_agents_usage_probe.py tests/test_agents_scheduler.py tests/test_agents_safety.py tests/test_agents_smoke.py -q` — 134/134 pass in 1.91s

Coverage highlights: stale-approval threshold boundaries + bad/missing timestamps + `Z`-suffix + datetime passthrough; scope drift with str & callable hashers, hasher exception recovery, missing approved hash; limit trigger both directions; cross-task conflict with overlap/disjoint/same-id/empty-scope/first-match-wins; pattern-repeat boundaries, reset behaviour, custom threshold; `check_all` first-match priority; `escalate` shape verification (event + queue update), misuse rejection, nested context round-trip.

## Files Changed
- `agents/escalation.py` — `Trigger` enum, `EscalationCheck` / `EscalationContext` dataclasses, 5 check functions, `check_all` aggregator, `escalate()`
- `tests/test_agents_escalation.py` — 33 unit tests with stub Supabase + fake clock
- `docs/agents/escalation.md` — trigger table, design overview, failure modes, wired dependencies
- `agents/__init__.py` — `escalation` added to `__all__`

## Follow-ups
- S2-3 (#298) dispatcher wires `check_all()` into its tick; escalations short-circuit dispatch
- S2-6 (#301) E2E test covers an escalated-via-stale-approval row end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)