### PR TITLE
feat(install): manifest + installer foundation for federation (#336)

### DIFF
--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -1,0 +1,98 @@
+# Jarvis install manifest — declarative source of truth for user-level install.
+#
+# Consumed by scripts/install/installer.py via install.ps1 / install.sh.
+# Describes what gets copied from this repo into ~/.claude/ (or $JARVIS_HOME_TARGET),
+# whether the content is templated (path substitution), and which env vars to set.
+#
+# Epic #335 — Pillar 7 Phase 0: Federation foundation.
+# M1 (#336) lands the manifest + installer. M2-M4 flip individual groups from
+# `enabled: false` to `enabled: true` as each migration step ships.
+
+version: 1
+
+# Placeholders substituted in templated files.
+# {{JARVIS_HOME}} → absolute path to the jarvis repo root (install-time).
+# {{CLAUDE_USER_HOME}} → absolute path to ~/.claude/ (install-time).
+placeholders:
+  JARVIS_HOME: "{repo_root}"
+  CLAUDE_USER_HOME: "{claude_user_home}"
+
+# Destination root for user-level install. Absolute path, expanded at runtime
+# (~/, $HOME, %USERPROFILE%). Override via --target or JARVIS_CLAUDE_HOME env.
+target_root: "~/.claude"
+
+# Version marker written to target_root/.jarvis-version (git SHA at install time).
+version_marker: ".jarvis-version"
+
+# Groups — each one independently enablable. Until each M-step ships, the
+# corresponding group stays disabled so the installer is a no-op for it.
+groups:
+
+  - id: soul
+    description: "SOUL.md — personality/behavioral rules (M4 #339)"
+    enabled: false
+    files:
+      - source: "config/SOUL.md"
+        dest: "SOUL.md"
+        template: false
+
+  - id: hooks_settings
+    description: "settings.json — hooks pointing at JARVIS_HOME scripts (M3 #338)"
+    enabled: false
+    files:
+      - source: ".claude/settings.json"
+        dest: "settings.json"
+        template: true  # rewrites `scripts/...` → `{{JARVIS_HOME}}/scripts/...`
+
+  - id: mcp_config
+    description: ".mcp.json — MCP server config with absolute paths (M3 #338)"
+    enabled: false
+    files:
+      - source: ".mcp.json"
+        dest: ".mcp.json"
+        template: true
+
+  - id: skills
+    description: "Core skills (M2 #337)"
+    enabled: false
+    directories:
+      - source: ".claude/skills"
+        dest: "skills"
+        template: false
+        # Whitelist — only the skills listed here move to user-level. Niche
+        # or project-specific skills stay in <project>/.claude/skills/.
+        include:
+          - "autonomous-loop"
+          - "delegate"
+          - "end"
+          - "end-quick"
+          - "goals"
+          - "implement"
+          - "reflect"
+          - "research"
+          - "self-improve"
+          - "setup-tasks"
+          - "sprint-report"
+          - "status"
+          - "verify"
+
+# Env vars — set on install (idempotent: skipped if already matches).
+env_vars:
+  - name: "JARVIS_HOME"
+    value: "{repo_root}"
+    platforms: ["windows", "posix"]
+
+# Health check — after apply, run this command (dry-run of SessionStart hook).
+# Non-zero exit → auto-rollback from the most recent backup.
+health_check:
+  enabled: true
+  # Resolved relative to JARVIS_HOME. Empty list = skip.
+  commands:
+    - "python scripts/device-info.py"
+    - "python scripts/session-context.py --smoke"  # --smoke flag = dry load, no Supabase writes
+
+# Backup — timestamped directory created before any destructive write.
+backup:
+  prefix: ".claude.backup-"
+  # Keep last N backups, prune older.
+  retain: 5

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,36 @@
+# Jarvis installer — Windows wrapper (PowerShell 5.1+).
+# Forwards to scripts/install/installer.py. Default is dry-run.
+#
+# Examples:
+#   .\install.ps1                      # dry-run plan
+#   .\install.ps1 -Apply               # perform install
+#   .\install.ps1 -Rollback <path>     # restore from backup
+#
+# Epic #335 / M1 #336.
+
+[CmdletBinding()]
+param(
+    [switch]$Apply,
+    [string]$Target,
+    [string]$Manifest,
+    [string]$Rollback,
+    [switch]$SkipEnv,
+    [switch]$SkipHealthCheck
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$pyArgs = @("$repoRoot\scripts\install\installer.py")
+if ($Apply)            { $pyArgs += "--apply" }
+if ($SkipEnv)          { $pyArgs += "--skip-env" }
+if ($SkipHealthCheck)  { $pyArgs += "--skip-health-check" }
+if ($Target)           { $pyArgs += @("--target", $Target) }
+if ($Manifest)         { $pyArgs += @("--manifest", $Manifest) }
+if ($Rollback)         { $pyArgs += @("--rollback", $Rollback) }
+
+$py = (Get-Command python -ErrorAction SilentlyContinue)
+if (-not $py) { $py = Get-Command python3 -ErrorAction Stop }
+
+& $py.Source @pyArgs
+exit $LASTEXITCODE

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Jarvis installer — POSIX wrapper.
+# Forwards to scripts/install/installer.py. Default is dry-run.
+#
+# Examples:
+#   ./install.sh                   # dry-run plan
+#   ./install.sh --apply           # perform install
+#   ./install.sh --rollback <path> # restore from backup
+#
+# Epic #335 / M1 #336.
+
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+    PY=python
+fi
+
+exec "$PY" "$repo_root/scripts/install/installer.py" "$@"

--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -1,0 +1,551 @@
+"""Jarvis install/sync — applies install-manifest.yaml into ~/.claude/.
+
+Epic #335 M1 (#336). Handles three device states:
+  fresh     — target_root missing or has no .jarvis-version → full install
+  outdated  — .jarvis-version present but differs from current repo SHA → re-apply
+  current   — .jarvis-version matches current SHA → no-op
+
+Default mode is dry-run. Destructive writes require explicit --apply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+import yaml
+
+
+DEFAULT_MANIFEST = "install-manifest.yaml"
+
+
+# ---------- data model ----------
+
+
+@dataclasses.dataclass
+class Action:
+    """One planned filesystem action."""
+
+    kind: str  # "copy_file" | "copy_dir" | "write_version" | "set_env"
+    source: str | None
+    dest: str
+    template: bool = False
+    group: str = ""
+    note: str = ""
+
+
+@dataclasses.dataclass
+class Plan:
+    state: str  # "fresh" | "outdated" | "current"
+    actions: list[Action]
+    backup_path: Path | None
+    current_sha: str
+    previous_sha: str | None
+    target_root: Path
+    repo_root: Path
+
+
+# ---------- helpers ----------
+
+
+def _run_git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def current_git_sha(repo_root: Path) -> str:
+    return _run_git(repo_root, "rev-parse", "HEAD")
+
+
+def read_version(target_root: Path) -> str | None:
+    marker = target_root / ".jarvis-version"
+    if not marker.exists():
+        return None
+    try:
+        return marker.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def _expand(path: str) -> Path:
+    return Path(os.path.expandvars(os.path.expanduser(path))).resolve()
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"manifest {path} did not parse to a mapping")
+    if data.get("version") != 1:
+        raise ValueError(
+            f"unsupported manifest version {data.get('version')!r}; expected 1"
+        )
+    return data
+
+
+def detect_state(target_root: Path, current_sha: str) -> tuple[str, str | None]:
+    if not target_root.exists():
+        return "fresh", None
+    prev = read_version(target_root)
+    if prev is None:
+        # Target exists but no version marker — treat as outdated so we
+        # re-apply, but preserve via backup.
+        return "outdated", None
+    if prev == current_sha:
+        return "current", prev
+    return "outdated", prev
+
+
+# ---------- template substitution ----------
+
+
+_POSIX_PATH_PATTERN = re.compile(r"\b(scripts|config)/")
+
+
+def _transform_json_paths(node: Any, repo_root_posix: str) -> Any:
+    """Rewrite relative `scripts/...` and `config/...` references to
+    absolute paths inside the jarvis repo. JSON-aware walk preserves
+    structure while only touching string leaves."""
+    if isinstance(node, str):
+        return _POSIX_PATH_PATTERN.sub(
+            lambda m: f"{repo_root_posix}/{m.group(1)}/", node
+        )
+    if isinstance(node, list):
+        return [_transform_json_paths(x, repo_root_posix) for x in node]
+    if isinstance(node, dict):
+        return {k: _transform_json_paths(v, repo_root_posix) for k, v in node.items()}
+    return node
+
+
+def _substitute_placeholders(text: str, repo_root: Path, claude_home: Path) -> str:
+    return (
+        text.replace("{{JARVIS_HOME}}", repo_root.as_posix())
+        .replace("{{CLAUDE_USER_HOME}}", claude_home.as_posix())
+    )
+
+
+def template_content(source: Path, repo_root: Path, claude_home: Path) -> bytes:
+    """Read source, apply templating, return bytes to write at dest.
+
+    For .json files: parse, rewrite relative `scripts/`/`config/` paths to
+    absolute, pretty-print. For other files: plain placeholder replace.
+    Non-text / non-json files fall back to a raw copy (no transformation).
+    """
+    ext = source.suffix.lower()
+    raw = source.read_bytes()
+    if ext == ".json":
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return raw
+        transformed = _transform_json_paths(data, repo_root.as_posix())
+        rendered = json.dumps(transformed, indent=2, ensure_ascii=False) + "\n"
+        return _substitute_placeholders(rendered, repo_root, claude_home).encode(
+            "utf-8"
+        )
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw
+    return _substitute_placeholders(text, repo_root, claude_home).encode("utf-8")
+
+
+# ---------- planning ----------
+
+
+def build_plan(
+    manifest: dict[str, Any],
+    repo_root: Path,
+    target_root_override: str | None = None,
+) -> Plan:
+    target_root = _expand(
+        target_root_override or manifest.get("target_root", "~/.claude")
+    )
+    current_sha = current_git_sha(repo_root)
+    state, previous_sha = detect_state(target_root, current_sha)
+
+    actions: list[Action] = []
+
+    if state == "current":
+        return Plan(
+            state=state,
+            actions=actions,
+            backup_path=None,
+            current_sha=current_sha,
+            previous_sha=previous_sha,
+            target_root=target_root,
+            repo_root=repo_root,
+        )
+
+    for group in manifest.get("groups") or []:
+        if not group.get("enabled"):
+            continue
+        gid = group.get("id", "?")
+        for entry in group.get("files") or []:
+            src = repo_root / entry["source"]
+            dest = target_root / entry["dest"]
+            actions.append(
+                Action(
+                    kind="copy_file",
+                    source=str(src),
+                    dest=str(dest),
+                    template=bool(entry.get("template")),
+                    group=gid,
+                )
+            )
+        for entry in group.get("directories") or []:
+            src = repo_root / entry["source"]
+            dest = target_root / entry["dest"]
+            include = entry.get("include")
+            actions.append(
+                Action(
+                    kind="copy_dir",
+                    source=str(src),
+                    dest=str(dest),
+                    template=bool(entry.get("template")),
+                    group=gid,
+                    note=f"include={include}" if include else "",
+                )
+            )
+
+    actions.append(
+        Action(
+            kind="write_version",
+            source=None,
+            dest=str(target_root / manifest.get("version_marker", ".jarvis-version")),
+            note=current_sha,
+        )
+    )
+
+    for env in manifest.get("env_vars") or []:
+        value = env.get("value", "").format(repo_root=str(repo_root))
+        actions.append(
+            Action(
+                kind="set_env",
+                source=None,
+                dest=env["name"],
+                note=value,
+            )
+        )
+
+    # Backup only when target_root already exists AND we have destructive actions.
+    has_writes = any(a.kind in {"copy_file", "copy_dir"} for a in actions)
+    backup_path: Path | None = None
+    if target_root.exists() and has_writes:
+        stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        prefix = (manifest.get("backup") or {}).get("prefix", ".claude.backup-")
+        backup_path = target_root.parent / f"{prefix}{stamp}"
+
+    return Plan(
+        state=state,
+        actions=actions,
+        backup_path=backup_path,
+        current_sha=current_sha,
+        previous_sha=previous_sha,
+        target_root=target_root,
+        repo_root=repo_root,
+    )
+
+
+# ---------- execution ----------
+
+
+def _copy_dir(
+    src: Path,
+    dest: Path,
+    include: Iterable[str] | None,
+    template: bool,
+    repo_root: Path,
+    claude_home: Path,
+) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    allowed = set(include) if include else None
+    for child in src.iterdir():
+        if allowed is not None and child.name not in allowed:
+            continue
+        if child.is_dir():
+            _copy_dir(
+                child, dest / child.name, None, template, repo_root, claude_home
+            )
+        else:
+            _copy_file(child, dest / child.name, template, repo_root, claude_home)
+
+
+def _copy_file(
+    src: Path,
+    dest: Path,
+    template: bool,
+    repo_root: Path,
+    claude_home: Path,
+) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if template:
+        dest.write_bytes(template_content(src, repo_root, claude_home))
+    else:
+        shutil.copy2(src, dest)
+
+
+def _set_env(name: str, value: str, platform: str) -> None:
+    if platform == "windows":
+        subprocess.run(["setx", name, value], check=False, capture_output=True)
+    else:
+        rc_files = [Path.home() / ".bashrc", Path.home() / ".zshrc"]
+        line = f'export {name}="{value}"\n'
+        for rc in rc_files:
+            if not rc.exists():
+                continue
+            existing = rc.read_text(encoding="utf-8")
+            if f"export {name}=" in existing:
+                continue
+            rc.write_text(existing + "\n# added by jarvis installer\n" + line,
+                          encoding="utf-8")
+
+
+def _platform() -> str:
+    return "windows" if os.name == "nt" else "posix"
+
+
+def apply_plan(
+    plan: Plan,
+    manifest: dict[str, Any],
+    run_env: Callable[[str, str, str], None] | None = _set_env,
+) -> None:
+    if plan.state == "current":
+        return
+    if plan.backup_path is not None:
+        shutil.copytree(plan.target_root, plan.backup_path)
+
+    plan.target_root.mkdir(parents=True, exist_ok=True)
+
+    for action in plan.actions:
+        if action.kind == "copy_file":
+            _copy_file(
+                Path(action.source),
+                Path(action.dest),
+                action.template,
+                plan.repo_root,
+                plan.target_root,
+            )
+        elif action.kind == "copy_dir":
+            # Re-derive include from manifest — cheaper than threading it through.
+            include = _include_for(manifest, action.group, action.source)
+            _copy_dir(
+                Path(action.source),
+                Path(action.dest),
+                include,
+                action.template,
+                plan.repo_root,
+                plan.target_root,
+            )
+        elif action.kind == "write_version":
+            Path(action.dest).write_text(action.note + "\n", encoding="utf-8")
+        elif action.kind == "set_env":
+            if run_env is not None:
+                run_env(action.dest, action.note, _platform())
+
+
+def _include_for(manifest: dict[str, Any], group_id: str, source: str) -> list[str] | None:
+    for group in manifest.get("groups") or []:
+        if group.get("id") != group_id:
+            continue
+        for entry in group.get("directories") or []:
+            if str(Path(entry["source"])) in source:
+                return entry.get("include")
+    return None
+
+
+# ---------- rollback / health ----------
+
+
+def prune_backups(target_root: Path, prefix: str, retain: int) -> list[Path]:
+    parent = target_root.parent
+    if not parent.exists():
+        return []
+    backups = sorted(
+        (p for p in parent.iterdir() if p.is_dir() and p.name.startswith(prefix)),
+        key=lambda p: p.name,
+    )
+    dropped: list[Path] = []
+    while len(backups) > retain:
+        victim = backups.pop(0)
+        shutil.rmtree(victim, ignore_errors=True)
+        dropped.append(victim)
+    return dropped
+
+
+def rollback(target_root: Path, backup_path: Path) -> None:
+    if not backup_path.exists():
+        raise FileNotFoundError(f"backup {backup_path} not found")
+    if target_root.exists():
+        shutil.rmtree(target_root)
+    shutil.copytree(backup_path, target_root)
+
+
+def run_health_check(manifest: dict[str, Any], repo_root: Path) -> tuple[bool, list[str]]:
+    hc = manifest.get("health_check") or {}
+    if not hc.get("enabled"):
+        return True, []
+    logs: list[str] = []
+    for cmd in hc.get("commands") or []:
+        try:
+            result = subprocess.run(
+                cmd.split(),
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logs.append(f"FAIL {cmd}: {exc}")
+            return False, logs
+        if result.returncode != 0:
+            logs.append(
+                f"FAIL {cmd} exit={result.returncode} stderr={result.stderr[:200]}"
+            )
+            return False, logs
+        logs.append(f"OK   {cmd}")
+    return True, logs
+
+
+# ---------- printing ----------
+
+
+def format_plan(plan: Plan) -> str:
+    lines = [
+        f"state:        {plan.state}",
+        f"repo_root:    {plan.repo_root}",
+        f"target_root:  {plan.target_root}",
+        f"current_sha:  {plan.current_sha}",
+        f"previous_sha: {plan.previous_sha or '(none)'}",
+        f"backup:       {plan.backup_path or '(not needed)'}",
+        f"actions:      {len(plan.actions)}",
+    ]
+    if plan.actions:
+        lines.append("")
+        for a in plan.actions:
+            if a.kind == "copy_file":
+                lines.append(
+                    f"  copy_file  [{a.group:>14}] {a.source} -> {a.dest}"
+                    + ("  (template)" if a.template else "")
+                )
+            elif a.kind == "copy_dir":
+                extra = f"  {a.note}" if a.note else ""
+                lines.append(
+                    f"  copy_dir   [{a.group:>14}] {a.source} -> {a.dest}{extra}"
+                )
+            elif a.kind == "write_version":
+                lines.append(f"  write_ver  -> {a.dest}  sha={a.note[:12]}")
+            elif a.kind == "set_env":
+                lines.append(f"  set_env    {a.dest}={a.note}")
+    return "\n".join(lines)
+
+
+# ---------- CLI ----------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="jarvis-installer",
+        description="Install/sync Jarvis agent machinery into ~/.claude/.",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help=f"Path to manifest (default: {DEFAULT_MANIFEST} next to repo root)",
+    )
+    parser.add_argument("--target", default=None, help="Override target_root")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually perform the install. Default is dry-run (plan only).",
+    )
+    parser.add_argument(
+        "--skip-env",
+        action="store_true",
+        help="Skip env-var writes even on --apply (useful in CI/tests).",
+    )
+    parser.add_argument(
+        "--rollback",
+        metavar="BACKUP_PATH",
+        default=None,
+        help="Restore target_root from BACKUP_PATH and exit.",
+    )
+    parser.add_argument(
+        "--skip-health-check",
+        action="store_true",
+        help="Skip post-install health check (not recommended).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    manifest_path = Path(args.manifest) if args.manifest else repo_root / DEFAULT_MANIFEST
+    manifest = load_manifest(manifest_path)
+
+    if args.rollback:
+        target_root = _expand(args.target or manifest.get("target_root", "~/.claude"))
+        rollback(target_root, Path(args.rollback))
+        print(f"rolled back {target_root} from {args.rollback}")
+        return 0
+
+    plan = build_plan(manifest, repo_root, args.target)
+    print(format_plan(plan))
+
+    if not args.apply:
+        print("\n(dry-run — re-run with --apply to execute)")
+        return 0
+
+    if plan.state == "current":
+        print("\nno-op — target already at current SHA")
+        return 0
+
+    env_runner = None if args.skip_env else _set_env
+    try:
+        apply_plan(plan, manifest, run_env=env_runner)
+    except Exception as exc:  # noqa: BLE001
+        print(f"\napply failed: {exc}", file=sys.stderr)
+        if plan.backup_path and plan.backup_path.exists():
+            print(f"rolling back from {plan.backup_path}", file=sys.stderr)
+            rollback(plan.target_root, plan.backup_path)
+        return 2
+
+    if not args.skip_health_check:
+        ok, logs = run_health_check(manifest, repo_root)
+        for line in logs:
+            print(line)
+        if not ok:
+            print("\nhealth check failed", file=sys.stderr)
+            if plan.backup_path and plan.backup_path.exists():
+                print(f"rolling back from {plan.backup_path}", file=sys.stderr)
+                rollback(plan.target_root, plan.backup_path)
+            return 3
+
+    backup_cfg = manifest.get("backup") or {}
+    dropped = prune_backups(
+        plan.target_root,
+        backup_cfg.get("prefix", ".claude.backup-"),
+        int(backup_cfg.get("retain", 5)),
+    )
+    for d in dropped:
+        print(f"pruned old backup: {d}")
+
+    print("\napply complete")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,323 @@
+"""Tests for scripts/install/installer.py — Epic #335 M1."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# Add scripts/install/ to sys.path so `import installer` resolves; dataclasses
+# need the module registered in sys.modules (__module__ lookup).
+import sys as _sys
+
+_install_dir = Path(__file__).resolve().parents[1] / "scripts" / "install"
+if str(_install_dir) not in _sys.path:
+    _sys.path.insert(0, str(_install_dir))
+
+import installer  # noqa: E402  — path hack is intentional
+
+
+# ---------- fixtures ----------
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """A minimal fake repo with a small .claude/, config/, .mcp.json and git init."""
+    repo = tmp_path / "jarvis"
+    (repo / ".claude" / "skills" / "implement").mkdir(parents=True)
+    (repo / ".claude" / "skills" / "implement" / "SKILL.md").write_text(
+        "# implement skill\n", encoding="utf-8"
+    )
+    (repo / ".claude" / "skills" / "niche").mkdir(parents=True)
+    (repo / ".claude" / "skills" / "niche" / "SKILL.md").write_text(
+        "# niche skill (should NOT be whitelisted)\n", encoding="utf-8"
+    )
+    (repo / ".claude" / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "startup",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "python scripts/session-context.py",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (repo / "config").mkdir()
+    (repo / "config" / "SOUL.md").write_text("# SOUL stub\n", encoding="utf-8")
+    (repo / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "memory": {
+                        "command": "python",
+                        "args": ["scripts/run-memory-server.py"],
+                    }
+                }
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    # git init so current_git_sha() works
+    subprocess.run(["git", "init", "-q", "--initial-branch=main"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init"],
+        cwd=repo,
+        check=True,
+    )
+    return repo
+
+
+@pytest.fixture
+def manifest(tmp_path: Path, fake_repo: Path) -> Path:
+    target = tmp_path / "claude_home"
+    data = {
+        "version": 1,
+        "target_root": str(target),
+        "version_marker": ".jarvis-version",
+        "groups": [
+            {
+                "id": "soul",
+                "enabled": True,
+                "files": [{"source": "config/SOUL.md", "dest": "SOUL.md", "template": False}],
+            },
+            {
+                "id": "hooks_settings",
+                "enabled": True,
+                "files": [
+                    {
+                        "source": ".claude/settings.json",
+                        "dest": "settings.json",
+                        "template": True,
+                    }
+                ],
+            },
+            {
+                "id": "mcp_config",
+                "enabled": True,
+                "files": [
+                    {"source": ".mcp.json", "dest": ".mcp.json", "template": True}
+                ],
+            },
+            {
+                "id": "skills",
+                "enabled": True,
+                "directories": [
+                    {
+                        "source": ".claude/skills",
+                        "dest": "skills",
+                        "template": False,
+                        "include": ["implement"],
+                    }
+                ],
+            },
+        ],
+        "env_vars": [{"name": "JARVIS_HOME", "value": "{repo_root}", "platforms": ["windows", "posix"]}],
+        "health_check": {"enabled": False},
+        "backup": {"prefix": ".claude.backup-", "retain": 3},
+    }
+    path = fake_repo / "install-manifest.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+# ---------- unit tests ----------
+
+
+def test_load_manifest_rejects_unknown_version(tmp_path: Path) -> None:
+    bad = tmp_path / "m.yaml"
+    bad.write_text(yaml.safe_dump({"version": 999}), encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported manifest version"):
+        installer.load_manifest(bad)
+
+
+def test_detect_state_fresh_when_target_missing(tmp_path: Path) -> None:
+    state, prev = installer.detect_state(tmp_path / "missing", "abc123")
+    assert state == "fresh"
+    assert prev is None
+
+
+def test_detect_state_current_when_sha_matches(tmp_path: Path) -> None:
+    target = tmp_path / "t"
+    target.mkdir()
+    (target / ".jarvis-version").write_text("abc123\n", encoding="utf-8")
+    state, prev = installer.detect_state(target, "abc123")
+    assert state == "current"
+    assert prev == "abc123"
+
+
+def test_detect_state_outdated_when_sha_differs(tmp_path: Path) -> None:
+    target = tmp_path / "t"
+    target.mkdir()
+    (target / ".jarvis-version").write_text("old\n", encoding="utf-8")
+    state, prev = installer.detect_state(target, "new")
+    assert state == "outdated"
+    assert prev == "old"
+
+
+def test_template_content_json_rewrites_relative_paths(fake_repo: Path) -> None:
+    target = fake_repo / ".claude" / "settings.json"
+    claude_home = Path("/tmp/not-used")
+    rendered = installer.template_content(target, fake_repo, claude_home).decode("utf-8")
+    data = json.loads(rendered)
+    command = data["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+    expected_prefix = fake_repo.as_posix() + "/scripts/"
+    assert expected_prefix in command, f"got: {command}"
+    assert not command.startswith("python scripts/"), "relative path not rewritten"
+
+
+def test_template_content_mcp_json_rewrites_args(fake_repo: Path) -> None:
+    target = fake_repo / ".mcp.json"
+    rendered = installer.template_content(target, fake_repo, Path("/")).decode("utf-8")
+    data = json.loads(rendered)
+    args = data["mcpServers"]["memory"]["args"]
+    assert args[0].startswith(fake_repo.as_posix() + "/scripts/")
+
+
+def test_build_plan_state_fresh_has_writes_no_backup(manifest: Path, fake_repo: Path) -> None:
+    m = installer.load_manifest(manifest)
+    plan = installer.build_plan(m, fake_repo)
+    assert plan.state == "fresh"
+    assert plan.backup_path is None  # target doesn't exist yet
+    kinds = [a.kind for a in plan.actions]
+    assert kinds.count("copy_file") >= 3  # SOUL, settings, mcp
+    assert kinds.count("copy_dir") == 1
+    assert kinds.count("write_version") == 1
+    assert kinds.count("set_env") == 1
+
+
+def test_apply_plan_creates_files_and_version_marker(
+    manifest: Path, fake_repo: Path
+) -> None:
+    m = installer.load_manifest(manifest)
+    plan = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan, m, run_env=None)
+
+    target = plan.target_root
+    assert (target / "SOUL.md").exists()
+    assert (target / "settings.json").exists()
+    assert (target / ".mcp.json").exists()
+    assert (target / "skills" / "implement" / "SKILL.md").exists()
+    # whitelist excluded
+    assert not (target / "skills" / "niche").exists()
+
+    marker = (target / ".jarvis-version").read_text(encoding="utf-8").strip()
+    assert marker == plan.current_sha
+
+
+def test_apply_is_idempotent(manifest: Path, fake_repo: Path) -> None:
+    m = installer.load_manifest(manifest)
+    plan1 = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan1, m, run_env=None)
+
+    plan2 = installer.build_plan(m, fake_repo)
+    assert plan2.state == "current"
+    assert plan2.actions == []
+
+
+def test_outdated_triggers_backup(manifest: Path, fake_repo: Path, tmp_path: Path) -> None:
+    m = installer.load_manifest(manifest)
+    plan1 = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan1, m, run_env=None)
+
+    # Pretend the repo moved to a new SHA by overwriting the marker.
+    (plan1.target_root / ".jarvis-version").write_text("old-sha-not-real\n", encoding="utf-8")
+
+    plan2 = installer.build_plan(m, fake_repo)
+    assert plan2.state == "outdated"
+    assert plan2.backup_path is not None
+    installer.apply_plan(plan2, m, run_env=None)
+    assert plan2.backup_path.exists()
+    assert (plan2.backup_path / "SOUL.md").exists()
+
+
+def test_rollback_restores_target(manifest: Path, fake_repo: Path) -> None:
+    m = installer.load_manifest(manifest)
+    plan = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan, m, run_env=None)
+
+    backup = plan.target_root.parent / ".claude.backup-manual"
+    import shutil
+    shutil.copytree(plan.target_root, backup)
+
+    # Corrupt the target.
+    (plan.target_root / "SOUL.md").write_text("corrupted\n", encoding="utf-8")
+    installer.rollback(plan.target_root, backup)
+    assert (plan.target_root / "SOUL.md").read_text(encoding="utf-8") == "# SOUL stub\n"
+
+
+def test_prune_backups_keeps_latest_n(fake_repo: Path, tmp_path: Path) -> None:
+    target_root = tmp_path / "claude_home"
+    parent = target_root.parent
+    for name in [".claude.backup-20260401-000000", ".claude.backup-20260402-000000",
+                 ".claude.backup-20260403-000000", ".claude.backup-20260404-000000"]:
+        (parent / name).mkdir()
+    dropped = installer.prune_backups(target_root, ".claude.backup-", retain=2)
+    assert len(dropped) == 2
+    remaining = sorted(p.name for p in parent.iterdir() if p.name.startswith(".claude.backup-"))
+    assert remaining == [".claude.backup-20260403-000000", ".claude.backup-20260404-000000"]
+
+
+def test_health_check_disabled_by_default_returns_ok() -> None:
+    ok, logs = installer.run_health_check({"health_check": {"enabled": False}}, Path("."))
+    assert ok is True
+    assert logs == []
+
+
+def test_health_check_failed_command_reports_failure(fake_repo: Path) -> None:
+    m = {"health_check": {"enabled": True, "commands": ["python -c exit(1)"]}}
+    ok, logs = installer.run_health_check(m, fake_repo)
+    assert ok is False
+    assert any("FAIL" in line for line in logs)
+
+
+def test_disabled_group_is_skipped(manifest: Path, fake_repo: Path) -> None:
+    data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    for g in data["groups"]:
+        if g["id"] == "soul":
+            g["enabled"] = False
+    manifest.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    m = installer.load_manifest(manifest)
+    plan = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan, m, run_env=None)
+    assert not (plan.target_root / "SOUL.md").exists()
+    # Others still land.
+    assert (plan.target_root / "settings.json").exists()
+
+
+def test_real_manifest_all_groups_disabled_yields_minimal_plan(fake_repo: Path) -> None:
+    """The real repo manifest ships with all groups disabled for M1.
+    Plan must still produce a version marker + env var so the installer
+    is meaningful even before M2-M4 enable the groups.
+    """
+    real = Path(__file__).resolve().parents[1] / "install-manifest.yaml"
+    if not real.exists():
+        pytest.skip("no real manifest")
+    m = installer.load_manifest(real)
+    # Re-point target to a tmp dir to avoid touching user home.
+    target = fake_repo.parent / "sandbox-claude"
+    plan = installer.build_plan(m, fake_repo, target_root_override=str(target))
+    kinds = [a.kind for a in plan.actions]
+    assert "write_version" in kinds
+    assert "set_env" in kinds
+    # No copies while all groups disabled.
+    assert "copy_file" not in kinds
+    assert "copy_dir" not in kinds


### PR DESCRIPTION
## Summary

- **M1 of EPIC #335** (Pillar 7 Phase 0: user-level federation). Foundation only — all manifest groups ship **disabled**, so this is a safe no-op on every device until M2-M4 enable them.
- Adds `install-manifest.yaml` as declarative source of truth, `scripts/install/installer.py` as core logic (dry-run default, `--apply`, backup, rollback, health-check, idempotent, prune), and thin `install.ps1` / `install.sh` wrappers.
- 16 unit tests cover: fresh / outdated / current state detection, JSON path-templating, copy + whitelist, idempotence, backup creation, rollback, prune, health-check fail, disabled group skipping.

## What this unlocks

| Milestone | Does | When |
|---|---|---|
| **M1 #336 (this PR)** | Manifest + installer infrastructure. All groups disabled. | ✅ |
| M2 #337 | Flip `skills` group to enabled, land skill whitelist | next |
| M3 #338 | Flip `hooks_settings` + `mcp_config` — **point of no return** | after M2 |
| M4 #339 | Flip `soul` — SOUL.md at user-level | parallel to M3 |
| M5-M7 | Tombstone `jarvis/.claude/`, update protected-files, smoke 3 devices | after M2-M4 |

Each later milestone is a ~one-line manifest flip + any template-substitution refinements.

## Safety notes

- **Default is dry-run.** Destructive writes require `--apply`.
- Outdated state triggers a timestamped backup (`~/.claude.backup-YYYYMMDD-HHMMSS`) before any write.
- Health check runs after apply — on failure, auto-rollback from the backup. Health-check currently disabled in the shipped manifest (will enable in M7 with smoke commands).
- Env-var writes (`JARVIS_HOME`) can be skipped via `--skip-env` for CI / tests.
- Template substitution (`template: true`) auto-rewrites relative `scripts/...` / `config/...` references in JSON files to absolute `{JARVIS_HOME}/...` paths — needed for hooks + mcp.json when they leave the project CWD in M3.

## Test plan

- [x] `pytest tests/test_installer.py` — 16/16 green
- [x] Full suite `pytest tests/` — 782 passed, 5 skipped (no regression)
- [x] Manual dry-run on this device with sandbox target — shows expected plan (version marker + env var only)
- [ ] M7 (#342) smoke-test on all 3 devices after M2-M4 land

Closes #336