### PR TITLE
fix(mcp-memory): resolve memory names->UUIDs in record_decision (#325)

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -29,6 +29,7 @@ import asyncio
 import json
 import math
 import os
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -3295,13 +3296,91 @@ async def _handle_credential_check_expiry(args: dict) -> list[TextContent]:
     return [TextContent(type="text", text="\n".join(lines))]
 
 
+def _looks_like_uuid(s: str) -> bool:
+    """True if s is a canonical UUID string (case-insensitive, hyphenated)."""
+    try:
+        uuid.UUID(s)
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _resolve_memory_refs(
+    client, refs: list, project: str | None
+) -> tuple[list[str], list[str]]:
+    """Normalize mixed memory names and UUIDs into canonical UUIDs (#325).
+
+    Policy:
+    - Inputs already shaped like a UUID pass through, canonicalized via
+      uuid.UUID() (lower-cased, hyphenated).
+    - Non-UUID strings are treated as memory names and resolved against
+      the memories table, preferring the most recently updated live row
+      (same join heuristic as scripts/backfill-outcome-memories.py).
+    - When ``project`` is provided, the name lookup is scoped to that
+      project. Otherwise the most-recent-live match across all projects
+      wins.
+    - Unresolvable names are returned separately so the handler can
+      surface them without breaking the write.
+
+    Returns (resolved_uuids, unresolved_names). Insertion order is
+    preserved; resolved UUIDs are de-duplicated.
+    """
+    resolved: list[str] = []
+    unresolved: list[str] = []
+    seen: set[str] = set()
+    for ref in refs or []:
+        if not isinstance(ref, str):
+            continue
+        ref_s = ref.strip()
+        if not ref_s:
+            continue
+        if _looks_like_uuid(ref_s):
+            canonical = str(uuid.UUID(ref_s))
+            if canonical not in seen:
+                resolved.append(canonical)
+                seen.add(canonical)
+            continue
+        try:
+            q = (
+                client.table("memories")
+                .select("id")
+                .eq("name", ref_s)
+                .is_("deleted_at", "null")
+            )
+            if project is not None:
+                q = q.eq("project", project)
+            rows = q.order("updated_at", desc=True).limit(1).execute()
+        except Exception:
+            unresolved.append(ref_s)
+            continue
+        data = getattr(rows, "data", None)
+        if not isinstance(data, list) or not data:
+            unresolved.append(ref_s)
+            continue
+        uid = data[0].get("id") if isinstance(data[0], dict) else None
+        if not uid or not _looks_like_uuid(uid):
+            unresolved.append(ref_s)
+            continue
+        canonical = str(uuid.UUID(uid))
+        if canonical not in seen:
+            resolved.append(canonical)
+            seen.add(canonical)
+    return resolved, unresolved
+
+
 async def _handle_record_decision(args: dict) -> list[TextContent]:
-    """Insert a 'decision_made' episode with structured payload (#252).
+    """Insert a 'decision_made' episode with structured payload (#252, #325).
 
     The episode is the agent's reasoning trace: what was decided, why,
     which memories/outcomes informed it, predicted confidence, and
     reversibility. /reflect reads these back via the episodes table to
     analyze whether the basis was sound when outcomes come in.
+
+    ``memories_used`` accepts either UUIDs or memory names — names are
+    resolved server-side so the payload always stores canonical UUIDs,
+    keeping the Pillar 3 FK (``task_outcomes.memory_id``) joinable
+    forward. Unresolved names are surfaced in the response text and
+    preserved on ``payload.memories_used_unresolved`` for audit.
     """
     decision = (args.get("decision") or "").strip()
     rationale = (args.get("rationale") or "").strip()
@@ -3327,21 +3406,29 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
             return [TextContent(type="text", text="Error: confidence must be in [0.0, 1.0]")]
 
     actor = args.get("actor") or "skill:unknown"
+    project = args.get("project")
+
+    client = _get_client()
+
+    resolved_memories, unresolved_memories = _resolve_memory_refs(
+        client, args.get("memories_used") or [], project
+    )
 
     payload = {
         "decision": decision,
         "rationale": rationale,
-        "memories_used": args.get("memories_used") or [],
+        "memories_used": resolved_memories,
         "outcomes_referenced": args.get("outcomes_referenced") or [],
         "alternatives_considered": args.get("alternatives_considered") or [],
         "reversibility": reversibility,
     }
+    if unresolved_memories:
+        payload["memories_used_unresolved"] = unresolved_memories
     if confidence is not None:
         payload["confidence"] = confidence
-    if args.get("project"):
-        payload["project"] = args["project"]
+    if project:
+        payload["project"] = project
 
-    client = _get_client()
     try:
         result = client.table("episodes").insert({
             "actor": actor,
@@ -3351,10 +3438,18 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
     except Exception as exc:
         return [TextContent(type="text", text=f"Error recording decision: {exc}")]
 
-    if result.data:
-        eid = result.data[0].get("id", "?")
-        return [TextContent(type="text", text=f"Decision recorded: episode {eid}")]
-    return [TextContent(type="text", text="Failed to record decision.")]
+    if not result.data:
+        return [TextContent(type="text", text="Failed to record decision.")]
+
+    eid = result.data[0].get("id", "?")
+    msg = f"Decision recorded: episode {eid}"
+    if unresolved_memories:
+        msg += (
+            f" (warning: {len(unresolved_memories)} memory name(s) did not "
+            f"resolve to UUIDs: {unresolved_memories} — check spelling or "
+            "pass memory UUID from recall)"
+        )
+    return [TextContent(type="text", text=msg)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_record_decision.py
+++ b/tests/test_record_decision.py
@@ -1,7 +1,8 @@
-"""Unit tests for the record_decision tool (#252).
+"""Unit tests for the record_decision tool (#252, #325).
 
 Exercises the real handler in mcp-memory/server.py with a mock Supabase
-client — asserts validation logic, episode-row shape, and failure paths.
+client — asserts validation logic, episode-row shape, name→UUID
+resolution, and failure paths.
 """
 
 from __future__ import annotations
@@ -11,15 +12,60 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from server import _handle_record_decision
+from server import (
+    _handle_record_decision,
+    _looks_like_uuid,
+    _resolve_memory_refs,
+)
+
+# Stable UUIDs for tests — chosen so the same input yields the same
+# canonical form after uuid.UUID().
+_UID_A = "11111111-1111-1111-1111-111111111111"
+_UID_B = "22222222-2222-2222-2222-222222222222"
+_UID_C = "33333333-3333-3333-3333-333333333333"
 
 
-def _make_client_returning(inserted_id: str = "ep-1") -> MagicMock:
-    """MagicMock client whose table().insert().execute() returns one row."""
+def _make_client_returning(
+    inserted_id: str = "ep-1",
+    name_to_id: dict[str, str] | None = None,
+) -> MagicMock:
+    """MagicMock client wiring both insert and name-lookup paths.
+
+    - table().insert().execute() -> inserted_id row.
+    - table().select().eq(name=X).is_(deleted_at=null).[eq(project=P)].order().limit().execute()
+      -> {"id": name_to_id[X]} if X is mapped, else empty list.
+
+    The select side-effect is implemented by configuring ``eq``'s return
+    value as a MagicMock whose chained ``.is_().order().limit().execute()``
+    returns ``data=[]`` by default, and by hooking ``eq`` on the ``name``
+    column to look up ``name_to_id``.
+    """
     client = MagicMock()
     client.table.return_value.insert.return_value.execute.return_value = MagicMock(
         data=[{"id": inserted_id}]
     )
+
+    lookup = dict(name_to_id or {})
+
+    def _select_side_effect(*_args, **_kwargs):
+        chain = MagicMock()
+
+        def _eq_name(column, value):
+            # Only the ``name`` column drives resolution; other .eq() calls
+            # (e.g. project scoping) pass through with the same return value.
+            hit = lookup.get(value) if column == "name" else None
+            leaf = MagicMock()
+            leaf.data = [{"id": hit}] if hit else []
+            tail = MagicMock()
+            tail.is_.return_value.order.return_value.limit.return_value.execute.return_value = leaf
+            tail.is_.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = leaf
+            tail.eq.return_value.is_.return_value.order.return_value.limit.return_value.execute.return_value = leaf
+            return tail
+
+        chain.eq.side_effect = _eq_name
+        return chain
+
+    client.table.return_value.select.side_effect = _select_side_effect
     return client
 
 
@@ -28,10 +74,12 @@ class TestRecordDecisionValidation:
     async def test_missing_decision_errors(self, monkeypatch):
         client = _make_client_returning()
         monkeypatch.setattr("server._get_client", lambda: client)
-        result = await _handle_record_decision({
-            "rationale": "because reasons",
-            "reversibility": "reversible",
-        })
+        result = await _handle_record_decision(
+            {
+                "rationale": "because reasons",
+                "reversibility": "reversible",
+            }
+        )
         assert "decision is required" in result[0].text.lower()
         assert not client.table.called
 
@@ -39,10 +87,12 @@ class TestRecordDecisionValidation:
     async def test_missing_rationale_errors(self, monkeypatch):
         client = _make_client_returning()
         monkeypatch.setattr("server._get_client", lambda: client)
-        result = await _handle_record_decision({
-            "decision": "pick X",
-            "reversibility": "reversible",
-        })
+        result = await _handle_record_decision(
+            {
+                "decision": "pick X",
+                "reversibility": "reversible",
+            }
+        )
         assert "rationale is required" in result[0].text.lower()
         assert not client.table.called
 
@@ -50,11 +100,13 @@ class TestRecordDecisionValidation:
     async def test_invalid_reversibility_errors(self, monkeypatch):
         client = _make_client_returning()
         monkeypatch.setattr("server._get_client", lambda: client)
-        result = await _handle_record_decision({
-            "decision": "pick X",
-            "rationale": "because",
-            "reversibility": "permanent",  # not in enum
-        })
+        result = await _handle_record_decision(
+            {
+                "decision": "pick X",
+                "rationale": "because",
+                "reversibility": "permanent",  # not in enum
+            }
+        )
         assert "reversibility" in result[0].text.lower()
         assert not client.table.called
 
@@ -63,12 +115,14 @@ class TestRecordDecisionValidation:
         client = _make_client_returning()
         monkeypatch.setattr("server._get_client", lambda: client)
         for bad in (-0.1, 1.1, 2.0):
-            result = await _handle_record_decision({
-                "decision": "pick X",
-                "rationale": "because",
-                "reversibility": "reversible",
-                "confidence": bad,
-            })
+            result = await _handle_record_decision(
+                {
+                    "decision": "pick X",
+                    "rationale": "because",
+                    "reversibility": "reversible",
+                    "confidence": bad,
+                }
+            )
             assert "confidence" in result[0].text.lower()
         assert not client.table.called
 
@@ -79,17 +133,19 @@ class TestRecordDecisionInsert:
         client = _make_client_returning("ep-42")
         monkeypatch.setattr("server._get_client", lambda: client)
 
-        result = await _handle_record_decision({
-            "decision": "implement #252 directly",
-            "rationale": "additive change, no breaking schema modifications",
-            "memories_used": ["mem-a", "mem-b"],
-            "outcomes_referenced": ["out-1"],
-            "confidence": 0.85,
-            "alternatives_considered": ["delegate to agent"],
-            "reversibility": "reversible",
-            "actor": "skill:delegate",
-            "project": "jarvis",
-        })
+        result = await _handle_record_decision(
+            {
+                "decision": "implement #252 directly",
+                "rationale": "additive change, no breaking schema modifications",
+                "memories_used": [_UID_A, _UID_B],
+                "outcomes_referenced": ["out-1"],
+                "confidence": 0.85,
+                "alternatives_considered": ["delegate to agent"],
+                "reversibility": "reversible",
+                "actor": "skill:delegate",
+                "project": "jarvis",
+            }
+        )
 
         # Returned message contains episode id
         assert "ep-42" in result[0].text
@@ -103,7 +159,9 @@ class TestRecordDecisionInsert:
         payload = insert_arg["payload"]
         assert payload["decision"] == "implement #252 directly"
         assert payload["rationale"].startswith("additive change")
-        assert payload["memories_used"] == ["mem-a", "mem-b"]
+        # UUIDs pass through, canonicalized (lower-case, hyphenated).
+        assert payload["memories_used"] == [_UID_A, _UID_B]
+        assert "memories_used_unresolved" not in payload
         assert payload["outcomes_referenced"] == ["out-1"]
         assert payload["confidence"] == 0.85
         assert payload["alternatives_considered"] == ["delegate to agent"]
@@ -115,11 +173,13 @@ class TestRecordDecisionInsert:
         client = _make_client_returning()
         monkeypatch.setattr("server._get_client", lambda: client)
 
-        await _handle_record_decision({
-            "decision": "x",
-            "rationale": "y",
-            "reversibility": "hard",
-        })
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "hard",
+            }
+        )
         insert_arg = client.table.return_value.insert.call_args.args[0]
         assert insert_arg["actor"] == "skill:unknown"
 
@@ -128,11 +188,13 @@ class TestRecordDecisionInsert:
         client = _make_client_returning()
         monkeypatch.setattr("server._get_client", lambda: client)
 
-        await _handle_record_decision({
-            "decision": "x",
-            "rationale": "y",
-            "reversibility": "reversible",
-        })
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+            }
+        )
         payload = client.table.return_value.insert.call_args.args[0]["payload"]
         assert payload["memories_used"] == []
         assert payload["outcomes_referenced"] == []
