### PR TITLE
fix(installer): tolerate mid-copy vanishing files in backup (#350)

### DIFF
--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -413,6 +413,33 @@ def _platform() -> str:
     return "windows" if os.name == "nt" else "posix"
 
 
+def _copy_tolerant(src: str, dst: str, *, follow_symlinks: bool = True) -> str | None:
+    """shutil.copy2 that tolerates entries which vanish mid-copy.
+
+    Claude Code actively rotates files under ``~/.claude/debug/`` while the
+    installer runs. ``shutil.copytree`` defaults to aggregate-then-raise on
+    such races, aborting the whole backup (#350). These artefacts aren't
+    user data — skip with a stderr note and continue instead of failing
+    the install.
+    """
+    try:
+        return shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
+    except FileNotFoundError as e:
+        print(f"backup: skipped vanished entry {src} ({e})", file=sys.stderr)
+        return None
+
+
+def _backup_target_root(target_root: Path, backup_path: Path) -> None:
+    """Copy ``target_root`` to ``backup_path`` tolerating mid-copy file disappearance."""
+    shutil.copytree(
+        target_root,
+        backup_path,
+        copy_function=_copy_tolerant,
+        symlinks=True,
+        ignore_dangling_symlinks=True,
+    )
+
+
 def apply_plan(
     plan: Plan,
     manifest: dict[str, Any],
@@ -421,7 +448,7 @@ def apply_plan(
     if plan.state == "current":
         return
     if plan.backup_path is not None:
-        shutil.copytree(plan.target_root, plan.backup_path)
+        _backup_target_root(plan.target_root, plan.backup_path)
 
     plan.target_root.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -414,23 +414,33 @@ def _platform() -> str:
 
 
 def _copy_tolerant(src: str, dst: str, *, follow_symlinks: bool = True) -> str | None:
-    """shutil.copy2 that tolerates entries which vanish mid-copy.
+    """shutil.copy2 that tolerates entries which vanish or lock mid-copy.
 
     Claude Code actively rotates files under ``~/.claude/debug/`` while the
     installer runs. ``shutil.copytree`` defaults to aggregate-then-raise on
     such races, aborting the whole backup (#350). These artefacts aren't
     user data — skip with a stderr note and continue instead of failing
     the install.
+
+    Tolerated errors:
+    - ``FileNotFoundError`` — entry disappeared between scandir and copy
+    - ``PermissionError`` — entry is held open with an exclusive lock
+      (common on Windows while a log file is being rotated / appended to)
     """
     try:
         return shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
-    except FileNotFoundError as e:
-        print(f"backup: skipped vanished entry {src} ({e})", file=sys.stderr)
+    except (FileNotFoundError, PermissionError) as e:
+        print(f"backup: skipped unreadable entry {src} ({e})", file=sys.stderr)
         return None
 
 
 def _backup_target_root(target_root: Path, backup_path: Path) -> None:
-    """Copy ``target_root`` to ``backup_path`` tolerating mid-copy file disappearance."""
+    """Copy ``target_root`` to ``backup_path`` tolerating mid-copy disappearance/locks.
+
+    ``symlinks=True`` preserves symlinks as symlinks rather than dereferencing;
+    combined with ``ignore_dangling_symlinks=True`` this future-proofs against
+    broken junctions inside the target tree (Claude Code can create them).
+    """
     shutil.copytree(
         target_root,
         backup_path,

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -726,4 +726,34 @@ def test_backup_tolerates_vanished_file(
     assert (plan2.backup_path / "SOUL.md").exists()
     assert not (plan2.backup_path / "debug" / "latest").exists()  # the vanishing one
     stderr = capsys.readouterr().err
-    assert "vanished" in stderr and "latest" in stderr
+    assert "unreadable" in stderr and "latest" in stderr
+
+
+def test_backup_tolerates_locked_file(
+    manifest: Path, fake_repo: Path, monkeypatch, capsys
+) -> None:
+    """Windows log rotation can hold a PermissionError on the file being appended to.
+    Same tolerance applies (#350 review nit)."""
+    m = installer.load_manifest(manifest)
+    plan1 = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan1, m, run_env=None)
+
+    (plan1.target_root / "debug").mkdir(exist_ok=True)
+    (plan1.target_root / "debug" / "locked.log").write_text("x\n", encoding="utf-8")
+
+    real_copy2 = installer.shutil.copy2
+
+    def locked_copy2(src, dst, *, follow_symlinks=True):
+        if str(src).endswith("locked.log"):
+            raise PermissionError(13, "file is locked by another process", str(src))
+        return real_copy2(src, dst, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(installer.shutil, "copy2", locked_copy2)
+
+    (plan1.target_root / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+    plan2 = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan2, m, run_env=None)
+
+    assert plan2.backup_path.exists()
+    assert not (plan2.backup_path / "debug" / "locked.log").exists()
+    assert "locked.log" in capsys.readouterr().err

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -683,3 +683,47 @@ def test_userlevel_skills_dir_exists_and_has_whitelisted_skills() -> None:
     for name in include:
         skill_md = src / name / "SKILL.md"
         assert skill_md.exists(), f"whitelisted skill missing: {skill_md}"
+
+
+# ── #350: backup tolerates files that vanish mid-copy ────────────────
+
+
+def test_backup_tolerates_vanished_file(
+    manifest: Path, fake_repo: Path, monkeypatch, capsys
+) -> None:
+    """Claude Code rotates files in ~/.claude/debug/ while the installer runs.
+    shutil.copytree would abend the whole install with shutil.Error; we patch
+    _copy_tolerant onto shutil.copy2 so the backup completes and the install
+    proceeds, logging the skipped entry to stderr."""
+    m = installer.load_manifest(manifest)
+    plan1 = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan1, m, run_env=None)
+
+    # Create an extra debug entry that will "vanish" during the next backup.
+    debug_dir = plan1.target_root / "debug"
+    debug_dir.mkdir(exist_ok=True)
+    vanishing = debug_dir / "latest"
+    vanishing.write_text("ephemeral\n", encoding="utf-8")
+
+    real_copy2 = installer.shutil.copy2
+
+    def flaky_copy2(src, dst, *, follow_symlinks=True):
+        if str(src).endswith("latest"):
+            raise FileNotFoundError(2, "simulated mid-copy vanish", str(src))
+        return real_copy2(src, dst, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(installer.shutil, "copy2", flaky_copy2)
+
+    # Trigger outdated re-apply → exercises the backup path.
+    (plan1.target_root / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+    plan2 = installer.build_plan(m, fake_repo)
+    assert plan2.state == "outdated"
+
+    # Must NOT raise. Backup completes; skipped entry is logged to stderr.
+    installer.apply_plan(plan2, m, run_env=None)
+
+    assert plan2.backup_path.exists()
+    assert (plan2.backup_path / "SOUL.md").exists()
+    assert not (plan2.backup_path / "debug" / "latest").exists()  # the vanishing one
+    stderr = capsys.readouterr().err
+    assert "vanished" in stderr and "latest" in stderr


### PR DESCRIPTION
## Summary
- \`shutil.copytree\` aborts the whole install when Claude Code rotates files under \`~/.claude/debug/\` mid-backup. Custom \`copy_function\` now catches \`FileNotFoundError\`, logs to stderr, and continues — skipping ephemeral debug artefacts rather than failing the install.
- Extracts \`_backup_target_root\` for testability; adds \`symlinks=True\` + \`ignore_dangling_symlinks=True\` as future-proofing against broken junctions.
- Regression test injects a vanishing file via monkeypatched \`shutil.copy2\` and asserts the backup completes with the skipped entry logged.

## Context
Blocks M7 (#342) on Main PC (device already has active Claude Code runs writing to \`~/.claude/debug/\`). Part of [EPIC #335](https://github.com/Osasuwu/jarvis/issues/335) Pillar 7 Phase 0.

## Test plan
- [x] \`python -m pytest tests/test_installer.py\` — 32 passed (1 new)
- [x] \`python -m pytest tests/test_installer.py::test_backup_tolerates_vanished_file\` — passes
- [ ] \`python scripts/install/installer.py --apply\` on Main PC — verify M7 outdated-state cell goes green (follow-up after merge)

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)