### PR TITLE
feat(autonomy): escalation ladder for flag-only findings (#327)

### DIFF
--- a/.claude-userlevel/skills/autonomous-loop/SKILL.md
+++ b/.claude-userlevel/skills/autonomous-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autonomous-loop
 description: "Autonomous orchestrator: perceive events, evaluate against goals, decide and act within safety bounds. Runs daily via scheduled task or manual invocation."
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Autonomous Loop Orchestrator
@@ -77,6 +77,81 @@ Generate candidates:
 - Repos under any other owner (e.g. `SergazyNarynov/redrobot`) → **flag-only**: record the finding in memory (`type=project, name=hygiene_sweep_proposals_<repo>_<date>, source_provenance="skill:autonomous-loop"`) and surface it in the output, but never execute the action. Owner acts manually or flips the repo to an owned org.
 
 **Dedup per-finding:** before closing a milestone / creating a retroactive one, check `outcome_list(task_type='autonomous', pattern_tags=['hygiene'])` for matching description from last 3 days. Skip if same finding already actioned.
+
+### Step 2b — Escalate stale flag-only findings (#327)
+
+After writing (or skipping, per dedup) today's `hygiene_sweep_proposals_<repo>_<date>` memory, count consecutive prior flags for the same repo to detect ignored findings. This closes the loop for foreign-owner repos where Jarvis can't take the action itself.
+
+**Count** — via `execute_sql`:
+
+```sql
+SELECT name, created_at
+FROM memories
+WHERE name LIKE 'hygiene_sweep_proposals_<repo>_%'
+  AND archived = false
+  AND created_at >= now() - interval '10 days'
+ORDER BY created_at ASC;
+```
+
+`N = row count`, `first_flagged_at = min(created_at)`, `days_unaddressed = date(today) - date(first_flagged_at)`.
+
+**Escalation rungs:**
+
+| Rung | Threshold | Action |
+|----|----|----|
+| 1 | N ≥ 1 | Memory exists (handled above) |
+| 2 | N ≥ 2 or days_unaddressed ≥ 1 | `/status` surfaces `STALE FLAG` badge (handled by `/status` skill reading these memories — nothing to do here) |
+| 3 | N ≥ 3 | Emit one `events` row with `severity=high` so `telegram-notify-hook.py` picks it up this run |
+| 4 | N ≥ 5 | Create a jarvis-side tracking issue so the stale state is visible on GitHub |
+
+**Dedup before emitting (rung 3):** skip if an unprocessed `events` row with `event_type='hygiene_stale'` and `repo=<R>` already exists.
+
+```sql
+SELECT id FROM events
+WHERE event_type = 'hygiene_stale'
+  AND repo = '<R>'
+  AND processed = false
+ORDER BY created_at DESC LIMIT 1;
+```
+
+If none, insert:
+
+```sql
+INSERT INTO events (event_type, severity, repo, source, title, payload)
+VALUES (
+  'hygiene_stale',
+  'high',
+  '<R>',
+  'skill:autonomous-loop',
+  'Flag ignored <N>d: <repo> hygiene findings unaddressed',
+  jsonb_build_object(
+    'days_flagged', <N>,
+    'first_flagged_at', '<first_flagged_at ISO>',
+    'memory_names', <array of hygiene_sweep_proposals_* names>,
+    'detail', '<brief: top finding from latest memory>',
+    'url', 'https://github.com/<R>'
+  )
+);
+```
+
+**Dedup before creating jarvis issue (rung 4):**
+
+```bash
+gh issue list --repo Osasuwu/jarvis --state open --search "in:title stale flag <repo>" --json number --limit 1
+```
+
+If empty → create:
+
+```bash
+gh issue create --repo Osasuwu/jarvis \
+  --title "Stale flag: <repo> findings unaddressed <N>d" \
+  --label "process,autonomous-loop" \
+  --body "Autonomous-loop has flagged findings for \`<R>\` on <N> consecutive days without owner action. Memories: <list>. First flagged: <date>. Jarvis cannot open issues in \`<R>\` (flag-only repo), so tracking here for visibility. Close this when the upstream finding is resolved."
+```
+
+Record the issue URL in the event payload (`payload.jarvis_tracking_issue = <url>`) via an update to the event row.
+
+**Ordering:** run Step 2b for every repo in `config/repos.conf` after Step 2a. Emitting an event here creates work the Low-risk batch will count (counts toward the 5-max limit).
 
 ## Step 3 — Score Each Candidate
 
@@ -179,6 +254,20 @@ memory_store(
 ```
 
 If any action advances a goal → `goal_update(slug=..., progress=[...])` — append `{item: "<5-word summary> (YYYY-MM-DD)", done: true}` to existing progress array.
+
+## Step 7.5 — Drain high-severity events to Telegram (#327)
+
+Any `severity=high` events emitted this run (including Step 2b escalations) need to reach the owner outside of `/status`. Run the notifier as the final durable side effect:
+
+```bash
+python scripts/telegram-notify-hook.py --min-severity high
+```
+
+- Reads unprocessed `events` at or above the threshold, sends one message each, marks them processed.
+- Requires `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOW_USER_ID` in env. If either is missing, the script exits 1 — log the failure in the output but don't abort the run.
+- The script is idempotent via `processed=true`, so running it multiple times in one day is safe (it drains only what's pending).
+
+Skip silently if the script doesn't exist (older checkouts) — don't make this a hard blocker.
 
 ## Safety Rules
 

--- a/.claude-userlevel/skills/status/SKILL.md
+++ b/.claude-userlevel/skills/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: status
 description: "Project dashboard: git state, PRs, issues, CI health, risks, stale/blocked work, goal alerts. Absorbs morning-brief, risk-radar, triage. Use at session start or when needing cross-project awareness."
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Status Dashboard
@@ -54,6 +54,18 @@ SELECT query, hit_count, last_seen_at FROM known_unknowns WHERE status='open' OR
 ```
 Execute via `execute_sql` MCP. Cloud sessions won't have local memory client. Include in alerts if results returned.
 
+**Stale flag-only findings** (once, not per repo — #327 escalation rung 2):
+```sql
+SELECT name, created_at, updated_at, content
+FROM memories
+WHERE name LIKE 'hygiene_sweep_proposals_%'
+  AND archived = false
+  AND created_at < now() - interval '1 day'
+ORDER BY created_at ASC
+LIMIT 10;
+```
+These are flag-only findings autonomous-loop recorded against foreign-owner repos (e.g. redrobot). Each day without owner action compounds — the `/status` prompt is the daily nudge. Compute `days_unaddressed = today - date(created_at)` per memory and group by repo (name format `hygiene_sweep_proposals_<repo>_<date>`).
+
 
 ## Step 3 — Analyze
 
@@ -93,10 +105,21 @@ Flag: N stale branches (remote gone), M unmerged branches, K stashes.
 
 ## Step 4 — Output
 
+**STALE FLAG section goes at the top of Alerts** — these compound daily and the owner needs to see them first. Group by repo; show oldest first so the most-ignored rises to the top:
+
+```
+[STALE FLAG] <repo> — <N>d unaddressed (<M> consecutive flags)
+  first flagged: YYYY-MM-DD | latest memory: hygiene_sweep_proposals_<repo>_<date>
+  top finding: <brief from content>
+```
+
+Omit the section if no stale flag-only findings were returned.
+
 ```markdown
 # Status — YYYY-MM-DD
 
 ## Alerts
+- [STALE FLAG] <repo> — <N>d unaddressed (<memory>) — see hygiene findings
 - <P0 deadline, neglect warnings, or "Goals on track">
 - <Credential expiry warnings, if any>
 

--- a/scripts/telegram-notify-hook.py
+++ b/scripts/telegram-notify-hook.py
@@ -1,0 +1,219 @@
+"""Telegram notify hook — drain high-severity unprocessed events to owner's Telegram.
+
+Part of flag-only escalation ladder (#327). Day-3 rung of the ladder:
+`autonomous-loop` emits `severity=high` events when a flag-only finding has
+been ignored N>=3 days; this hook reads those events and sends a one-line
+message to the owner via Telegram Bot API, then marks them processed.
+
+Can be invoked:
+- At the tail of `autonomous-loop` (recommended — runs once daily)
+- As a scheduled task (hourly drain)
+- Manually to flush pending notifications
+
+Usage:
+    python scripts/telegram-notify-hook.py              # drain all pending high/critical events
+    python scripts/telegram-notify-hook.py --dry-run    # print what would be sent
+    python scripts/telegram-notify-hook.py --min-severity critical
+    python scripts/telegram-notify-hook.py --limit 10
+
+Env: SUPABASE_URL, SUPABASE_KEY, TELEGRAM_BOT_TOKEN, TELEGRAM_ALLOW_USER_ID. .env auto-loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+try:
+    from dotenv import load_dotenv
+
+    here = Path(__file__).resolve().parent
+    for candidate in (here.parent / ".env", here.parent.parent / ".env"):
+        if candidate.exists():
+            load_dotenv(candidate, override=True)
+            break
+except ImportError:
+    pass
+
+try:
+    import httpx
+except ImportError:
+    httpx = None
+
+
+TELEGRAM_API = "https://api.telegram.org"
+SEVERITIES = ("critical", "high", "medium", "low", "info")
+DEFAULT_LIMIT = 20
+
+
+def fetch_pending_events(client, min_severity: str, limit: int) -> list[dict]:
+    """Pending (unprocessed) events at or above `min_severity`, newest first."""
+    idx = SEVERITIES.index(min_severity)
+    allowed = list(SEVERITIES[: idx + 1])
+
+    result = (
+        client.table("events")
+        .select("id, event_type, severity, repo, source, title, payload, created_at")
+        .eq("processed", False)
+        .in_("severity", allowed)
+        .order("created_at", desc=True)
+        .limit(limit)
+        .execute()
+    )
+    return result.data or []
+
+
+def format_message(ev: dict) -> str:
+    """One Telegram message per event. Keep it scannable on mobile."""
+    severity = (ev.get("severity") or "").upper()
+    title = ev.get("title") or "(no title)"
+    repo = ev.get("repo") or "unknown"
+    event_type = ev.get("event_type") or "unknown"
+
+    payload = ev.get("payload") or {}
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (ValueError, TypeError):
+            payload = {}
+
+    days = payload.get("days_flagged")
+    url = payload.get("url")
+    detail = payload.get("detail")
+
+    lines = [f"[{severity}] {title}", f"Repo: {repo} | Type: {event_type}"]
+    if days is not None:
+        lines.append(f"Stale: {days}d unaddressed")
+    if detail:
+        lines.append(f"Detail: {detail}")
+    if url:
+        lines.append(url)
+    lines.append(f"Event: {ev.get('id')}")
+    return "\n".join(lines)
+
+
+def send_telegram(token: str, chat_id: str, text: str) -> tuple[bool, str]:
+    """Send one message via Bot API. Returns (ok, description)."""
+    if httpx is None:
+        return False, "httpx not available"
+
+    url = f"{TELEGRAM_API}/bot{token}/sendMessage"
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            resp = client.post(
+                url,
+                json={
+                    "chat_id": chat_id,
+                    "text": text,
+                    "disable_web_page_preview": True,
+                },
+            )
+            body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
+            if resp.status_code == 200 and body.get("ok"):
+                return True, "sent"
+            return False, f"HTTP {resp.status_code}: {body.get('description', resp.text[:200])}"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def mark_processed(client, event_id: str, action: str) -> None:
+    """Mark event processed so it won't notify again."""
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        client.table("events").update(
+            {
+                "processed": True,
+                "processed_at": now,
+                "processed_by": "telegram-notify-hook",
+                "action_taken": action,
+            }
+        ).eq("id", event_id).execute()
+    except Exception as e:
+        print(f"WARN: failed to mark {event_id} processed: {e}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Drain high-severity events to owner's Telegram (#327 escalation ladder)"
+    )
+    parser.add_argument(
+        "--min-severity",
+        default="high",
+        choices=SEVERITIES,
+        help="Minimum severity to notify (default: high)",
+    )
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT, help="Max events per run")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be sent")
+    args = parser.parse_args()
+
+    token = (os.environ.get("TELEGRAM_BOT_TOKEN") or "").strip()
+    chat_id = (os.environ.get("TELEGRAM_ALLOW_USER_ID") or "").strip()
+
+    if not args.dry_run and (not token or not chat_id):
+        print(
+            "Error: TELEGRAM_BOT_TOKEN and TELEGRAM_ALLOW_USER_ID must be set. "
+            "(Use --dry-run to preview without sending.)",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        from supabase import create_client
+    except ImportError:
+        print("Error: supabase library not available", file=sys.stderr)
+        return 1
+
+    supa_url = os.environ.get("SUPABASE_URL")
+    supa_key = os.environ.get("SUPABASE_KEY")
+    if not supa_url or not supa_key:
+        print("Error: SUPABASE_URL and SUPABASE_KEY must be set", file=sys.stderr)
+        return 1
+
+    client = create_client(supa_url, supa_key)
+    events = fetch_pending_events(client, args.min_severity, args.limit)
+
+    if not events:
+        print(f"No pending events at severity >= {args.min_severity}.")
+        return 0
+
+    print(f"Draining {len(events)} pending events (min severity: {args.min_severity})")
+    sent = 0
+    failed = 0
+
+    for ev in events:
+        msg = format_message(ev)
+        if args.dry_run:
+            print("--- [DRY RUN] would send ---")
+            print(msg)
+            print()
+            continue
+
+        ok, detail = send_telegram(token, chat_id, msg)
+        if ok:
+            mark_processed(client, ev["id"], f"telegram sent: {detail}")
+            sent += 1
+            print(f"[OK] {ev['id']} — sent")
+        else:
+            failed += 1
+            print(f"[FAIL] {ev['id']} — {detail}", file=sys.stderr)
+
+    if args.dry_run:
+        print(f"DRY RUN complete. Would have sent {len(events)} messages.")
+    else:
+        print(f"Done. sent={sent} failed={failed}")
+
+    return 0 if failed == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Escalation ladder for flag-only findings — autonomous-loop promotes ignored flags through visibility channels as days pass, closing the loop for foreign-owner repos (e.g. `SergazyNarynov/redrobot` CI billing) where Jarvis can only flag but not action.

## Why
Three consecutive days of CI-billing flags against redrobot with no owner response (2026-04-21 → 2026-04-23). Pattern is load-bearing: autonomous-loop writes a memory, the memory sits, nothing changes. Own outcome lessons from 2026-04-21 and 2026-04-23 explicitly asked for this.

Closes #327

## Decisions & Alternatives

**Ladder thresholds aligned with issue table** (days 1/2/3/5 = rungs 1/2/3/4). Rung 3 uses `N>=3 consecutive flags` rather than `days_unaddressed>=3`, matching the issue body phrasing. If autonomous-loop misses a day, the next run still catches up — latency is not SLA-sensitive here.

**Telegram via Bot API, not existing Telethon MCP server**: the existing `scripts/telegram-mcp-server.py` is a full user-level Telegram client (Telethon); wrong tool for simple notifications. New `telegram-notify-hook.py` uses the Bot API via `httpx` — lightweight, env-driven (`TELEGRAM_BOT_TOKEN` + `TELEGRAM_ALLOW_USER_ID` already in `.env.example`), idempotent via `processed=true`.

**Tail-call from autonomous-loop (Step 7.5), not a separate scheduler**: keeps the pipeline linear. Events emitted this run get delivered this run. A future iteration can add hourly drain if latency matters.

**Per-repo granularity, not per-finding (yet)**: memory names use `hygiene_sweep_proposals_<repo>_<date>`. We count all findings for a repo as one escalation unit. Covers 80% of the value; per-finding tracking (via signature in payload) is a future sharpening.

**Dedup on events table**: skip emitting if an unprocessed `hygiene_stale` event for the same repo already exists. Prevents duplicate Telegram spam when autonomous-loop runs more than once in a 24h window.

Trade-offs: skill files grew ~80 lines; keeping the logic in markdown makes it hot-swappable across sessions (user-level skills) but means changes propagate only after next session start.

## Risk Assessment

- **LOW**: `/status` skill edit — additive, only adds STALE FLAG section; omits silently if no stale memories.
- **LOW**: `scripts/telegram-notify-hook.py` — new file, no callers unless autonomous-loop invokes it. Standalone + dry-run supported.
- **MEDIUM**: autonomous-loop skill edit — adds new Step 2b (SQL queries + events insert + optional `gh issue create`). The issue creation path is guarded by dedup + N>=5 threshold; smoke not yet tested end-to-end in a live autonomous run (will happen on next daily tick).

Not safety-adjacent — no changes under `driver/`, `planning/`, `mujoco/`, or protected files.

## Testing

- `python -c "ast.parse(...)"` — syntax OK
- `python scripts/telegram-notify-hook.py --dry-run` with no events in queue → "No pending events at severity >= high." (clean exit)
- **Live smoke**: inserted fake `hygiene_stale` event via `execute_sql`, ran dry-run — script fetched, formatted correctly (severity, title, repo, type, days, detail, url, event id), reported "would have sent 1 messages"; deleted test event after.
- **Not yet tested in prod**: actual Telegram send (requires live bot run); autonomous-loop Step 2b full path (requires autonomous-loop run with N>=3 flags — will be verified on next scheduled tick).

## Files Changed

- `.claude-userlevel/skills/autonomous-loop/SKILL.md` (v1.1.0 → v1.2.0) — Step 2b (consecutive-flag detection + event emit + issue creation), Step 7.5 (tail-call telegram-notify)
- `.claude-userlevel/skills/status/SKILL.md` (v2.1.0 → v2.2.0) — reads stale `hygiene_sweep_proposals_*`, surfaces STALE FLAG badge at top of Alerts
- `scripts/telegram-notify-hook.py` (new) — drains unprocessed high/critical events via Telegram Bot API; idempotent; supports `--dry-run`, `--limit`, `--min-severity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)