### PR TITLE
fix(dispatcher): pass permission flags to spawned 'claude -p' (#372)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ reports/self-review-*.md
 
 # Ad-hoc smoke-test / one-shot script artifacts
 .tmp/
+scripts/.smoke-markers/
+scripts/.dispatcher_smoke_state.json
 
 # Legacy Python (may remain locally)
 __pycache__/

--- a/agents/dispatcher.py
+++ b/agents/dispatcher.py
@@ -70,6 +70,26 @@ _SENSITIVE_ENV_KEYS: frozenset[str] = frozenset(
     }
 )
 
+# Permission spec for the spawned ``claude -p`` session (#372). Without
+# these flags, headless Claude hangs waiting for approval that no operator
+# can give. Design: ``acceptEdits`` auto-approves Write/Edit (matches
+# dispatcher's primary shape — "make the change"), plus a narrow allowlist
+# of read-only and safely-namespaced tools that ``acceptEdits`` does not
+# cover. Widen this list only with a design note; do NOT switch to
+# ``bypassPermissions`` — that defeats the Sprint 2 safety layering.
+_SPAWN_PERMISSION_MODE = "acceptEdits"
+_SPAWN_ALLOWED_TOOLS = (
+    "Read",
+    "Glob",
+    "Grep",
+    "TodoWrite",
+    "Bash(git:*)",
+    "Bash(gh:*)",
+    "Bash(pytest:*)",
+    "Bash(npm:*)",
+    "Bash(python:*)",
+)
+
 # How many recent dispatches to scan for pattern-repeat detection. Large
 # enough that a run of 3 same-goal tasks plus the pending one is visible;
 # small enough that the Supabase query stays cheap on every tick.
