### PR TITLE
feat(security): wire protected-files.py as PreToolUse hook (#355)

### DIFF
--- a/.claude-userlevel/settings.json
+++ b/.claude-userlevel/settings.json
@@ -73,6 +73,15 @@
             "command": "python scripts/memory-dedup-check.py"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python scripts/protected-files.py"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [


### PR DESCRIPTION
## Summary

- Wire `scripts/protected-files.py` into `.claude-userlevel/settings.json` PreToolUse for `Edit|Write|NotebookEdit` — it already had 27 tests but no runtime wiring.
- Installer's `_transform_json_paths` rewrites the relative `scripts/` prefix to absolute at install time, same as the other PreToolUse hooks.

## Why this mattered

`docs/security/agent-boundaries.md:35` says \"Enforced via PreToolUse hook: scripts/protected-files.py\". Grep across `.claude-userlevel/settings.json`, `.claude/settings.json`, and `install-manifest.yaml` found zero references. So the protected-file list (including SOUL.md, CLAUDE.md, settings.json itself, memory-server) was protected only by skills' instructions to agents — not by a hard gate.

## Smoke tests

```
$ echo '{\"tool_input\":{\"file_path\":\"config/SOUL.md\"}}' | python scripts/protected-files.py
{\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"permissionDecision\": \"deny\", ...}}
exit=2

$ echo '{\"tool_input\":{\"file_path\":\"docs/PROJECT_PLAN.md\"}}' | python scripts/protected-files.py
exit=0

$ pytest tests/test_installer.py tests/test_protected_files.py
61 passed in 9.24s
```

## Risk

- **Agents will no longer be able to Edit/Write protected files.** That's the goal. If an agent has a legitimate need, it must document the change in the PR description and leave it for the owner (per `docs/security/agent-boundaries.md`).
- **Installer itself is unaffected** — it runs as a subprocess from `install.ps1`/`install.sh`, not through Claude Code's Edit/Write tools.
- **SessionStart `cat ~/.claude/SOUL.md`** is unaffected — matcher is `Edit|Write|NotebookEdit`, not read.

## Deployment

After merge, run `install.ps1 -Apply` (or `install.sh --apply`) on each device to propagate the new hook to `~/.claude/settings.json`. Idempotent — safe to re-run.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)