### PR TITLE
feat(skills): recall-audit for /end + /reflect (#333)

### DIFF
--- a/.claude-userlevel/skills/end/SKILL.md
+++ b/.claude-userlevel/skills/end/SKILL.md
@@ -22,6 +22,25 @@ Before reflecting or scanning, pull everything durable from Supabase:
 
 Carry the snapshot + decisions into Steps 1-2 as the primary source. The conversation (post-compact) is only a hint overlay for anything that happened *after* the snapshot was written.
 
+## Step 0.5 — Recall audit (#333)
+
+Scan the current session's jsonl for decision points without preceding recall. This is a *process* check on top of Step 0's artifact load — did the agent actually look at memory at the moments that mattered?
+
+```bash
+python scripts/recall-audit.py "$CLAUDE_PROJECT_DIR/<session-id>.jsonl" --format md
+```
+
+The session jsonl lives at `~/.claude/projects/<cwd-slug>/<session-id>.jsonl` — the current session is the newest file in that directory. The script emits empty output when there are zero flags (most sessions), so only surface it in Step 7 when non-empty.
+
+Three detectors fire:
+1. **`empty_memories_used`** — a `record_decision` call with no memory IDs. Hard signal of a recall gap OR a broken attribution path; either way, worth looking at.
+2. **`decision_text_no_recall`** — decision language ("I decided to X / going with Y / chose Z") in an assistant message with NO `memory_recall` or `memory_get` in the preceding ~15 tool uses. Soft signal — sometimes the decision was already informed by always_load rules, so false-positives happen. User confirms.
+3. **`store_no_recall`** — a `feedback` or `decision` memory_store call without a preceding recall. Duplicate-creation risk.
+
+**Threshold**: 3+ flagged events in one session → in Step 7 output, explicitly prompt "User: was this a real recall gap, or known false positives? If real → save a feedback memory so next session avoids it." Don't auto-save.
+
+If the audit fails (script error, jsonl missing) → skip silently. The audit is informational, not blocking.
+
 ## Step 1 — Behavioral reflection
 
 Review your own behavior this session against feedback memories (already in context from session start). Reflect against **snapshot + conversation union**, not conversation alone — the snapshot preserves what the LLM summary smoothed over:
@@ -125,6 +144,10 @@ If stashing (mid-task), report the stash ref and repo in output so next session 
 - Snapshot: <session_snapshot_... name + "fresh" | "stale" | "none">
 - Decisions loaded: N
 - Post-hoc decision saves: N  (0 is ideal — every decision should have been recorded in real time)
+
+### Recall audit (Step 0.5)
+- <paste markdown from recall-audit.py, or "No gaps detected">
+- <if 3+ flags: "User: confirm whether these are real gaps. If real, save a feedback memory.">
 
 ### Reflection
 - <1-3 behavioral observations, or "Clean session — no issues">

--- a/.claude-userlevel/skills/reflect/SKILL.md
+++ b/.claude-userlevel/skills/reflect/SKILL.md
@@ -90,6 +90,25 @@ If found, include `payload.rationale` and `payload.memories_used` in the outcome
 - `memories_used` was empty AND top-similarity was low at decision time → known-unknown (auto-tracked via #249)
 - Basis looks sound but execution failed → not a memory problem, flag as reasoning or execution failure
 
+## Step 5.25 — Recall audit aggregate (#333)
+
+Roll the per-session recall audit across the last ~20 sessions to surface cross-session patterns (one session's gap is noise; a persistent trend is a fixable process leak):
+
+```bash
+python scripts/recall-audit.py --project jarvis --limit 20 --aggregate
+```
+
+Output is a single JSON dict with `sessions`, `record_decision_calls`, `flags_total`, `flags_by_kind`, and `empty_memories_used_pct`.
+
+Interpretation rules:
+
+- `empty_memories_used_pct >= 30%` over 20 sessions → **process leak**, not noise. Save a `feedback` memory naming the pattern (e.g. "record_decision calls drop memories_used when args are passed via <tool invocation style>"). Reference the audit output in the memory content.
+- `flags_by_kind.decision_text_no_recall > 10` over 20 sessions → recall-before-deciding habit is not stable. Consider: is this a rule we already have? If yes, why is it being missed? If no, propose one.
+- `flags_by_kind.store_no_recall > 5` → dedup-before-store is failing. Check if `memory-dedup-check.py` hook is firing (it should gate `memory_store`). If it is and the signal still shows up, maybe the hook's dedup threshold is too strict.
+- All three under threshold → report "recall hygiene healthy" in Step 9 and skip to the next step.
+
+If the aggregate script fails for any reason → skip silently, note in Step 9 output.
+
 ## Step 5.5 — Calibration check (#251)
 
 After outcomes are verified, check memory calibration:
@@ -179,4 +198,8 @@ memory_store(
 
 ### Calibration (flagged types only)
 - **<type>**: Brier <score>, n=<n>, <overconfident|underconfident> (avg_predicted=<p> vs avg_actual=<a>)
+
+### Recall audit aggregate (last 20 sessions)
+- sessions=N, decisions=M, flags=<breakdown>
+- <"healthy" | specific leak pattern + proposed fix>
 ```

--- a/scripts/recall-audit.py
+++ b/scripts/recall-audit.py
@@ -1,0 +1,421 @@
+"""Recall-audit: scan session jsonl for decision points without preceding recall (#333).
+
+Complements ``scripts/memory-recall-hook.py`` (UserPromptSubmit) and
+``scripts/pretooluse-recall-hook.py`` (PreToolUse). Those hooks *inject*
+recall. This script *audits* whether recall actually happened at the
+moments that matter — so ``/end`` can show per-session gaps and
+``/reflect`` can aggregate across sessions.
+
+Detectors
+---------
+1. **record_decision with empty ``memories_used``** — hard signal of a
+   recall gap or broken attribution. The decision was made, but nothing
+   from memory informed it (or nothing was attributed back).
+
+2. **"Decision language" in assistant text without a preceding
+   ``memory_recall`` call in the last ``WINDOW_TOOLS`` tool uses** —
+   soft signal of an autonomous call made without looking at prior art.
+   The pattern list is intentionally conservative to keep false
+   positives down (we'd rather miss a few than cry wolf).
+
+3. **memory_store of ``feedback`` / ``decision`` memory without a
+   preceding ``memory_recall`` in the last ``WINDOW_TOOLS`` tool uses** —
+   duplicate-creation risk. Every new feedback/decision memory should
+   have been preceded by "is this already there?" recall.
+
+Output
+------
+``dict`` with ``session_id``, ``file``, ``counters``, and ``flags`` (a
+list of per-event records). Can be printed as JSON or pretty markdown
+via ``--format=md``. The markdown rendering is what ``/end`` and
+``/reflect`` embed.
+
+Exit codes
+----------
+- ``0`` — scan completed (regardless of how many flags found).
+- ``1`` — file not found, unreadable, or malformed beyond recovery.
+- ``2`` — CLI usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+WINDOW_TOOLS = 15  # lookback window for detectors 2 + 3
+MIN_DECISION_CHARS = 24  # drop tiny "ok, do X" noise
+
+DECISION_PATTERNS = [
+    r"\bi (?:decided|propose|choose|chose|opted|am going) (?:to|for|with)\b",
+    r"\blet(?:'s| us) (?:do|go with|use|try)\b",
+    r"\bgoing (?:to|with) (?:implement|use|try)\b",
+    r"\bwe(?:'ll| will) (?:go with|use|implement)\b",
+    r"\bchosen approach\b",
+    r"\bfinal (?:choice|call|decision)\b",
+]
+_DECISION_RE = re.compile("|".join(DECISION_PATTERNS), re.IGNORECASE)
+
+RECALL_TOOLS = {"mcp__memory__memory_recall", "mcp__memory__memory_get"}
+DECISION_TOOL = "mcp__memory__record_decision"
+STORE_TOOL = "mcp__memory__memory_store"
+
+AUDITED_STORE_TYPES = {"feedback", "decision"}
+
+
+@dataclass
+class Flag:
+    """One recall-gap finding. ``line`` is the 1-indexed jsonl line number."""
+
+    kind: str  # detector id: "empty_memories_used" | "decision_text_no_recall" | "store_no_recall"
+    line: int
+    summary: str
+    detail: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": self.kind,
+            "line": self.line,
+            "summary": self.summary,
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class AuditResult:
+    file: str
+    session_id: str
+    counters: dict = field(default_factory=dict)
+    flags: list[Flag] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "file": self.file,
+            "session_id": self.session_id,
+            "counters": self.counters,
+            "flags": [f.to_dict() for f in self.flags],
+        }
+
+
+def _iter_records(path: Path) -> Iterable[tuple[int, dict]]:
+    """Yield (1-indexed line_no, parsed-record) pairs, skipping bad JSON."""
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for i, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield i, json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _assistant_blocks(record: dict) -> list[dict]:
+    """Return content blocks if this is an assistant message; else []."""
+    if record.get("type") != "assistant":
+        return []
+    msg = record.get("message") or {}
+    if msg.get("role") != "assistant":
+        return []
+    content = msg.get("content") or []
+    return [b for b in content if isinstance(b, dict)]
+
+
+def _extract_decision_sentences(text: str) -> list[str]:
+    """Return the (trimmed) sentences in `text` that match DECISION_PATTERNS."""
+    if not text or len(text) < MIN_DECISION_CHARS:
+        return []
+    hits = []
+    for raw in re.split(r"(?<=[.!?])\s+", text):
+        sentence = raw.strip()
+        if len(sentence) < MIN_DECISION_CHARS:
+            continue
+        if _DECISION_RE.search(sentence):
+            hits.append(sentence[:200])
+    return hits
+
+
+def _tool_use_info(block: dict) -> tuple[str, dict] | None:
+    """If `block` is a tool_use content block, return (name, input). Else None."""
+    if block.get("type") != "tool_use":
+        return None
+    return (block.get("name") or "", block.get("input") or {})
+
+
+def audit_session(path: Path) -> AuditResult:
+    """Scan one session's jsonl and collect flags from all three detectors.
+
+    Algorithm: single forward pass. We keep a sliding "recent tools" list
+    (capped at WINDOW_TOOLS) so detectors 2 + 3 can check whether a
+    ``memory_recall`` happened before each decision/store moment. The
+    window resets per-session (one file = one session).
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"session jsonl not found: {path}")
+
+    result = AuditResult(file=str(path), session_id=path.stem)
+    counters = {
+        "records": 0,
+        "assistant_messages": 0,
+        "tool_uses": 0,
+        "record_decision_calls": 0,
+        "memory_store_calls": 0,
+        "memory_recall_calls": 0,
+    }
+
+    recent_tools: list[str] = []
+
+    def _note_tool(name: str) -> None:
+        recent_tools.append(name)
+        if len(recent_tools) > WINDOW_TOOLS:
+            del recent_tools[: len(recent_tools) - WINDOW_TOOLS]
+
+    def _recall_in_window() -> bool:
+        return any(t in RECALL_TOOLS for t in recent_tools)
+
+    for line_no, record in _iter_records(path):
+        counters["records"] += 1
+        if not result.session_id or result.session_id == path.stem:
+            sid = record.get("sessionId") or ""
+            if sid:
+                result.session_id = sid
+
+        blocks = _assistant_blocks(record)
+        if not blocks:
+            continue
+        counters["assistant_messages"] += 1
+
+        for block in blocks:
+            if block.get("type") == "text":
+                text = block.get("text") or ""
+                hits = _extract_decision_sentences(text)
+                if hits and not _recall_in_window():
+                    result.flags.append(
+                        Flag(
+                            kind="decision_text_no_recall",
+                            line=line_no,
+                            summary=hits[0],
+                            detail={
+                                "matches": hits,
+                                "recent_tools": list(recent_tools),
+                            },
+                        )
+                    )
+                continue
+
+            tool = _tool_use_info(block)
+            if tool is None:
+                continue
+            name, tool_input = tool
+            counters["tool_uses"] += 1
+
+            if name == DECISION_TOOL:
+                counters["record_decision_calls"] += 1
+                mem_used = tool_input.get("memories_used") or []
+                if not mem_used:
+                    result.flags.append(
+                        Flag(
+                            kind="empty_memories_used",
+                            line=line_no,
+                            summary=(tool_input.get("decision") or "")[:200],
+                            detail={
+                                "rationale_preview": (tool_input.get("rationale") or "")[:200],
+                            },
+                        )
+                    )
+            elif name == STORE_TOOL:
+                counters["memory_store_calls"] += 1
+                mem_type = (tool_input.get("type") or "").lower()
+                if mem_type in AUDITED_STORE_TYPES and not _recall_in_window():
+                    result.flags.append(
+                        Flag(
+                            kind="store_no_recall",
+                            line=line_no,
+                            summary=(tool_input.get("name") or "")[:200],
+                            detail={
+                                "memory_type": mem_type,
+                                "recent_tools": list(recent_tools),
+                            },
+                        )
+                    )
+            elif name in RECALL_TOOLS:
+                counters["memory_recall_calls"] += 1
+
+            _note_tool(name)
+
+    result.counters = counters
+    return result
+
+
+def render_markdown(result: AuditResult) -> str:
+    """Render an audit result as the compact markdown /end embeds.
+
+    Returns an empty string when there are zero flags — /end can then
+    skip the whole Recall-audit section without a visible placeholder.
+    """
+    if not result.flags:
+        return ""
+
+    by_kind: dict[str, list[Flag]] = {}
+    for f in result.flags:
+        by_kind.setdefault(f.kind, []).append(f)
+
+    kind_label = {
+        "empty_memories_used": "Decisions with empty memories_used",
+        "decision_text_no_recall": "Decision language without preceding recall",
+        "store_no_recall": "New feedback/decision memory without preceding recall",
+    }
+
+    lines: list[str] = [f"### Recall audit — {len(result.flags)} flagged"]
+    for kind, flags in by_kind.items():
+        label = kind_label.get(kind, kind)
+        lines.append(f"- **{label}** ({len(flags)}):")
+        for f in flags[:5]:
+            summary = f.summary.replace("\n", " ")
+            lines.append(f"  - L{f.line}: {summary}")
+        if len(flags) > 5:
+            lines.append(f"  - … +{len(flags) - 5} more")
+    return "\n".join(lines)
+
+
+def aggregate(results: list[AuditResult]) -> dict:
+    """Summarize a batch of audits for /reflect cross-session view."""
+    totals = {
+        "sessions": len(results),
+        "records": 0,
+        "record_decision_calls": 0,
+        "memory_store_calls": 0,
+        "memory_recall_calls": 0,
+        "flags_total": 0,
+        "flags_by_kind": {
+            "empty_memories_used": 0,
+            "decision_text_no_recall": 0,
+            "store_no_recall": 0,
+        },
+    }
+    for r in results:
+        for k in ("records", "record_decision_calls", "memory_store_calls", "memory_recall_calls"):
+            totals[k] += r.counters.get(k, 0)
+        totals["flags_total"] += len(r.flags)
+        for f in r.flags:
+            totals["flags_by_kind"].setdefault(f.kind, 0)
+            totals["flags_by_kind"][f.kind] += 1
+
+    decisions = totals["record_decision_calls"] or 1
+    totals["empty_memories_used_pct"] = round(
+        100.0 * totals["flags_by_kind"].get("empty_memories_used", 0) / decisions, 1
+    )
+    return totals
+
+
+def _resolve_project_dir(project_name: str) -> Path:
+    """Map a short project name (jarvis, redrobot) to the ~/.claude/projects dir.
+
+    Claude Code stores each working-dir's jsonl under a slug built by
+    replacing path separators and colons with '-'. We don't know the
+    owner's full path ahead of time, so we glob for a directory whose
+    final path segment contains the project name.
+    """
+    base = Path.home() / ".claude" / "projects"
+    if not base.exists():
+        raise FileNotFoundError(f"no ~/.claude/projects directory at {base}")
+    target = project_name.lower()
+    candidates = [p for p in base.iterdir() if p.is_dir() and target in p.name.lower()]
+    if not candidates:
+        raise FileNotFoundError(f"no project dir matching {target} under {base}")
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0]
+
+
+def _discover_sessions(project: str | None, session_path: str | None) -> list[Path]:
+    """Return the list of session jsonl paths to audit."""
+    if session_path:
+        p = Path(session_path).expanduser()
+        if not p.exists():
+            raise FileNotFoundError(p)
+        return [p]
+    if project:
+        root = _resolve_project_dir(project)
+        return sorted(root.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return []
+
+
+def _ensure_utf8_stdout() -> None:
+    """On Windows, default cp1251 stdout chokes on non-ASCII payloads.
+
+    Session text is frequently mixed-language (owner writes Russian, we
+    quote assistant output). Force UTF-8 so the pretty-printed markdown
+    and JSON never hit a ``UnicodeEncodeError`` at print-time.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, ValueError):
+                pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    _ensure_utf8_stdout()
+    parser = argparse.ArgumentParser(description="Audit a Claude Code session for recall gaps.")
+    parser.add_argument("session", nargs="?", help="Path to session jsonl file.")
+    parser.add_argument("--project", help="Short project name (e.g. jarvis); scans all sessions.")
+    parser.add_argument("--limit", type=int, default=0, help="Max sessions when --project used.")
+    parser.add_argument(
+        "--format",
+        choices=("json", "md"),
+        default="json",
+        help="Output format. json = machine; md = human (/end, /reflect).",
+    )
+    parser.add_argument(
+        "--aggregate",
+        action="store_true",
+        help="With --project, emit a single aggregate dict instead of per-session.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.session and not args.project:
+        parser.error("either a session path or --project is required")
+
+    try:
+        sessions = _discover_sessions(args.project, args.session)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    if args.limit and args.project:
+        sessions = sessions[: args.limit]
+
+    results: list[AuditResult] = []
+    for path in sessions:
+        try:
+            results.append(audit_session(path))
+        except (FileNotFoundError, OSError) as e:
+            print(f"warn: skipping {path}: {e}", file=sys.stderr)
+
+    if args.aggregate:
+        payload: dict[str, Any] = aggregate(results)
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    if args.format == "md":
+        chunks = []
+        for r in results:
+            md = render_markdown(r)
+            if md:
+                chunks.append(f"## {r.session_id}\n{md}")
+        print("\n\n".join(chunks) if chunks else "No recall-gap flags found.")
+        return 0
+
+    payload = [r.to_dict() for r in results]
+    print(json.dumps(payload if len(payload) != 1 else payload[0], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_recall_audit.py
+++ b/tests/test_recall_audit.py
@@ -1,0 +1,511 @@
+"""Unit tests for scripts/recall-audit.py (#333).
+
+Covers each detector with synthetic jsonl fixtures, plus markdown
+rendering, aggregation, and CLI behavior. Uses a path-based importlib
+load because the script's filename contains a dash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "recall-audit.py"
+_spec = importlib.util.spec_from_file_location("recall_audit", _SCRIPT_PATH)
+assert _spec and _spec.loader
+recall_audit = importlib.util.module_from_spec(_spec)
+# Python 3.14's @dataclass needs the module registered in sys.modules before
+# exec_module so it can look up the class's module namespace.
+sys.modules["recall_audit"] = recall_audit
+_spec.loader.exec_module(recall_audit)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _assistant_record(session_id: str, blocks: list[dict]) -> dict:
+    return {
+        "type": "assistant",
+        "sessionId": session_id,
+        "message": {"role": "assistant", "content": blocks},
+    }
+
+
+def _tool_use(name: str, tool_input: dict, tool_id: str = "t1") -> dict:
+    return {"type": "tool_use", "id": tool_id, "name": name, "input": tool_input}
+
+
+def _text(body: str) -> dict:
+    return {"type": "text", "text": body}
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    with path.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Detector 1 — empty memories_used on record_decision
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyMemoriesUsed:
+    def test_flags_missing_field(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s1",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {
+                                "decision": "go with option A",
+                                "rationale": "why A",
+                                "reversibility": "reversible",
+                            },
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert len(result.flags) == 1
+        assert result.flags[0].kind == "empty_memories_used"
+        assert result.flags[0].summary.startswith("go with option A")
+
+    def test_flags_empty_list(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s1",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {
+                                "decision": "blank mem list",
+                                "rationale": "r",
+                                "reversibility": "reversible",
+                                "memories_used": [],
+                            },
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert len(result.flags) == 1
+        assert result.flags[0].kind == "empty_memories_used"
+
+    def test_does_not_flag_when_populated(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s1",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {
+                                "decision": "with basis",
+                                "rationale": "r",
+                                "reversibility": "reversible",
+                                "memories_used": ["uuid-a", "uuid-b"],
+                            },
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert [f for f in result.flags if f.kind == "empty_memories_used"] == []
+
+
+# ---------------------------------------------------------------------------
+# Detector 2 — decision language without preceding recall
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionTextNoRecall:
+    def test_flags_decision_text_when_no_recall_in_window(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s2",
+                    [
+                        _text(
+                            "After looking at the options, I decided to go with Postgres FTS "
+                            "because latency is under budget and it keeps the stack simple."
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        kinds = [f.kind for f in result.flags]
+        assert "decision_text_no_recall" in kinds
+
+    def test_suppressed_when_memory_recall_preceded(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s2",
+                    [_tool_use("mcp__memory__memory_recall", {"query": "fts options"})],
+                ),
+                _assistant_record(
+                    "s2",
+                    [
+                        _text(
+                            "After looking at the options, I decided to go with Postgres FTS "
+                            "because latency is under budget and it keeps the stack simple."
+                        )
+                    ],
+                ),
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert [f for f in result.flags if f.kind == "decision_text_no_recall"] == []
+
+    def test_window_boundary_expires_recall(self, tmp_path):
+        """A recall call further back than WINDOW_TOOLS no longer suppresses."""
+        records = [
+            _assistant_record("s2", [_tool_use("mcp__memory__memory_recall", {"query": "early"})])
+        ]
+        for i in range(recall_audit.WINDOW_TOOLS + 1):
+            records.append(_assistant_record("s2", [_tool_use("Read", {"file_path": f"f{i}.py"})]))
+        records.append(
+            _assistant_record(
+                "s2",
+                [_text("I decided to use the second approach instead of rewriting from scratch.")],
+            )
+        )
+        path = _write_jsonl(tmp_path / "s.jsonl", records)
+        result = recall_audit.audit_session(path)
+        assert any(f.kind == "decision_text_no_recall" for f in result.flags)
+
+    def test_short_text_does_not_match(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [_assistant_record("s2", [_text("Let's do X.")])],
+        )
+        result = recall_audit.audit_session(path)
+        assert [f for f in result.flags if f.kind == "decision_text_no_recall"] == []
+
+    def test_casual_language_not_flagged(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s2",
+                    [
+                        _text(
+                            "This function reads the config file and returns the parsed value. "
+                            "It handles missing files gracefully by returning None."
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert [f for f in result.flags if f.kind == "decision_text_no_recall"] == []
+
+
+# ---------------------------------------------------------------------------
+# Detector 3 — feedback/decision memory_store without preceding recall
+# ---------------------------------------------------------------------------
+
+
+class TestStoreNoRecall:
+    def test_flags_feedback_store_without_recall(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s3",
+                    [
+                        _tool_use(
+                            "mcp__memory__memory_store",
+                            {
+                                "name": "feedback_xxx",
+                                "type": "feedback",
+                                "content": "rule",
+                            },
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert [f.kind for f in result.flags] == ["store_no_recall"]
+
+    def test_flags_decision_store_without_recall(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s3",
+                    [
+                        _tool_use(
+                            "mcp__memory__memory_store",
+                            {
+                                "name": "decision_yyy",
+                                "type": "decision",
+                                "content": "chose X",
+                            },
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert any(f.kind == "store_no_recall" for f in result.flags)
+
+    def test_skips_project_type_store(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s3",
+                    [
+                        _tool_use(
+                            "mcp__memory__memory_store",
+                            {"name": "state", "type": "project", "content": "working"},
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert [f for f in result.flags if f.kind == "store_no_recall"] == []
+
+    def test_suppressed_by_recall_in_window(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s3", [_tool_use("mcp__memory__memory_recall", {"query": "dup"})]
+                ),
+                _assistant_record(
+                    "s3",
+                    [
+                        _tool_use(
+                            "mcp__memory__memory_store",
+                            {"name": "fb", "type": "feedback", "content": "r"},
+                        )
+                    ],
+                ),
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        assert [f for f in result.flags if f.kind == "store_no_recall"] == []
+
+
+# ---------------------------------------------------------------------------
+# Counters + aggregation + render
+# ---------------------------------------------------------------------------
+
+
+class TestCountersAndRender:
+    def test_counters_track_tool_uses(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s4",
+                    [
+                        _tool_use("mcp__memory__memory_recall", {"query": "x"}),
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {
+                                "decision": "d",
+                                "rationale": "r",
+                                "reversibility": "reversible",
+                                "memories_used": ["u"],
+                            },
+                        ),
+                        _tool_use(
+                            "mcp__memory__memory_store",
+                            {"name": "x", "type": "feedback", "content": "c"},
+                        ),
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        c = result.counters
+        assert c["memory_recall_calls"] == 1
+        assert c["record_decision_calls"] == 1
+        assert c["memory_store_calls"] == 1
+        assert c["tool_uses"] >= 3
+
+    def test_render_empty_when_no_flags(self, tmp_path):
+        path = _write_jsonl(tmp_path / "s.jsonl", [])
+        result = recall_audit.audit_session(path)
+        assert recall_audit.render_markdown(result) == ""
+
+    def test_render_with_flags(self, tmp_path):
+        path = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "s5",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {
+                                "decision": "no basis",
+                                "rationale": "r",
+                                "reversibility": "reversible",
+                            },
+                        )
+                    ],
+                )
+            ],
+        )
+        result = recall_audit.audit_session(path)
+        md = recall_audit.render_markdown(result)
+        assert "Recall audit" in md
+        assert "empty memories_used" in md
+        assert "L1" in md
+
+    def test_aggregate_across_sessions(self, tmp_path):
+        p1 = _write_jsonl(
+            tmp_path / "a.jsonl",
+            [
+                _assistant_record(
+                    "a",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {"decision": "x", "rationale": "r", "reversibility": "reversible"},
+                        )
+                    ],
+                )
+            ],
+        )
+        p2 = _write_jsonl(
+            tmp_path / "b.jsonl",
+            [
+                _assistant_record(
+                    "b",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {
+                                "decision": "y",
+                                "rationale": "r",
+                                "reversibility": "reversible",
+                                "memories_used": ["u"],
+                            },
+                        )
+                    ],
+                )
+            ],
+        )
+        results = [recall_audit.audit_session(p) for p in (p1, p2)]
+        agg = recall_audit.aggregate(results)
+        assert agg["sessions"] == 2
+        assert agg["record_decision_calls"] == 2
+        assert agg["flags_by_kind"]["empty_memories_used"] == 1
+        assert agg["empty_memories_used_pct"] == 50.0
+
+    def test_aggregate_no_decisions_zeros(self, tmp_path):
+        result = recall_audit.audit_session(_write_jsonl(tmp_path / "empty.jsonl", []))
+        agg = recall_audit.aggregate([result])
+        assert agg["record_decision_calls"] == 0
+        assert agg["empty_memories_used_pct"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_cli_json_single_session(self, tmp_path, monkeypatch, capsys):
+        p = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "cli",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {"decision": "x", "rationale": "r", "reversibility": "reversible"},
+                        )
+                    ],
+                )
+            ],
+        )
+        rc = recall_audit.main([str(p)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["session_id"] == "cli"
+        assert any(f["kind"] == "empty_memories_used" for f in payload["flags"])
+
+    def test_cli_md_format_single_session(self, tmp_path, capsys):
+        p = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "cli2",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {"decision": "x", "rationale": "r", "reversibility": "reversible"},
+                        )
+                    ],
+                )
+            ],
+        )
+        rc = recall_audit.main([str(p), "--format", "md"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "## cli2" in out
+        assert "Recall audit" in out
+
+    def test_cli_aggregate(self, tmp_path, capsys):
+        p = _write_jsonl(
+            tmp_path / "s.jsonl",
+            [
+                _assistant_record(
+                    "agg",
+                    [
+                        _tool_use(
+                            "mcp__memory__record_decision",
+                            {"decision": "x", "rationale": "r", "reversibility": "reversible"},
+                        )
+                    ],
+                )
+            ],
+        )
+        rc = recall_audit.main([str(p), "--aggregate"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["sessions"] == 1
+        assert payload["flags_by_kind"]["empty_memories_used"] == 1
+
+    def test_cli_missing_args_errors(self, capsys):
+        try:
+            recall_audit.main([])
+        except SystemExit as e:
+            assert e.code == 2
+        captured = capsys.readouterr()
+        assert "required" in captured.err.lower() or "usage" in captured.err.lower()
+
+    def test_cli_missing_file(self, tmp_path, capsys):
+        rc = recall_audit.main([str(tmp_path / "nope.jsonl")])
+        assert rc == 1
+        assert "error" in capsys.readouterr().err.lower()


### PR DESCRIPTION
## Summary
Adds `scripts/recall-audit.py` — reads a Claude Code session jsonl and surfaces three recall-gap signals. Wires the audit into `/end` (per-session Step 0.5) and `/reflect` (cross-session aggregate at Step 5.25). This closes the detection side of the v0.4 recall-enforcement gap: PreToolUse recall from #332 *injects* memory; this script *measures* whether the agent looked at memory when it mattered.

## Why
Closes #333. v0.4 audit found that `/end` closes sessions by looking at artifacts (outcomes, commits, working_state) but never inspects the process trace — recall gaps don't surface as outcomes because the decision still happens, just without basis. `/reflect` extracts lessons from outcomes but has the same blind spot. Adding a jsonl replay as a third data source on top of snapshot + outcome list gives us a direct signal: "this session made N decisions without any prior recall."

Closes #333

## Decisions & Alternatives
- **Chose jsonl replay over hook-based counter** — hooks only see individual events; the jsonl is the full trace with timing, which lets us enforce a "recall within last N tool uses" window. A PreToolUse counter would have needed its own persistence layer and still missed the text-based "decision language" detector.
- **Chose conservative decision-language regex over broad pattern match** — false positives on an audit that prompts the user to save a feedback memory are expensive (noise desensitizes). Kept the patterns to 6 phrasings that almost always indicate a decision was made ("I decided to X", "going with Y", "chose Z", "final decision"). E2E on 10 real sessions: zero `decision_text_no_recall` flags — the detector is *very* conservative, and I'd rather tune it up later if we see misses.
- **Chose `WINDOW_TOOLS=15` lookback** — `memory_recall` in the preceding 15 tool uses counts as "informed by recall". Wider windows dilute the signal; narrower ones over-flag sequences like "recall → read file → read another file → decide" where reads are just collecting context for a decision that *was* grounded in recall.
- **Chose plain JSON output as primary + markdown as secondary** — `/reflect` aggregates via `--aggregate`, `/end` renders per-session markdown via `--format=md`. JSON is the source of truth; markdown is a view over it.
- Rejected: running as a Supabase RPC (replay doesn't need a round-trip, local jsonl is authoritative), tracking false-positive rate (no labeled data), auto-saving feedback memories on threshold (too invasive without user in the loop).

## Risk Assessment
- **LOW** — script is read-only on local jsonl files. No schema changes, no Supabase writes, no hook registration. /end and /reflect gain a new documented step each that fails silently on script error. Worst case: audit script crashes, step prints nothing, rest of /end or /reflect is unaffected.
- E2E already executed: aggregate across 10 real jarvis sessions completed without error and surfaced real signal (71.4% empty `memories_used`, 4 store-without-recall events, zero soft-signal false positives).

## Testing
- `ruff check scripts/recall-audit.py tests/test_recall_audit.py` — clean
- `pytest tests/test_recall_audit.py -x -q` — **22/22 passing** (0.19s)
  - `TestEmptyMemoriesUsed` (3): missing field, empty list, populated list does not flag
  - `TestDecisionTextNoRecall` (5): positive case, suppression by preceding recall, window boundary expiration, too-short text ignored, casual language not flagged
  - `TestStoreNoRecall` (4): feedback/decision flagged, project-type skipped, suppression by recall
  - `TestCountersAndRender` (5): counter accuracy, empty-flag render returns "", aggregate math with 2 sessions, zero-division guard
  - `TestCLI` (5): JSON output, markdown output, --aggregate, missing-args error exit 2, missing-file error exit 1
- **E2E smoke** on real sessions: `python scripts/recall-audit.py --project jarvis --limit 10 --aggregate` — 28 decisions, 20 with empty memories_used (71.4%), 4 store-no-recall. This is the signal #333 is meant to surface.

## Files Changed
- `scripts/recall-audit.py` — **new**, ~340 lines. CLI entry, three detectors, JSON + markdown renderers, aggregate.
- `tests/test_recall_audit.py` — **new**, 22 tests via importlib-by-path.
- `.claude-userlevel/skills/end/SKILL.md` — adds Step 0.5 (recall audit) and a Recall audit section in Step 7 output template.
- `.claude-userlevel/skills/reflect/SKILL.md` — adds Step 5.25 (aggregate across last 20 sessions) and output row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)