@@ -284,8 +304,17 @@ def dispatch_node(
 
     try:
         env = _sanitize_env()
+        argv = [
+            "claude",
+            "-p",
+            goal,
+            "--permission-mode",
+            _SPAWN_PERMISSION_MODE,
+            "--allowedTools",
+            *_SPAWN_ALLOWED_TOOLS,
+        ]
         spawn(
-            ["claude", "-p", goal],
+            argv,
             env=env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/scripts/dispatcher_smoke_live.py
+++ b/scripts/dispatcher_smoke_live.py
@@ -1,0 +1,168 @@
+"""One-shot live smoke test for the dispatcher — seed one row, spawn real Claude, verify.
+
+Usage:
+    python scripts/dispatcher_smoke_live.py seed      # insert a row, print marker
+    python scripts/dispatcher_smoke_live.py check     # inspect row/audit/marker file
+    python scripts/dispatcher_smoke_live.py cleanup   # delete row + audit + marker file
+
+The workflow is deliberately split so the operator runs `python -m agents.dispatcher`
+in between `seed` and `check`, keeping each subprocess boundary observable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+STATE_FILE = Path(__file__).parent / ".dispatcher_smoke_state.json"
+MARKER_DIR = Path(__file__).parent / ".smoke-markers"
+
+
+def seed() -> int:
+    load_dotenv()
+    from agents.supabase_client import get_client
+
+    MARKER_DIR.mkdir(exist_ok=True)
+    marker = uuid.uuid4().hex[:12]
+    # Marker lives inside the project dir so the spawned Claude's acceptEdits
+    # permission mode approves the Write. Writes outside the project root
+    # still require explicit --add-dir flags, which the dispatcher does not
+    # grant (and shouldn't for a test utility).
+    smoke_file = MARKER_DIR / f"{marker}.ok"
+
+    goal = (
+        f"DISPATCHER SMOKE TEST. Create a file at the absolute path "
+        f"{smoke_file.as_posix()!r} with the single line content 'ok'. "
+        f"Then stop. Do not edit any source code. Do not run git. "
+        f"Do not create issues, PRs, or commits. Do not make network calls. "
+        f"Only use the Write tool once. This is a smoke test, not a real task."
+    )
+
+    scope_files: list[str] = []
+    scope_hash = hashlib.sha256("\n".join(sorted(scope_files)).encode("utf-8")).hexdigest()
+    idem_key = hashlib.sha256(f"dispatcher-smoke-live-{marker}".encode("utf-8")).hexdigest()
+
+    cli = get_client()
+    inserted = (
+        cli.table("task_queue")
+        .insert(
+            {
+                "goal": goal,
+                "scope_files": scope_files,
+                "approved_at": datetime.now(UTC).isoformat(),
+                "approved_by": "dispatcher-smoke-operator",
+                "approved_scope_hash": scope_hash,
+                "auto_dispatch": True,
+                "idempotency_key": idem_key,
+                "status": "pending",
+            }
+        )
+        .execute()
+        .data
+    )
+    if not inserted:
+        print("INSERT returned no data", file=sys.stderr)
+        return 1
+
+    row = inserted[0]
+    state = {
+        "row_id": row["id"],
+        "marker": marker,
+        "smoke_file": str(smoke_file),
+        "idempotency_key": idem_key,
+    }
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+    print(f"[seed] row_id={row['id']}")
+    print(f"[seed] marker={marker}")
+    print(f"[seed] expected smoke file: {smoke_file}")
+    print(f"[seed] state saved to: {STATE_FILE}")
+    print()
+    print("Next: python -m agents.dispatcher")
+    return 0
+
+
+def check() -> int:
+    load_dotenv()
+    if not STATE_FILE.exists():
+        print(f"No state file at {STATE_FILE} — run `seed` first", file=sys.stderr)
+        return 1
+
+    state = json.loads(STATE_FILE.read_text())
+    row_id = state["row_id"]
+    marker = state["marker"]
+    smoke_file = Path(state["smoke_file"])
+
+    from agents.supabase_client import get_client
+
+    cli = get_client()
+
+    row = (
+        cli.table("task_queue")
+        .select("id, status, goal, dispatched_at, escalated_reason")
+        .eq("id", row_id)
+        .limit(1)
+        .execute()
+        .data
+    )
+    audit = (
+        cli.table("audit_log")
+        .select("agent_id, tool_name, action, outcome, details, timestamp")
+        .eq("target", f"task_queue:{row_id}")
+        .order("timestamp", desc=True)
+        .limit(5)
+        .execute()
+        .data
+        or []
+    )
+
+    print(f"[check] marker={marker}")
+    print(f"[check] row: {json.dumps(row[0] if row else None, indent=2, default=str)}")
+    print(f"[check] audit_log rows ({len(audit)}):")
+    for entry in audit:
+        print(f"  - {entry['timestamp']} {entry['agent_id']}/{entry['action']}={entry['outcome']}")
+    print(f"[check] smoke file exists? {smoke_file.exists()} ({smoke_file})")
+    if smoke_file.exists():
+        print(f"[check] smoke file content: {smoke_file.read_text()!r}")
+    return 0
+
+
+def cleanup() -> int:
+    load_dotenv()
+    if not STATE_FILE.exists():
+        print(f"No state file at {STATE_FILE} — nothing to clean", file=sys.stderr)
+        return 0
+
+    state = json.loads(STATE_FILE.read_text())
+    row_id = state["row_id"]
+    smoke_file = Path(state["smoke_file"])
+
+    from agents.supabase_client import get_client
+
+    cli = get_client()
+    cli.table("audit_log").delete().eq("target", f"task_queue:{row_id}").execute()
+    cli.table("task_queue").delete().eq("id", row_id).execute()
+
+    if smoke_file.exists():
+        smoke_file.unlink()
+
+    STATE_FILE.unlink()
+    print(f"[cleanup] deleted row {row_id}, audit rows, marker file, state file")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cmd", choices=["seed", "check", "cleanup"])
+    args = parser.parse_args()
+    return {"seed": seed, "check": check, "cleanup": cleanup}[args.cmd]()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agents_dispatcher.py
+++ b/tests/test_agents_dispatcher.py
@@ -392,6 +392,16 @@ def test_full_flow_dispatches_healthy_row(monkeypatch: pytest.MonkeyPatch) -> No
     call = popen.calls[0]
     assert call["argv"][0:2] == ["claude", "-p"]
 
+    # Permission flags present — without these, headless Claude hangs
+    # on approval prompts (#372). acceptEdits + narrow allowedTools,
+    # not bypassPermissions (which defeats Sprint 2 safety layering).
+    argv = call["argv"]
+    assert "--permission-mode" in argv
+    assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+    assert "--allowedTools" in argv
+    assert "Bash(git:*)" in argv, "expected narrow Bash allowlist"
+    assert "--dangerously-skip-permissions" not in argv
+
     # Row flipped to dispatched.
     updates = [c for c in client.calls if c[0] == "update" and c[1] == "task_queue"]
     assert len(updates) == 1


### PR DESCRIPTION
## Summary
- Dispatcher now spawns `claude -p` with `--permission-mode acceptEdits --allowedTools …`, so headless runs no longer hang on approval prompts.
- Whitelist is hybrid per owner's call: acceptEdits covers in-project Write/Edit; allowed-tools explicitly grants Read/Glob/Grep/TodoWrite plus scoped Bash (git, gh, pytest, npm, python). No `--dangerously-skip-permissions`.
- Adds a reusable live-smoke utility (`scripts/dispatcher_smoke_live.py`) that seeds a minimal approved row, waits for the spawned Claude to write a marker file inside the project dir, and cleans up.

Closes #372

**Stacked on #371** — retarget to `main` when that merges.

## Test plan
- [x] Unit: `tests/test_agents_dispatcher.py` — argv assertions check the flags are passed and `--dangerously-skip-permissions` is absent.
- [x] Live smoke (this machine, AGENTS_E2E gate not required):
  - `python scripts/dispatcher_smoke_live.py seed`
  - `python -m agents.dispatcher`
  - Marker file `scripts/.smoke-markers/<id>.ok` appears within ~1 minute with content `ok`.
  - `task_queue.status=dispatched`, one `audit_log` row with `agent_id=task-dispatcher, action=dispatch, outcome=success`.
  - `python scripts/dispatcher_smoke_live.py cleanup` removes all artifacts.

## Notes
- The smoke marker lives **inside the project directory** by design: `acceptEdits` only auto-approves Write to paths under `cwd`. Writes to `%TEMP%` or other out-of-tree paths would still block without an explicit `--add-dir`, which the dispatcher does not (and shouldn't) grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)