### PR TITLE
fix(install): tighten path regex + fresh-rollback + shlex health-check (#344)

### DIFF
--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -16,6 +16,7 @@ import datetime as dt
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -114,7 +115,11 @@ def detect_state(target_root: Path, current_sha: str) -> tuple[str, str | None]:
 # ---------- template substitution ----------
 
 
-_POSIX_PATH_PATTERN = re.compile(r"\b(scripts|config)/")
+# Match `scripts/` or `config/` only at a token boundary — start of string or
+# preceded by whitespace. Protects URLs (`https://.../scripts/x`) and compound
+# names (`my-scripts/x`) from being rewritten, while still catching embedded
+# commands like `python scripts/foo.py && cat config/SOUL.md`.
+_POSIX_PATH_PATTERN = re.compile(r"(?<!\S)(scripts|config)/")
 
 
 def _transform_json_paths(node: Any, repo_root_posix: str) -> Any:
@@ -396,15 +401,38 @@ def rollback(target_root: Path, backup_path: Path) -> None:
     shutil.copytree(backup_path, target_root)
 
 
+def _rollback_failed_apply(plan: Plan) -> None:
+    """Restore target_root to pre-apply state after a failed apply.
+
+    - outdated/current path → restore from backup (backup_path is set).
+    - fresh path → backup_path is None (nothing to restore from), so rmtree
+      the half-written target so the next run starts clean. Without this,
+      a failed fresh install leaves a stub that `detect_state` reads as
+      outdated, masking the real failure.
+    """
+    if plan.backup_path and plan.backup_path.exists():
+        print(f"rolling back from {plan.backup_path}", file=sys.stderr)
+        rollback(plan.target_root, plan.backup_path)
+        return
+    if plan.state == "fresh" and plan.target_root.exists():
+        print(
+            f"fresh install failed — removing {plan.target_root}", file=sys.stderr
+        )
+        shutil.rmtree(plan.target_root, ignore_errors=True)
+
+
 def run_health_check(manifest: dict[str, Any], repo_root: Path) -> tuple[bool, list[str]]:
     hc = manifest.get("health_check") or {}
     if not hc.get("enabled"):
         return True, []
     logs: list[str] = []
     for cmd in hc.get("commands") or []:
+        # Use shlex so paths with spaces survive — `cmd.split()` breaks them.
+        # posix=False on Windows keeps backslashes intact.
+        argv = shlex.split(cmd, posix=(os.name != "nt"))
         try:
             result = subprocess.run(
-                cmd.split(),
+                argv,
                 cwd=repo_root,
                 capture_output=True,
                 text=True,
@@ -518,9 +546,7 @@ def main(argv: list[str] | None = None) -> int:
         apply_plan(plan, manifest, run_env=env_runner)
     except Exception as exc:  # noqa: BLE001
         print(f"\napply failed: {exc}", file=sys.stderr)
-        if plan.backup_path and plan.backup_path.exists():
-            print(f"rolling back from {plan.backup_path}", file=sys.stderr)
-            rollback(plan.target_root, plan.backup_path)
+        _rollback_failed_apply(plan)
         return 2
 
     if not args.skip_health_check:
@@ -529,9 +555,7 @@ def main(argv: list[str] | None = None) -> int:
             print(line)
         if not ok:
             print("\nhealth check failed", file=sys.stderr)
-            if plan.backup_path and plan.backup_path.exists():
-                print(f"rolling back from {plan.backup_path}", file=sys.stderr)
-                rollback(plan.target_root, plan.backup_path)
+            _rollback_failed_apply(plan)
             return 3
 
     backup_cfg = manifest.get("backup") or {}

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -325,6 +325,117 @@ def test_real_manifest_m2_enables_only_skills_group() -> None:
         )
 
 
+# ---------- #344: tightening before M3 ----------
+
+
+def test_path_rewrite_preserves_urls() -> None:
+    """Regex must NOT rewrite `scripts/` / `config/` tokens that are part of
+    a URL or a compound identifier. Was `\\b(scripts|config)/` — too greedy.
+    """
+    data = {
+        "docs": "https://example.com/scripts/foo",
+        "nested": {"ref": "https://cdn.example.com/config/v2/x.yaml"},
+        "compound": "my-scripts/foo",
+        "list": ["https://gh.io/scripts/a", "scripts/keep"],
+    }
+    out = installer._transform_json_paths(data, "/abs/repo")
+    assert out["docs"] == "https://example.com/scripts/foo"
+    assert out["nested"]["ref"] == "https://cdn.example.com/config/v2/x.yaml"
+    assert out["compound"] == "my-scripts/foo"
+    # The one real path still gets rewritten.
+    assert out["list"][0] == "https://gh.io/scripts/a"
+    assert out["list"][1] == "/abs/repo/scripts/keep"
+
+
+def test_path_rewrite_handles_embedded_command_paths() -> None:
+    """Command strings with multiple relative paths (whitespace-separated)
+    must have all path tokens rewritten."""
+    cmd = "python scripts/a.py && cat config/SOUL.md && python scripts/b.py"
+    out = installer._transform_json_paths(cmd, "/abs/repo")
+    assert "/abs/repo/scripts/a.py" in out
+    assert "/abs/repo/config/SOUL.md" in out
+    assert "/abs/repo/scripts/b.py" in out
+    assert " scripts/" not in out
+    assert " config/" not in out
+
+
+def test_fresh_install_rollback_on_apply_failure(
+    manifest: Path, fake_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fresh-state apply failure must leave target_root removed, not half-written.
+
+    Without the fix, a failure mid-apply leaves a stub directory that
+    detect_state reads as outdated next time, masking the original error.
+    """
+    m = installer.load_manifest(manifest)
+    plan = installer.build_plan(m, fake_repo)
+    assert plan.state == "fresh"
+    assert plan.backup_path is None
+
+    # Make apply create the target dir (simulating partial write) then fail.
+    real_copy_file = installer._copy_file
+    call_count = {"n": 0}
+
+    def flaky_copy_file(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            real_copy_file(*args, **kwargs)
+            return
+        raise RuntimeError("simulated apply failure")
+
+    monkeypatch.setattr(installer, "_copy_file", flaky_copy_file)
+
+    with pytest.raises(RuntimeError, match="simulated apply failure"):
+        installer.apply_plan(plan, m, run_env=None)
+
+    # Sanity: target_root exists and has partial content.
+    assert plan.target_root.exists()
+    assert any(plan.target_root.iterdir())
+
+    # Now invoke the rollback helper directly (what main() does in the except).
+    installer._rollback_failed_apply(plan)
+    assert not plan.target_root.exists(), (
+        "fresh install failure must remove target_root entirely"
+    )
+
+
+def test_health_check_uses_shlex_for_argv_parsing(
+    fake_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cmd.split() broke on paths with spaces; shlex handles quoted args."""
+    seen: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(argv, **kwargs):
+        seen.append(list(argv))
+        return FakeResult()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+
+    m = {
+        "health_check": {
+            "enabled": True,
+            "commands": [
+                'python "/tmp/path with spaces/script.py" --flag value',
+            ],
+        }
+    }
+    ok, _logs = installer.run_health_check(m, fake_repo)
+    assert ok is True
+    assert len(seen) == 1
+    argv = seen[0]
+    # Whether posix or windows flavor of shlex, the quoted path must stay
+    # as ONE argv element (not split on spaces).
+    assert any("path with spaces" in tok for tok in argv), (
+        f"quoted path split by whitespace: argv={argv}"
+    )
+    assert argv[0] == "python"
+
+
 def test_userlevel_skills_dir_exists_and_has_whitelisted_skills() -> None:
     """Source-of-truth directory must exist with every whitelisted skill."""
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

Three M3-blocking fixes surfaced by independent review of #336 (installer foundation). All must land before #338 enables JSON templating on `.claude/settings.json` and `.mcp.json`.

### 1. Path-rewrite regex was too greedy
`\b(scripts|config)/` rewrote any string that merely **contained** those prefixes. URLs like `https://example.com/scripts/foo` and compound names like `my-scripts/x` were being corrupted.

Fix: anchor with negative lookbehind `(?<!\S)` — matches at start-of-string or preceded by whitespace. This still catches embedded command paths (`python scripts/foo.py && cat config/SOUL.md`) but leaves URLs/identifiers alone.

### 2. Fresh-install failure left target half-written
`apply_plan` creates `target_root` before any copy. If a copy then failed, `backup_path` was `None` (no prior target → no backup made), so the except-branch skipped cleanup. The stub then read as `outdated` on the next run, masking the original error.

Fix: extracted `_rollback_failed_apply(plan)` helper that handles both:
- outdated/current: restore from backup
- fresh: `rmtree(target_root)` so the next run starts clean

Called uniformly from both apply-failure and health-check-failure branches.

### 3. Health-check `cmd.split()` broke on paths with spaces
Very real on Windows. Replaced with `shlex.split(cmd, posix=(os.name != 'nt'))` — quoted args with spaces now survive argv construction.

## Why now (not deferred)

M3 (#338) flips `hooks_settings` and `mcp_config` from `enabled: false` to `enabled: true`. Those are the first groups that go through `template_content` → `_transform_json_paths`. Until then, the greedy regex has no victims. After M3 merges, any URL value in a templated JSON file silently corrupts. Fix first, flip second.

## Test plan

- [x] 4 new unit tests (21 total for installer, 787 for full suite)
  - `test_path_rewrite_preserves_urls` — URLs and compound names stay intact
  - `test_path_rewrite_handles_embedded_command_paths` — `python scripts/a.py && cat config/SOUL.md` rewrites both tokens
  - `test_fresh_install_rollback_on_apply_failure` — monkeypatches `_copy_file` to fail mid-apply, asserts target removed after `_rollback_failed_apply`
  - `test_health_check_uses_shlex_for_argv_parsing` — quoted path with spaces survives as one argv element
- [x] All 787 existing tests pass (no regressions)

## Scope note

Closes items 1-3 of #344 (MUST-FIX before M3). Items 4-6 (SHOULD-FIX: `_include_for` substring match, `setx` silent failures, JSON round-trip loss documentation) remain open for follow-up — none block M3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)