### PR TITLE
docs: refresh architecture + setup docs post-federation (#356)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,13 @@ You (any device)
   |
   |-- Claude Code CLI / Desktop / Web
   |     |
-  |     |-- .claude/skills/     7 custom slash commands
-  |     |-- .claude/agents/     subagent definitions
-  |     |-- config/SOUL.md      personality (auto-loaded)
-  |     |-- CLAUDE.md           rules + autonomy config
+  |     |-- ~/.claude/skills/      12 universal slash commands (user-level, CWD-agnostic)
+  |     |-- ~/.claude/SOUL.md      personality (auto-loaded)
+  |     |-- ~/.claude/settings.json    hooks (SessionStart, PreToolUse, ...)
+  |     |-- ~/.claude/.mcp.json    MCP servers (memory, github, context7, ...)
   |     |
-  |     |-- MCP Servers:
-  |     |     memory    --> Supabase (cross-device)
-  |     |     github    --> GitHub Copilot MCP
-  |     |     context7  --> library docs
-  |     |     firecrawl --> web research
+  |     |-- jarvis/CLAUDE.md       project rules + autonomy config
+  |     |-- jarvis/.claude/        project-scoped extras (e.g. /sprint-report)
   |     |
   |-- Telegram (via Claude Code Channels, optional)
 
@@ -57,6 +54,10 @@ Supabase DB
   |-- goals       (strategic context)
   |-- events      (CI, alerts, deployments)
 ```
+
+User-level Jarvis is seeded from `.claude-userlevel/` in this repo by
+`install.ps1` / `install.sh` (idempotent, backup-first). See
+`scripts/install/installer.py`.
 
 **Design principle:** Claude Code native first. The only custom Python is `mcp-memory/server.py` -- everything else uses skills, hooks, and subagents.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -75,8 +75,8 @@ Skills are designed to work in both environments:
 - Local: `memory_store`/`memory_recall` via custom MCP
 - Cloud: `execute_sql` via Supabase connector, `gh` CLI for GitHub
 
-Task prompts should reference the skill file:
+Task prompts should invoke skills via slash command — resolves against whichever Claude Code home (`~/.claude/` after federation) is loaded:
 ```
-Read and follow .claude/skills/nightly-research/SKILL.md
+Run /research in --mode=autonomous
 ```
-This way updating the skill in the repo automatically updates the task.
+This way updating the skill in the repo (via `.claude-userlevel/skills/<name>/` → re-apply the installer) automatically updates task behaviour.

--- a/config/SETUP.md
+++ b/config/SETUP.md
@@ -184,5 +184,7 @@ Then open the project in Claude Code and run `/triage`.
 | MCP config | `.mcp.json` (repo root) |
 | Memory server | `mcp-memory/server.py` |
 | Memory schema | `mcp-memory/schema.sql` |
-| Claude Code global config | `~/.claude/settings.json` (device-local) |
-| Skills | `.claude/skills/` |
+| Claude Code global config | `~/.claude/settings.json` (seeded from `.claude-userlevel/settings.json` by installer) |
+| Universal skills (source) | `.claude-userlevel/skills/` (installs to `~/.claude/skills/`) |
+| Project-scoped skills | `.claude/skills/` (jarvis-only — currently just `/sprint-report`) |
+| Installer | `scripts/install/installer.py`, entry points `install.ps1` / `install.sh` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,27 +1,33 @@
 # Jarvis Architecture
 
-Version: 4.0
-Date: 2026-03-31
+Version: 4.1
+Date: 2026-04-24
 Status: Active
 
 ## 1. System Overview
 
 Jarvis is a personal AI agent built on top of **Claude Code** — not a custom Python application. Claude Code is the runtime; Jarvis adds identity, memory, and skills on top of it.
 
+Since EPIC #335 (2026-04-23), Jarvis is **federated** to user level: the SOUL, the core skills, the hooks, and the MCP servers live at `~/.claude/` and load regardless of which project Claude Code was launched in. Project repos only carry project-specific additions.
+
 ```
-┌──────────────────────────────────────────────────┐
-│                   Claude Code                     │
-│                                                   │
-│  config/SOUL.md      ← Jarvis identity            │
-│  .claude/CLAUDE.md   ← session rules              │
-│  .claude/skills/     ← custom slash commands      │
-│  .claude/agents/     ← subagent definitions       │
-│                                                   │
-│  MCP Servers:                                     │
-│  ├── memory   ← Supabase (this repo)              │
-│  ├── github   ← official MCP                      │
-│  └── reddit   ← uvx, no auth                     │
-└──────────────────────┬───────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│                     Claude Code                       │
+│                                                       │
+│  ~/.claude/SOUL.md       ← Jarvis identity            │
+│  ~/.claude/skills/       ← universal slash commands   │
+│  ~/.claude/settings.json ← hooks (SessionStart, ...)  │
+│  ~/.claude/.mcp.json     ← MCP servers (user-level)   │
+│                                                       │
+│  <project>/CLAUDE.md     ← project rules              │
+│  <project>/.claude/      ← project-specific skills    │
+│                            + agents (e.g. coding.md)  │
+│                                                       │
+│  MCP Servers:                                         │
+│  ├── memory   ← Supabase (this repo)                  │
+│  ├── github   ← official MCP                          │
+│  └── context7 ← live library docs                     │
+└──────────────────────┬───────────────────────────────┘
                        │
                   Supabase DB
            (memory syncs across all devices)
@@ -29,21 +35,35 @@ Jarvis is a personal AI agent built on top of **Claude Code** — not a custom P
 
 ## 2. What lives where
 
-### Inside Claude Code (zero custom Python)
+### User-level (universal, one install per device)
+
+Installed to `~/.claude/` by `scripts/install/installer.py` (entry points `install.ps1` / `install.sh`). Source of truth for most of it lives in this repo under `.claude-userlevel/`; SOUL stays canonical at `config/SOUL.md`.
+
+| Component | Source in repo | Installed to | Purpose |
+|-----------|----------------|--------------|---------|
+| Identity | `config/SOUL.md` | `~/.claude/SOUL.md` | Personality, tone, behavior rules (loaded by SessionStart) |
+| Universal skills | `.claude-userlevel/skills/*/SKILL.md` | `~/.claude/skills/*/SKILL.md` | 12 core slash commands: `implement`, `delegate`, `verify`, `status`, `reflect`, `end`, `end-quick`, `research`, `goals`, `self-improve`, `setup-tasks`, `autonomous-loop` |
+| Hooks | `.claude-userlevel/settings.json` | `~/.claude/settings.json` (deep-merged) | SessionStart, PreCompact, PreToolUse secret/dedup/protected-file scans, UserPromptSubmit memory recall |
+| MCP servers | `.claude-userlevel/.mcp.json` | `~/.claude/.mcp.json` (deep-merged) | memory, github, context7, etc. |
+| Version pin | — | `~/.claude/.jarvis-version` | Current applied jarvis SHA (for no-op detection) |
+
+### Project-level (jarvis repo)
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| Identity | `config/SOUL.md` | Personality, tone, behavior rules |
-| Session init | `.claude/CLAUDE.md` | What to do at session start |
-| Skills | `.claude/skills/*/SKILL.md` | User-invoked slash commands |
-| Commands | `.claude/commands/*.md` | Additional slash commands |
-| Subagents | `.claude/agents/*.md` | Delegated task runners |
+| Project init | `CLAUDE.md` | Session rules specific to the jarvis project |
+| Project skills | `.claude/skills/sprint-report/` | Only skill that isn't universal (redrobot release flow) |
+| Project subagents | `.claude/agents/coding.md` | Project-scoped coding agent definition |
+| Empty hooks | `.claude/settings.json` (`{}`) | Reserved for jarvis-only hooks if ever needed |
+| Tombstone | `.claude/README.md` | Redirects readers to `.claude-userlevel/` |
 
 ### External Python (only what Claude Code can't do)
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
 | Memory server | `mcp-memory/server.py` | Cross-device Supabase memory via MCP |
+| Installer | `scripts/install/installer.py` | Seeds `~/.claude/` from this repo; idempotent, backup-first |
+| Hook scripts | `scripts/*.py` | SessionStart context, PreCompact backup, secret scanner, protected-file guard, memory recall |
 | Risk scanner | `src/risk_radar.py` | Deterministic pattern scan, no LLM |
 
 Everything else (Telegram, scheduling, background tasks) uses Anthropic-native features — not custom code.
@@ -105,24 +125,23 @@ Claude Code (Sonnet — default)
 
 ## 5. Skills
 
-Skills live in `.claude/skills/` and are invoked as `/skill-name`.
+Universal skills live at `~/.claude/skills/` (source of truth: `.claude-userlevel/skills/`) and are invoked as `/skill-name` from any CWD. The routing table in `CLAUDE.md` describes when each is used.
 
-| Skill | Model | Purpose |
-|-------|-------|---------|
-| `triage` | Haiku | GitHub board health, stale issues |
-| `research` | Sonnet | Topic investigation, source validation |
-| `delegate` | Sonnet | Issue → PR via coding subagent |
-| `risk-radar` | Haiku | CI health, security alerts, pattern scan |
-| `self-review` | Sonnet | Codebase quality audit |
-| `self-improve` | Sonnet | Auto-apply low/medium-risk fixes → PR |
-| `intel` | Haiku | Claude/MCP/AI ecosystem digest |
+| Skill | Purpose |
+|-------|---------|
+| `/implement` | Deliver a single GitHub issue in this session |
+| `/delegate` | Dispatch multiple issues to parallel coding subagents |
+| `/verify` | Check pending outcomes: PRs merged, tests pass, extract lessons |
+| `/status` | Project dashboard: git, PRs, issues, CI, risks, goal alerts |
+| `/reflect` | Learning loop — review decisions, check outcomes via PRs |
+| `/end`, `/end-quick` | Session closure (full / 30-sec checkpoint) |
+| `/research` | Topic investigation, option comparison, autonomous discovery |
+| `/goals` | View / set / update strategic goals |
+| `/self-improve` | Health check + gap analysis + auto-apply low-risk fixes |
+| `/setup-tasks` | Bootstrap scheduled tasks on a new device (idempotent) |
+| `/autonomous-loop` | Perceive → evaluate → decide → act (daily scheduled or manual) |
 
-Commands in `.claude/commands/`:
-
-| Command | Purpose |
-|---------|---------|
-| `end` | Session closure — save unsaved decisions |
-| `repo-health` | Structural audit (docs, branches, actions) |
+Project-specific skills stay under `<project>/.claude/skills/`. In this repo the only one is `/sprint-report` (redrobot release flow).
 
 ## 6. Mobile access
 
@@ -142,37 +161,66 @@ Nightly research runs at 03:00, topics configured in `config/research-topics.yam
 
 - Coder subagent: branch + PR only, never direct push to `main`
 - Human review required before merge
-- Protected files (never auto-modified): `.mcp.json`, `CLAUDE.md`, `mcp-memory/server.py`, `config/SOUL.md`
+- Protected-file list — canonical in `docs/security/agent-boundaries.md`; enforced at runtime by `scripts/protected-files.py` (PreToolUse hook for Edit/Write/NotebookEdit)
 - Cost default: Haiku; escalate to Sonnet only when reasoning required
+- Secrets never touched — PreToolUse `scripts/secret-scanner.py` blocks Bash, GitHub writes, and memory_store calls that contain credential values
 
 ## 9. Project structure
 
 ```
 jarvis/
 ├── config/
-│   ├── SOUL.md              ← Jarvis personality (loaded every session)
+│   ├── SOUL.md              ← Jarvis personality (canonical; installed to ~/.claude/SOUL.md)
 │   ├── SETUP.md             ← First-time device setup
-│   └── repos.conf           ← Repos scanned by triage/risk-radar
+│   └── repos.conf           ← Repos scanned by risk-radar / autonomous-loop
+├── .claude-userlevel/       ← SOURCE OF TRUTH for user-level install
+│   ├── settings.json        ← Hooks (installed to ~/.claude/settings.json)
+│   ├── .mcp.json            ← MCP servers (installed to ~/.claude/.mcp.json)
+│   └── skills/              ← 12 universal skills (installed to ~/.claude/skills/)
+├── scripts/
+│   ├── install/
+│   │   ├── installer.py     ← Seeds ~/.claude/ from this repo
+│   │   └── install-manifest.yaml  ← Whitelist of what ships
+│   ├── session-context.py   ← SessionStart: load memory + goals
+│   ├── memory-recall-hook.py  ← UserPromptSubmit: topic-aware recall
+│   ├── secret-scanner.py    ← PreToolUse: block credential values
+│   ├── protected-files.py   ← PreToolUse: block edits to protected files
+│   ├── pre-compact-backup.py  ← PreCompact: snapshot before summarization
+│   └── device-info.py       ← SessionStart: banner
 ├── mcp-memory/
 │   ├── server.py            ← MCP memory server (Supabase)
 │   ├── schema.sql           ← Supabase table + vector index
-│   └── requirements.txt     ← Python deps for server.py
+│   └── requirements.txt
 ├── src/
 │   └── risk_radar.py        ← Standalone risk scanner (no LLM)
-├── tests/
-│   └── test_risk_radar.py
+├── tests/                   ← pytest suite (800+ tests)
 ├── docs/
 │   ├── PROJECT_PLAN.md      ← Vision, milestones
 │   ├── architecture.md      ← This file
-│   └── telegram-setup.md    ← Telegram Channels setup
-├── .claude/
-│   ├── CLAUDE.md            ← Session initialization rules
-│   ├── skills/              ← Slash commands (model-invoked)
-│   ├── commands/            ← Slash commands (user-invoked)
-│   └── agents/              ← Subagent definitions
-├── .github/
-│   └── workflows/           ← CI (PR checks, issue validation)
-├── .mcp.json                ← MCP server registry
-├── .env.example             ← Secrets template
-└── pyproject.toml           ← Python packaging (memory extra)
+│   ├── security/
+│   │   └── agent-boundaries.md  ← Protected-file + scope rules (single source)
+│   └── design/              ← Design notes per pillar
+├── .claude/                 ← Project-scoped (tombstoned — see .claude/README.md)
+│   ├── README.md            ← Tombstone pointer
+│   ├── settings.json        ← `{}` — reserved for project-local hooks
+│   ├── agents/coding.md     ← Project-scoped coding subagent
+│   └── skills/sprint-report/  ← Only non-universal skill
+├── install.ps1              ← Windows entry point to installer.py
+├── install.sh               ← POSIX entry point
+├── CLAUDE.md                ← Jarvis-project session rules
+├── .github/workflows/       ← CI
+├── .mcp.json                ← Project MCP registry (repo-scoped extras)
+├── .env.example
+└── pyproject.toml
+```
+
+After `install.ps1 -Apply` (or `install.sh --apply`), user-level artefacts land under:
+
+```
+~/.claude/
+├── SOUL.md                  ← copied from config/SOUL.md
+├── settings.json            ← deep-merged from .claude-userlevel/settings.json
+├── .mcp.json                ← deep-merged from .claude-userlevel/.mcp.json
+├── skills/                  ← 12 universal skills
+└── .jarvis-version          ← git SHA of applied jarvis version
 ```

--- a/docs/design/autonomous-loop.md
+++ b/docs/design/autonomous-loop.md
@@ -187,13 +187,13 @@ Scheduled tasks are local (per-device). Three approaches:
 
 | File | Purpose |
 |------|---------|
-| `.claude/skills/autonomous-loop/SKILL.md` | Orchestrator skill (manual + scheduled) |
-| `.claude/skills/setup-tasks/SKILL.md` | Bootstrap tasks on new device |
+| `.claude-userlevel/skills/autonomous-loop/SKILL.md` | Orchestrator skill (manual + scheduled); ships to `~/.claude/skills/autonomous-loop/` |
+| `.claude-userlevel/skills/setup-tasks/SKILL.md` | Bootstrap tasks on new device |
 | `.github/workflows/event-dispatch.yml` | GitHub Action → Supabase events |
 | `mcp-memory/schema.sql` | Events table schema |
 | `mcp-memory/server.py` | events_list + events_mark_processed tools |
 | `~/.claude/scheduled-tasks/*/SKILL.md` | 6 scheduled task wrappers |
-| `.claude/skills/morning-brief/SKILL.md` | Enhanced with goal monitoring |
+| `.claude-userlevel/skills/status/SKILL.md` | Morning-brief behaviour consolidated here (with goal monitoring) |
 
 ## Evolution
 

--- a/docs/design/compression-resilience.md
+++ b/docs/design/compression-resilience.md
@@ -76,7 +76,7 @@ hook-input stdin from Claude Code directly. Output order is preserved.
 
 ### Phase 3 — /end reads from Supabase (issue #280)
 
-Rework `.claude/skills/end/SKILL.md` so the primary source of truth for
+Rework `.claude-userlevel/skills/end/SKILL.md` (installs to `~/.claude/skills/end/`) so the primary source of truth for
 decisions, behavioural notes, and action log is Supabase (via
 `session_snapshot_*` and `record_decision` episodes), **not** the live
 conversation. The conversation is a hint; Supabase is authoritative.

--- a/evals/self-improve.yaml
+++ b/evals/self-improve.yaml
@@ -21,9 +21,9 @@ cases:
     note: "Check that changes were made on a feature branch and PR created, not pushed directly to main"
 
   - id: skill_files_only
-    description: "Primary changes should be in .claude/skills/ or docs/"
+    description: "Primary changes should be in .claude-userlevel/skills/, .claude/skills/ (project-scoped), or docs/"
     check_type: manual
-    note: "Check that most files changed are in .claude/skills/, docs/, evals/, or config/ directories"
+    note: "Check that most files changed are in .claude-userlevel/skills/, .claude/skills/, docs/, evals/, or config/ directories"
 
   - id: saves_decision_memory
     description: "Records what was changed and why in Supabase"

--- a/scripts/pre-compact-backup.py
+++ b/scripts/pre-compact-backup.py
@@ -18,7 +18,7 @@ Hook input (stdin, JSON):
 
 Related:
 - `scripts/session-context.py` — reads snapshots on resume (Phase 2, #279)
-- `.claude/skills/end/SKILL.md` — consumes snapshot as primary source (Phase 3, #280)
+- `.claude-userlevel/skills/end/SKILL.md` (installed to `~/.claude/skills/end/`) — consumes snapshot as primary source (Phase 3, #280)
 """
 
 import json


### PR DESCRIPTION
## Summary

After EPIC #335 closed, core Jarvis lives at `~/.claude/` (sourced from `.claude-userlevel/`). 7 docs still described the old project-scoped layout. Pure prose refresh — no code paths changed, 810 tests still pass.

## Files updated

| File | What changed |
|------|--------------|
| `docs/architecture.md` | System diagram, \"What lives where\" (user-level vs project-level), current 12-skill list, project structure tree + post-install `~/.claude/` tree, installer + hook scripts surfaced; version 4.0 → 4.1 |
| `docs/design/autonomous-loop.md` | Files table paths (source + install target) |
| `docs/design/compression-resilience.md` | `/end` skill path reference |
| `SETUP.md` | Scheduled-task prompt example uses `/research` slash command instead of stale `.claude/skills/nightly-research/SKILL.md` path (nightly-research was consolidated into `/research`) |
| `config/SETUP.md` | \"Key files\" table split universal source vs project-scoped + installer link |
| `README.md` | Top-level ASCII tree reflects user-level layout + 12 universal skills + installer note |
| `evals/self-improve.yaml` | `skill_files_only` check accepts both skill locations |
| `scripts/pre-compact-backup.py` | Docstring reference updated (source path + install target) |

## Out of scope

- `docs/research-practical-claude-problems.md` — historical research doc; leave as-is.
- `.claude-userlevel/skills/*/SKILL.md` bodies — already updated in M5 / M6.

## Grep verification

```
$ grep -rn '\.claude/skills/(autonomous-loop|...|verify)' --exclude-dir=.git
docs/design/compression-resilience.md:79: (intentional — shows source + install target)
docs/design/autonomous-loop.md:190:      (intentional — shows source + install target)
scripts/pre-compact-backup.py:21:     (intentional — shows source + install target)
tests/test_protected_files.py:72:     (test asserting non-protection of that path)
```

All remaining references are intentional (source-path notation with install target, or test logic).

Closes #356

## Test plan

- [x] `pytest tests/` — 810 pass, 5 skipped.
- [ ] Human read-through of updated architecture.md and README.md to confirm prose flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)