### PR TITLE
feat(install): migrate hooks + .mcp.json to user-level w/ deep-merge (#338)

### DIFF
--- a/.claude-userlevel/.mcp.json
+++ b/.claude-userlevel/.mcp.json
@@ -1,0 +1,55 @@
+{
+  "mcpServers": {
+    "memory": {
+      "command": "python",
+      "args": ["scripts/run-memory-server.py"]
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    },
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
+      }
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    },
+    "reddit": {
+      "command": "uvx",
+      "args": ["reddit-no-auth-mcp-server"]
+    },
+    "obsidian": {
+      "command": "npx",
+      "args": ["-y", "@bitbonsai/mcpvault@latest", "${OBSIDIAN_VAULT_PATH}"]
+    },
+    "tg-messenger": {
+      "command": "python",
+      "args": ["scripts/run-telegram-mcp.py"]
+    },
+    "blender": {
+      "command": "uvx",
+      "args": ["blender-mcp"]
+    },
+    "bambu-printer": {
+      "command": "npx",
+      "args": ["-y", "bambu-printer-mcp"],
+      "env": {
+        "BAMBU_IP": "${BAMBU_IP}",
+        "BAMBU_TOKEN": "${BAMBU_TOKEN}",
+        "BAMBU_SERIAL": "${BAMBU_SERIAL}"
+      }
+    }
+  }
+}

--- a/.claude-userlevel/README.md
+++ b/.claude-userlevel/README.md
@@ -62,10 +62,16 @@ for the no-op window). Pick one as canonical on each edit:
 - After M5 merges, `.claude/skills/<core>/` is deleted and the
   userlevel copy becomes the only copy.
 
-## Path portability audit (follow-up)
+## Path portability — status after M3
 
-Skill bodies currently reference `scripts/` and `config/` as
-project-CWD-relative paths. Once user-level Jarvis runs from non-jarvis
-CWDs (post-M3), these need `$JARVIS_HOME/scripts/...` rewrites. Tracked
-as a follow-up — non-blocking for M2 because until M3 flips, skills
-still execute inside jarvis CWD where relative paths resolve.
+Hook command strings in `settings.json` and MCP server entries in `.mcp.json`
+are **rewritten at install time** by `_transform_json_paths` (relative
+`scripts/`/`config/` → absolute `<JARVIS_HOME>/scripts/...`). All jarvis
+hook + MCP bootstrap scripts resolve their own root via
+`Path(__file__).resolve().parent.parent`, so they work under any CWD.
+
+**Skill body** references to `scripts/` and `config/` are still
+project-CWD-relative prose (no shell invocation), and skills currently
+execute in whatever CWD Claude Code was launched from. If a skill starts
+shelling out with a CWD-relative path in future, prefer `$JARVIS_HOME`
+or absolute paths over CWD-relative.

