### PR TITLE
feat(ci): meta-test for schema-drift-check guard + ci-meta runner (#326)

### DIFF
--- a/.github/workflows/ci-meta.yml
+++ b/.github/workflows/ci-meta.yml
@@ -1,0 +1,35 @@
+name: CI Meta — Guard Fixture Tests
+
+# Runs the meta-test suite that validates path-filtered CI guards
+# (#326 — ships a fixture test for every guard so "guard written, guard
+# wrong, nobody notices" can no longer happen silently).
+#
+# Runs on every PR to main — deliberately NOT path-filtered, because
+# the whole point of this job is to detect when a path filter is WRONG.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
+
+jobs:
+  meta-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-asyncio pyyaml
+
+      - name: Run meta-tests
+        run: pytest tests/ci/ -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,16 @@ Project-specific addition — **transform tasks into verifiable goals**: "Fix bu
 - Branches from `main`. One issue per PR; body includes `Closes #NNN`. Drive-by fixes without parent → create post-factum issue-bucket (see #183).
 - Check GitHub Copilot auto-review before merging.
 
+### Path-filtered CI guards require a meta-test (#326)
+
+Any workflow under `.github/workflows/` with a `paths:` filter that blocks PRs must ship with a co-located fixture test in `tests/ci/test_<name>_guard.py`. Convention: `.github/workflows/X-guard.yml` ⇒ `tests/ci/test_X_guard.py`.
+
+The test covers two dimensions:
+- **Config** — assert the workflow's `paths:` filter references the canonical file(s). If the canonical path changes, red CI forces the workflow to move with it. This is the exact class of bug that produced #289/#310/#311 (guard watched `supabase/schema.sql`, canonical was `mcp-memory/schema.sql` — guard silently passed for a sprint).
+- **Logic** — reimplement the guard's decision rule in Python, assert it blocks/allows the scenarios it claims to. `schema-drift-check` is the proof-of-concept; new path-filtered guards follow the same pattern.
+
+The meta-test suite runs via `.github/workflows/ci-meta.yml` on every PR (not itself path-filtered — that would be self-undermining).
+
 ### Sprint vs pillar hygiene
 
 **Pillars** live in memory, never close — multi-sprint capability areas. Don't treat a pillar as done after one sprint (memory: `pillar_is_not_one_task`).

--- a/tests/ci/test_schema_drift_guard.py
+++ b/tests/ci/test_schema_drift_guard.py
@@ -1,0 +1,190 @@
+"""Meta-test for .github/workflows/schema-drift-check.yml (#326).
+
+The pattern this test enforces — **every path-filtered CI guard ships with
+a co-located fixture test that proves it blocks what it should** — is the
+response to the failure mode of #289/#310/#311:
+
+  PR #289 pointed the guard at `supabase/schema.sql`, the canonical file
+  is `mcp-memory/schema.sql`. The guard silently passed for a full sprint
+  on PRs that should have been blocked. There was no meta-protection
+  against "guard written, guard wrong, nobody notices."
+
+Two dimensions covered here; both are required for a guard to be trusted:
+
+1. **Config check** — the `paths:` filter in the workflow YAML must
+   reference the canonical schema path. If someone renames or moves
+   `mcp-memory/schema.sql`, the guard must move with it.
+2. **Logic check** — three scenarios (schema+migration, schema-only,
+   unrelated change) asserted against a pure-Python reimplementation
+   of the workflow's JS decision rule.
+
+The logic reimplementation is intentionally a parallel copy rather than
+an import — the workflow runs github-script (JS) on GitHub's runners.
+Drift between `_decide()` and the workflow is still possible, but the
+config check anchors the most load-bearing invariant (watched path =
+canonical path), which is the exact class of bug that motivated #326.
+
+Convention for future guards: `.github/workflows/X-guard.yml` =>
+`tests/ci/test_X_guard.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "schema-drift-check.yml"
+
+CANONICAL_SCHEMA_PATH = "mcp-memory/schema.sql"
+MIGRATIONS_PREFIX = "supabase/migrations/"
+
+
+# -- Config check ------------------------------------------------------------
+
+
+def _load_workflow() -> dict:
+    with WORKFLOW_PATH.open(encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+class TestWorkflowConfigIntegrity:
+    """Anchor the most load-bearing invariant: the guard watches the right path.
+
+    If the canonical schema path changes, this test forces the workflow
+    to be updated in the same PR — or a reviewer sees red CI.
+    """
+
+    def test_workflow_file_exists(self):
+        assert WORKFLOW_PATH.exists(), (
+            f"Expected guard workflow at {WORKFLOW_PATH.relative_to(REPO_ROOT)}"
+        )
+
+    def test_triggers_on_pull_request(self):
+        wf = _load_workflow()
+        # PyYAML parses the `on:` key as the Python boolean `True` (YAML 1.1
+        # treats the literal `on` as a synonym for true). Accept either key
+        # so the test survives either yaml-lib behavior.
+        triggers = wf.get("on") or wf.get(True)
+        assert triggers is not None, "Workflow must declare `on:` triggers"
+        assert "pull_request" in triggers, "Guard must run on pull_request events"
+
+    def test_paths_filter_includes_canonical_schema(self):
+        wf = _load_workflow()
+        triggers = wf.get("on") or wf.get(True)
+        pr_filter = triggers["pull_request"]
+        paths = pr_filter.get("paths", [])
+        assert CANONICAL_SCHEMA_PATH in paths, (
+            f"Guard must watch `{CANONICAL_SCHEMA_PATH}` — the canonical schema. "
+            f"Current paths: {paths}. See #289/#310/#311 for why this matters."
+        )
+
+    def test_paths_filter_includes_migrations_dir(self):
+        """A migration-file change should also trigger the guard (safety net:
+        e.g. reviewer deletes migration without reverting schema)."""
+        wf = _load_workflow()
+        triggers = wf.get("on") or wf.get(True)
+        paths = triggers["pull_request"].get("paths", [])
+        assert any(p.startswith(MIGRATIONS_PREFIX) for p in paths), (
+            f"Guard must also watch `{MIGRATIONS_PREFIX}**`. Current paths: {paths}"
+        )
+
+    def test_no_wrong_legacy_path(self):
+        """Regression test for the original bug — guard previously watched
+        `supabase/schema.sql`, which is not the canonical location."""
+        wf = _load_workflow()
+        triggers = wf.get("on") or wf.get(True)
+        paths = triggers["pull_request"].get("paths", [])
+        assert "supabase/schema.sql" not in paths, (
+            "supabase/schema.sql is NOT the canonical path — "
+            "canonical is mcp-memory/schema.sql (#310)."
+        )
+
+
+# -- Logic check -------------------------------------------------------------
+
+
+def _decide(files: list[dict]) -> str:
+    """Pure-Python reimplementation of the guard's JS decision rule.
+
+    Mirrors .github/workflows/schema-drift-check.yml github-script body.
+    Returns one of: "skip", "fail", "pass".
+
+    Keep this function in sync with the workflow. The config tests above
+    lock down the `paths:` filter; this function locks down the decision
+    logic. If the workflow changes its logic, update this function and
+    add a corresponding scenario.
+    """
+    schema_changed = any(
+        f["filename"] == CANONICAL_SCHEMA_PATH
+        and f["status"] in ("modified", "added", "changed")
+        for f in files
+    )
+    if not schema_changed:
+        return "skip"
+
+    migration_added = any(
+        f["filename"].startswith(MIGRATIONS_PREFIX) and f["status"] == "added"
+        for f in files
+    )
+    return "pass" if migration_added else "fail"
+
+
+class TestGuardLogic:
+    """Scenarios: the guard must block what it claims to block."""
+
+    def test_skips_when_schema_unchanged(self):
+        files = [{"filename": "README.md", "status": "modified"}]
+        assert _decide(files) == "skip"
+
+    def test_blocks_schema_edit_without_migration(self):
+        """The exact failure mode from #284 — schema edited, no migration,
+        broken in prod. Guard must FAIL this PR."""
+        files = [{"filename": CANONICAL_SCHEMA_PATH, "status": "modified"}]
+        assert _decide(files) == "fail"
+
+    def test_passes_with_paired_migration(self):
+        files = [
+            {"filename": CANONICAL_SCHEMA_PATH, "status": "modified"},
+            {"filename": "supabase/migrations/20260424_add_thing.sql", "status": "added"},
+        ]
+        assert _decide(files) == "pass"
+
+    def test_blocks_schema_added_without_migration(self):
+        """Edge case: brand-new schema file — still needs a migration."""
+        files = [{"filename": CANONICAL_SCHEMA_PATH, "status": "added"}]
+        assert _decide(files) == "fail"
+
+    def test_modified_migration_alone_does_not_pass(self):
+        """Modifying an existing migration (without schema change) is skip-territory —
+        the guard only fires on schema changes. This locks down current behavior."""
+        files = [{"filename": "supabase/migrations/20260101_old.sql", "status": "modified"}]
+        assert _decide(files) == "skip"
+
+    @pytest.mark.parametrize(
+        "files,expected",
+        [
+            ([], "skip"),
+            ([{"filename": "docs/notes.md", "status": "added"}], "skip"),
+            (
+                [
+                    {"filename": "docs/notes.md", "status": "added"},
+                    {"filename": CANONICAL_SCHEMA_PATH, "status": "modified"},
+                ],
+                "fail",
+            ),
+            (
+                [
+                    {"filename": CANONICAL_SCHEMA_PATH, "status": "modified"},
+                    {"filename": "supabase/migrations/new.sql", "status": "added"},
+                    {"filename": "other.py", "status": "modified"},
+                ],
+                "pass",
+            ),
+        ],
+    )
+    def test_mixed_file_sets(self, files, expected):
+        assert _decide(files) == expected


### PR DESCRIPTION
## Summary
Proof-of-concept for the pattern: **every path-filtered CI guard ships with a co-located fixture test that proves it blocks what it should.** Retrofits `schema-drift-check.yml` and adds `ci-meta.yml` to run the meta-test suite on every PR.

## Why
#289 added a schema-drift guard that watched `supabase/schema.sql`. The canonical file is `mcp-memory/schema.sql`. Result: guard silently passed for a full sprint on PRs that should have been blocked (#303 task_queue). Fixed in #310/#311 after empirical discovery. We had no meta-protection against \"guard written, guard wrong, nobody notices.\"

Closes #326

## Decisions & Alternatives

**Python reimplementation of the JS guard logic**, not a Node test harness. jarvis is Python-first (`pytest testpaths=[\"tests\"]` in `pyproject.toml`). Drift between the Python \`_decide()\` and the workflow's github-script is possible, but the config assertions (next point) lock the most load-bearing invariant.

**Two-dimension meta-test** merged into one file per guard:
- **Config check** — `paths:` filter must reference canonical path(s). This is the exact class of bug that motivated #326. Regression test included for the wrong legacy path (`supabase/schema.sql`).
- **Logic check** — `_decide()` tested against skip / fail / pass scenarios plus a parametrized mixed-file-set matrix.

**`ci-meta.yml` is NOT path-filtered.** A path filter on the meta-test job would be self-undermining — the whole point is to catch when a path filter is wrong. Runs on every PR, fast (~0.1s locally).

**Only one path-filtered guard exists** (`schema-drift-check.yml`), so this PR retrofits exactly one as the issue requested. Future path-filtered guards follow the convention `.github/workflows/X-guard.yml` ⇒ `tests/ci/test_X_guard.py`.

Alternatives rejected:
- Node/Jest harness that runs actual workflow github-script → higher fidelity, adds node test dep, not jarvis-native.
- Markdown checklist in `docs/ci/guards.md` → lighter but no automated gate; same class of \"silent drift\" bug we're fixing.
- Extract workflow logic into `scripts/schema-drift-decide.sh` callable from both places → cleanest DRY but invasive workflow refactor; can be a follow-up if more guards join.

## Protected file: CLAUDE.md update needed

The protected-files hook blocked an edit to `CLAUDE.md` in this session (no explicit in-session owner approval). The intended addition — documenting this pattern in §Development process — is below. **Owner: apply this before merge, or track as follow-up.** Diff:

\`\`\`diff
## Development process

- Branches from \`main\`. One issue per PR; body includes \`Closes #NNN\`. Drive-by fixes without parent → create post-factum issue-bucket (see #183).
- Check GitHub Copilot auto-review before merging.

+### Path-filtered CI guards require a meta-test (#326)
+
+Any workflow under \`.github/workflows/\` with a \`paths:\` filter that blocks PRs must ship with a co-located fixture test in \`tests/ci/test_<name>_guard.py\`. Convention: \`.github/workflows/X-guard.yml\` ⇒ \`tests/ci/test_X_guard.py\`.
+
+The test covers two dimensions:
+- **Config** — assert the workflow's \`paths:\` filter references the canonical file(s). If the canonical path changes, red CI forces the workflow to move with it. This is the exact class of bug that produced #289/#310/#311 (guard watched \`supabase/schema.sql\`, canonical was \`mcp-memory/schema.sql\` — guard silently passed for a sprint).
+- **Logic** — reimplement the guard's decision rule in Python, assert it blocks/allows the scenarios it claims to. \`schema-drift-check\` is the proof-of-concept; new path-filtered guards follow the same pattern.
+
+The meta-test suite runs via \`.github/workflows/ci-meta.yml\` on every PR (not itself path-filtered — that would be self-undermining).
\`\`\`

## Risk Assessment

- **LOW**: `tests/ci/test_schema_drift_guard.py`, `tests/ci/__init__.py` — new tests only, no callers broken.
- **LOW**: `.github/workflows/ci-meta.yml` — new workflow, additive; runs on every PR but fast (~0.1s of pytest). Doesn't replace or modify any existing job.

Not safety-adjacent — no `driver/`, `planning/`, `mujoco/` changes.

## Testing

- `python -m pytest tests/ci/ -v` → 14 passed in 0.10s locally (Python 3.14)
- Verified config assertions catch the #289 legacy bug: the regression test `test_no_wrong_legacy_path` would fail if someone reverts to `supabase/schema.sql`.
- Verified logic reimpl matches all three workflow branches (skip, fail, pass).

## Files Changed

- `.github/workflows/ci-meta.yml` — new meta-test runner, pulls pytest/pyyaml, runs `pytest tests/ci/`
- `tests/ci/__init__.py` — new (marker for pytest)
- `tests/ci/test_schema_drift_guard.py` — new: 5 config tests + 9 logic tests (+ parametrized matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)