@@ -146,12 +208,210 @@ class TestRecordDecisionInsert:
         client.table.return_value.insert.return_value.execute.side_effect = RuntimeError("boom")
         monkeypatch.setattr("server._get_client", lambda: client)
 
-        result = await _handle_record_decision({
-            "decision": "x",
-            "rationale": "y",
-            "reversibility": "reversible",
-        })
+        result = await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+            }
+        )
         assert "boom" in result[0].text
+
+
+class TestLooksLikeUuid:
+    def test_accepts_canonical(self):
+        assert _looks_like_uuid(_UID_A) is True
+
+    def test_accepts_uppercase(self):
+        # uuid.UUID accepts case-insensitively — important because callers
+        # sometimes paste UUIDs copied from PostgREST/Supabase logs.
+        assert _looks_like_uuid(_UID_A.upper()) is True
+
+    def test_rejects_plain_name(self):
+        assert _looks_like_uuid("mem-a") is False
+
+    def test_rejects_empty_string(self):
+        assert _looks_like_uuid("") is False
+
+    def test_rejects_non_string(self):
+        assert _looks_like_uuid(None) is False
+        assert _looks_like_uuid(123) is False
+
+
+def _resolver_client(
+    name_to_id: dict[str, str] | None = None,
+    project_capture: list | None = None,
+) -> MagicMock:
+    """Client for direct ``_resolve_memory_refs`` tests.
+
+    - ``name_to_id``: maps memory name -> id returned by the select leaf.
+    - ``project_capture``: if provided, every ``.eq("project", v)`` call on
+      the chained query appends v to the list — lets tests assert that
+      project scoping actually reached the query builder.
+    """
+    name_to_id = dict(name_to_id or {})
+    client = MagicMock()
+
+    def _select_side_effect(*_args, **_kwargs):
+        chain = MagicMock()
+
+        def _eq_name(column, value):
+            assert column == "name", "_resolve_memory_refs must key on 'name'"
+            hit = name_to_id.get(value)
+            leaf = MagicMock()
+            leaf.data = [{"id": hit}] if hit else []
+
+            head = MagicMock()
+            # Unscoped: .eq(name).is_(deleted_at).order.limit.execute
+            head.is_.return_value.order.return_value.limit.return_value.execute.return_value = leaf
+
+            def _project_eq(col, val):
+                if col == "project" and project_capture is not None:
+                    project_capture.append(val)
+                scoped = MagicMock()
+                scoped.order.return_value.limit.return_value.execute.return_value = leaf
+                return scoped
+
+            head.is_.return_value.eq.side_effect = _project_eq
+            return head
+
+        chain.eq.side_effect = _eq_name
+        return chain
+
+    client.table.return_value.select.side_effect = _select_side_effect
+    return client
+
+
+class TestResolveMemoryRefs:
+    def test_passes_through_uuid(self):
+        client = _resolver_client()
+        resolved, unresolved = _resolve_memory_refs(client, [_UID_A], project=None)
+        assert resolved == [_UID_A]
+        assert unresolved == []
+
+    def test_canonicalizes_uppercase_uuid(self):
+        client = _resolver_client()
+        resolved, unresolved = _resolve_memory_refs(client, [_UID_A.upper()], project=None)
+        # Canonical form is lowercase — uuid.UUID() normalizes so downstream
+        # joins against memories.id (lowercase in PostgreSQL) always hit.
+        assert resolved == [_UID_A]
+        assert unresolved == []
+
+    def test_dedups_repeated_uuid(self):
+        client = _resolver_client()
+        resolved, unresolved = _resolve_memory_refs(
+            client, [_UID_A, _UID_A.upper(), _UID_A], project=None
+        )
+        assert resolved == [_UID_A]
+        assert unresolved == []
+
+    def test_resolves_name_via_db(self):
+        client = _resolver_client({"mem-a": _UID_A})
+        resolved, unresolved = _resolve_memory_refs(client, ["mem-a"], project=None)
+        assert resolved == [_UID_A]
+        assert unresolved == []
+
+    def test_unknown_name_goes_to_unresolved(self):
+        client = _resolver_client()
+        resolved, unresolved = _resolve_memory_refs(client, ["ghost-name"], project=None)
+        assert resolved == []
+        assert unresolved == ["ghost-name"]
+
+    def test_mixed_preserves_input_order(self):
+        client = _resolver_client({"mem-b": _UID_B})
+        resolved, unresolved = _resolve_memory_refs(client, [_UID_A, "mem-b", _UID_C], project=None)
+        assert resolved == [_UID_A, _UID_B, _UID_C]
+        assert unresolved == []
+
+    def test_scopes_lookup_by_project_when_provided(self):
+        capture: list = []
+        client = _resolver_client({"mem-a": _UID_A}, project_capture=capture)
+        resolved, _ = _resolve_memory_refs(client, ["mem-a"], project="jarvis")
+        assert resolved == [_UID_A]
+        assert capture == ["jarvis"]
+
+    def test_no_project_scope_when_project_none(self):
+        capture: list = []
+        client = _resolver_client({"mem-a": _UID_A}, project_capture=capture)
+        resolved, _ = _resolve_memory_refs(client, ["mem-a"], project=None)
+        assert resolved == [_UID_A]
+        assert capture == []
+
+    def test_skips_empty_and_non_string_refs(self):
+        client = _resolver_client()
+        resolved, unresolved = _resolve_memory_refs(client, [None, 123, "", "   "], project=None)
+        assert resolved == []
+        assert unresolved == []
+
+    def test_db_error_marks_name_unresolved(self):
+        client = MagicMock()
+        client.table.return_value.select.side_effect = RuntimeError("postgrest down")
+        resolved, unresolved = _resolve_memory_refs(client, ["mem-a"], project=None)
+        assert resolved == []
+        # A DB blip shouldn't throw — unresolved is the safe fallback so
+        # the outer handler still writes the decision episode.
+        assert unresolved == ["mem-a"]
+
+
+class TestRecordDecisionResolution:
+    """End-to-end: ``memories_used`` resolution visible through the handler."""
+
+    @pytest.mark.asyncio
+    async def test_name_resolves_to_canonical_uuid_in_payload(self, monkeypatch):
+        client = _make_client_returning("ep-99", name_to_id={"mem-a": _UID_A})
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+                "memories_used": ["mem-a"],
+                "project": "jarvis",
+            }
+        )
+        payload = client.table.return_value.insert.call_args.args[0]["payload"]
+        assert payload["memories_used"] == [_UID_A]
+        assert "memories_used_unresolved" not in payload
+
+    @pytest.mark.asyncio
+    async def test_unresolved_names_surface_in_response_and_payload(self, monkeypatch):
+        client = _make_client_returning("ep-99", name_to_id={})
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+                "memories_used": ["ghost-a", "ghost-b"],
+            }
+        )
+        text = result[0].text
+        assert "ep-99" in text
+        # Warning text must name the unresolved refs so the owner can fix
+        # spelling or re-run with a UUID.
+        assert "ghost-a" in text and "ghost-b" in text
+        payload = client.table.return_value.insert.call_args.args[0]["payload"]
+        assert payload["memories_used"] == []
+        assert payload["memories_used_unresolved"] == ["ghost-a", "ghost-b"]
+
+    @pytest.mark.asyncio
+    async def test_mix_of_uuid_and_name_resolves_both(self, monkeypatch):
+        client = _make_client_returning("ep-99", name_to_id={"mem-b": _UID_B})
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+                "memories_used": [_UID_A, "mem-b", _UID_C],
+            }
+        )
+        payload = client.table.return_value.insert.call_args.args[0]["payload"]
+        assert payload["memories_used"] == [_UID_A, _UID_B, _UID_C]
+        assert "memories_used_unresolved" not in payload
 
 
 def test_handler_defined_before_main_entry():