--- a/.claude-userlevel/README.md
+++ b/.claude-userlevel/README.md
@@ -10,6 +10,8 @@ project-specific skills that legitimately stay under
 
 ```
 .claude-userlevel/
+├── settings.json    # Hooks (M3 #338) — deep-merged with user's existing
+├── .mcp.json        # MCP servers (M3 #338) — deep-merged with user's existing
 └── skills/          # Core universal skills (M2 #337)
     ├── implement/
     ├── delegate/
@@ -19,8 +21,28 @@ project-specific skills that legitimately stay under
 Later milestones will add:
 
 - `SOUL.md` (M4 #339)
-- `settings.json` (M3 #338 — hooks)
-- `.mcp.json` (M3 #338)
+
+## M3: how `settings.json` / `.mcp.json` land at `~/.claude/`
+
+Both files use **deep-merge** (not plain copy), preserving user keys that
+jarvis doesn't own:
+
+- `settings.json` — per-event wholesale replace inside `hooks.<Event>`;
+  events jarvis doesn't declare (`Stop`, etc.) stay put.
+- `.mcp.json` — per-server wholesale replace inside `mcpServers.<name>`;
+  user-added servers stay put.
+
+**Known trade-off**: if a user has a *custom entry* under an event/server
+jarvis owns (e.g. their own SessionStart hook, or a user-defined `memory`
+server), it is replaced on apply. Backup preserves it under
+`.claude.backup-<ts>/`. Users wanting extra logic for jarvis-owned events
+should compose downstream (e.g. add logic inside `session-context.py`).
+
+Relative paths (`scripts/...`, `config/...`) in the source templates are
+rewritten to absolute paths inside the jarvis repo at install time by
+`installer.py:_transform_json_paths`. So these templates stay readable as
+in-repo artefacts, and the rewrite logic is the single place path-portability
+concerns land.
 
 ## Why a whitelist in `install-manifest.yaml`?
 

--- a/.claude-userlevel/settings.json
+++ b/.claude-userlevel/settings.json
@@ -1,0 +1,89 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [
+          { "type": "command", "command": "python scripts/pre-compact-backup.py" }
+        ]
+      },
+      {
+        "matcher": "manual",
+        "hooks": [
+          { "type": "command", "command": "python scripts/pre-compact-backup.py" }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python scripts/device-info.py && echo '' && cat config/SOUL.md && echo ''"
+          },
+          {
+            "type": "command",
+            "command": "python scripts/session-context.py"
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python scripts/device-info.py && echo '' && cat config/SOUL.md && echo ''"
+          },
+          {
+            "type": "command",
+            "command": "python scripts/session-context.py"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github__(issue_write|create_pull_request|update_pull_request|add_issue_comment|add_reply_to_pull_request_comment|add_comment_to_pending_review|create_or_update_file|push_files|pull_request_review_write|sub_issue_write)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python scripts/secret-scanner.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python scripts/secret-scanner.py"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__memory__memory_store",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python scripts/secret-scanner.py"
+          },
+          {
+            "type": "command",
+            "command": "python scripts/memory-dedup-check.py"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python scripts/memory-recall-hook.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -38,19 +38,25 @@ groups:
 
   - id: hooks_settings
     description: "settings.json — hooks pointing at JARVIS_HOME scripts (M3 #338)"
-    enabled: false
+    enabled: true
     files:
-      - source: ".claude/settings.json"
+      # Source of truth under .claude-userlevel/ (same pattern as skills M2).
+      # template: rewrites `scripts/...` → `{{JARVIS_HOME}}/scripts/...` at apply time.
+      # merge: deep-merge onto existing ~/.claude/settings.json per jarvis-owned
+      #        `hooks.<Event>` keys; other events stay put (see README).
+      - source: ".claude-userlevel/settings.json"
         dest: "settings.json"
-        template: true  # rewrites `scripts/...` → `{{JARVIS_HOME}}/scripts/...`
+        template: true
+        merge: true
 
   - id: mcp_config
     description: ".mcp.json — MCP server config with absolute paths (M3 #338)"
-    enabled: false
+    enabled: true
     files:
-      - source: ".mcp.json"
+      - source: ".claude-userlevel/.mcp.json"
         dest: ".mcp.json"
         template: true
+        merge: true  # preserve user-added mcpServers entries on re-apply
 
   - id: skills
     description: "Core skills (M2 #337) — universal, not project-specific"

--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -36,7 +36,7 @@ DEFAULT_MANIFEST = "install-manifest.yaml"
 class Action:
     """One planned filesystem action."""
 
-    kind: str  # "copy_file" | "copy_dir" | "write_version" | "set_env"
+    kind: str  # "copy_file" | "copy_dir" | "merge_json" | "write_version" | "set_env"
     source: str | None
     dest: str
     template: bool = False
@@ -204,9 +204,12 @@ def build_plan(
         for entry in group.get("files") or []:
             src = repo_root / entry["source"]
             dest = target_root / entry["dest"]
+            # `merge: true` → deep-merge JSON instead of plain overwrite.
+            # Preserves user keys not owned by jarvis (M3 #338).
+            kind = "merge_json" if entry.get("merge") else "copy_file"
             actions.append(
                 Action(
-                    kind="copy_file",
+                    kind=kind,
                     source=str(src),
                     dest=str(dest),
                     template=bool(entry.get("template")),
@@ -249,7 +252,9 @@ def build_plan(
         )
 
     # Backup only when target_root already exists AND we have destructive actions.
-    has_writes = any(a.kind in {"copy_file", "copy_dir"} for a in actions)
+    has_writes = any(
+        a.kind in {"copy_file", "copy_dir", "merge_json"} for a in actions
+    )
     backup_path: Path | None = None
     if target_root.exists() and has_writes:
         stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -305,6 +310,89 @@ def _copy_file(
         shutil.copy2(src, dest)
 
 
+# Keys inside `settings.json.hooks` and `.mcp.json.mcpServers` are treated
+# as "wholesale-replace on conflict": when the source declares a hook event
+# or MCP server, it overwrites the target's entry for that key and leaves
+# every other key alone. Per-child-dict replace is the only strategy that
+# stays idempotent (re-apply never duplicates) while still letting users
+# keep custom entries under events/servers jarvis doesn't own.
+_JARVIS_OWNED_REPLACE_PARENTS = ("hooks", "mcpServers")
+
+
+def _deep_merge_jarvis_json(existing: Any, source: Any) -> Any:
+    """Merge `source` onto `existing` using jarvis-aware semantics.
+
+    - For dict parents named in `_JARVIS_OWNED_REPLACE_PARENTS`
+      (top-level `hooks`, `mcpServers`): each child key in `source`
+      wholesale replaces the same key in `existing`; children in
+      `existing` not mentioned by `source` are preserved.
+    - For other dicts: recurse.
+    - For non-dicts at the leaf: `source` wins.
+
+    Not a general-purpose deep-merge — tuned for the two files M3 ships.
+    """
+    if not isinstance(existing, dict) or not isinstance(source, dict):
+        return source
+    out = dict(existing)
+    for key, src_val in source.items():
+        if (
+            key in _JARVIS_OWNED_REPLACE_PARENTS
+            and isinstance(src_val, dict)
+            and isinstance(out.get(key), dict)
+        ):
+            merged_child = dict(out[key])
+            for child_key, child_val in src_val.items():
+                merged_child[child_key] = child_val
+            out[key] = merged_child
+        elif isinstance(src_val, dict) and isinstance(out.get(key), dict):
+            out[key] = _deep_merge_jarvis_json(out[key], src_val)
+        else:
+            out[key] = src_val
+    return out
+
+
+def _merge_json_file(
+    src: Path,
+    dest: Path,
+    template: bool,
+    repo_root: Path,
+    claude_home: Path,
+) -> None:
+    """Write `src` to `dest`, deep-merging with any existing dest JSON.
+
+    If dest exists and parses as JSON, merge (user keys jarvis doesn't own
+    are preserved). If dest is absent or unparseable, fall through to a
+    plain write — identical to `_copy_file` in that case.
+    """
+    if template:
+        new_bytes = template_content(src, repo_root, claude_home)
+    else:
+        new_bytes = src.read_bytes()
+    try:
+        new_data = json.loads(new_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        # Not JSON — fall back to plain write. Shouldn't happen for
+        # manifest entries flagged `merge: true`, but safe by default.
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(new_bytes)
+        return
+
+    merged: Any = new_data
+    if dest.exists():
+        try:
+            existing = json.loads(dest.read_text(encoding="utf-8"))
+            merged = _deep_merge_jarvis_json(existing, new_data)
+        except (OSError, json.JSONDecodeError):
+            # Unparseable existing → treat as absent (backup already captured it).
+            merged = new_data
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(
+        json.dumps(merged, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _set_env(name: str, value: str, platform: str) -> None:
     if platform == "windows":
         subprocess.run(["setx", name, value], check=False, capture_output=True)
@@ -340,6 +428,14 @@ def apply_plan(
     for action in plan.actions:
         if action.kind == "copy_file":
             _copy_file(
+                Path(action.source),
+                Path(action.dest),
+                action.template,
+                plan.repo_root,
+                plan.target_root,
+            )
+        elif action.kind == "merge_json":
+            _merge_json_file(
                 Path(action.source),
                 Path(action.dest),
                 action.template,
@@ -469,6 +565,11 @@ def format_plan(plan: Plan) -> str:
             if a.kind == "copy_file":
                 lines.append(
                     f"  copy_file  [{a.group:>14}] {a.source} -> {a.dest}"
+                    + ("  (template)" if a.template else "")
+                )
+            elif a.kind == "merge_json":
+                lines.append(
+                    f"  merge_json [{a.group:>14}] {a.source} -> {a.dest}"
                     + ("  (template)" if a.template else "")
                 )
             elif a.kind == "copy_dir":

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -303,9 +303,10 @@ def test_disabled_group_is_skipped(manifest: Path, fake_repo: Path) -> None:
     assert (plan.target_root / "settings.json").exists()
 
 
-def test_real_manifest_m2_enables_only_skills_group() -> None:
-    """Real manifest shape after M2 (#337): skills group flipped on, others
-    still disabled pending M3/M4. Guards against accidental early flips.
+def test_real_manifest_m3_enables_skills_hooks_mcp_but_not_soul() -> None:
+    """Real manifest shape after M3 (#338): skills + hooks_settings +
+    mcp_config flipped on; soul still disabled (pending M4 #339).
+    Guards against accidental early flip of SOUL.
     """
     real = Path(__file__).resolve().parents[1] / "install-manifest.yaml"
     assert real.exists(), "install-manifest.yaml must ship in-tree"
@@ -314,15 +315,35 @@ def test_real_manifest_m2_enables_only_skills_group() -> None:
     by_id = {g["id"]: g for g in m["groups"]}
     assert by_id["skills"]["enabled"] is True
     assert by_id["skills"]["directories"][0]["source"] == ".claude-userlevel/skills"
-    # Whitelist must exclude sprint-report (project-scoped per #337 spec).
     include = by_id["skills"]["directories"][0]["include"]
     assert "sprint-report" not in include
     assert "implement" in include and "delegate" in include
 
-    for gid in ("soul", "hooks_settings", "mcp_config"):
-        assert by_id[gid]["enabled"] is False, (
-            f"{gid} flipped ahead of its milestone — should stay off until M3/M4"
-        )
+    # M3: hooks + mcp enabled, both pointing at .claude-userlevel/ sources
+    # and marked merge:true so user keys survive.
+    assert by_id["hooks_settings"]["enabled"] is True
+    settings_entry = by_id["hooks_settings"]["files"][0]
+    assert settings_entry["source"] == ".claude-userlevel/settings.json"
+    assert settings_entry["merge"] is True
+    assert settings_entry["template"] is True
+
+    assert by_id["mcp_config"]["enabled"] is True
+    mcp_entry = by_id["mcp_config"]["files"][0]
+    assert mcp_entry["source"] == ".claude-userlevel/.mcp.json"
+    assert mcp_entry["merge"] is True
+    assert mcp_entry["template"] is True
+
+    # SOUL stays off until M4.
+    assert by_id["soul"]["enabled"] is False, (
+        "soul flipped ahead of M4 — must stay off until #339"
+    )
+
+
+def test_userlevel_source_files_exist() -> None:
+    """Source-of-truth files for M3 must ship in-tree."""
+    repo_root = Path(__file__).resolve().parents[1]
+    assert (repo_root / ".claude-userlevel" / "settings.json").exists()
+    assert (repo_root / ".claude-userlevel" / ".mcp.json").exists()
 
 
 # ---------- #344: tightening before M3 ----------
@@ -434,6 +455,190 @@ def test_health_check_uses_shlex_for_argv_parsing(
         f"quoted path split by whitespace: argv={argv}"
     )
     assert argv[0] == "python"
+
+
+# ---------- #338 (M3): settings.json + .mcp.json deep-merge ----------
+
+
+def test_deep_merge_preserves_user_hook_events(tmp_path: Path) -> None:
+    """User events jarvis doesn't own (e.g. Stop) must survive merge."""
+    existing = {
+        "hooks": {
+            "SessionStart": [{"matcher": "startup", "hooks": [
+                {"type": "command", "command": "user-custom-session.sh"}
+            ]}],
+            "Stop": [{"hooks": [{"type": "command", "command": "user-cleanup.sh"}]}],
+        },
+        "theme": "dark",  # top-level user key
+    }
+    source = {
+        "hooks": {
+            "SessionStart": [{"matcher": "startup", "hooks": [
+                {"type": "command", "command": "python /abs/jarvis/scripts/session-context.py"}
+            ]}],
+            "PreCompact": [{"hooks": [{"type": "command", "command": "python /abs/jarvis/scripts/pre-compact-backup.py"}]}],
+        }
+    }
+    merged = installer._deep_merge_jarvis_json(existing, source)
+
+    # Jarvis replaces SessionStart wholesale — user's custom SessionStart entry is gone.
+    ss = merged["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+    assert "session-context.py" in ss
+    assert "user-custom-session.sh" not in ss
+
+    # Jarvis adds PreCompact (it didn't exist before).
+    assert "PreCompact" in merged["hooks"]
+    assert "pre-compact-backup.py" in merged["hooks"]["PreCompact"][0]["hooks"][0]["command"]
+
+    # Stop (user-owned event jarvis doesn't touch) is preserved.
+    assert merged["hooks"]["Stop"][0]["hooks"][0]["command"] == "user-cleanup.sh"
+
+    # Top-level non-hooks user key preserved.
+    assert merged["theme"] == "dark"
+
+
+def test_deep_merge_preserves_user_mcp_servers(tmp_path: Path) -> None:
+    """User-added mcpServers entries must survive; jarvis-owned ones replaced."""
+    existing = {
+        "mcpServers": {
+            "memory": {"command": "old-memory", "args": ["obsolete"]},
+            "user-custom": {"command": "npx", "args": ["user-server"]},
+        }
+    }
+    source = {
+        "mcpServers": {
+            "memory": {"command": "python", "args": ["/abs/jarvis/scripts/run-memory-server.py"]},
+            "context7": {"command": "npx", "args": ["-y", "@upstash/context7-mcp@latest"]},
+        }
+    }
+    merged = installer._deep_merge_jarvis_json(existing, source)
+
+    assert merged["mcpServers"]["memory"]["command"] == "python"
+    assert "run-memory-server.py" in merged["mcpServers"]["memory"]["args"][0]
+    assert merged["mcpServers"]["context7"]["args"][0] == "-y"
+    # User-added server preserved.
+    assert merged["mcpServers"]["user-custom"]["command"] == "npx"
+    assert merged["mcpServers"]["user-custom"]["args"] == ["user-server"]
+
+
+def test_merge_json_file_fresh_write_when_dest_missing(tmp_path: Path) -> None:
+    """No existing target → write source as-is (still templated)."""
+    src = tmp_path / "src.json"
+    src.write_text(json.dumps({"hooks": {"SessionStart": [{"command": "x"}]}}),
+                   encoding="utf-8")
+    dest = tmp_path / "out" / "settings.json"
+    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path,
+                               claude_home=tmp_path)
+    assert dest.exists()
+    loaded = json.loads(dest.read_text(encoding="utf-8"))
+    assert loaded["hooks"]["SessionStart"][0]["command"] == "x"
+
+
+def test_merge_json_file_merges_onto_existing(tmp_path: Path) -> None:
+    """Existing dest → deep-merge (user keys preserved)."""
+    dest = tmp_path / "settings.json"
+    dest.write_text(json.dumps({"hooks": {"Stop": [{"c": "user"}]}, "theme": "dark"}),
+                    encoding="utf-8")
+    src = tmp_path / "src.json"
+    src.write_text(json.dumps({"hooks": {"SessionStart": [{"c": "jarvis"}]}}),
+                   encoding="utf-8")
+
+    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path,
+                               claude_home=tmp_path)
+    merged = json.loads(dest.read_text(encoding="utf-8"))
+    assert merged["hooks"]["Stop"][0]["c"] == "user"  # survived
+    assert merged["hooks"]["SessionStart"][0]["c"] == "jarvis"  # added
+    assert merged["theme"] == "dark"  # survived
+
+
+def test_merge_json_file_corrupt_existing_falls_back_to_source(tmp_path: Path) -> None:
+    """Unparseable existing dest → treat as absent and write source fresh."""
+    dest = tmp_path / "settings.json"
+    dest.write_text("{not valid json", encoding="utf-8")
+    src = tmp_path / "src.json"
+    src.write_text(json.dumps({"hooks": {"SessionStart": [{"c": "new"}]}}),
+                   encoding="utf-8")
+
+    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path,
+                               claude_home=tmp_path)
+    merged = json.loads(dest.read_text(encoding="utf-8"))
+    assert merged["hooks"]["SessionStart"][0]["c"] == "new"
+
+
+def test_merge_json_preserves_user_mcp_on_reapply(
+    manifest: Path, fake_repo: Path
+) -> None:
+    """Full flow: apply once, user adds a custom mcpServer, re-apply,
+    jarvis-owned server updates while custom server survives.
+    Idempotency for jarvis keys: re-apply doesn't duplicate."""
+    # Manifest mcp_config uses copy_file by default in fixture; switch to merge.
+    data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    for g in data["groups"]:
+        if g["id"] == "mcp_config":
+            g["files"][0]["merge"] = True
+    manifest.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    m = installer.load_manifest(manifest)
+    plan1 = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan1, m, run_env=None)
+
+    # User manually adds a custom server.
+    mcp_path = plan1.target_root / ".mcp.json"
+    existing = json.loads(mcp_path.read_text(encoding="utf-8"))
+    existing["mcpServers"]["user-obsidian"] = {"command": "npx", "args": ["user-mcp"]}
+    mcp_path.write_text(json.dumps(existing), encoding="utf-8")
+
+    # Bump SHA so build_plan considers us outdated.
+    (plan1.target_root / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+    plan2 = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan2, m, run_env=None)
+
+    final = json.loads(mcp_path.read_text(encoding="utf-8"))
+    # User-added server preserved across re-apply.
+    assert final["mcpServers"]["user-obsidian"]["command"] == "npx"
+    # Jarvis-owned server present.
+    assert "memory" in final["mcpServers"]
+    assert "run-memory-server.py" in final["mcpServers"]["memory"]["args"][0]
+    # No duplicates — idempotency check.
+    assert len(final["mcpServers"]) == 2
+
+
+def test_merge_action_kind_in_plan(manifest: Path, fake_repo: Path) -> None:
+    """Entries flagged `merge: true` produce merge_json actions, not copy_file."""
+    data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    for g in data["groups"]:
+        if g["id"] == "hooks_settings":
+            g["files"][0]["merge"] = True
+    manifest.write_text(yaml.safe_dump(data), encoding="utf-8")
+    m = installer.load_manifest(manifest)
+    plan = installer.build_plan(m, fake_repo)
+    kinds = {a.group: a.kind for a in plan.actions if a.group}
+    assert kinds.get("hooks_settings") == "merge_json"
+    assert kinds.get("mcp_config") == "copy_file"  # not flagged, stays copy
+
+
+def test_real_userlevel_templates_rewrite_scripts_paths(fake_repo: Path) -> None:
+    """The real .claude-userlevel/ templates must get scripts/ -> abs rewritten."""
+    repo_root = Path(__file__).resolve().parents[1]
+    settings_src = repo_root / ".claude-userlevel" / "settings.json"
+    mcp_src = repo_root / ".claude-userlevel" / ".mcp.json"
+
+    settings_rendered = installer.template_content(
+        settings_src, repo_root, Path("/tmp/ignore")
+    ).decode("utf-8")
+    mcp_rendered = installer.template_content(
+        mcp_src, repo_root, Path("/tmp/ignore")
+    ).decode("utf-8")
+
+    repo_posix = repo_root.as_posix()
+    # Every `scripts/` reference in the rendered output is absolute-rooted.
+    assert "python scripts/" not in settings_rendered
+    assert f"{repo_posix}/scripts/" in settings_rendered
+    assert f"{repo_posix}/config/" in settings_rendered
+    # mcp: args use relative paths that should rewrite too.
+    assert "scripts/run-memory-server.py" not in json.dumps(
+        json.loads(mcp_rendered)["mcpServers"]["memory"]["args"]
+    ) or f"{repo_posix}/scripts/run-memory-server.py" in mcp_rendered
 
 
 def test_userlevel_skills_dir_exists_and_has_whitelisted_skills() -> None:


### PR DESCRIPTION
## Summary

M3 of EPIC #335 — **point of no return**. After this, user-level Jarvis hooks fire in any CWD (not just the jarvis repo). Repo-scoped `jarvis/.claude/` stays in place and still works from jarvis CWD until M5 (#340) tombstones it.

## Changes

### New source templates
- `.claude-userlevel/settings.json` — seeded from in-tree `.claude/settings.json` (hooks config)
- `.claude-userlevel/.mcp.json` — seeded from in-tree `.mcp.json` (MCP servers)

Relative path references (`scripts/...`, `config/...`) get rewritten to absolute `<JARVIS_HOME>/scripts/...` at apply time by the existing `_transform_json_paths` pass. The `(?<!\S)` anchor from #346 lets the rewrite touch embedded command strings (`python scripts/foo.py && cat config/SOUL.md`) without mangling URLs.

### `merge_json` action kind (new)
Manifest entries flagged `merge: true` produce a `merge_json` action instead of plain `copy_file`. Strategy is jarvis-aware:

- Top-level `hooks` and `mcpServers`: **per-child-key wholesale replace**. Jarvis-owned events/servers get the new definition; user-added children (custom `Stop` hook, personal MCP server) stay put.
- Other dicts: recurse. Non-dicts at the leaf: source wins.

Per-child-key replace is the only strategy that stays idempotent (re-apply never duplicates) while still letting users keep custom entries under keys jarvis doesn't own.

**Known trade-off**: a user's custom entry *under a jarvis-owned key* (e.g. their own `SessionStart` hook, or a user-defined `memory` server) gets replaced on apply. Backup preserves it under `.claude.backup-<ts>/`. Documented in `.claude-userlevel/README.md`.

### Manifest flip
Groups `hooks_settings` and `mcp_config` go from `enabled: false` to `enabled: true`. Both source paths move to `.claude-userlevel/` (same pattern as M2 skills). Both carry `merge: true`. SOUL stays off until M4 (#339).

## Hook script portability

All 6 jarvis hook scripts (`session-context.py`, `memory-recall-hook.py`, `pre-compact-backup.py`, `device-info.py`, `secret-scanner.py`, `memory-dedup-check.py`) already resolve `_root = Path(__file__).resolve().parent.parent` — CWD-independent. When the installed hook command invokes an absolute script path, the script's view of "repo root" is correct regardless of where Claude Code was launched.

## Test plan

- [x] +9 unit tests, 30 total for installer, 796 for full suite (zero regressions)
  - `_deep_merge_jarvis_json` semantics for `hooks` AND `mcpServers`
  - fresh-write path (no existing target)
  - corrupt-existing-target fallback
  - full-flow idempotency: apply → user adds custom server → re-apply → both coexist, no dupes
  - `build_plan` emits `merge_json` for flagged entries, `copy_file` otherwise
  - real userlevel templates render with absolute paths (no leftover `python scripts/...` strings)
- [x] **End-to-end smoke on fake target**:
  - All `scripts/...` / `config/...` rewritten to absolute Windows paths
  - URLs (`https://api.githubcopilot.com/mcp`) preserved intact — regex fix from #346 kicks in
  - Env var placeholders (`${GITHUB_TOKEN}`, `${FIRECRAWL_API_KEY}`) preserved
  - User-added `mcpServers` entry survives re-apply
  - Jarvis-owned servers stay at 1 copy (no duplication)

## Rollback

Any `--apply` on an existing `~/.claude/` creates `.claude.backup-<timestamp>/` first. If apply or health-check fails, `_rollback_failed_apply` (from #346) restores from backup for outdated state or rmtree's the target for fresh state.

Closes #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)