### PR TITLE
docs(security): user-level ~/.claude/* in protected-file list (M6 #341)

### DIFF
--- a/.claude-userlevel/skills/autonomous-loop/SKILL.md
+++ b/.claude-userlevel/skills/autonomous-loop/SKILL.md
@@ -103,7 +103,7 @@ Classify each candidate by risk (see Step 5), then select:
 3. **High-risk** candidates → save as proposals only, never batch
 
 Selection filters (apply to all):
-- Not a protected file (`mcp-memory/server.py`, `SOUL.md`, `CLAUDE.md`, `.mcp.json`)
+- Not a protected file — see [`docs/security/agent-boundaries.md`](../../../docs/security/agent-boundaries.md) (covers repo-level + user-level `~/.claude/*`)
 - Not already actioned (check memory)
 
 **No candidates pass?** Skip gracefully — don't invent work.
@@ -183,7 +183,7 @@ If any action advances a goal → `goal_update(slug=..., progress=[...])` — ap
 ## Safety Rules
 
 **Never:**
-- Touch protected files: `.mcp.json`, `SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`
+- Touch protected files — authoritative list in [`docs/security/agent-boundaries.md`](../../../docs/security/agent-boundaries.md) (both repo-level and user-level `~/.claude/*` are covered)
 - Create more than 1 PR per run (even in a batch)
 - Execute more than 5 Low-risk + 1 Medium-risk per run
 - Execute High-risk actions without explicit proposal

--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -82,8 +82,7 @@ Always emit for issue implementation — outcome attribution needs the basis. Fo
 
 ### 4. Implement
 
-**Protected files — policy depends on who is editing** (see `docs/security/agent-boundaries.md`):
-`.mcp.json`, `config/SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`, `.claude/settings.json`, `.gitleaks.toml`, `.pre-commit-config.yaml`
+**Protected files — policy depends on who is editing.** The canonical list (repo-level + user-level `~/.claude/*`) lives in [`docs/security/agent-boundaries.md`](../../../docs/security/agent-boundaries.md). Don't duplicate it here — check that file before editing.
 
 - **Subagent dispatch (`/delegate`)** — never edits protected files. If the task requires it, escalate to inline `/implement`.
 - **Inline `/implement` with explicit owner approval in-session** — MAY edit protected files. Document the change prominently in the PR body (mark the file `[PROTECTED]` in the §Files Changed list + rationale) so the owner sees it before merge.

--- a/.claude/skills/autonomous-loop/SKILL.md
+++ b/.claude/skills/autonomous-loop/SKILL.md
@@ -103,7 +103,7 @@ Classify each candidate by risk (see Step 5), then select:
 3. **High-risk** candidates → save as proposals only, never batch
 
 Selection filters (apply to all):
-- Not a protected file (`mcp-memory/server.py`, `SOUL.md`, `CLAUDE.md`, `.mcp.json`)
+- Not a protected file — see [`docs/security/agent-boundaries.md`](../../../docs/security/agent-boundaries.md) (covers repo-level + user-level `~/.claude/*`)
 - Not already actioned (check memory)
 
 **No candidates pass?** Skip gracefully — don't invent work.
@@ -183,7 +183,7 @@ If any action advances a goal → `goal_update(slug=..., progress=[...])` — ap
 ## Safety Rules
 
 **Never:**
-- Touch protected files: `.mcp.json`, `SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`
+- Touch protected files — authoritative list in [`docs/security/agent-boundaries.md`](../../../docs/security/agent-boundaries.md) (both repo-level and user-level `~/.claude/*` are covered)
 - Create more than 1 PR per run (even in a batch)
 - Execute more than 5 Low-risk + 1 Medium-risk per run
 - Execute High-risk actions without explicit proposal

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -82,8 +82,7 @@ Always emit for issue implementation — outcome attribution needs the basis. Fo
 
 ### 4. Implement
 
-**Protected files — policy depends on who is editing** (see `docs/security/agent-boundaries.md`):
-`.mcp.json`, `config/SOUL.md`, `CLAUDE.md`, `mcp-memory/server.py`, `.claude/settings.json`, `.gitleaks.toml`, `.pre-commit-config.yaml`
+**Protected files — policy depends on who is editing.** The canonical list (repo-level + user-level `~/.claude/*`) lives in [`docs/security/agent-boundaries.md`](../../../docs/security/agent-boundaries.md). Don't duplicate it here — check that file before editing.
 
 - **Subagent dispatch (`/delegate`)** — never edits protected files. If the task requires it, escalate to inline `/implement`.
 - **Inline `/implement` with explicit owner approval in-session** — MAY edit protected files. Document the change prominently in the PR body (mark the file `[PROTECTED]` in the §Files Changed list + rationale) so the owner sees it before merge.

--- a/docs/security/agent-boundaries.md
+++ b/docs/security/agent-boundaries.md
@@ -1,11 +1,13 @@
 # Agent Sandbox Boundaries
 
-Date: 2026-04-15
+Date: 2026-04-15 (revised 2026-04-23 for Pillar 7 Phase 0 federation — #341)
 Scope: Rules for subagents (current /delegate + future Pillar 7 agents)
 
 ## Protected Files
 
-These files must NEVER be modified by subagents. Changes require owner review in the main session.
+These files must NEVER be modified by subagents. Changes require owner review in the main session. This table is the **single source of truth** — skills reference it rather than redefining their own lists.
+
+### Repo-level (jarvis working copy)
 
 | File | Why |
 |------|-----|
@@ -17,7 +19,20 @@ These files must NEVER be modified by subagents. Changes require owner review in
 | `.gitleaks.toml` | Secret scanning config — disabling = security bypass |
 | `.pre-commit-config.yaml` | Pre-commit hooks — disabling = security bypass |
 
-Enforced via PreToolUse hook: `scripts/protected-files.py`
+### User-level (installed under `~/.claude/` by `scripts/install/installer.py`)
+
+Editing these changes behaviour for **every Claude Code session on the device**, across all projects — strictly broader blast radius than the repo-level copies.
+
+| File | Why |
+|------|-----|
+| `~/.claude/settings.json` | User-level hooks — run in every session on this device |
+| `~/.claude/SOUL.md` | User-level identity — loaded by SessionStart hook before project CLAUDE.md |
+| `~/.claude/.mcp.json` | User-level MCP config — mounts servers for every project |
+| `~/.claude/skills/*/SKILL.md` | User-level skill definitions — available in every project |
+
+The source of truth for these files lives in the jarvis repo (`config/SOUL.md`, `.claude-userlevel/settings.json`, `.claude-userlevel/.mcp.json`, `.claude-userlevel/skills/*/SKILL.md`). The installer copies or templates them into `~/.claude/`. Direct edits to `~/.claude/` drift from source and are lost on the next `install.ps1 --apply`.
+
+Enforced via PreToolUse hook: `scripts/protected-files.py` (covers both surfaces; user-level paths anchored to `Path.home() / ".claude"` or `$JARVIS_CLAUDE_HOME` override).
 
 ## Branch Rules
 

--- a/scripts/protected-files.py
+++ b/scripts/protected-files.py
@@ -2,12 +2,20 @@
 
 Checks Edit/Write tool inputs for file paths that match the protected list.
 Exits 2 to block if a protected file is targeted.
+
+Covers two surfaces (kept in sync with ``docs/security/agent-boundaries.md``):
+- Repo-level files under the jarvis working copy (source of truth).
+- User-level files under ``~/.claude/`` installed by ``scripts/install/installer.py``.
+  Editing those affects every Claude Code session on the device, so they get
+  the same protection as the jarvis-repo source.
 """
 
 import json
+import os
 import sys
+from pathlib import Path
 
-# Files that require owner review — agents must not modify these.
+# Repo-level files that require owner review — agents must not modify these.
 PROTECTED_FILES = {
     ".mcp.json",
     "config/SOUL.md",
@@ -17,6 +25,21 @@ PROTECTED_FILES = {
     ".gitleaks.toml",
     ".pre-commit-config.yaml",
 }
+
+# User-level paths (relative to ``~/.claude/``) that require owner review.
+# Expansion target matches installer.py — respects JARVIS_CLAUDE_HOME override.
+_USER_LEVEL_PROTECTED_FILES = {
+    "settings.json",
+    "SOUL.md",
+    ".mcp.json",
+}
+
+
+def _user_claude_home() -> str:
+    """Return the user-level Claude home directory as a forward-slash string."""
+    override = os.environ.get("JARVIS_CLAUDE_HOME")
+    home = Path(override).expanduser() if override else (Path.home() / ".claude")
+    return home.as_posix().rstrip("/")
 
 
 def normalize_path(path: str) -> str:
@@ -34,10 +57,30 @@ def normalize_path(path: str) -> str:
     return path
 
 
+def _is_user_level_protected(normalized: str) -> bool:
+    """True if `normalized` points at a user-level protected file under ``~/.claude/``.
+
+    Anchored to the resolved user home (or ``$JARVIS_CLAUDE_HOME``) so paths
+    like ``some-other-project/.claude/settings.json`` don't false-positive.
+    """
+    claude_home = _user_claude_home()
+    prefix = claude_home + "/"
+    if not normalized.startswith(prefix):
+        return False
+    rel = normalized[len(prefix):]
+    if rel in _USER_LEVEL_PROTECTED_FILES:
+        return True
+    # skills/<name>/SKILL.md — any user-level skill definition.
+    parts = rel.split("/")
+    return len(parts) == 3 and parts[0] == "skills" and parts[2] == "SKILL.md"
+
+
 def is_protected(file_path: str) -> bool:
-    """Check if a file path matches any protected file."""
+    """Check if a file path matches any protected file (repo-level or user-level)."""
     normalized = normalize_path(file_path)
-    return normalized in PROTECTED_FILES
+    if normalized in PROTECTED_FILES:
+        return True
+    return _is_user_level_protected(normalized)
 
 
 def block(file_path: str):

--- a/scripts/protected-files.py
+++ b/scripts/protected-files.py
@@ -62,12 +62,18 @@ def _is_user_level_protected(normalized: str) -> bool:
 
     Anchored to the resolved user home (or ``$JARVIS_CLAUDE_HOME``) so paths
     like ``some-other-project/.claude/settings.json`` don't false-positive.
+
+    On Windows, the filesystem is case-insensitive so prefix matching is too
+    (e.g. ``c:/users/petrk/.claude/...`` must still match regardless of drive
+    letter / user dir casing); ``os.path.normcase`` handles this. POSIX is
+    left case-sensitive by the same call.
     """
     claude_home = _user_claude_home()
-    prefix = claude_home + "/"
-    if not normalized.startswith(prefix):
+    prefix = os.path.normcase(claude_home + "/")
+    candidate = os.path.normcase(normalized)
+    if not candidate.startswith(prefix):
         return False
-    rel = normalized[len(prefix):]
+    rel = normalized[len(prefix):]  # slice the original so case of `rel` is preserved
     if rel in _USER_LEVEL_PROTECTED_FILES:
         return True
     # skills/<name>/SKILL.md — any user-level skill definition.

--- a/tests/test_protected_files.py
+++ b/tests/test_protected_files.py
@@ -111,6 +111,21 @@ def test_blocks_user_level_skill_backslashes(fake_claude_home):
     assert is_protected(winpath)
 
 
+def test_blocks_user_level_mcp_backslashes(fake_claude_home):
+    # Symmetry with SKILL.md — ensure the full user-level surface handles backslashes.
+    winpath = fake_claude_home.replace("/", "\\") + "\\.mcp.json"
+    assert is_protected(winpath)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only: NTFS is case-insensitive")
+def test_blocks_user_level_case_insensitive_on_windows(fake_claude_home):
+    # On Windows the FS is case-insensitive, so the guard must be too —
+    # otherwise an agent could bypass by lower-casing the drive letter or
+    # the ``Users\\<name>`` path segment.
+    mixed = fake_claude_home.lower() + "/settings.json"
+    assert is_protected(mixed)
+
+
 # ── User-level: look-alike paths allowed ────────────────────────────
 
 def test_allows_other_project_claude_settings(fake_claude_home, tmp_path):

--- a/tests/test_protected_files.py
+++ b/tests/test_protected_files.py
@@ -2,6 +2,9 @@
 
 import sys
 import os
+from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
@@ -10,6 +13,15 @@ protected_files = importlib.import_module("protected-files")
 
 is_protected = protected_files.is_protected
 normalize_path = protected_files.normalize_path
+
+
+@pytest.fixture
+def fake_claude_home(tmp_path, monkeypatch):
+    """Pin ``JARVIS_CLAUDE_HOME`` to a tmp dir so user-level assertions don't
+    depend on the developer's real home."""
+    home = tmp_path / ".claude"
+    monkeypatch.setenv("JARVIS_CLAUDE_HOME", str(home))
+    return home.as_posix().rstrip("/")
 
 
 # ── Protected files: blocked ─────────────────────────────────────────
@@ -73,3 +85,47 @@ def test_normalize_leading_dot_slash():
 
 def test_normalize_absolute():
     assert normalize_path("C:/Users/petrk/GitHub/jarvis/CLAUDE.md") == "CLAUDE.md"
+
+
+# ── User-level (~/.claude/) paths: blocked ───────────────────────────
+
+def test_blocks_user_level_settings(fake_claude_home):
+    assert is_protected(f"{fake_claude_home}/settings.json")
+
+
+def test_blocks_user_level_soul(fake_claude_home):
+    assert is_protected(f"{fake_claude_home}/SOUL.md")
+
+
+def test_blocks_user_level_mcp(fake_claude_home):
+    assert is_protected(f"{fake_claude_home}/.mcp.json")
+
+
+def test_blocks_user_level_skill(fake_claude_home):
+    assert is_protected(f"{fake_claude_home}/skills/implement/SKILL.md")
+
+
+def test_blocks_user_level_skill_backslashes(fake_claude_home):
+    # Normalize must handle native Windows separators on the user-level surface too.
+    winpath = fake_claude_home.replace("/", "\\") + "\\skills\\delegate\\SKILL.md"
+    assert is_protected(winpath)
+
+
+# ── User-level: look-alike paths allowed ────────────────────────────
+
+def test_allows_other_project_claude_settings(fake_claude_home, tmp_path):
+    """`.claude/settings.json` inside some unrelated repo is NOT user-level —
+    and since normalize_path doesn't strip its prefix, it must not match
+    the repo-level `.claude/settings.json` entry either."""
+    other = (tmp_path / "other-project" / ".claude" / "settings.json").as_posix()
+    assert not is_protected(other)
+
+
+def test_allows_user_level_non_protected(fake_claude_home):
+    # Files under ~/.claude/ that aren't on the list (e.g. projects/, history) stay allowed.
+    assert not is_protected(f"{fake_claude_home}/projects/some-project/history.jsonl")
+
+
+def test_allows_user_level_skill_subresource(fake_claude_home):
+    # Only SKILL.md itself is protected — co-located scripts or resources aren't.
+    assert not is_protected(f"{fake_claude_home}/skills/implement/helper.py")


### PR DESCRIPTION
## Summary
- Extends the protected-file surface with user-level paths (`~/.claude/{settings.json, SOUL.md, .mcp.json, skills/*/SKILL.md}`) so Pillar 7 Phase 0 federation doesn't open a broader blast radius for subagents.
- Makes `docs/security/agent-boundaries.md` the single source of truth; trims inline duplicates in `implement` + `autonomous-loop` skills (both `.claude-userlevel/` and `.claude/` copies per the M2-to-M5 DRY rule).
- Enforcer (`scripts/protected-files.py`) anchors user-level detection to `Path.home() / .claude` — respects `JARVIS_CLAUDE_HOME` override to match installer. Prevents false-positives on other-project `.claude/*`.

## Context
Part of [EPIC #335](https://github.com/Osasuwu/jarvis/issues/335) — M6 is a docs-only milestone (no M7 gate). M5 (tombstone) is still blocked on M7 smoke-test.

## Test plan
- [x] `python -m pytest tests/test_protected_files.py` — 25 passed (8 new user-level tests)
- [x] `python -m pytest` — full suite 805 passed / 5 skipped, no regressions
- [x] Canonical doc (`docs/security/agent-boundaries.md`) + enforcer + tests in sync
- [x] Inline list duplicates removed from skills; references point at canonical doc

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)