@@ -169,13 +429,15 @@ def test_handler_defined_before_main_entry():
     src = server_path.read_text(encoding="utf-8").splitlines()
 
     handler_line = next(
-        (i for i, line in enumerate(src, start=1)
-         if line.startswith("async def _handle_record_decision")),
+        (
+            i
+            for i, line in enumerate(src, start=1)
+            if line.startswith("async def _handle_record_decision")
+        ),
         None,
     )
     main_guard_line = next(
-        (i for i, line in enumerate(src, start=1)
-         if line.startswith('if __name__ == "__main__"')),
+        (i for i, line in enumerate(src, start=1) if line.startswith('if __name__ == "__main__"')),
         None,
     )
     assert handler_line is not None, "_handle_record_decision def not found in server.py"
@@ -199,5 +461,6 @@ def test_decision_made_in_schema_check_constraint():
     #   check (kind in ('tool_call', 'decision', ..., 'decision_made'))
     lines = [line for line in schema.splitlines() if "check (kind in" in line]
     assert lines, "No 'check (kind in ...)' clause found in schema.sql"
-    assert any("'decision_made'" in line for line in lines), \
+    assert any("'decision_made'" in line for line in lines), (
         "episodes.kind CHECK constraint does not include 'decision_made'"
+    )


### PR DESCRIPTION
## Summary
`record_decision` now normalizes `memories_used` server-side: UUIDs pass through canonicalized, non-UUID strings are resolved against the `memories` table, and unresolvable names are preserved separately on `payload.memories_used_unresolved` + surfaced in the response text. Payload always stores canonical UUIDs, keeping the Pillar 3 FK joinable forward.

