### PR TITLE
ci(schema-drift): guard mcp-memory/schema.sql (actual canonical path) (#310)

### DIFF
--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
     paths:
-      - 'supabase/schema.sql'
+      - 'mcp-memory/schema.sql'
       - 'supabase/migrations/**'
 
 jobs:
@@ -24,12 +24,12 @@ jobs:
             });
 
             const schemaChanged = files.some(f =>
-              f.filename === 'supabase/schema.sql' &&
+              f.filename === 'mcp-memory/schema.sql' &&
               (f.status === 'modified' || f.status === 'added' || f.status === 'changed')
             );
 
             if (!schemaChanged) {
-              core.info('supabase/schema.sql unchanged — skipping drift check.');
+              core.info('mcp-memory/schema.sql unchanged — skipping drift check.');
               return;
             }
 
@@ -40,7 +40,7 @@ jobs:
 
             if (!migrationAdded) {
               core.setFailed(
-                'supabase/schema.sql changed without a paired migration file.\n' +
+                'mcp-memory/schema.sql changed without a paired migration file.\n' +
                 'schema.sql is aspirational documentation — it does not execute against the live DB.\n' +
                 'Apply the change via `mcp supabase apply_migration` and commit the new\n' +
                 'supabase/migrations/<timestamp>_<name>.sql file in the same PR.\n' +


### PR DESCRIPTION
## Summary
Fix `.github/workflows/schema-drift-check.yml` to guard the actual schema path (`mcp-memory/schema.sql`) instead of the non-existent `supabase/schema.sql`. Three string substitutions in one YAML file.

## Why
The guard added in #289 exists to prevent a repeat of the #284 regression (schema.sql edit without paired migration caused memory_recall to silently return soft-deleted rows). It was watching `supabase/schema.sql` — a file that does not exist in this repo. The canonical schema file is `mcp-memory/schema.sql`.

Result: any PR that edited `mcp-memory/schema.sql` without pairing a migration either didn't trigger the workflow at all (path-filter mismatch) or ran and returned SUCCESS spuriously (the internal `schemaChanged` test found no `supabase/schema.sql` in the changed files, so it early-returned OK). Confirmed on [#303](https://github.com/Osasuwu/jarvis/pull/303) — `require-paired-migration` returned SUCCESS without actually verifying the migration pairing.

Closes #310

## Decisions & Alternatives
- **Chose: fix the guard in place (change the path)**. The codebase is consistent — setup-device.py, config/SETUP.md, memory-overhaul.md, autonomous-loop.md, agents/dispatcher.py docstring all reference `mcp-memory/schema.sql` as the source of truth.
- **Rejected: move the file to `supabase/schema.sql`**. Would touch many unrelated files (docs, setup scripts), inflate scope, no benefit — tooling already points at `mcp-memory/schema.sql`.
- **Rejected: dual-path guard**. Would carry the dead `supabase/schema.sql` reference forward; the file genuinely does not exist.

## Risk Assessment
- **LOW**: workflow-only change, no runtime code affected. Worst case: the guard doesn't behave as expected and we catch it the next time someone edits schema.sql — same level of protection as before the PR (which was zero, because the guard was already a silent pass).

## Testing
- `git diff` reviewed — three substitutions only, no structural YAML changes.
- End-to-end verification happens on the next PR that edits `mcp-memory/schema.sql` without a migration. This PR itself does not touch schema.sql, so the `require-paired-migration` check will not run on it (expected).

## Files Changed
- `.github/workflows/schema-drift-check.yml` — path filter, filename equality check, and error message all now reference `mcp-memory/schema.sql`.