### PR TITLE
fix(scheduler): wire dispatcher, not _placeholder_tick (#368)

### DIFF
--- a/agents/dispatcher.py
+++ b/agents/dispatcher.py
@@ -476,23 +476,35 @@ def _scheduled_tick() -> None:
         logger.exception("[dispatcher] tick failed: %s", exc)
 
 
-def register(handle: Any, *, dry_run: bool = False, interval_seconds: int = 60) -> Any:
+def register(
+    handle: Any,
+    *,
+    dry_run: bool = False,
+    interval_seconds: int = 60,
+    jitter_seconds: int | None = None,
+) -> Any:
     """Register the dispatcher as an APScheduler job on ``handle``.
 
     ``dry_run`` is persisted via an env var so :func:`_scheduled_tick`
     picks it up at fire time — APScheduler's jobstore pickles the job
     target, and a closure carrying ``dry_run`` would bloat the persisted
     row and couple the stored job to this process's Python instance.
+
+    ``jitter_seconds=None`` means "use scheduler default"; pass an int to
+    override when multiple devices run the same agent and need to avoid
+    lockstep DB contention.
     """
     from agents.scheduler import register_agent
 
     os.environ["TASK_DISPATCHER_DRY_RUN"] = "1" if dry_run else "0"
-    return register_agent(
-        handle,
-        agent_id=AGENT_ID,
-        fn=_scheduled_tick,
-        interval_seconds=interval_seconds,
-    )
+    kwargs: dict[str, Any] = {
+        "agent_id": AGENT_ID,
+        "fn": _scheduled_tick,
+        "interval_seconds": interval_seconds,
+    }
+    if jitter_seconds is not None:
+        kwargs["jitter_seconds"] = jitter_seconds
+    return register_agent(handle, **kwargs)
 
 
 def main() -> int:

--- a/agents/scheduler.py
+++ b/agents/scheduler.py
@@ -22,11 +22,12 @@ Usage::
     )
     handle.scheduler.start()
 
-CLI (placeholder tick for smoke-testing before S2-3 lands)::
+CLI (runs the task-dispatcher on a persistent schedule)::
 
     python -m agents.scheduler                 # tick every 60s + 10s jitter
     python -m agents.scheduler --interval 30   # override interval
     python -m agents.scheduler --once          # fire one tick and exit
+    python -m agents.scheduler --once --dry-run  # graph only, no 'claude -p'
 
 Restart semantics: each agent's job is identified by ``agent_id`` and
 registered with ``replace_existing=True`` / ``max_instances=1`` /
@@ -190,18 +191,23 @@ def run(
     jitter_seconds: int,
     *,
     once: bool = False,
+    dry_run: bool = False,
 ) -> int:
-    """CLI entry-point: start scheduler, register placeholder, block.
+    """CLI entry-point: start scheduler, register the dispatcher, block.
 
     ``--once`` forces one immediate run of every registered agent and exits.
     Useful for smoke tests that don't want to wait a full interval.
