### PR TITLE
refactor(docs): unify SOUL/CLAUDE/always_load roles, remove 3-way recall dup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,12 @@ Architecture: Claude Code native (skills, hooks, MCP, subagents) + Supabase memo
 
 Before marking any task complete:
 1. **Integration**: does it work in context? Backend → check frontend. API → check consumers. Config → check all 3 devices (different paths/usernames).
-2. **Side effects**: grep callers, run tests. What else uses what you changed?
+2. **Side effects**: what else uses what you changed?
 3. **Memory**: non-obvious learning or improvement idea → `memory_store` (with `source_provenance`).
 4. **Tooling**: manual step that should be automated → propose or record.
 5. **Tests**: end-to-end, not just in isolation.
 
-Before any significant action (delegate, research, architecture decision) → `memory_recall(query=<relevant topic>)`. Past decisions and rejected approaches live in memory — don't contradict them.
+Recall + sibling-grep before implementing come from always_load (`always_recall_before_action`, `feedback_symmetric_fixes`). Don't duplicate here.
 
 ## Project-specific rules
 
@@ -86,14 +86,9 @@ Rules:
 
 ## Autonomous work
 
-Owner often leaves Jarvis to work alone:
+Owner often leaves Jarvis to work alone. Core loop comes from always_load (`quality_over_speed`, `always_recall_before_action`, `verify_before_assuming_implemented`, `autonomous_long_sessions`) + SOUL §Goal awareness.
 
-1. **Don't interpret — understand.** Re-read the issue and discussions. Unclear → do less but correctly.
-2. **Acceptance criteria before code, not after.**
-3. **Tests verify requirements, not implementation.**
-4. **Transform tasks into verifiable goals**: "Fix bug" → write test that reproduces it → make it pass. "Add validation" → tests for invalid inputs → make them pass. "Refactor X" → tests pass before and after.
-5. **Stuck → research, don't hack.** Web search, Context7, docs.
-6. **Check against the goal at every step** — don't drift.
+Project-specific addition — **transform tasks into verifiable goals**: "Fix bug" → write failing test → make it pass. "Add validation" → tests for invalid inputs → make them pass. "Refactor X" → tests pass before and after.
 
 ## Development process
 

--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -10,7 +10,6 @@ Concise, direct, opinionated. Senior peer, not intern.
 - No filler, no sycophancy, no corporate speak.
 - Have opinions — push back on bad ideas with a better alternative.
 - Honest about limits — if you don't know or can't do it, say so immediately.
-- Resourceful — read files, grep, recall before asking.
 - Lead with answer or action; explain only the non-obvious.
 
 ## Communication


### PR DESCRIPTION
## Summary

Remove triplicate "recall before action" rule and quintuplet "autonomous work" duplications now that `always_load` tag has content (6 memories seeded today). Makes the SOUL/CLAUDE/always_load split crisp.

## Why

Closes #330

Audit session 2026-04-23 uncovered that `always_load` infrastructure existed but was empty — 0 rows. Seeded 6 memories today. With content present, SOUL and CLAUDE now have explicit duplicates that should delegate to always_load instead.

Also prerequisite for "Jarvis federation → user-level" migration — don't drag duplicates into `~/.claude/`.

## Decisions & Alternatives

- **Chose: delegate to always_load memories, reference by name** (alternative: keep duplicates everywhere \"for safety\" → rejected, defeats token budget purpose).
- **Chose: collapse Autonomous work 6→1 with pointer** (alternative: move to always_load as single memory → possible, but transform-tasks-into-verifiable-goals is project-process, not universal rule).
- **Chose: keep role split SOUL=identity, CLAUDE=project-anatomy** (already established in `always_loaded_context_budget_principle` — this PR enforces it).

## Risk Assessment

- **LOW**: documentation-only, no code or config changed, no behavior lost (rules now sourced from memory that's already loaded).

## Testing

- `git diff --stat`: 2 files, +4 / -10 net
- SessionStart hook loads `always_load` tag — verified 6 rows now tagged (SQL check).
- No scripts, code, or tests touched.

## Files Changed

- `config/SOUL.md` **[PROTECTED]** — drop 1 line (\"Resourceful — read files, grep, recall before asking\"). Content covered by always_load `always_recall_before_action` + `unpack_brief_recall_before_guessing_defaults`.
- `CLAUDE.md` **[PROTECTED]** — DoD: drop recall paragraph + trim side-effects bullet; Autonomous work: collapse 6 points to 1 + always_load pointer. Owner approval obtained in-session (audit 2026-04-23).