### PR TITLE
feat(install): migrate core skills to .claude-userlevel/ + enable skills group (#337)

### DIFF
--- a/.claude-userlevel/README.md
+++ b/.claude-userlevel/README.md
@@ -1,0 +1,49 @@
+# `.claude-userlevel/` — source of truth for user-level Jarvis
+
+This directory mirrors what ships to `~/.claude/` via
+`scripts/install/installer.py`. Keep it separate from `.claude/` so M5 (#340)
+can tombstone the project-scoped copy cleanly without deleting
+project-specific skills that legitimately stay under
+`jarvis/.claude/skills/` (e.g. `/sprint-report`).
+
+## Layout
+
+```
+.claude-userlevel/
+└── skills/          # Core universal skills (M2 #337)
+    ├── implement/
+    ├── delegate/
+    └── ...
+```
+
+Later milestones will add:
+
+- `SOUL.md` (M4 #339)
+- `settings.json` (M3 #338 — hooks)
+- `.mcp.json` (M3 #338)
+
+## Why a whitelist in `install-manifest.yaml`?
+
+An explicit whitelist means dropping a README, experiment note, or
+half-finished skill into this tree doesn't auto-leak into every user's
+`~/.claude/`. Add new core skills to the `skills.include` list in
+`install-manifest.yaml` at the same time you add the directory here.
+
+## Keeping in sync with `.claude/skills/`
+
+Until M5, the same skill exists in two places (DRY violation accepted
+for the no-op window). Pick one as canonical on each edit:
+
+- **Core skill change** → edit `.claude-userlevel/skills/<name>/` and
+  also update the duplicate in `.claude/skills/<name>/` so project-CWD
+  Claude Code keeps working. Simplest rule: edit both in one commit.
+- After M5 merges, `.claude/skills/<core>/` is deleted and the
+  userlevel copy becomes the only copy.
+
+## Path portability audit (follow-up)
+
+Skill bodies currently reference `scripts/` and `config/` as
+project-CWD-relative paths. Once user-level Jarvis runs from non-jarvis
+CWDs (post-M3), these need `$JARVIS_HOME/scripts/...` rewrites. Tracked
+as a follow-up — non-blocking for M2 because until M3 flips, skills
+still execute inside jarvis CWD where relative paths resolve.

--- a/.claude-userlevel/skills/autonomous-loop/SKILL.md
+++ b/.claude-userlevel/skills/autonomous-loop/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: autonomous-loop
+description: "Autonomous orchestrator: perceive events, evaluate against goals, decide and act within safety bounds. Runs daily via scheduled task or manual invocation."
+version: 1.1.0
+---
+
+# Autonomous Loop Orchestrator
+
+Daily orchestrator that perceives events and perception outputs (goals, risks, research findings), evaluates them against active goals, decides actions within safety bounds, and executes them autonomously. Batches multiple Low-risk actions per run; limits Medium-risk to one.
+
+Implements the perceive→evaluate→decide→act→record loop from the Autonomous Work Loop architecture.
+
+## Usage
+
+- `/autonomous-loop` — manual invocation (full run)
+- Scheduled: daily 09:00 (after morning-brief)
+- Part of: Jarvis Pillar 2 — Autonomous Work Loop
+
+## Architecture
+
+```
+Load Context → Build Candidates → Score → Select (batch Low, pick 1 Medium) → Risk-Gate → Execute → Record
+```
+
+## Step 1 — Load Context
+
+In parallel, load:
+
+- `goal_list(status="active")` — active goals for evaluation
+- `memory_recall(query="morning brief")` — overnight activity + daily plan
+- `memory_recall(query="risk radar")` — CI failures, security alerts, stale issues
+- `memory_recall(query="research findings unacted")` — research outputs waiting for action
+- `memory_recall(query="autonomous_loop_last_run")` — dedup check (don't run twice in same day)
+- `memory_recall(query="outcome patterns feedback")` — past pattern detections to inform scoring
+- Read `config/repos.conf` — target repos for perception + hygiene sweep
+
+**Dedup rule:** If `autonomous_loop_last_run` exists and is today's date, skip gracefully (return "Already ran today").
+
+## Step 2 — Build Action Candidates
+
+From perception outputs, generate candidates:
+
+- **Risks** with severity HIGH+ → mitigation action
+- **Goal deadline** < 3 days → escalation action (prioritize, nudge timeline)
+- **Goal progress** stale > 7 days → review action (check status, unblock)
+- **Actionable research** (marked in memory) → execute finding
+- **Events** from event queue (HIGH+ severity) → handle event
+- **Morning-brief** items marked "needs action" → act on them
+- **Memory clusters** from `find_consolidation_clusters()` → consolidation action (Low-risk)
+- **Workflow hygiene sweep** (per repo in `config/repos.conf`) — see Step 2a.
+
+### Step 2a — Workflow hygiene sweep
+
+For each repo `R` in `config/repos.conf`, query in parallel:
+
+```bash
+# Milestones
+gh api "repos/<R>/milestones?state=open&per_page=50" --jq '.[] | {number,title,state,open_issues,closed_issues,due_on}'
+# Epics without milestone
+gh issue list --repo <R> --label epic --state open --json number,title,milestone,labels --limit 30
+# CI runs for failure rate
+gh run list --repo <R> --json conclusion,name,createdAt --limit 20
+```
+
+Generate candidates:
+
+| Signal | Detection | Risk | Action |
+|--------|-----------|------|--------|
+| **Orphan milestone** | `state==open && open_issues==0` | Low | `gh api repos/<R>/milestones/<N> -X PATCH -F state=closed` |
+| **Orphan sprint** | `label==epic && /Sprint/i.test(title) && milestone==null` | Medium | Create milestone from epic title + attach epic + merged-PRs that reference it |
+| **CI workflow broken** | Same-name workflow ≥50% fail rate in last 10 runs AND ≥24h old | Medium | Spawn debug task via `/delegate` pointing at the workflow file |
+| **Milestone deadline risk** | `due_on within 3 days && open_issues > 0` | — (flag only) | Add to `## Alerts` in output; don't auto-act |
+| **Epic missing Children heading** | body fails `/##+\s*Children/i` regex | Low | Flag + record proposal (don't auto-rewrite body — content judgment) |
+
+**Write-action permissions (enforced here):**
+- Repos under `Osasuwu/*` → all Low/Medium actions execute normally.
+- Repos under any other owner (e.g. `SergazyNarynov/redrobot`) → **flag-only**: record the finding in memory (`type=project, name=hygiene_sweep_proposals_<repo>_<date>, source_provenance="skill:autonomous-loop"`) and surface it in the output, but never execute the action. Owner acts manually or flips the repo to an owned org.
+
+**Dedup per-finding:** before closing a milestone / creating a retroactive one, check `outcome_list(task_type='autonomous', pattern_tags=['hygiene'])` for matching description from last 3 days. Skip if same finding already actioned.
+
+## Step 3 — Score Each Candidate
+
+```
+score = goal_alignment(0-3) × urgency(1-3) + severity_bonus + outcome_adjustment
+```
+
+- **goal_alignment**: 3 = directly serves P0 | 2 = serves P1 | 1 = serves P2 | 0 = unaligned
+- **urgency**: 3 = blocking/deadline | 2 = should be soon | 1 = can wait
+- **severity_bonus**: +3 for CRITICAL risk | +2 for HIGH | +1 for MEDIUM
+- **outcome_adjustment**: check outcome history for the candidate's area (pattern_tags overlap):
+  - Area has 3+ recent failures → -2 (deprioritize, needs investigation first)
+  - Area has high success rate (>80%) → +1 (proven approach)
+  - No outcome data → 0 (neutral)
+
+**Disqualify:** unaligned (goal_alignment=0) or uncertain candidates.
+
+## Step 4 — Select Actions
+
+Classify each candidate by risk (see Step 5), then select:
+
+1. **All Low-risk** candidates with score ≥ 3 (up to 5 max)
+2. **Top-1 Medium-risk** candidate (only if score ≥ 5 and no High-risk in the batch)
+3. **High-risk** candidates → save as proposals only, never batch
+
+Selection filters (apply to all):
+- Not a protected file (`mcp-memory/server.py`, `SOUL.md`, `CLAUDE.md`, `.mcp.json`)
+- Not already actioned (check memory)
+
+**No candidates pass?** Skip gracefully — don't invent work.
+
+**Ordering:** Execute Low-risk batch first, then the Medium-risk action (if any). This ensures quick wins land even if the Medium action fails.
+
+## Step 5 — Risk Classification
+
+| Risk | Examples | Autonomy |
+|------|----------|----------|
+| **Low** | Create issue, fix label, memory cleanup, triage | Auto-execute |
+| **Medium** | Run self-improve, create PR, update goal, tag memory | Auto-execute + record |
+| **High** | Architecture change, SOUL.md, memory schema, protected files | Save proposal only |
+
+## Step 6 — Execute Actions
+
+Process the selected actions in order. Track results as `{action, status, detail}`.
+
+**Partial failure rule:** if one action fails, log it and continue with the rest. Don't abort the batch.
+
+### Low-risk batch (up to 5)
+Execute each independently:
+- Create GitHub issue: `gh issue create --repo <R> --title "..." --body "..."`
+  - **Epics** (`--label epic`) MUST use the `.github/ISSUE_TEMPLATE/epic.yml` structure: body requires `### Children` heading with `- [ ]` checkbox items, else `Issue Checks` CI fails. No `Parent: #NNN` — epics use milestones, not parent links.
+  - **Tasks/bugs**: link parent via GitHub sub-issue relationship or `Parent: #NNN` at top of body.
+- Memory operations: `memory_store(..., source_provenance="skill:autonomous-loop")`, `goal_update(...)`
+- Tag or label work: `gh issue edit`, `gh pr edit`
+- Triage events: `events_mark_processed(...)`
+- Memory consolidation: run `find_consolidation_clusters()` via `execute_sql`, for each cluster: read all memories, merge content into one authoritative memory via `memory_store(..., source_provenance="skill:autonomous-loop")`, archive originals via `archive_memories(ids)`
+- **Hygiene: close orphan milestone** (only on `Osasuwu/*` repos): `gh api repos/<R>/milestones/<N> -X PATCH -F state=closed` — for each milestone with `state=open && open_issues==0`.
+- **Hygiene: flag epic missing Children heading**: record proposal via `memory_store(type="project", name="hygiene_epic_<N>_needs_children", ..., source_provenance="skill:autonomous-loop")`. Don't auto-rewrite bodies.
+
+### Medium-risk (at most 1)
+Execute after Low-risk batch completes:
+- Invoke skill: `/self-improve`, `/research`, `/verify`
+- Create PR: delegate via `/delegate` or `gh pr create`
+- Update goal: `goal_update(slug=..., progress=...)`
+- **Hygiene: retroactive milestone** for orphan sprint — `gh api repos/<R>/milestones -X POST` with title from epic, attach epic + linked merged PRs, close milestone. Only on `Osasuwu/*`.
+- **Hygiene: broken CI debug** — `/delegate` a task to investigate the failing workflow, pointing at the specific workflow file and failure rate. Only on `Osasuwu/*`.
+
+### High-risk (proposals only)
+Never execute — save to memory:
+- Record: `memory_store(type="project", name="autonomous_proposals", ..., source_provenance="skill:autonomous-loop")`
+- Output proposal text to user
+
+## Step 7 — Record Outcomes
+
+**Each action** gets its own `outcome_record` (Pillar 3):
+
+```
+outcome_record(
+  task_type: "autonomous",
+  task_description: "<action title>",
+  outcome_status: "success" | "partial" | "failure",
+  outcome_summary: "<what was done, reasoning, result>",
+  goal_slug: "<aligned goal slug if any>",
+  project: "jarvis",
+  lessons: "<what was learned>",
+  pattern_tags: ["autonomous-loop", "<action-area>"]
+)
+```
+
+After all actions complete, update dedup marker with batch summary:
+
+```
+memory_store(
+  type="project",
+  name="autonomous_loop_last_run",
+  content="{\"date\": \"YYYY-MM-DD\", \"actions_count\": N, \"succeeded\": N, \"failed\": N, \"top_action\": \"...\"}",
+  description="last orchestrator run",
+  source_provenance="skill:autonomous-loop"
+)
+```
+
+If any action advances a goal → `goal_update(slug=..., progress=[...])` — append `{item: "<5-word summary> (YYYY-MM-DD)", done: true}` to existing progress array.
+
+## Safety Rules
+
+**Never:**
+- Touch protected files: `.mcp.json`, `SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`
+- Create more than 1 PR per run (even in a batch)
+- Execute more than 5 Low-risk + 1 Medium-risk per run
+- Execute High-risk actions without explicit proposal
+- Execute write actions (close milestone, create milestone, delete branch, `gh issue/pr edit`) on repos outside `Osasuwu/*`. For other owners (e.g. `SergazyNarynov/redrobot`): flag-only — record the finding and surface in output, owner executes manually.
+
+**Always:**
+- Dedup: check `autonomous_loop_last_run` before acting
+- Risk-gate: only auto-execute Low/Medium actions
+- Record: every action gets its own `outcome_record`
+- Partial failure: if one action fails, continue with the rest
+- Graceful exit: if no candidates, return "No high-priority actions" and exit
+
+## Output
+
+```markdown
+# Autonomous Loop — YYYY-MM-DD
+
+## Perception
+- <N goals loaded, deadline alerts, stale work>
+- <N risks flagged, severity summary>
+- <N research findings, M events in queue>
+
+## Candidates (scored)
+| Action | Alignment | Urgency | Score | Risk |
+|--------|-----------|---------|-------|------|
+| <action 1> | <score> | <score> | <total> | Low/Med/High |
+
+## Selected (N actions)
+| # | Action | Score | Risk | Status |
+|---|--------|-------|------|--------|
+| 1 | <action> | N | Low | success/failure |
+
+## Execution
+- [EXECUTED / PROPOSED]: <per-action summary>
+- <links to created issues/PRs/memories>
+
+## Status
+- ✓ N/M actions succeeded
+- ✓ Each action recorded via `outcome_record`
+- ✓ `autonomous_loop_last_run` updated
+```
+
+If no candidates: "No high-priority actions found. System running normally."
+
+## Implementation Notes
+
+1. **Parallel loads:** Use `memory_recall` with `limit=1` for each query to get most recent memory
+2. **Scoring:** Treat missing fields conservatively (e.g., missing urgency = 1)
+3. **Events:** Read from `events_list()` if available; skip if unavailable
+4. **Graceful degradation:** If any perception output fails, continue with what loaded successfully
+5. **Timezone:** All date comparisons use local time

--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: delegate
+description: This skill should be used when the owner asks Jarvis to dispatch one or more GitHub issues to coding subagents (typically multiple issues in parallel), or says "делегируй #X #Y", "раскидай на агентов", "параллельно реализуй #X #Y #Z". Also used by autonomous-loop to hand off a single subagent-scoped job (e.g. CI debug). For a single issue the main session will do itself, use /implement instead. Jarvis's own judgment on task complexity OVERRIDES blind delegation — if a task is unfit for a subagent (needs session context, cross-cutting reasoning, safety review), keep it inline even if owner said "раскидай".
+version: 1.0.0
+---
+
+# Delegate Skill
+
+Dispatch **multiple** GitHub issues to coding subagents running in parallel.
+
+The main session stays as orchestrator: it reviews each subagent's diff, resolves scope drift, and decides merges. **Subagents NEVER merge.** They push the PR and stop.
+
+## When to /delegate vs /implement
+
+**Prefer /implement (inline, current session):**
+- Single issue
+- Task touches safety-critical zones (`driver/`, `planning/`, `mujoco/`)
+- Task needs cross-cutting awareness (spans multiple projects, shared infra)
+- Issue description alone isn't enough — requires the current session's reasoning trail or just-loaded memory context
+
+**Prefer /delegate (subagent dispatch):**
+- Multiple independent issues (any order works)
+- Each issue description is self-contained — a fresh coding session could act on it without Jarvis's context
+- Tasks touch disjoint files / areas
+
+**Mixed batch — split the work:**
+- Keep context-heavy or safety-critical issues for yourself (inline via /implement flow)
+- Delegate the rest to subagents
+- Report the split reasoning briefly to the owner
+
+**Jarvis judgment overrides the owner's "параллельно":** The owner has explicitly delegated this call to Jarvis (memory: this decision). If a task looks deceptively complex or a subagent will struggle (needs memory context, cross-file reasoning, recent-decisions awareness), keep it inline even if asked to delegate. Don't silently downgrade — tell the owner "keeping #X inline because <reason>".
+
+## Pipeline
+
+### 0. Load context from memory (parallel)
+
+Same as /implement §0:
+- `memory_recall(query="delegation", limit=3)` — past delegation rules and feedback
+- `memory_recall(query=<batch topic>, limit=3)` — decisions about this area
+- `memory_recall(type="feedback", project="global", limit=3)` — behavioral rules
+
+### 1. Classify each issue: delegatable or inline
+
+For each issue in the batch:
+
+1. Run pre-flight (5 checks — same as /implement §1).
+2. Classify:
+   - **Delegatable** → fresh subagent can handle it from the issue body alone
+   - **Inline** → needs session context / safety review / cross-cutting peripheral vision
+
+Produce a short split plan for the owner before acting. Example:
+
+> Batch: #604, #613, #617.
+> - #604 (uncertainty map) → **delegate** — self-contained, single module.
+> - #613 (swept path) → **inline** — safety-adjacent, `planning/`.
+> - #617 (docs tweak) → **delegate** — trivial.
+
+### 2. Claim all issues
+
+Claim *everything* in the batch up front (label `status:in-progress` + comment), even the ones staying inline. Prevents race with other Jarvis instances or owner forgetting to route.
+
+```bash
+for N in <N1> <N2> ...; do
+  gh issue edit $N --add-label "status:in-progress"
+  gh issue comment $N --body "Claimed by Jarvis. Branch: feat/$N-<slug>"
+done
+```
+
+### 3. Record decision
+
+Emit one `record_decision` covering the batch — which went to subagents, which stayed inline, why.
+
+```
+mcp__memory__record_decision(
+  decision="delegate batch #<N1> #<N2> ... (split <inline>/<delegated>)",
+  rationale="<why this split — subagent fitness, session-context dependency, safety zones>",
+  memories_used=[<ids>],
+  confidence=<0.0-1.0>,
+  alternatives_considered=["all inline", "all delegated", "sequential"],
+  reversibility="reversible"
+)
+```
+
+### 4. Dispatch subagents
+
+For each delegatable issue, spawn a coding subagent:
+
+```
+Agent(
+  subagent_type="coding",
+  isolation="worktree",  # REQUIRED — each agent in its own worktree
+  description="Implement #<N>: <title>",
+  prompt="<self-contained prompt — see template below>",
+  run_in_background=true,  # parallel execution
+)
+```
+
+**Subagent prompt template** (self-contained — subagent does NOT share main-session memory):
+
+```
+Implement GitHub issue #<N> in repo <owner/repo>.
+
+Title: <title>
+Body: <full issue body>
+Acceptance criteria: <enumerated from issue>
+Files likely to change: <list>
+
+Branch name: feat/<N>-<slug>   (MUST use exactly this — branch-name race mitigation)
+Target repo CWD: <absolute path to worktree>
+
+Follow the /implement skill pipeline (loaded in your session). Specifically:
+- §4 Implement — read existing code first, check if already done, lint, test
+- §5 Commit & PR — use the rich PR body template, include "Closes #<N>"
+- §6 Record outcome — always record, pattern_tags=["delegation", "subagent", "<area>"]
+
+HARD RULES for you (subagent):
+- Do NOT merge the PR. Open it, push it, record outcome, stop.
+- Do NOT modify protected files (.mcp.json, CLAUDE.md, etc — see docs/security/agent-boundaries.md)
+- Do NOT send messages as the owner
+- Do NOT change values, defaults, or constants that are not explicitly named as targets in the issue body. Centralization / refactoring tasks are structural only — IK seeds, default timeouts, magic numbers, tuple constants must be preserved exactly unless the issue says to change them. If the issue is unclear, preserve the value and flag in the PR body.
+- If you hit a blocker you can't resolve, record a "partial" outcome with a clear note about what's missing
+
+Report back: PR URL + 2-line summary of what you did.
+```
+
+### 4a. Worktree-isolation caveat
+
+**`isolation: "worktree"` is advisory only, not guaranteed.** Documented failures: #295, #640 v1, #640 v2, and 2026-04-20 parallel-delegate contamination (memory `parallel_delegate_worktree_isolation_failed_2026_04_20`). Observed modes:
+- Branch-name races (two agents picked the same branch)
+- Cross-worktree file contamination (writes from agent A showed up in agent B's worktree)
+- Worktree not created at all — agent worked in the main repo directly
+
+**Mitigations:**
+- Branch names are explicit, per-issue, and unique (`feat/<N>-<slug>`) — encode in the prompt
+- Cap parallelism: **2-3 agents concurrently** is the safe band; 5+ is a red flag
+- **Review the diff in the main repo tree as the authoritative check** — `cd <main repo> && git fetch && git diff origin/master...origin/feat/<N>-<slug>`. Treat the agent's worktree as a staging area, not a trusted sandbox.
+- If you see contamination, abort and re-dispatch sequentially
+
+### 5. Implement inline tasks (parallel with the subagents)
+
+While subagents run, use the /implement pipeline for anything you kept for yourself. The two streams are independent.
+
+### 6. Review each subagent's diff
+
+When a subagent reports done, review **in the main repo tree, not the agent's worktree** (§4a — worktree isolation is advisory):
+
+```bash
+cd <main repo>
+git fetch origin
+git diff origin/master...origin/feat/<N>-<slug> --stat
+git diff origin/master...origin/feat/<N>-<slug>
+```
+
+Run the following checks in order — do NOT short-circuit:
+
+- **Scope fit**: file list matches issue scope? Unrelated files → revert
+- **Protected files** untouched?
+- **Value-change audit**: grep the diff for numeric literals, default parameter values, seed arrays, tuple constants, timeouts, thresholds. For each value that changed, confirm the change is explicitly mandated by the issue body. Silent replacements are scope drift and must be reverted.
+  - Lesson #648: subagent silently replaced IK seeds `[0,-30,30,0,-60,0]` with `ready_position` — same shape, different semantics (optimizer convergence inputs, not motion targets). Silent behavior change the subagent didn't flag.
+- **Interaction audit**: for every non-trivial edit, trace data flow outward — what callers depend on the pre-existing behavior? what fallbacks or post-processors run after the changed code? Ask "does this still compose correctly?" not just "does the code do what it says?"
+  - Lesson #649 v2: after 6-DOF IK fires for in-place rotation, the pre-existing J6-pin fallback would clobber J6 back to its previous value, silently undoing the rotation. The subagent's diff was locally correct but interacted incorrectly with existing code.
+- **Tests added + passing?** Run them from the main repo on the branch (`git checkout feat/<N>-<slug> && pytest ...`).
+- **PR body** rich? (matches /implement §5 template)
+- **Debug code / secrets** leaked?
+- **Symmetric patterns**: did the subagent fix only the one instance, or apply to siblings too?
+
+If issues found:
+- Push a fix yourself (faster than re-prompting for small stuff)
+- Or use `SendMessage` to the agent with specific revision instructions
+- If the diff contains ANY silent value change or broken interaction → revert those hunks before merge decision, even if the rest is fine
+
+### 7. Decide merge (orchestrator only)
+
+Per each PR (subagent's or your own):
+- Tests green + Copilot clean + LOW/MEDIUM risk → **merge** (see /implement §7.5)
+- HIGH/CRITICAL or safety-critical → wait for owner
+- CI infra-blocked (billing, not failing tests) → merge if local tests pass + Copilot clean
+
+### 8. Record outcomes
+
+One `outcome_record` per issue (delegated or inline). Distinguish:
+- Subagent: `pattern_tags: ["delegation", "subagent", "<area>"]`
+- Inline: `pattern_tags: ["delegation", "inline", "<area>"]`
+
+**Also pass `memory_id`** — the primary informing memory id from the per-task `record_decision` episode. Rule: `memory_id = memories_used[0]` (first = dominant basis). For batch-level inline work, use the inline task's own decision_made memories_used; for subagent work, the subagent's record_decision episode is the source. If `memories_used` was empty at decision time, omit `memory_id`.
+
+In `lessons`, note anything non-obvious: subagent misread the issue, scope drift, worktree contamination, etc. These make future delegation decisions smarter.
+
+### 9. Post-merge cleanup
+
+For each merged PR:
+```bash
+git checkout master && git pull
+git branch -d feat/<N>-<slug>
+# if this was a subagent job:
+git worktree remove <worktree-path>
+```
+
+Stale worktrees and branches accumulate fast with multi-issue batches. Clean up at the end.
+
+## Safety rules
+- All /implement safety rules apply
+- **Subagents must NEVER**: merge PRs, force-push, modify protected files, send messages as owner
+- Orchestrator reviews **every** subagent diff before merge
+- Parallelism > 3 concurrent → red flag; prefer sequential or smaller batches
+- If owner says "параллельно все" but one task is unfit → keep it inline and tell the owner why
+
+## Recovery playbook
+
+See `docs/security/recovery-playbook.md`. Subagent-specific:
+- Subagent edited wrong files → revert in its worktree, re-prompt with stricter scope
+- Subagent broke its worktree → `git worktree remove --force <path>` + reclaim branch in fresh worktree
+- Two subagents raced on same file → abort both, re-dispatch sequentially
+- Subagent silently merged → revert merge on `master` immediately, open incident note, add to agent-boundaries.md

--- a/.claude-userlevel/skills/end-quick/SKILL.md
+++ b/.claude-userlevel/skills/end-quick/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: end-quick
+description: "Quick session close: checkpoint + commit only. ~30 sec. Use when owner needs to leave fast."
+---
+
+# End Session (Quick)
+
+Fast exit. No reflection, no memory scan. For full close, use `/end`.
+
+**Note — compaction-safe:** end-quick skips the session-journal scan on purpose. The PreCompact hook (`scripts/pre-compact-backup.py`) already persists a pre-compact snapshot to Supabase under `session_snapshot_<session_id>` on every compaction, and `record_decision` writes decisions in real time. That's enough durable handoff. Run `/end` instead if you want reflection + decision reconciliation.
+
+## Step 1 — Working state
+
+If there is meaningful unfinished work:
+- Save `working_state_jarvis` (type=project) to Supabase: what was done, what's pending, key context
+- If nothing notable — skip
+
+## Step 2 — Commit (leave nothing uncommitted)
+
+Check ALL project repos for uncommitted changes (jarvis, redrobot, any other repo touched this session).
+
+For each repo with changes:
+1. `git status`
+2. If on an **unrelated branch** → `git stash && git checkout $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull --ff-only && git stash pop` (resolve conflicts if any)
+3. Complete work → stage and commit. Mid-task → `git stash push -m "session YYYY-MM-DD: <description>"` and note stash ref.
+
+## Step 3 — Output
+
+One-liner:
+
+```
+Session saved. <committed: hash | no commit: reason>. <working state: saved | nothing to save>.
+```
+
+That's it. Go.

--- a/.claude-userlevel/skills/end/SKILL.md
+++ b/.claude-userlevel/skills/end/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: end
+description: "Full session close: behavioral reflection, decision log, memory save, commit, handoff. ~5 min."
+---
+
+# End Session (Full)
+
+Closes the session with quality reflection. For quick exit, use `/end-quick`.
+
+**Mindset — survives compaction:** *Supabase is the session journal. The conversation is working memory.* The post-compact conversation is a lossy summary; the journal (pre-compact snapshot + real-time `record_decision` entries) is the authoritative record. `/end` consolidates the journal into learnings. Don't rely on scanning the conversation alone — anything older than the last summary may already be gone from your window.
+
+## Step 0 — Load the session journal (non-negotiable)
+
+Before reflecting or scanning, pull everything durable from Supabase:
+
+1. **Pre-compact snapshot** — `memory_recall(query="pre-compact session snapshot", project="jarvis", type="project", limit=5, brief=true)`. Results are live memories sorted by relevance + recency. Pick the entry whose name starts with `session_snapshot_` and whose tags include `session-snapshot` (ignore any with `test` in the name). Then `memory_get` on that name to load the full content.
+   - If no snapshot found → this session never compacted. Fine, skip. Conversation alone is enough.
+   - If the freshest snapshot looks like a *different* session's work (content references work unrelated to what you remember from the current context) → flag in Step 7 output and fall back to conversation only.
+   - Multiple compacts in one session share a single snapshot (same session_id, upserted on each compaction); the one you pick is the latest state.
+2. **Real-time decisions** — `memory_recall(query="decisions today <date>", project="jarvis", type="decision", limit=20, brief=true)` where `<date>` is today's ISO date. These should already be in place via `record_decision` calls made during the session. Step 2 will verify completeness.
+3. **Recent episodes (optional)** — if you need finer-grained provenance, `events_list` surfaces `tool_call`, `decision`, and `observation` episodes the extractor captured.
+
+Carry the snapshot + decisions into Steps 1-2 as the primary source. The conversation (post-compact) is only a hint overlay for anything that happened *after* the snapshot was written.
+
+## Step 1 — Behavioral reflection
+
+Review your own behavior this session against feedback memories (already in context from session start). Reflect against **snapshot + conversation union**, not conversation alone — the snapshot preserves what the LLM summary smoothed over:
+
+1. **Rule violations**: did you break any known rules? (e.g., skipped memory load, assumed instead of verified, added unrequested features, was sycophantic)
+2. **Missed context**: did you ignore goals, forget cross-project impact, miss something obvious?
+3. **Quality**: did you deliver end-to-end or leave loose ends? Did you verify your work?
+4. **Communication**: were you too verbose? Too terse? Did you ask when you should have acted, or act when you should have asked?
+
+If you find a pattern worth recording (not a one-off): save as `feedback` memory. Include **why** it matters and **how to apply** next time.
+
+If nothing notable — skip. Don't fabricate observations.
+
+## Step 2 — Decision & knowledge scan
+
+Reconcile pre-existing records with anything surfaced in reflection:
+
+- **Decisions** made this session should already live in Supabase via `record_decision` (fires in real time). Go through the snapshot + conversation and check: every decision you can identify → is it in the list from Step 0?
+  - If yes → do nothing. Don't re-save.
+  - If no → save it now via `record_decision` (or `memory_store` type=decision) **and flag in Step 7 output**: "Decision X was not recorded in real time — consider why". Real-time capture is the goal; post-hoc saves are a regression.
+- **User preferences** or profile updates → `user` memory (upsert existing, don't duplicate).
+- **Project state** changes → `project` memory.
+- **Feedback** given by owner → `feedback` memory.
+
+Upsert existing memories, don't create duplicates. Check name before creating new.
+
+## Step 3 — Goal progress log
+
+If work this session advanced any active goal:
+
+1. Call `goal_list(status="active")`
+2. For each goal that was advanced, call `goal_update(slug=..., progress=[...])` — append new items as `{item: "<5-word summary> (YYYY-MM-DD)", done: true}`
+3. Keep existing progress items unchanged. Only append new ones.
+
+Keep items terse — "secret scanner + credential registry (2026-04-13)", not a sentence. Details live in git history.
+
+Skip if the session didn't advance any goal (e.g., pure discussion, research without deliverables).
+
+## Step 4 — Working state (non-negotiable)
+
+Save `working_state_jarvis` (type=project) to Supabase. Always. Content:
+- What was done this session
+- Open items: unfinished work, things to fix, deferred tasks
+- Key context for next session (blockers, decisions pending review)
+
+This is the handoff to the next session. If open items exist in Step 7 output, they MUST be in this memory too — output is ephemeral, memory persists.
+
+Only exception: truly empty session (user asked one question and left).
+
+## Step 5 — Branch cleanup
+
+Check for local branches whose remote tracking branch has been deleted:
+```bash
+git branch -vv | grep ': gone]' | awk '{print $1}'
+```
+
+If any found, for each branch:
+1. Try `git branch -d <name>` (safe delete)
+2. If it fails ("not fully merged") — this usually means the PR was squash-merged. Verify:
+   ```bash
+   gh pr list --head <branch> --state merged --json number --limit 1
+   ```
+3. If PR confirmed merged → `git branch -D <name>` (force delete is safe)
+4. If no merged PR found → report in output, don't delete
+
+Skip if none found.
+
+## Step 6 — Commit (non-negotiable: leave nothing uncommitted)
+
+Check ALL project repos for uncommitted changes (jarvis, redrobot, any other repo touched this session).
+
+For each repo with changes:
+
+1. `git status` and `git diff --stat`
+2. Determine if changes are committable:
+   - Complete work → commit
+   - Mid-task, broken, merge conflicts → stash with descriptive message (`git stash push -m "session YYYY-MM-DD: <description>"`) and note in output
+3. **Branch handling** (before committing):
+   - On `main` → commit directly
+   - On a feature branch **created/used for this session's work** → commit there
+   - On an **unrelated branch** (pre-existing branch for different work) → relocate changes:
+     ```bash
+     git stash
+     DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+     git checkout $DEFAULT_BRANCH
+     git pull --ff-only  # get latest, fail-safe
+     git stash pop
+     ```
+     Then commit on the default branch. If stash pop has conflicts, resolve them (add our version). If pull fails, commit as-is (don't block on upstream).
+4. Stage only session-related files. Standard commit format with Co-Authored-By.
+
+**Goal: zero uncommitted changes across all repos after /end.**
+If stashing (mid-task), report the stash ref and repo in output so next session can recover.
+
+## Step 7 — Output
+
+```
+## Session closed — YYYY-MM-DD
+
+### Journal source
+- Snapshot: <session_snapshot_... name + "fresh" | "stale" | "none">
+- Decisions loaded: N
+- Post-hoc decision saves: N  (0 is ideal — every decision should have been recorded in real time)
+
+### Reflection
+- <1-3 behavioral observations, or "Clean session — no issues">
+
+### Saved to memory (N)
+- <name> — <one-line>
+
+### Committed
+- <hash + message, or "No commit — <reason>">
+
+### What was done
+- <bullets — draw from snapshot where applicable, not just post-compact conversation>
+
+### Open items
+- <unfinished work, deferred tasks, things for next session>
+```
+
+Keep it concise. This is a handoff, not a report.

--- a/.claude-userlevel/skills/goals/SKILL.md
+++ b/.claude-userlevel/skills/goals/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: goals
+description: "Manage strategic goals — view, set, update, review, close. Goals drive Jarvis's priorities and autonomous decisions."
+---
+
+# Goals
+
+Strategic goal management. Goals are NOT tasks — they are outcomes Jarvis pursues.
+
+## Usage
+
+- `/goals` — show all active goals with progress
+- `/goals set` — create or update a goal (interactive)
+- `/goals review` — review progress, suggest corrections
+- `/goals close <slug>` — close a goal with outcome + lessons
+
+## Commands
+
+### `/goals` (default) — Dashboard
+
+1. Call `goal_list(status="active")`
+2. Display goals ordered by priority, with:
+   - Title, project, priority, deadline (if any)
+   - Accomplishment log (progress items marked done, with dates)
+   - Risks (if any)
+   - Owner focus / Jarvis focus
+3. If any goals have deadline within 7 days — highlight them
+4. If any P0 goals have no recent progress (no done items in last 14 days) — flag risk
+
+### `/goals set` — Create or Update
+
+Interactive flow:
+
+1. Ask: "What's the goal?" (or parse from args/context)
+2. Ask for or infer:
+   - `slug` — auto-generate from title if not provided
+   - `project` — which project? (null if cross-project)
+   - `direction` — which strategic direction?
+   - `priority` — P0/P1/P2
+   - `why` — motivation
+   - `success_criteria` — what does success look like?
+   - `deadline` — when? (optional)
+   - `progress` — initial milestones
+   - `owner_focus` / `jarvis_focus` — division of work
+3. Call `goal_set(...)` with all fields
+4. Confirm creation
+
+If a slug already exists, update the existing goal.
+
+**From context:** If the user describes a goal in conversation, extract fields and confirm before saving. Don't force the full form — infer what you can.
+
+### `/goals review` — Progress Review
+
+1. Call `goal_list(status="active")`
+2. For each goal:
+   - Check GitHub issues/PRs related to the project (if applicable)
+   - Review accomplishment log — what's been done since last review?
+   - Check if deadline is at risk
+   - Identify what's NOT progressing (success_criteria without matching accomplishments)
+3. Output:
+   - Per-goal status: recent accomplishments, gaps, risks
+   - Concrete suggestions: re-prioritize? adjust scope? escalate?
+4. Append any newly discovered accomplishments via `goal_update(slug=..., progress=[...])`
+5. If any goal should be closed — propose it
+
+### `/goals close <slug>` — Close a Goal
+
+1. Call `goal_get(slug=<slug>)`
+2. Ask (or infer):
+   - Status: `achieved` or `abandoned`?
+   - `outcome` — what actually happened?
+   - `lessons` — what did we learn?
+3. Call `goal_update(slug=<slug>, status=..., outcome=..., lessons=...)`
+4. Confirm closure
+
+## Goal Awareness (applies to ALL skills, not just /goals)
+
+Active goals are loaded at session start. They guide every interaction:
+
+- **Before any task:** Does this serve an active goal? If not, say so.
+- **If higher-priority goal neglected:** Bring it up.
+- **Morning brief:** Plan day around goals, not events.
+- **Self-improve:** Only improve what's relevant to goals.
+- **Delegate:** Prioritize by goal alignment.
+- **Research:** Focus on knowledge gaps for current goals.
+
+This is not a feature — it's the operating model.
+
+## Output Format
+
+```markdown
+# Active Goals
+
+## [P0] Redrobot Demo (redrobot)
+Deadline: 2026-04-20 (12 days) | Direction: Redrobot production-ready
+Done:
+- Scenario 1 (2026-04-01)
+- Scenario 2 (2026-04-08)
+Remaining (from success_criteria):
+- Scenario 3
+- UI polish
+Risks: #38 harder than expected
+Owner: Scenario 3 | Jarvis: Monitor #38, infra
+
+---
+
+## [P1] Goals System (jarvis)
+No deadline | Direction: Jarvis 2.0
+Done:
+- Design (2026-03-20)
+- DB + MCP methods (2026-03-25)
+Remaining:
+- Skill
+- Integration (CLAUDE.md, SOUL.md)
+Owner: Review | Jarvis: Implement
+```

--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: implement
+description: This skill should be used when the owner asks Jarvis to implement a SINGLE GitHub issue directly in the current session, or says "реализуй #42", "сделай #42", "implement #X". For MULTIPLE issues that can run in parallel use /delegate instead. Do NOT trigger for viewing, triaging, or discussing issues — only for actual implementation requests.
+version: 1.0.0
+---
+
+# Implement Skill
+
+Autonomously implement a GitHub issue **inline, in the current session** — no subagents.
+
+Use this when the work benefits from the full session context (memories just loaded, recent decisions, cross-cutting awareness) or when the issue is safety-adjacent and you can't afford a context-blind coding agent.
+
+## Usage
+
+Invoke when owner says "реализуй #42", "сделай #42", "implement #X".
+Single-issue by default. If multiple issues arrive but only one needs session context → implement the context-heavy one here, hand the rest to `/delegate`.
+
+Target repo: determined from context (CWD, recent conversation, user mention). If ambiguous, ask. Read `config/repos.conf` for the full list of tracked repos.
+
+## Pipeline
+
+### 0. Load context from memory (parallel)
+
+Before anything else, recall relevant memories:
+- `memory_recall(query="delegation", limit=3)` — past delegation rules and feedback
+- `memory_recall(query=<issue topic>, limit=3)` — decisions about this area
+- `memory_recall(type="feedback", project="global", limit=3)` — behavioral rules
+
+Apply recalled context to all subsequent steps. Skip if memories are empty.
+
+### 1. Pre-flight checks (parallel work protocol)
+
+Before claiming ANY issue, run 5 checks:
+1. `assignees` — someone already assigned?
+2. `status:in-progress` label?
+3. Comments with "Claimed by"?
+4. `gh pr list` — existing PR for this issue?
+5. `git branch -r | grep feat/<N>-` — existing branch?
+
+If ANY check positive → issue is taken, skip it.
+
+### 2. Fetch & analyze
+
+```bash
+gh issue view <N> --repo <owner/repo> --json number,title,body,labels,milestone
+```
+
+Read the issue body carefully. Check parent issue/epic for context.
+Identify: files to change, acceptance criteria, safety implications.
+
+**Safety-critical zones** (`driver/`, `planning/`, `mujoco/`):
+- Post analysis + plan as comment
+- Wait for owner approval before implementing
+- Do NOT dispatch to subagents (keep inline — this skill is the right tool)
+
+### 3. Claim & branch
+
+```bash
+gh issue edit <N> --add-label "status:in-progress"
+gh issue comment <N> --body "Claimed by Jarvis. Branch: feat/<N>-<slug>"
+git checkout master && git pull
+git checkout -b feat/<N>-<slug>
+```
+
+### 3.5. Record decision (reasoning trace, #252)
+
+After claim, before implementation — emit a `decision_made` episode so `/reflect` can later attribute outcomes to reasoning (missing memory / wrong memory / wrong reasoning):
+
+```
+mcp__memory__record_decision(
+  decision="implement <issue title> (#<N>)",
+  rationale="<one paragraph: why this issue matters now, what approach is planned, what non-obvious choices were made at claim time>",
+  memories_used=[<ids from step 0 recall>],
+  outcomes_referenced=[],
+  confidence=<0.0-1.0>,
+  alternatives_considered=["<rejected options — e.g. 'defer to next sprint', 'delegate to subagent'>"],
+  reversibility="reversible"
+)
+```
+
+Always emit for issue implementation — outcome attribution needs the basis. For non-issue decisions, emit only when `reversibility ∈ {hard, irreversible}` OR `confidence < 0.7`.
+
+### 4. Implement
+
+**Protected files — policy depends on who is editing** (see `docs/security/agent-boundaries.md`):
+`.mcp.json`, `config/SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`, `.claude/settings.json`, `.gitleaks.toml`, `.pre-commit-config.yaml`
+
+- **Subagent dispatch (`/delegate`)** — never edits protected files. If the task requires it, escalate to inline `/implement`.
+- **Inline `/implement` with explicit owner approval in-session** — MAY edit protected files. Document the change prominently in the PR body (mark the file `[PROTECTED]` in the §Files Changed list + rationale) so the owner sees it before merge.
+- **Inline `/implement` without explicit approval** — document the needed change in the PR body and leave the file untouched for the owner.
+
+#### 4a. Already-done audit (mandatory gate)
+
+Before writing any code, enumerate acceptance-criteria symbols from the issue body and grep each:
+- `rg -n "<symbol>"` for functions, classes, flags, constants, test names — scoped to likely files
+- Read the hits — confirm the existing code actually satisfies the criteria, including test coverage
+
+Three outcomes:
+- **All present + tests cover them** → STOP. Comment on the issue with `file:line` evidence, close as `not-planned` referencing the implementing PR/commit, record `success` outcome with `lessons` noting pre-existing implementation. No branch, no PR.
+- **Partial** → proceed, but narrow scope to what is actually missing. Note the partial starting state in the PR body Summary.
+- **None** → proceed with full scope.
+
+Why this is a gate, not a suggestion: recurring pattern (#237 closed as dup of #209; #656 partial — only tie-breaker missing; tool-width Z absent for a month under shared assumption it existed; multi-run batch where 2 of 6 issues were already done). 30-second grep pays for itself every time.
+
+#### 4b. For each change
+
+- Read existing code first (Read tool)
+- Check patterns in the codebase (Grep/Glob)
+- Edit existing files, don't create new ones unless needed
+- Run lint: `ruff check --fix && ruff format` (Python), `npx tsc --noEmit` (TS)
+- Run relevant tests: `pytest tests/test_<module>.py -x -q`
+- Build frontend: `npm run build`
+
+#### 4c. E2E smoke before claiming done (I/O-heavy / schema-touching work)
+
+Unit tests systematically miss integration bugs on:
+- File I/O — Windows CRLF inflating byte budgets, path separators, encoding (#281)
+- Network/DB I/O — composite unique constraints, PostgREST quirks (#281, #284)
+- DB schema changes — migration + live row verification (#288)
+- Hook registration — SessionStart, PreCompact, etc. (#281 settings.json)
+- Subprocess invocation — APScheduler pickling, env propagation (#304, #298)
+- Import-target scripts with venv re-exec guards (#313)
+
+Rule: if the change touches any of the above, run one real-input smoke **before** marking the outcome `success`:
+- File I/O — operate on a real file (not a synthetic fixture) and byte-compare output
+- DB writes — run the write against live Supabase and verify the row shape
+- Schema — apply the migration to a branch DB and run the affected smoke
+- Hooks — trigger the hook event manually and confirm the side effect
+- Subprocess/scheduler — run in a separate shell long enough to confirm restart / pickle behavior
+
+If unit tests green but smoke fails → outcome is `partial`, and the `lessons` field must describe the gap so a future session knows what the unit tests did not catch.
+
+### 5. Commit & PR
+
+```bash
+git add <specific files>
+git commit -m "<type>(<scope>): <description> (#N)"
+git push -u origin feat/<N>-<slug>
+```
+
+**PR body must be rich and informative** — this is the primary context for reviewers (human and Copilot). Use this template:
+
+```markdown
+## Summary
+<what changed, 2-3 sentences — the "what">
+
+## Why
+<problem being solved, link to issue — the "why">
+Closes #<N>
+
+## Decisions & Alternatives
+- **Chose X because Y** (alternative Z was rejected because...)
+- Trade-offs: <what we gained, what we gave up>
+- <any non-obvious choices that a reviewer would question>
+
+## Risk Assessment
+- **LOW**: <cosmetic, imports, naming — safe to auto-apply>
+- **MEDIUM**: <refactors, new helpers — review recommended>
+- **HIGH**: <logic changes, safety-adjacent — must review manually>
+- **CRITICAL**: <data loss risk, security, breaking API — block merge until reviewed>
+
+## Testing
+- <commands run: pytest, ruff, tsc, npm run build>
+- <what was verified: specific scenarios, edge cases>
+
+## Files Changed
+- `file.py` — <why this file, what changed>
+```
+
+Create PR:
+```bash
+gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+<filled template above>
+EOF
+)"
+```
+
+**Why this matters**: Copilot and human reviewers see reasoning inline, not just diff. HIGH/CRITICAL risks are flagged before review starts. No back-and-forth asking "why did you do X?"
+
+### 6. Record outcome
+
+After PR creation (or failure at any step), record the outcome for Pillar 3 tracking:
+
+```
+outcome_record(
+  task_type: "delegation",
+  task_description: "<issue title> (#N)",
+  outcome_status: "success" | "partial" | "failure",
+  outcome_summary: "<what happened — PR created, tests passed/failed, etc.>",
+  goal_slug: "<related goal if known>",
+  project: "<repo name>",
+  issue_url: "<issue URL>",
+  pr_url: "<PR URL if created>",
+  memory_id: "<primary informing memory id>",   # see rule below
+  tests_passed: true/false,
+  lessons: "<anything non-obvious learned>",
+  pattern_tags: ["delegation", "inline", "<area>"]
+)
+```
+
+**Rule — primary informing memory**: pass `memory_id = memories_used[0]` from the `record_decision` call at §3.5 (first element is the dominant basis). If `memories_used` was empty, omit `memory_id`. Never pass multiple — the FK is a single UUID and `memory_calibration` joins on one memory per outcome; richer attribution belongs at the view layer, not the row.
+
+**Always record**, even on failure — failed outcomes are the most valuable for learning.
+
+### 7. Batch (if multiple issues kept inline)
+
+When implementing multiple related issues back-to-back:
+- Group into one branch if they touch the same files
+- Separate branches for independent changes (can be merged independently)
+- Address Copilot review comments promptly
+
+### 7.5. Merge policy
+
+**The current session (the one running /implement) CAN merge — no permission needed for routine PRs:**
+- Tests green + Copilot review addressed + LOW/MEDIUM risk → **merge without asking**
+- HIGH/CRITICAL risk or safety-critical zone (`driver/`, `planning/`, `mujoco/`) → wait for owner explicit approval
+- CI infra-blocked (billing failure, empty `steps` array — not *failing* tests) → merge if local tests green AND Copilot review clean
+- Copilot findings are advisory — address substantive ones, ignore style nits
+
+Waiting for manual review on every LOW-risk PR is the anti-pattern. See memories: `pm_autonomy_redrobot`, `copilot_review_advisory_only`, `no_confirm_commits_pushes_merges`.
+
+### 8. Post-merge cleanup
+
+After a PR is merged (or when returning to a previously merged branch):
+```bash
+git checkout master && git pull
+git branch -d feat/<N>-<slug>
+```
+
+This prevents stale branch accumulation. If the branch has unmerged work, `-d` will refuse — that's correct, don't force it.
+
+## Safety rules
+- Check `git status` before branching — abort if dirty
+- Never force-push to `master` / `main` or a shared branch
+- If change fails tests or breaks build, fix before pushing
+- Safety-critical code (`driver/`, `planning/`, `mujoco/`): analyze and comment, don't implement without approval
+- Merge policy: see §7.5 — LOW/MEDIUM routine merges are autonomous, HIGH/CRITICAL wait for owner
+
+## Diff review (before marking done)
+
+Before creating the PR, review your own changes:
+```bash
+git diff main...HEAD --stat
+git diff main...HEAD
+```
+
+Check for:
+- **Scope fit**: does the file list match the issue scope? Unrelated files → revert them before pushing (memory `check_pr_scope_fit_at_open_time`)
+- Files that shouldn't have been modified (especially protected files)
+- Debug code, `console.log`, `print` statements left behind
+- Unrelated changes that crept in
+- Secrets or credentials in any form
+- **Symmetric patterns**: when fixing a class of bug, grep for sibling instances across the file AND other files — not just the one the reviewer flagged (memory `feedback_symmetric_fixes`)
+
+If the diff looks wrong, fix it before pushing.
+
+## Recovery playbook
+
+See `docs/security/recovery-playbook.md` for how to handle:
+- Broke a file → revert from master
+- Corrupted memory → `memory_restore`
+- Created bad PR → close + delete branch
+- Committed to wrong branch → cherry-pick + reset

--- a/.claude-userlevel/skills/reflect/SKILL.md
+++ b/.claude-userlevel/skills/reflect/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: reflect
+description: "Learning loop: review recent decisions, check outcomes via GitHub PRs, extract lessons, update memory. Integrates with outcome tracking (Pillar 3)."
+---
+
+# Reflect
+
+Reviews recent decisions and task outcomes, checks results (via GitHub PRs or user confirmation), extracts lessons as feedback memories.
+
+## When to run
+
+- After a PR is merged or closed
+- After an approach failed or succeeded unexpectedly
+- Weekly (e.g. as part of `/end`)
+- When the user says "that didn't work" or "that was the right call"
+
+## Step 1 — Load recent decisions
+
+```
+memory_recall(query="decision approach chosen rejected", type="decision")
+```
+
+Focus on last 2 weeks. Skip decisions that already have an `## Outcome` section.
+
+## Step 2 — Review task outcomes
+
+```
+outcome_list(outcome_status="pending", limit=10)
+```
+
+For each pending outcome with a `pr_url`:
+
+```bash
+gh pr view <number> --json state,mergedAt,closedAt,title --repo <owner/repo>
+```
+
+Update resolved outcomes:
+```
+outcome_update(
+  id="<outcome_id>",
+  outcome_status="success"/"failure"/"partial",
+  outcome_summary="<what happened>",
+  pr_merged=true/false,
+  lessons="<lesson if any>",
+  pattern_tags=["<relevant tags>"]
+)
+```
+
+## Step 3 — Check GitHub outcomes for decisions
+
+For each decision referencing a PR (`#NNN` in content):
+
+```bash
+gh pr view <number> --json state,mergedAt,closedAt,title --repo <owner/repo>
+```
+
+Determine `owner/repo` from context or `config/repos.conf`.
+
+Classify: `merged` → accepted, `closed` → rejected, `open` → skip.
+
+## Step 4 — Check non-PR decisions
+
+Ask the user:
+> "Decision: **<name>** — <summary>. How did it turn out? (worked / didn't work / ongoing / skip)"
+
+## Step 5 — Update decision memory + load basis
+
+For each resolved decision, upsert with appended `## Outcome`:
+```markdown
+## Outcome
+- **Result:** merged / rejected / worked / failed
+- **Date:** YYYY-MM-DD
+- **What actually happened:** <one sentence>
+- **Decision basis:** <rationale + memories_used from matching decision_made episode, if found>
+```
+
+**Load decision basis (#252):** before writing the outcome, query for a `decision_made` episode within ±24h of the decision's `created_at`:
+
+```sql
+SELECT id, payload FROM episodes
+WHERE kind = 'decision_made'
+  AND created_at BETWEEN (<decision_created_at> - interval '24 hours')
+                     AND (<decision_created_at> + interval '24 hours')
+ORDER BY abs(extract(epoch FROM created_at - <decision_created_at>)) ASC
+LIMIT 1;
+```
+
+If found, include `payload.rationale` and `payload.memories_used` in the outcome block. When the outcome is a failure, classify using the basis:
+- Memories listed in `memories_used` were wrong → supersede them
+- `memories_used` was empty AND top-similarity was low at decision time → known-unknown (auto-tracked via #249)
+- Basis looks sound but execution failed → not a memory problem, flag as reasoning or execution failure
+
+## Step 5.5 — Calibration check (#251)
+
+After outcomes are verified, check memory calibration:
+
+```
+mcp__memory__memory_calibration_summary(project="jarvis")
+```
+
+Renders per-type Brier score (mean squared error of `confidence - actual_outcome`). For each type with `n >= 20`, flag:
+- `brier > 0.25` AND `avg_predicted > avg_actual` → **overconfident** (confidence in these memories exceeds their track record)
+- `brier > 0.25` AND `avg_predicted < avg_actual` → **underconfident**
+- `n < 20` → warning (insufficient data, skip calibration-based action)
+
+Surface flagged types in Step 9 output under "Calibration". Poor-calibration types become ideation seeds for `/self-improve` — the root cause is usually a specific pattern (e.g. "my `decision` memories in jarvis are overconfident when they rely on research memories without owner confirmation").
+
+## Step 6 — Extract lessons + patterns
+
+For each resolved decision and outcome, ask: *what's the generalizable lesson?*
+
+**From outcomes** — look for patterns across multiple outcomes:
+```
+outcome_list(limit=20)
+```
+- Which task_types succeed most? Which fail?
+- Common pattern_tags on successful vs failed outcomes?
+- Are certain goal areas consistently under-delivered?
+
+If a pattern is non-obvious, save it:
+```
+memory_store(
+  name="lesson_<slug>", type="feedback",
+  project=<same as decision or "global">,
+  content="<rule>\n\n**Why:** <what happened>\n**How to apply:** <when this kicks in>",
+  source_provenance="skill:reflect"
+)
+```
+
+Only save if it would change future behavior. Don't save platitudes.
+
+## Step 7 — Hypothesis review
+
+```
+memory_recall(query="hypothesis", type="project", limit=20)
+```
+
+For each `hypothesis_<slug>` with `status: testing`:
+- Check if enough evidence to resolve
+- If resolved: update status to `confirmed`/`rejected`, add evidence
+- If open: surface in output
+
+Creating new hypotheses (when user says "I think X might be true"):
+```
+memory_store(
+  name="hypothesis_<slug>", type="project",
+  content="claim: <X>\nmetric: <how to verify>\nstatus: testing\nevidence: none yet",
+  source_provenance="skill:reflect"
+)
+```
+
+## Step 8 — Flag stale memories
+
+`memory_recall(type="project", limit=20)` — flag any not updated in 14+ days (except hypotheses).
+
+## Step 9 — Output
+
+```markdown
+## Reflect — YYYY-MM-DD
+
+### Outcomes Verified (N)
+- [+] <task_type>: <description> — <outcome_status>
+- [-] <task_type>: <description> — <outcome_status>, lesson: <one-liner>
+
+### Decisions Resolved (N)
+- **<name>**: <outcome> — lesson: <one-liner or "none">
+
+### Patterns Detected
+- <pattern description, e.g. "delegation tasks in jarvis repo: 80% success rate">
+
+### Lessons Saved (N)
+- <name>: <rule>
+
+### Hypotheses (N testing, N resolved)
+- <status emoji> **<slug>**: <claim> — <status>
+
+### Stale Project Memories (N)
+- <name> (last updated <date>)
+
+### Calibration (flagged types only)
+- **<type>**: Brier <score>, n=<n>, <overconfident|underconfident> (avg_predicted=<p> vs avg_actual=<a>)
+```

--- a/.claude-userlevel/skills/research/SKILL.md
+++ b/.claude-userlevel/skills/research/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: research
+description: "Investigate a topic, validate decisions, compare options, or run autonomous discovery. Absorbs intel and nightly-research. Trigger: 'исследуй', 'research', 'изучи', 'что лучше', 'сравни'."
+version: 3.0.0
+---
+
+# Research
+
+Two modes: **interactive** (user asks a question) and **discovery** (autonomous, finds gaps and researches them).
+
+## Mode: Interactive (default)
+
+User asks to research something specific.
+
+### Step 1 — Understand the query
+
+Determine type:
+- **Decision validation** → focus on trade-offs, risks, real-world experience
+- **Knowledge gap** → authoritative explanations, practical examples
+- **Comparison** → objective criteria, benchmarks, community consensus
+
+### Step 2 — Search
+
+Primary: `firecrawl_search(query="<topic>", limit=3)`.
+Fallback: `WebSearch` if Firecrawl unavailable.
+
+Run 2-3 searches with different angles. Preview results with `head -c 4000`.
+
+Prioritize: official docs, reputable blogs, GitHub discussions, benchmarks.
+Skip: SEO spam, articles >2 years old for fast-moving topics.
+
+For highly relevant results: `firecrawl_scrape(url=<url>, formats=["markdown"], onlyMainContent=true)` — max 2 scrapes per run.
+
+### Step 3 — Analyze
+
+1. Claims in multiple independent sources = strong signal
+2. Note contradictions between sources
+3. Distinguish facts (documented, benchmarked) from opinions
+4. For technical decisions: real-world usage at similar scale
+
+### Step 4 — Output
+
+```markdown
+## Summary
+One paragraph, lead with recommendation if it's a decision.
+
+## Key Findings
+- **Finding** — explanation [source]
+
+## Trade-offs & Risks
+- **Risk** — when it matters, mitigation
+
+## Alternatives
+- **Alternative** — why rejected or when better
+
+## Sources
+1. [Title](URL) — what it contributed
+
+## Confidence: N/100
+One sentence: what makes this confident or uncertain.
+```
+
+### Step 5 — Save
+
+Save to Supabase if finding is significant:
+```
+memory_store(type="reference", name="research_{slug}", description="...", content="...", source_provenance="skill:research")
+```
+
+If finding is actionable → create GitHub issue in appropriate repo:
+```
+gh issue create --repo <R> --title "[RESEARCH] <topic>" --body "..."
+```
+
+---
+
+## Mode: Discovery (autonomous)
+
+For scheduled runs. Finds gaps in current knowledge and researches them.
+
+### Step 1 — Load context
+
+```
+memory_recall(type="decision", limit=10)
+memory_recall(query="working_state", type="project", limit=3)
+```
+
+Also check recent GitHub issues for each repo in `config/repos.conf`.
+
+### Step 2 — Identify gaps
+
+From context, find genuine gaps:
+- Problems flagged as unsolved
+- Decisions made without sufficient research
+- Patterns that keep breaking
+- Capabilities mentioned but not explored
+
+Score: impact × urgency. Pick **top 3**. Each becomes a specific research question.
+
+Bad: "research AI agents"
+Good: "how do iterative planners detect premature convergence?"
+
+### Step 3 — Research
+
+For each topic: `WebSearch` or `firecrawl_search`, max 3 searches per topic.
+
+### Step 4 — Save
+
+Per topic:
+```
+memory_store(type="reference", name="research_{slug}", project="{project}", content="...", source_provenance="skill:research")
+```
+
+Actionable findings → GitHub issues (check for duplicates first).
+
+Dedup marker:
+```
+memory_store(type="project", name="research_last_run", content="{date} — topics: {t1}, {t2}, {t3}", source_provenance="skill:research")
+```
+
+---
+
+## Quality rules (both modes)
+
+- Non-trivial claims: 3+ independent sources when available
+- Every finding references specific sources
+- Source conflicts → list both sides
+- Call out unknowns and weak evidence
+- If confidence <50 → recommend follow-up

--- a/.claude-userlevel/skills/self-improve/SKILL.md
+++ b/.claude-userlevel/skills/self-improve/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: self-improve
+description: "Autonomous self-improvement: health check, gap analysis, ideation, research, implementation. Absorbs ideate, self-review, repo-health."
+version: 2.0.0
+---
+
+# Self-Improve
+
+Meta-agent: identify gaps, generate ideas, research, implement. Goal: introduce something genuinely new.
+
+## Usage
+
+- `/self-improve` — full pipeline
+- `/self-improve --dry-run` — plan only, no changes
+
+## Pipeline
+
+### Step 1 — Health check
+
+Quick codebase scan (replaces separate self-review + repo-health):
+- Run tests: `python -m pytest tests/ -q` (if tests exist)
+- Check for obvious issues: broken imports, stale configs, TODO/FIXME density
+- Note findings as context — don't fix directly yet
+
+### Step 2 — Load context
+
+In parallel:
+```
+memory_recall(type="decision", limit=5)
+memory_recall(query="working_state", type="project", limit=2)
+memory_recall(type="feedback", limit=5)
+```
+
+Build a picture: what friction repeats, what's missing, what research sits unacted.
+
+### Step 3 — Ideate
+
+Generate 3-5 ideas for improvement. For each, score:
+- **Impact**: H/M/L — how much does this improve Jarvis?
+- **Effort**: H/M/L — how long to implement?
+- **Risk**: H/M/L — what could break?
+
+Sources of ideas:
+- Health check findings (code quality, missing tests)
+- Repeated friction patterns (from feedback memories)
+- Unacted research findings
+- Missing capabilities observed in recent sessions
+- Opportunities from new Claude Code / MCP features
+- **Known-unknowns** (`known_unknowns` table → repeated recall gaps) — queries Jarvis has been asked but couldn't answer from memory
+- **Poor-calibration types** (`memory_calibration_summary` → types with Brier > 0.25) — systemic over/underconfidence is signal worth investigating
+
+#### Metacognition seeds
+
+Before ideating, pull both metacognition signals as candidate seeds. Run in parallel; both may return empty (skill must still work — just skip the section).
+
+**1. Known-unknowns** — retrieval gaps with highest recurrence:
+```sql
+SELECT query, hit_count, last_seen_at
+FROM known_unknowns
+WHERE status='open'
+ORDER BY hit_count DESC, last_seen_at DESC
+LIMIT 5
+```
+Run via `execute_sql` (works in cloud + local). A query with `hit_count >= 3` is a strong seed: "asked N times, still no answer" → candidate for a research run, a new memory, or a capability gap.
+
+**2. Calibration gaps** — types where confidence diverges from outcome:
+```
+mcp__memory__memory_calibration_summary(project="jarvis")
+```
+Types flagged `overconfident` (Brier > 0.25, avg_predicted > avg_actual) often point at a concrete pattern (e.g. "decision memories relying on unverified research") that can be fixed by a feedback rule, a hook, or a schema tweak.
+
+Render both under a **Ideation seeds (metacognition)** subsection in the output. Each seed becomes a candidate idea scored in the table below alongside health-check findings and friction patterns. If both sources return empty, omit the subsection (don't render empty headings).
+
+If no strong ideas: fall back to health check findings for code improvements.
+
+### Step 4 — Select
+
+Top-1 by: High impact + Low/Medium effort + Low/Medium risk.
+Prefer ideas connected to real observed problems over theoretical improvements.
+
+### Step 5 — Research
+
+Focused search on the selected idea:
+- Specific question, not generic scan
+- `firecrawl_search(limit=3)` or `WebSearch`
+- If research invalidates the idea → go back to Step 4
+
+### Step 6 — Risk classification
+
+| Risk | Criteria | Action |
+|------|----------|--------|
+| **Low** | New skill, config tweak, prompt improvement, docs | Auto-implement |
+| **Medium** | New hook, MCP config, tool wiring | Show plan, wait for confirmation |
+| **High** | Architecture, memory server, SOUL.md, CLAUDE.md | Propose only |
+
+**Never auto-apply:** `.mcp.json`, `mcp-memory/server.py`, `config/SOUL.md`, `CLAUDE.md`, `.env`.
+
+### Step 7 — Implement (skip in --dry-run)
+
+Low risk → implement directly.
+Medium risk → show plan, wait for confirmation.
+High risk → output proposal only.
+
+Verify: `python -m pytest tests/ -q` if applicable.
+
+### Step 8 — Branch + PR (skip in --dry-run or High risk)
+
+```bash
+git checkout -b self-improve/<date>-<slug>
+git add <specific files>
+git commit -m "self-improve: <what and why>"
+git push -u origin self-improve/<date>-<slug>
+gh pr create --title "self-improve: <description>" --body "..."
+```
+
+## Output
+
+```markdown
+## Self-Improve — YYYY-MM-DD
+
+### Health check
+- <key findings, or "Clean">
+
+### Ideation seeds (metacognition)
+<omit entire subsection if both sources empty>
+
+**Known-unknowns** (top open, by hit_count):
+| Query | Hits | Last seen |
+|-------|------|-----------|
+| ... | N | YYYY-MM-DD |
+
+**Calibration gaps** (Brier > 0.25, n >= 20):
+- `<type>` — Brier X.XX, overconfident/underconfident (avg_pred Y vs avg_actual Z)
+
+### Ideas (scored)
+| Idea | Impact | Effort | Risk |
+|------|--------|--------|------|
+| ... | H/M/L | H/M/L | H/M/L |
+
+### Selected
+**[Title]** — Impact: H | Effort: L | Risk: L
+
+### Research
+<key insight>
+
+### Result
+- Implemented / Proposed / Needs approval
+- PR: <url> (or --dry-run)
+```

--- a/.claude-userlevel/skills/setup-tasks/SKILL.md
+++ b/.claude-userlevel/skills/setup-tasks/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: setup-tasks
+description: "Bootstrap all scheduled tasks on a new device. Idempotent — safe to re-run."
+version: 1.0.0
+---
+
+# Setup Tasks
+
+Bootstrap all 6 scheduled tasks on a new device in one command.
+
+## Usage
+
+`/setup-tasks`
+
+This skill idempotently registers all scheduled tasks. If a task already exists, it's skipped. Safe to re-run on the same device.
+
+## Implementation
+
+1. Call `list_scheduled_tasks` to see what's already registered
+2. For each of the 6 required tasks:
+   - If exists with matching name → skip ("already registered")
+   - If missing → `create_scheduled_task` with cron + prompt
+3. Print summary: N created, N skipped (already existed)
+
+## Tasks to Register
+
+| Task ID | Cron | Prompt |
+|---------|------|--------|
+| nightly-research | `17 7 * * *` | Read `.claude/skills/research/SKILL.md` and run in `--mode=autonomous` |
+| morning-brief | `43 7 * * *` | Read and run `.claude/skills/status/SKILL.md` |
+| risk-radar | `7 9,14,19 * * *` | Quick risk scan: check CI status, stale issues, security alerts across repos in `config/repos.conf` |
+| autonomous-loop | `3 9 * * *` | Read and run `.claude/skills/autonomous-loop/SKILL.md` |
+| intel | `12 10 * * 1` | Weekly tech intelligence: search for new Claude Code features, MCP servers, AI agent patterns. Save findings to memory. |
+| verify | `47 16 * * 5` | Read and run `.claude/skills/verify/SKILL.md` — verify pending outcomes, detect patterns, save lessons. |
+
+## Notes
+
+- All tasks run locally with full MCP access
+- Times are in local timezone (not UTC)
+- Cron dedup via Supabase memory: scheduled tasks check `*_last_run` markers to prevent duplicate runs across devices
+- Prompts reference skill files so updates to skills automatically update scheduled task behavior

--- a/.claude-userlevel/skills/status/SKILL.md
+++ b/.claude-userlevel/skills/status/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: status
+description: "Project dashboard: git state, PRs, issues, CI health, risks, stale/blocked work, goal alerts. Absorbs morning-brief, risk-radar, triage. Use at session start or when needing cross-project awareness."
+version: 2.1.0
+---
+
+# Status Dashboard
+
+Single command for full project awareness. Replaces morning-brief, risk-radar, and triage.
+
+## Usage
+
+- `/status` — all repos, full dashboard
+- `/status <repo>` — single repo focus
+
+## Step 1 — Load repos
+
+Read `config/repos.conf` (one `owner/repo` per line, `#` = comment). This is the single source of truth — no hardcoded repo names.
+
+Local path resolution (portable across 3 devices): `{device.json.repos_path}/{repo-name}` where `repo-name` is the segment after `/`. Example on Main PC: `C:/Users/petrk/GitHub/redrobot`. If the directory doesn't exist (e.g. not cloned on this device), skip local git checks gracefully — GitHub-side checks still run.
+
+## Step 2 — Gather data (parallel)
+
+For each repo, run in parallel:
+
+**Git state** (if local directory exists):
+```bash
+git -C <path> log --oneline -5
+git -C <path> status --short
+git -C <path> branch --show-current
+```
+
+**GitHub state:**
+```bash
+gh pr list --repo <R> --state open --json number,title,updatedAt,reviewDecision,isDraft --limit 10
+gh issue list --repo <R> --state open --json number,title,labels,updatedAt --limit 20
+gh run list --repo <R> --json conclusion,name --limit 10
+gh api "repos/<R>/milestones?state=open&per_page=50" --jq '.[] | {number, title, open_issues, closed_issues, due_on}'
+```
+
+**Security** (skip silently on 403):
+```bash
+gh api repos/<R>/dependabot/alerts --jq '[.[] | select(.state=="open")]' 2>/dev/null
+```
+
+**Credential expiry** (once, not per repo):
+```
+credential_check_expiry(days_ahead=14)
+```
+If results returned, include in output. If no credentials expiring — silent (no noise).
+**Known unknowns** (memory/recall gaps — once, not per repo):
+```sql
+SELECT query, hit_count, last_seen_at FROM known_unknowns WHERE status='open' ORDER BY hit_count DESC, last_seen_at DESC LIMIT 5
+```
+Execute via `execute_sql` MCP. Cloud sessions won't have local memory client. Include in alerts if results returned.
+
+
+## Step 3 — Analyze
+
+For each repo, compute:
+
+**CI health**: failure rate from last 10 runs. >=50% CRITICAL, 30-49% HIGH, 15-29% MEDIUM.
+
+**Stale issues**: open issues not updated >14 days (skip blocked). Flag count.
+
+**Blocked work**: issues/PRs with `blocked` label or `CHANGES_REQUESTED` review >3 days old.
+
+**Review backlog**: non-draft PRs awaiting review >2 days.
+
+**Repo hygiene** (if local directory exists):
+```bash
+# Local branches whose remote tracking branch is deleted
+git -C <path> branch -vv | grep ': gone]'
+# Local branches not merged into master/main
+git -C <path> branch --no-merged master 2>/dev/null || git -C <path> branch --no-merged main
+# Stashes
+git -C <path> stash list
+```
+Flag: N stale branches (remote gone), M unmerged branches, K stashes.
+
+**Goal alerts** (from session context — goals are already loaded):
+- Deadline within 3 days → urgent flag
+- P0 goal with no related activity → neglect flag
+
+**Milestone hygiene** (from `gh api .../milestones?state=open` + closed milestones when goals reference them):
+- `open_issues == 0 && state == "open"` → **orphan milestone** (work done, milestone never closed). Flag with proposal to close.
+- Issue labeled `epic` with "Sprint" in title but `milestone == null` → **orphan sprint** (sprint running without milestone tracking). Flag with proposal to create+attach milestone.
+- Milestone `due_on` within 3 days and `open_issues > 0` → **sprint deadline risk**.
+- **Goal-vs-milestone divergence** (new): for each active goal from session context, find any linked milestone — linkage via `goal.slug` appearing in milestone title/description, or milestone title referenced in `goal.notes`. Then:
+  - `goal.progress >= 100` OR `goal.state == completed`, but linked milestone has `state == "open" && open_issues > 0` → flag **"goal done but milestone still open"**: name the goal, milestone, and open-issue count; propose either (a) close open issues first, then close milestone, or (b) reopen the goal if the remaining issues are still real work. Example from M15 Facehugger Foundation (2026-04-21): goal notes said Sprint 15 complete 2026-04-18, GitHub showed #620-#623 still open.
+  - Linked milestone has `state == "closed"`, but `goal.progress < 100 && goal.state != completed` → flag **"stale goal — linked milestone already closed"**: review whether remaining goal work is real or just un-updated progress notes.
+- Treat all of the above as actionable items, not just reports — suggest the fix command inline.
+
+## Step 4 — Output
+
+```markdown
+# Status — YYYY-MM-DD
+
+## Alerts
+- <P0 deadline, neglect warnings, or "Goals on track">
+- <Credential expiry warnings, if any>
+
+## <Repo Name>
+**Branch:** main | **Clean:** yes/no
+**CI:** N/M passed (CRITICAL/HIGH/MEDIUM/ok)
+**Recent:** <last 3 commits, one-line>
+**PRs:** N open (<titles of notable ones>)
+**Issues:** N open, M stale, K blocked
+**Security:** N alerts (or clean)
+**Hygiene:** N stale branches, M unmerged, K stashes (or clean)
+
+## <Repo 2>
+...
+
+## Action items
+1. <most urgent thing — fix CI, respond to review, merge ready PR>
+2. <next priority>
+3. <etc>
+```
+
+Keep concise. Skip empty sections. Owner scans in 30 seconds.

--- a/.claude-userlevel/skills/verify/SKILL.md
+++ b/.claude-userlevel/skills/verify/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: verify
+description: "Verify pending task outcomes: check PR merge status, test results, update records, extract lessons."
+---
+
+# Verify Outcomes
+
+Closes the outcome tracking loop: did the work actually land?
+
+## When to use
+
+- After delegations have had time to merge
+- As part of autonomous-loop (scheduled)
+- Manual: `/verify` to check all pending outcomes
+
+## Step 1 — Fetch pending outcomes
+
+```
+outcome_list(outcome_status="pending")
+```
+
+If none found → report "No pending outcomes" and stop.
+
+## Step 2 — Verify each outcome
+
+For each pending outcome, verify based on available data:
+
+### If `pr_url` exists (delegation/fix):
+```bash
+gh pr view <pr_url> --json state,mergedAt,statusCheckRollup --jq '{state, mergedAt, checks: [.statusCheckRollup[] | {name: .name, conclusion: .conclusion}]}'
+```
+
+Determine:
+- **success**: PR merged + checks passed
+- **partial**: PR merged but some checks failed, OR PR open but checks pass
+- **failure**: PR closed without merge, OR checks failing
+- **pending**: PR still open, reviews pending → skip (not yet verifiable)
+
+### If `issue_url` exists (no PR):
+```bash
+gh issue view <issue_url> --json state,stateReason --jq '{state, stateReason}'
+```
+
+- **success**: issue closed as completed
+- **failure**: issue closed as not planned
+- **pending**: issue still open → skip
+
+### If neither URL exists (autonomous/research):
+- Outcomes older than 7 days with no URL → mark as **unknown**
+- Otherwise → skip
+
+## Step 3 — Update verified outcomes
+
+For each outcome that changed status:
+
+```
+outcome_update(
+  id="<outcome_id>",
+  outcome_status="<new_status>",
+  pr_merged=<true/false>,
+  tests_passed=<true/false>,
+  memory_id="<primary informing memory id>",   # enrich if still unset — see rule
+  lessons="<brief result if any>"
+)
+```
+
+**Enrich `memory_id` if the outcome row has it NULL**: look up the linked `decision_made` episode (same issue/PR) and pass `memory_id = payload.memories_used[0]`. Rule — primary informing memory = first entry (dominant basis). If the outcome already has `memory_id`, leave it alone; `/verify` is not where you rewrite attribution. If no decision episode references this issue, omit — the backfill script (`scripts/backfill-outcome-memories.py`) can handle historical rows in bulk.
+
+`verified_at` is set automatically when status changes from pending.
+
+## Step 4 — Detect patterns
+
+**Minimum data**: skip pattern analysis if fewer than 5 total outcomes exist.
+
+Run these queries via `execute_sql` (project: `svwrzttdkxeselkpxfgm`):
+
+### 4a. Success rate by task type
+```sql
+SELECT task_type,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE outcome_status = 'success') AS succeeded,
+       ROUND(100.0 * COUNT(*) FILTER (WHERE outcome_status = 'success') / COUNT(*)) AS success_pct
+FROM task_outcomes
+WHERE outcome_status != 'pending'
+GROUP BY task_type
+ORDER BY total DESC;
+```
+
+### 4b. Failure clusters by pattern_tags
+```sql
+SELECT tag, COUNT(*) AS failures
+FROM task_outcomes, LATERAL unnest(pattern_tags) AS tag
+WHERE outcome_status = 'failure'
+GROUP BY tag
+HAVING COUNT(*) >= 2
+ORDER BY failures DESC;
+```
+
+### 4c. Repeated lessons (same lesson appearing 2+ times)
+```sql
+SELECT lessons, COUNT(*) AS occurrences
+FROM task_outcomes
+WHERE lessons IS NOT NULL AND lessons != ''
+GROUP BY lessons
+HAVING COUNT(*) >= 2
+ORDER BY occurrences DESC
+LIMIT 5;
+```
+
+### Pattern → feedback memory rules
+
+Save as `feedback` memory when:
+- A task type has **success rate < 60%** with 3+ samples → save: "task_type X has low success rate — investigate root cause"
+- A pattern_tag appears in **2+ failures** → save: "area X is failure-prone — add extra verification"
+- A lesson repeats **3+ times** → save: "recurring lesson — make this a permanent rule"
+
+Only save non-obvious patterns. Don't save "PR was merged successfully" — that's expected.
+
+## Step 5 — Output
+
+```
+## Outcome Verification — YYYY-MM-DD
+
+### Verified (N)
+- [+] <task_description> → success (PR merged, checks passed)
+- [-] <task_description> → failure (PR closed without merge)
+
+### Still pending (N)
+- [?] <task_description> — PR open, awaiting review
+
+### Patterns (last 30 days)
+| Task Type | Total | Success % |
+|-----------|-------|-----------|
+| delegation | N | N% |
+
+Failure clusters: <tag1 (N), tag2 (N), or "None">
+Repeated lessons: <lesson (Nx), or "None">
+
+### Feedback saved (N)
+- <memory name> — <one-line>
+```

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -53,14 +53,18 @@ groups:
         template: true
 
   - id: skills
-    description: "Core skills (M2 #337)"
-    enabled: false
+    description: "Core skills (M2 #337) — universal, not project-specific"
+    enabled: true
     directories:
-      - source: ".claude/skills"
+      # Source of truth for user-level skills lives in a separate directory so
+      # M5 tombstone can cleanly delete jarvis/.claude/skills/* without touching
+      # project-scoped skills that stay behind (e.g. /sprint-report).
+      - source: ".claude-userlevel/skills"
         dest: "skills"
         template: false
-        # Whitelist — only the skills listed here move to user-level. Niche
-        # or project-specific skills stay in <project>/.claude/skills/.
+        # Whitelist kept explicit so an accidentally-added file (e.g. a README
+        # scratch note under .claude-userlevel/skills/) doesn't leak into
+        # every user's ~/.claude/. Update when adding/removing a core skill.
         include:
           - "autonomous-loop"
           - "delegate"
@@ -72,7 +76,6 @@ groups:
           - "research"
           - "self-improve"
           - "setup-tasks"
-          - "sprint-report"
           - "status"
           - "verify"
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -303,21 +303,40 @@ def test_disabled_group_is_skipped(manifest: Path, fake_repo: Path) -> None:
     assert (plan.target_root / "settings.json").exists()
 
 
-def test_real_manifest_all_groups_disabled_yields_minimal_plan(fake_repo: Path) -> None:
-    """The real repo manifest ships with all groups disabled for M1.
-    Plan must still produce a version marker + env var so the installer
-    is meaningful even before M2-M4 enable the groups.
+def test_real_manifest_m2_enables_only_skills_group() -> None:
+    """Real manifest shape after M2 (#337): skills group flipped on, others
+    still disabled pending M3/M4. Guards against accidental early flips.
     """
     real = Path(__file__).resolve().parents[1] / "install-manifest.yaml"
-    if not real.exists():
-        pytest.skip("no real manifest")
+    assert real.exists(), "install-manifest.yaml must ship in-tree"
     m = installer.load_manifest(real)
-    # Re-point target to a tmp dir to avoid touching user home.
-    target = fake_repo.parent / "sandbox-claude"
-    plan = installer.build_plan(m, fake_repo, target_root_override=str(target))
-    kinds = [a.kind for a in plan.actions]
-    assert "write_version" in kinds
-    assert "set_env" in kinds
-    # No copies while all groups disabled.
-    assert "copy_file" not in kinds
-    assert "copy_dir" not in kinds
+
+    by_id = {g["id"]: g for g in m["groups"]}
+    assert by_id["skills"]["enabled"] is True
+    assert by_id["skills"]["directories"][0]["source"] == ".claude-userlevel/skills"
+    # Whitelist must exclude sprint-report (project-scoped per #337 spec).
+    include = by_id["skills"]["directories"][0]["include"]
+    assert "sprint-report" not in include
+    assert "implement" in include and "delegate" in include
+
+    for gid in ("soul", "hooks_settings", "mcp_config"):
+        assert by_id[gid]["enabled"] is False, (
+            f"{gid} flipped ahead of its milestone — should stay off until M3/M4"
+        )
+
+
+def test_userlevel_skills_dir_exists_and_has_whitelisted_skills() -> None:
+    """Source-of-truth directory must exist with every whitelisted skill."""
+    repo_root = Path(__file__).resolve().parents[1]
+    src = repo_root / ".claude-userlevel" / "skills"
+    assert src.is_dir(), f"{src} must exist — M2 source of truth"
+
+    m = installer.load_manifest(repo_root / "install-manifest.yaml")
+    include = next(
+        d["include"]
+        for g in m["groups"] if g["id"] == "skills"
+        for d in g["directories"]
+    )
+    for name in include:
+        skill_md = src / name / "SKILL.md"
+        assert skill_md.exists(), f"whitelisted skill missing: {skill_md}"


### PR DESCRIPTION
## Summary

M2 of EPIC #335 (Pillar 7 Phase 0 — Federation foundation).

- Adds `.claude-userlevel/skills/` as the source of truth for user-level skills (12 universal core skills, excludes project-scoped `sprint-report`).
- Flips the `skills` group in `install-manifest.yaml` from `enabled: false` to `enabled: true`, pointing at `.claude-userlevel/skills`.
- Other groups (`soul`, `hooks_settings`, `mcp_config`) remain `enabled: false` — M3/M4 will flip them.

## Why a separate directory?

`.claude-userlevel/` mirrors what ships to `~/.claude/`. Keeping it separate from `.claude/` lets M5 (#340) tombstone the project-scoped copy cleanly without deleting project-specific skills that legitimately stay under `jarvis/.claude/skills/` (e.g. `/sprint-report`).

## Safety properties preserved

- No hook/settings/MCP writes yet — still a no-op on user-level Claude Code until M3.
- Whitelist in `install-manifest.yaml` stays explicit — accidental additions to `.claude-userlevel/skills/` won't auto-leak into every user's `~/.claude/`.
- DRY violation (same skill in two places) is intentional for the M2→M5 window; documented in `.claude-userlevel/README.md`.

## Known follow-ups (non-blocking for M2)

- Skill bodies reference `scripts/` and `config/` as CWD-relative paths. Once user-level Jarvis runs from non-jarvis CWDs (post-M3), these need `$JARVIS_HOME/scripts/...` rewrites. Tracked as path-portability audit.
- Issue #344 tracks 6 SHOULD-FIX items from M1 review — some (regex greediness, rollback-on-fresh, health-check shlex) must land before M3 because M3 enables JSON templating that hits the greedy regex.

## Test plan

- [x] 17/17 installer unit tests pass (`pytest tests/test_installer.py`)
- [x] Full suite 783 tests pass
- [x] Dry-run on Main PC shows correct `copy_dir` action for skills group
- [ ] Post-merge: real `--apply` smoke on one device (deferred until M3 provides full end-to-end install flow)

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)