+
+    ``--dry-run`` makes the dispatcher tick traverse the full graph without
+    spawning ``claude -p``; audit rows are still written.
     """
+    from agents import dispatcher
+
     cfg = load_config()
     handle = build_scheduler(cfg.postgres_url)
-    register_agent(
+    dispatcher.register(
         handle,
-        agent_id="scheduler-placeholder",
-        fn=_placeholder_tick,
+        dry_run=dry_run,
         interval_seconds=interval_seconds,
         jitter_seconds=jitter_seconds,
     )
@@ -255,8 +261,13 @@ def main() -> int:
         action="store_true",
         help="Run registered jobs once and exit (useful for smoke tests).",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Dispatcher traverses full graph but does not spawn 'claude -p'.",
+    )
     args = parser.parse_args()
-    return run(args.interval, args.jitter, once=args.once)
+    return run(args.interval, args.jitter, once=args.once, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/tests/test_agents_scheduler.py
+++ b/tests/test_agents_scheduler.py
@@ -257,17 +257,20 @@ def test_install_signal_handlers_is_safe_on_current_platform(memory_handle) -> N
 
 
 def test_main_cli_exposes_flags(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The CLI should accept --interval, --jitter, --once without error,
-    and forward them to ``run``. We don't actually start the scheduler.
+    """The CLI should accept --interval, --jitter, --once, --dry-run without
+    error, and forward them to ``run``. We don't actually start the scheduler.
     """
     from agents import scheduler
 
     called: dict[str, object] = {}
 
-    def fake_run(interval: int, jitter: int, *, once: bool = False) -> int:
+    def fake_run(
+        interval: int, jitter: int, *, once: bool = False, dry_run: bool = False
+    ) -> int:
         called["interval"] = interval
         called["jitter"] = jitter
         called["once"] = once
+        called["dry_run"] = dry_run
         return 0
 
     monkeypatch.setattr(scheduler, "run", fake_run)
@@ -275,7 +278,7 @@ def test_main_cli_exposes_flags(monkeypatch: pytest.MonkeyPatch) -> None:
 
     rc = scheduler.main()
     assert rc == 0
-    assert called == {"interval": 42, "jitter": 3, "once": False}
+    assert called == {"interval": 42, "jitter": 3, "once": False, "dry_run": False}
 
 
 def test_main_cli_once_flag(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -283,8 +286,11 @@ def test_main_cli_once_flag(monkeypatch: pytest.MonkeyPatch) -> None:
 
     captured: dict[str, object] = {}
 
-    def fake_run(interval: int, jitter: int, *, once: bool = False) -> int:
+    def fake_run(
+        interval: int, jitter: int, *, once: bool = False, dry_run: bool = False
+    ) -> int:
         captured["once"] = once
+        captured["dry_run"] = dry_run
         return 0
 
     monkeypatch.setattr(scheduler, "run", fake_run)
@@ -292,3 +298,85 @@ def test_main_cli_once_flag(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert scheduler.main() == 0
     assert captured["once"] is True
+    assert captured["dry_run"] is False
+
+
+def test_main_cli_dry_run_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agents import scheduler
+
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        interval: int, jitter: int, *, once: bool = False, dry_run: bool = False
+    ) -> int:
+        captured["dry_run"] = dry_run
+        return 0
+
+    monkeypatch.setattr(scheduler, "run", fake_run)
+    monkeypatch.setattr("sys.argv", ["agents.scheduler", "--once", "--dry-run"])
+
+    assert scheduler.main() == 0
+    assert captured["dry_run"] is True
+
+
+def test_run_wires_dispatcher_and_not_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``scheduler.run`` must register the dispatcher, not the placeholder.
+
+    Regression guard for the CLI wiring gap that was caught on 2026-04-24
+    during the first live prod smoke: ``python -m agents.scheduler`` was
+    still ticking ``_placeholder_tick`` because nobody swapped the target
+    after the dispatcher (S2-3) landed.
+    """
+    from agents import dispatcher, scheduler
+
+    captured: dict[str, object] = {}
+
+    class _FakeHandle:
+        class _FakeScheduler:
+            def start(self) -> None:
+                captured["started"] = True
+
+            def get_jobs(self) -> list:
+                return []
+
+            def shutdown(self, wait: bool = True) -> None:
+                captured["shut_down"] = True
+
+        scheduler = _FakeScheduler()
+        jobstore_alias = "default"
+
+    def fake_build_scheduler(_url: str) -> _FakeHandle:
+        return _FakeHandle()
+
+    def fake_dispatcher_register(
+        handle, *, dry_run: bool = False, interval_seconds: int = 60, jitter_seconds=None
+    ):
+        captured["register_target"] = "dispatcher"
+        captured["dry_run"] = dry_run
+        captured["interval_seconds"] = interval_seconds
+        captured["jitter_seconds"] = jitter_seconds
+
+    def fake_register_agent(*_args, **_kwargs):  # noqa: ANN002
+        # If this is called during run(), something registered the placeholder
+        # (or some other direct agent) instead of going through dispatcher.register.
+        captured["register_target"] = "placeholder-or-direct"
+
+    class _FakeConfig:
+        postgres_url = "postgresql://unused"
+
+    monkeypatch.setattr(scheduler, "build_scheduler", fake_build_scheduler)
+    monkeypatch.setattr(scheduler, "register_agent", fake_register_agent)
+    monkeypatch.setattr(scheduler, "load_config", lambda: _FakeConfig())
+    monkeypatch.setattr(dispatcher, "register", fake_dispatcher_register)
+    monkeypatch.setattr(scheduler, "_install_signal_handlers", lambda _h: None)
+
+    rc = scheduler.run(interval_seconds=30, jitter_seconds=5, once=True, dry_run=True)
+    assert rc == 0
+    assert captured["register_target"] == "dispatcher"
+    assert captured["dry_run"] is True
+    assert captured["interval_seconds"] == 30
+    assert captured["jitter_seconds"] == 5
+    assert captured.get("started") is True
+    assert captured.get("shut_down") is True


### PR DESCRIPTION
## Summary
- \`scheduler.run()\` now registers \`dispatcher.register(handle, ...)\` instead of \`_placeholder_tick\`. Before this, \`python -m agents.scheduler\` in prod ticked a no-op forever — the exact CLI wiring gap [#368](https://github.com/Osasuwu/jarvis/issues/368) called out.
- \`dispatcher.register()\` now accepts \`jitter_seconds\` so the CLI's \`--jitter\` isn't silently dropped.
- \`python -m agents.scheduler\` gains \`--dry-run\` (graph traversal without \`claude -p\`).
- Regression test asserts \`run(once=True)\` wires the dispatcher and never the placeholder.

**Partially closes #368** — the CLI-wiring bullet. NSSM service + operational signals still open on that issue.

**Stacked on** [#373](https://github.com/Osasuwu/jarvis/pull/373) → [#371](https://github.com/Osasuwu/jarvis/pull/371) → main.

## Test plan
- [x] \`pytest tests/test_agents_scheduler.py\` — 18 passed, incl. new \`test_run_wires_dispatcher_and_not_placeholder\`.
- [x] \`pytest tests/test_agents_dispatcher.py tests/test_agents_usage_probe.py\` — 42 passed.
- [x] Live end-to-end via scheduler (not direct dispatcher call):
  - \`python scripts/dispatcher_smoke_live.py seed\`
  - \`python -m agents.scheduler --once\`
  - Marker file appeared inside the project dir within ~30s; \`task_queue.status=dispatched\`; one \`audit_log\` success row.
  - Cleanup confirmed.

## Ops note
Before reopening long-running scheduler in prod, delete any stale \`scheduler-placeholder\` row from \`apscheduler_jobs\` — left over from pre-fix runs of the CLI:
\`\`\`sql
DELETE FROM apscheduler_jobs WHERE id = 'scheduler-placeholder';
\`\`\`
One-time cleanup on first deploy; harmless after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)