### PR TITLE
feat(skills): expand record_decision trigger list (#334)

### DIFF
--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -62,7 +62,7 @@ git checkout master && git pull
 git checkout -b feat/<N>-<slug>
 ```
 
-### 3.5. Record decision (reasoning trace, #252)
+### 3.5. Record decision (reasoning trace, #252, #334)
 
 After claim, before implementation — emit a `decision_made` episode so `/reflect` can later attribute outcomes to reasoning (missing memory / wrong memory / wrong reasoning):
 
@@ -78,7 +78,20 @@ mcp__memory__record_decision(
 )
 ```
 
-Always emit for issue implementation — outcome attribution needs the basis. For non-issue decisions, emit only when `reversibility ∈ {hard, irreversible}` OR `confidence < 0.7`.
+**Trigger list — emit `record_decision` when ANY of the following hold** (canonical rule; mirrored in global `record_decision_when_what` feedback memory):
+
+1. **Issue implementation** — always, even if reversible. Outcome attribution needs the basis.
+2. **`reversibility ∈ {hard, irreversible}`** — e.g. destructive DB ops, force-pushed history, published API changes.
+3. **`confidence < 0.7`** — uncertain calls deserve a recorded rationale so `/reflect` can classify the outcome as reasoning-failure vs execution-failure.
+4. **Policy / schema / tag / config change** — tagging memories `always_load`, editing protected files, adding/removing skills, changing hook config, schema migrations, installer manifest edits. These are *reversible* but affect the system's behavior across future sessions.
+5. **Architectural direction picked** — a resolved "chose X over Y" after discussion, even if reversible. The rationale matters more than the bit that's set; `/reflect` can only learn if the picked direction is captured at pick time.
+
+Rules of thumb:
+- "I just made a call that will outlive this session" → emit.
+- "I just clarified my own thinking on an approach" → don't emit (no persisted effect).
+- When unsure, emit. The cost is one tool call; the cost of missing a decision is a blind spot for `/reflect`.
+
+Pass `memories_used = [<uuids from step 0 recall>]` whenever recall surfaced something. Empty list is valid only when nothing in memory informed the decision — which itself is rare and should be noted in the rationale.
 
 ### 4. Implement
 

--- a/.claude-userlevel/skills/verify/SKILL.md
+++ b/.claude-userlevel/skills/verify/SKILL.md
@@ -66,6 +66,8 @@ outcome_update(
 
 **Enrich `memory_id` if the outcome row has it NULL**: look up the linked `decision_made` episode (same issue/PR) and pass `memory_id = payload.memories_used[0]`. Rule — primary informing memory = first entry (dominant basis). If the outcome already has `memory_id`, leave it alone; `/verify` is not where you rewrite attribution. If no decision episode references this issue, omit — the backfill script (`scripts/backfill-outcome-memories.py`) can handle historical rows in bulk.
 
+**Empty `memories_used` is valid** (per #334 expanded triggers: policy/schema/tag/config decisions may genuinely have no memory basis). If the matching decision episode exists but its `memories_used` list is empty, skip the enrichment — do NOT error, do NOT guess. Outcome stays `memory_id = NULL`; this is the correct representation for a decision that wasn't informed by prior memory.
+
 `verified_at` is set automatically when status changes from pending.
 
 ## Step 4 — Detect patterns


### PR DESCRIPTION
## Summary
Rewrites `/implement` §3.5 from a 2-clause exception ("always for issues; only hard/irreversible/low-confidence otherwise") into a canonical 5-trigger rule. Mirrors the rule into a new global feedback memory `record_decision_when_what` so it carries across all skills, not just `/implement`. Hardens `/verify` §3 to handle empty `memories_used` gracefully (the new trigger 4 creates legitimate cases of it).

## Why
Closes #334. Last gap in M28 recall-enforcement sprint: today's always_load seeding — tagging 6 cross-cutting feedback memories so they auto-load every session — was exactly the kind of policy-level reversible change the old rule didn't cover. No `record_decision` was emitted, so `/reflect` has no basis to attribute outcomes back to that reasoning. Pattern recurs any time we tag a memory, edit hook config, or pick an architectural direction after discussion.

Closes #334

## Decisions & Alternatives
- **Chose 5-trigger rule over "always emit"** — always-emit floods the reasoning trace with trivial "I decided to name the variable X" entries that bury the substantive calls. The 5 triggers are all "the call will outlive this session" — that's the load-bearing distinction.
- **Chose to mirror the rule in a global feedback memory** — `always_load`-tagged so session-context.py auto-injects it. Other skills (`/delegate`, `/research`, `/self-improve`) need the same trigger list. The canonical rule lives in `/implement` SKILL.md (where it was); the portable copy lives in memory. Both always say the same thing by construction — the memory quotes §3.5 verbatim.
- **Chose empty `memories_used` guard in /verify over requiring non-empty** — trigger 4 (policy/tag/config) has genuinely empty cases. Forcing `memories_used ≥ 1` would push the model to fake an entry just to pass validation, which is worse than no entry.
- **Backfilled one retroactive decision, not six** — the issue requested one test case (the always_load seeding). Recording six individual decisions (one per tagged memory) would be noise; the seeding event was one decision with six outputs. Retroactive episode id `0ef0df1a-7cdb-41dd-9a7b-802231f949a3`.
- Rejected: making the trigger list a hook-enforced gate (no reliable way to detect "a decision just happened" from tool trace alone; gating would have to live in the model's prompt, which is what the skill rule already is); creating per-skill rules (fragmentation — one global rule applies everywhere).

## Risk Assessment
- **LOW** — documentation + one new feedback memory + one retroactive decision episode. No code changes to MCP server, hooks, scripts, or CI. The `/verify` guard tightens a code path to be safer (skip-on-empty) rather than loosen it. Worst case: the new triggers get ignored by the model and we're back to the current state — same as pre-PR. Best case: `/reflect` gains real attribution coverage for policy/tag/config moments.

## Testing
- **Acceptance criterion 1**: `/implement` §3.5 updated with 5-trigger list + rules of thumb + canonical-rule pointer. ✓
- **Acceptance criterion 2**: global feedback memory `record_decision_when_what` created (id `1778e466-01b1-4327-9bfa-c5179db46c5e`, tagged `always_load` so session-context.py auto-loads it). ✓
- **Acceptance criterion 3**: `/verify` §3 now explicitly handles empty `memories_used` — skip enrichment, don't error. ✓
- **Acceptance criterion 4**: retroactive `record_decision` for the always_load seeding emitted as test case (episode `0ef0df1a-7cdb-41dd-9a7b-802231f949a3`, confidence 0.95, reversibility `reversible`, 7 memories cited including the always_loaded_context_budget_principle decision). ✓

No new automated tests — scope is skill documentation + memory content + retroactive event. Skills changes are reviewed by humans, not test suites.

## Files Changed
- `.claude-userlevel/skills/implement/SKILL.md` — §3.5 rewritten with 5-trigger canonical rule.
- `.claude-userlevel/skills/verify/SKILL.md` — §3 empty-`memories_used` guard added.

Plus out-of-tree artifacts:
- New global `feedback` memory `record_decision_when_what` (tagged `always_load`, `process`, `reasoning-trace`, `decisions`).
- Retroactive decision episode `0ef0df1a-7cdb-41dd-9a7b-802231f949a3` captured in Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)