### PR TITLE
fix(tests): dispatcher E2E assertion must match reuse contract

### DIFF
--- a/tests/test_agents_dispatcher_e2e.py
+++ b/tests/test_agents_dispatcher_e2e.py
@@ -227,7 +227,10 @@ def test_happy_path_dispatches_and_audits(
     details = entry.get("details") or {}
     assert details.get("tier") == 0  # Tier.AUTO
     idem = details.get("idempotency_key")
-    assert idem and len(idem) == 64, f"idempotency_key not a sha256 hex: {idem!r}"
+    assert idem == seeded["idempotency_key"], (
+        f"dispatcher must reuse row's idempotency_key (contract at "
+        f"dispatcher.py:261-264); got {idem!r} vs seeded {seeded['idempotency_key']!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Happy-path assertion required sha256 hex but fixture seeded non-sha256 marker string
- Dispatcher at [dispatcher.py:261-264](agents/dispatcher.py:261) reuses row's `idempotency_key` by design — test now checks that contract
- Surfaced on first live `AGENTS_E2E=1` run (Sprint 2 closed without one)

## Test plan

- [x] `AGENTS_E2E=1 pytest tests/test_agents_dispatcher_e2e.py -v` passes (2/2) on Main PC
- [x] Manual dispatcher run on real queue: `python -m agents.dispatcher --dry-run` → `outcome=no_pending reason=queue empty`

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)