### PR TITLE
fix(probe): audit_log column is 'timestamp', not 'created_at'

### DIFF
--- a/agents/usage_probe.py
+++ b/agents/usage_probe.py
@@ -194,7 +194,7 @@ class StaticBudgetProbe:
                 .eq("agent_id", DISPATCHER_AGENT_ID)
                 .eq("action", DISPATCH_ACTION)
                 .eq("outcome", "success")
-                .gte("created_at", window_start.isoformat())
+                .gte("timestamp", window_start.isoformat())
                 .execute()
             )
             return int(getattr(resp, "count", 0) or 0)

--- a/tests/test_agents_usage_probe.py
+++ b/tests/test_agents_usage_probe.py
@@ -160,9 +160,14 @@ def test_probe_counts_dispatcher_audit_rows() -> None:
     assert eqs["agent_id"] == "task-dispatcher"
     assert eqs["action"] == "dispatch"
     assert eqs["outcome"] == "success"
-    # And filtered by window_start in created_at.
+    # And filtered by window_start in timestamp.
+    # (audit_log's timestamp column is the canonical name — see
+    # mcp-memory/schema.sql and docs/agents/e2e-test.md:137. The prior
+    # "created_at" assertion matched the code but not the real schema,
+    # so unit tests were green while prod probes 400'd and the
+    # dispatcher escalated every tick on false-safe near_exhaustion.)
     gtes = dict(client.recorder["gte"])
-    assert "created_at" in gtes
+    assert "timestamp" in gtes
 
 
 def test_probe_near_exhaustion_flips_at_threshold() -> None:


### PR DESCRIPTION
## Summary

- usage_probe queried `audit_log.created_at`; canonical column is `timestamp`
- Effect: Supabase 400 → false-safe `near_exhaustion=True` → dispatcher escalates every tick, never dispatches
- Same mock-vs-schema failure class as #366

## Test plan

- [x] 22/22 unit tests pass
- [x] Live `python -m agents.dispatcher` on prod Supabase: post-fix → `outcome=dispatched` instead of `outcome=escalated reason=limit_near_exhaustion`

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)