## Why
Closes #325.

The handler used to store whatever the caller passed, and every `/implement` run emits `memories_used` as a list of memory NAMES (that's what the skill doc + memory_recall return). So `decision.payload.memories_used` has been 100% names since #252 shipped. That broke the forward path to Pillar 3: `task_outcomes.memory_id` is a UUID FK into `memories.id`, and `outcome_record` derives its `memory_id` from `decision.payload.memories_used[0]` — a name, so the FK never joined. #288 already backfilled this gap from the outcome side; #325 closes it at the source so new decisions stay linkable without another backfill.

## Decisions & Alternatives
- **Resolve at the handler, not at `/implement`.** The skill-side resolver would leak DB shape into every caller and miss non-skill writes. Handler-side centralizes the policy and keeps callers ergonomic (names are fine).
- **Store unresolved names on a separate payload key, don't drop them.** Reviewer/owner can audit what didn't resolve; `/reflect` can flag stale memory names. Alternative (drop silently) would hide the miss.
- **Warn in response text instead of erroring.** Decision episodes are reasoning traces — dropping the write because one of three memory names was misspelled would lose the whole trace. Warn + write is the right trade-off here.
- **Reuse the backfill script's query shape** (`.eq(name).is_(deleted_at, null).[eq(project)].order(updated_at desc).limit(1)`). Proven in production by `scripts/backfill-outcome-memories.py`.
- **Project scoping is opt-in.** When `project` is present on the args, the name lookup is scoped — disambiguates when two projects share a memory name. When absent, most-recent-live wins across projects (same as recall).

## Risk Assessment
- **MEDIUM**: payload shape is additive (new optional `memories_used_unresolved` key) and the primary-memory FK now populates correctly, but `mcp-memory/server.py` is a shared MCP surface used by redrobot too. No schema changes; no breaking API changes.

## Testing
- `pytest tests/test_record_decision.py -x -q` — 28 tests pass (validation + insert shape + resolver direct + handler integration + regression guards).
- `ruff check` + `ruff format` — clean.
- Live Supabase smoke (one-off script, deleted): resolved a real memory name → its canonical UUID, verified project-scoped resolve hits, verified unresolvable names go to the `unresolved` bucket without throwing, verified UUID pass-through.

## Files Changed
- `mcp-memory/server.py` **[PROTECTED]** — added `_looks_like_uuid` + `_resolve_memory_refs` helpers; `_handle_record_decision` now resolves `memories_used` before insert, stores `memories_used_unresolved` when names don't resolve, and appends a warning to the response text. Owner approved this protected-file edit in-session on 2026-04-24.
- `tests/test_record_decision.py` — added `TestLooksLikeUuid`, `TestResolveMemoryRefs` (direct helper coverage including project scoping, UUID canonicalization, dedup, DB-error fallback), and `TestRecordDecisionResolution` (handler-level integration). Updated the existing insert test to use canonical UUIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)