### PR TITLE
feat(memory): surface UUIDs in recall/get output (#318, #312)

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -1856,9 +1856,9 @@ async def _keyword_recall(
     scripts/session-context.py _load_recent_recall_results.
     """
     cols = (
-        "name, type, project, description, tags, updated_at, valid_to"
+        "id, name, type, project, description, tags, updated_at, valid_to"
         if brief
-        else "name, type, project, description, content, tags, updated_at, valid_to"
+        else "id, name, type, project, description, content, tags, updated_at, valid_to"
     )
     q = (
         client.table("memories")
@@ -1988,11 +1988,11 @@ def _format_memories(
                 score_str = ""
             desc = (mem.get("description") or "").strip()
             formatted.append(
-                f"- {mem['name']} [{mem['type']}/{proj}]{tags_str}{score_str}{link_str}: {desc}"
+                f"- {mem['name']} [{mem['type']}/{proj}]{tags_str}{score_str}{link_str}: {desc} — id={mem.get('id', '?')}"
             )
         else:
             formatted.append(
-                f"## {mem['name']} ({mem['type']}, {proj}){tags_str}{link_str}\n"
+                f"## {mem['name']} ({mem['type']}, {proj}){tags_str}{link_str} — id=`{mem.get('id', '?')}`\n"
                 f"*{mem.get('description', '')}*\n"
                 f"Updated: {mem.get('updated_at', '?')}\n\n"
                 f"{mem['content']}\n"

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -385,13 +385,13 @@ class TestFormatMemories:
             "content": "MUST_NOT_APPEAR",
         }
         result = _format_memories([mem], brief=True)
-        assert result == ["- foo [feedback/jarvis] [a, b] (sim 0.42): hello world"]
+        assert result == ["- foo [feedback/jarvis] [a, b] (sim 0.42): hello world — id=?"]
         assert "MUST_NOT_APPEAR" not in result[0]
 
     def test_brief_global_scope(self):
         mem = {"name": "g", "type": "user", "project": None, "description": "d"}
         result = _format_memories([mem], brief=True)
-        assert result[0] == "- g [user/global]: d"
+        assert result[0] == "- g [user/global]: d — id=?"
 
     def test_brief_temporal_score_leads_when_present(self):
         # `_temporal_score` is what drives actual ordering after
@@ -431,14 +431,14 @@ class TestFormatMemories:
     def test_brief_no_score_fields(self):
         mem = {"name": "n", "type": "reference", "project": None, "description": "d"}
         result = _format_memories([mem], brief=True)
-        assert result[0] == "- n [reference/global]: d"
+        assert result[0] == "- n [reference/global]: d — id=?"
 
     def test_brief_empty_description(self):
         # Migration-target memories carry empty descriptions — brief still
         # surfaces the name (no crash, trailing `: ` is intentional).
         mem = {"name": "bare", "type": "decision", "project": "jarvis"}
         result = _format_memories([mem], brief=True)
-        assert result[0] == "- bare [decision/jarvis]: "
+        assert result[0] == "- bare [decision/jarvis]:  — id=?"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_keyword_recall` now selects `id` (semantic path via `_hybrid_recall` already projects it through the `match_memories_v2` RPC).
- Brief format appends `— id=<uuid>` so tooling can split the line without regexing description text.
- Full format header includes ` — id=\`<uuid>\`` for symmetry.

Unblocks `/implement` and `/delegate` skill §6 — `outcome_record(memory_id=memories_used[0])` per the calibration FK design landed in #287 — which previously could not populate `memory_id` without a second `memory_get` round-trip.

Patch is the one diffed on #318 (after PR #319 merged the protected-file clarification allowing inline /implement to edit `mcp-memory/server.py` with owner approval).

## Test plan
- [x] `pytest tests/test_memory_server.py -x -q` — 95/95 pass
- [x] Format/recall slice (`-k "format or recall"`) — 22/22 pass
- [ ] Post-merge smoke: `memory_recall(brief=True)` lines end with `— id=<36-char-uuid>`; `outcome_record(memory_id=<uuid>)` accepts it

Closes #318
Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)