### PR TITLE
docs(skills): reconcile contradictions + fix stale refs (v0.4.0 audit)

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -133,7 +133,7 @@ Report back: PR URL + 2-line summary of what you did.
 **Mitigations:**
 - Branch names are explicit, per-issue, and unique (`feat/<N>-<slug>`) — encode in the prompt
 - Cap parallelism: **2-3 agents concurrently** is the safe band; 5+ is a red flag
-- **Review the diff in the main repo tree as the authoritative check** — `cd <main repo> && git fetch && git diff origin/master...origin/feat/<N>-<slug>`. Treat the agent's worktree as a staging area, not a trusted sandbox.
+- **Review the diff in the main repo tree as the authoritative check** — `cd <main repo> && git fetch && git diff origin/main...origin/feat/<N>-<slug>`. Treat the agent's worktree as a staging area, not a trusted sandbox.
 - If you see contamination, abort and re-dispatch sequentially
 
 ### 5. Implement inline tasks (parallel with the subagents)
@@ -147,8 +147,8 @@ When a subagent reports done, review **in the main repo tree, not the agent's wo
 ```bash
 cd <main repo>
 git fetch origin
-git diff origin/master...origin/feat/<N>-<slug> --stat
-git diff origin/master...origin/feat/<N>-<slug>
+git diff origin/main...origin/feat/<N>-<slug> --stat
+git diff origin/main...origin/feat/<N>-<slug>
 ```
 
 Run the following checks in order — do NOT short-circuit:
@@ -207,8 +207,8 @@ Stale worktrees and branches accumulate fast with multi-issue batches. Clean up 
 
 ## Recovery playbook
 
-See `docs/security/recovery-playbook.md`. Subagent-specific:
+See `/implement` for general recovery (broken file, bad PR, wrong branch). Subagent-specific:
 - Subagent edited wrong files → revert in its worktree, re-prompt with stricter scope
 - Subagent broke its worktree → `git worktree remove --force <path>` + reclaim branch in fresh worktree
 - Two subagents raced on same file → abort both, re-dispatch sequentially
-- Subagent silently merged → revert merge on `master` immediately, open incident note, add to agent-boundaries.md
+- Subagent silently merged → revert merge on `main` immediately, open incident note, add to agent-boundaries.md

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -89,6 +89,8 @@ Always emit for issue implementation — outcome attribution needs the basis. Fo
 - **Inline `/implement` with explicit owner approval in-session** — MAY edit protected files. Document the change prominently in the PR body (mark the file `[PROTECTED]` in the §Files Changed list + rationale) so the owner sees it before merge.
 - **Inline `/implement` without explicit approval** — document the needed change in the PR body and leave the file untouched for the owner.
 
+**Secrets rule supersedes** (SOUL.md): `.env`, `.env.local`, and any file with raw secret values are NEVER edited and NEVER read — even with owner approval. Use `.env.example` for metadata only. If a task needs a secret-bearing file edited, owner does it themselves.
+
 #### 4a. Already-done audit (mandatory gate)
 
 Before writing any code, enumerate acceptance-criteria symbols from the issue body and grep each:
@@ -256,8 +258,7 @@ If the diff looks wrong, fix it before pushing.
 
 ## Recovery playbook
 
-See `docs/security/recovery-playbook.md` for how to handle:
-- Broke a file → revert from master
-- Corrupted memory → `memory_restore`
-- Created bad PR → close + delete branch
-- Committed to wrong branch → cherry-pick + reset
+- Broke a file → revert from main (`git checkout origin/main -- <path>`)
+- Corrupted memory → `memory_restore(name=..., project=...)`
+- Created bad PR → `gh pr close <N> --delete-branch`
+- Committed to wrong branch → cherry-pick onto correct branch, then `git reset --hard origin/<wrong-branch>` on the wrong one

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -64,7 +64,9 @@ outcome_update(
 )
 ```
 
-**Enrich `memory_id` if the outcome row has it NULL**: look up the linked `decision_made` episode (same issue/PR) and pass `memory_id = payload.memories_used[0]`. Rule — primary informing memory = first entry (dominant basis). If the outcome already has `memory_id`, leave it alone; `/verify` is not where you rewrite attribution. If no decision episode references this issue, omit — the backfill script (`scripts/backfill-outcome-memories.py`) can handle historical rows in bulk.
+**Enrich `memory_id` if the outcome row has it NULL**: look up the linked `decision_made` episode (same issue/PR) and pass `memory_id = payload.memories_used[0]`. Rule — primary informing memory = first entry (dominant basis). If the outcome already has `memory_id`, leave it alone; `/verify` is not where you rewrite attribution.
+
+**Only backfill when `memories_used[0]` is a UUID** (matches `^[0-9a-f]{8}-`). Historical episodes store memory NAMES, not UUIDs — passing a name here creates a broken FK. If the first entry is a name, omit `memory_id` and leave the row for `scripts/backfill-outcome-memories.py`, which handles name→id resolution in bulk. If no decision episode references this issue, also omit.
 
 `verified_at` is set automatically when status changes from pending.
 


### PR DESCRIPTION
Closes #421

## Summary

Docs-only cleanup of three contradictions and four stale references found in a v0.4.0+ quality audit (2026-04-20 → 2026-04-23).

## Changes

**Contradictions resolved:**
- `implement/SKILL.md` — SOUL.md secrets rule now explicitly supersedes protected-file policy. Before: two independent rules with unclear precedence. Now: `.env` / secret-bearing files never edited even with owner approval.
- `verify/SKILL.md` — backfill `memory_id` only when `memories_used[0]` matches UUID regex. Empirically 100% of current `decision_made` episodes store memory NAMES, not UUIDs (33 rows, 21 empty, 12 name-only — see #325). Passing a name here would have written a broken FK.

**Stale references:**
- `delegate/SKILL.md` — `origin/master` → `origin/main` (4 occurrences). Project uses `main`.
- `implement/SKILL.md` — "revert from master" → "revert from main".
- `implement/SKILL.md` + `delegate/SKILL.md` — removed refs to `docs/security/recovery-playbook.md` (file does not exist); inlined the 4-line playbook.

## Non-goals

Does not touch protected files (SOUL.md, CLAUDE.md, settings.json, .mcp.json, server.py, .gitleaks.toml, .pre-commit-config.yaml). SOUL.md autonomy-vs-visibility contradiction flagged in the audit is left for owner review (handled in companion #329).

## Audit context

Follow-up to #325 (Pillar 3 FK), #326 (CI meta-test for guards), #327 (flag-only escalation). This PR bundles the non-protected docs portion; protected-file edits in #329.

## Test plan
- [x] `git grep "origin/master"` + `git grep "recovery-playbook"` under `.claude/skills/` both clean
- [ ] Next /implement or /verify invocation observes the new rules (empirical, next session)