### PR TITLE
test(scripts): gate venv re-exec on `__name__ == "__main__"` so pytest can import (#313)

### DIFF
--- a/scripts/memory-dedup-check.py
+++ b/scripts/memory-dedup-check.py
@@ -24,7 +24,10 @@ from pathlib import Path
 _root = Path(__file__).resolve().parent.parent
 _venv_py = _root / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 
-if _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
+# Guard: only re-exec when run as script. When imported (e.g. by tests via
+# importlib with a non-"__main__" module name), skip the re-exec so the
+# module's top-level sys.exit doesn't kill pytest collection.
+if __name__ == "__main__" and _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
     sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]))
 
 # ---------------------------------------------------------------------------

--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -54,7 +54,10 @@ from pathlib import Path
 _root = Path(__file__).resolve().parent.parent
 _venv_py = _root / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 
-if _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
+# Guard: only re-exec when run as script. When imported (e.g. by tests via
+# importlib with a non-"__main__" module name), skip the re-exec so the
+# module's top-level sys.exit doesn't kill pytest collection.
+if __name__ == "__main__" and _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
     sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]))
 
 # ---------------------------------------------------------------------------

--- a/scripts/pre-compact-backup.py
+++ b/scripts/pre-compact-backup.py
@@ -35,7 +35,10 @@ from pathlib import Path
 _root = Path(__file__).resolve().parent.parent
 _venv_py = _root / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 
-if _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
+# Guard: only re-exec when run as script. When imported (e.g. by tests via
+# importlib with a non-"__main__" module name), skip the re-exec so the
+# module's top-level sys.exit doesn't kill pytest collection.
+if __name__ == "__main__" and _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
     sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]))
 
 # ---------------------------------------------------------------------------

--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -29,7 +29,10 @@ from pathlib import Path
 _root = Path(__file__).resolve().parent.parent
 _venv_py = _root / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 
-if _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
+# Guard: only re-exec when run as script. When imported (e.g. by tests via
+# importlib with a non-"__main__" module name), skip the re-exec so the
+# module's top-level sys.exit doesn't kill pytest collection.
+if __name__ == "__main__" and _venv_py.exists() and Path(sys.executable).resolve() != _venv_py.resolve():
     sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]))
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Four hook scripts had `sys.exit(subprocess.call(...))` at module top-level as part of their venv re-exec bootstrap. When pytest loaded them via `importlib.util` (required because the filenames use dashes), the re-exec killed pytest collection: `INTERNALERROR> mainloop: caught unexpected SystemExit`. Fix: gate the re-exec on `__name__ == "__main__"`.

## Why
`pytest tests/` couldn't collect in one pass — 3 test files (`test_pre_compact_backup.py`, `test_memory_recall_hook.py`, `test_session_context_recovery.py`) crashed collection before any test ran. Developers had to enumerate targeted suites. This was a known-blocker in the #235 PR and earlier.

Closes #313

## Decisions & Alternatives
- **Chose: one-line guard (`if __name__ == "__main__" and ...`)**. Minimal change, idiomatic Python, preserves all existing script behavior.
- **Also fixed `scripts/memory-dedup-check.py`**, which shares the same pattern but has no tests today — preempts the same bug when tests get written.
- **Rejected: restructure re-exec into a helper or main() function**. Larger blast radius, no upside. The four scripts intentionally do work at module-load time (env loading, Supabase client init) — gating just the re-exec keeps the rest intact.
- **Rejected: use `sys.argv[0]` detection**. More complex; the `__name__` idiom is the standard Python answer.

## Risk Assessment
- **LOW**: one-line edit per script, all four exercised either by existing tests (3) or by production hook invocation (pre-compact, session-start, memory-recall, dedup-check). Behavior when invoked as script is unchanged — the guard passes (`__name__` is `"__main__"`) and the existing re-exec runs.

## Testing
- `python -m pytest tests/ --collect-only` → 771 tests collected (was: INTERNALERROR on 3 modules)
- `python -m pytest tests/test_pre_compact_backup.py tests/test_memory_recall_hook.py tests/test_session_context_recovery.py` → 166/166 pass
- `python -m pytest tests/` → 766 passed, 5 skipped (AGENTS_E2E-gated)
- `ruff check` on the 4 scripts → pre-existing `E402` errors, no new errors

## Files Changed
- `scripts/pre-compact-backup.py` — add `__name__ == "__main__"` to re-exec guard + explanatory comment
- `scripts/memory-recall-hook.py` — same
- `scripts/session-context.py` — same
- `scripts/memory-dedup-check.py` — same (pre-emptive)