### PR TITLE
fix(dispatcher): tighten spawn whitelist (#378)

### DIFF
--- a/agents/dispatcher.py
+++ b/agents/dispatcher.py
@@ -70,13 +70,19 @@ _SENSITIVE_ENV_KEYS: frozenset[str] = frozenset(
     }
 )
 
-# Permission spec for the spawned ``claude -p`` session (#372). Without
+# Permission spec for the spawned ``claude -p`` session (#372, #378). Without
 # these flags, headless Claude hangs waiting for approval that no operator
 # can give. Design: ``acceptEdits`` auto-approves Write/Edit (matches
 # dispatcher's primary shape — "make the change"), plus a narrow allowlist
 # of read-only and safely-namespaced tools that ``acceptEdits`` does not
 # cover. Widen this list only with a design note; do NOT switch to
 # ``bypassPermissions`` — that defeats the Sprint 2 safety layering.
+#
+# Security rationale (#378):
+# - Dropped: Bash(python:*) — arbitrary code escape hatch. If a task needs
+#   to run a script, agent can invoke Edit + commit; CI tests for us.
+# - Replaced: Bash(gh:*) with scoped read/create verbs only. Removed:
+#   destructive verbs (merge --admin, repo delete, api DELETE).
 _SPAWN_PERMISSION_MODE = "acceptEdits"
 _SPAWN_ALLOWED_TOOLS = (
     "Read",
@@ -84,10 +90,17 @@ _SPAWN_ALLOWED_TOOLS = (
     "Grep",
     "TodoWrite",
     "Bash(git:*)",
-    "Bash(gh:*)",
+    "Bash(gh pr view:*)",
+    "Bash(gh pr create:*)",
+    "Bash(gh pr list:*)",
+    "Bash(gh issue view:*)",
+    "Bash(gh issue create:*)",
+    "Bash(gh issue list:*)",
+    "Bash(gh issue comment:*)",
+    "Bash(gh api repos/*/issues:*)",
+    "Bash(gh api repos/*/pulls:*)",
     "Bash(pytest:*)",
     "Bash(npm:*)",
-    "Bash(python:*)",
 )
 
 # How many recent dispatches to scan for pattern-repeat detection. Large

--- a/tests/test_agents_dispatcher.py
+++ b/tests/test_agents_dispatcher.py
@@ -239,6 +239,48 @@ def test_agent_id_matches_probe_and_escalation() -> None:
     assert AGENT_ID == DISPATCHER_AGENT_ID == PROBE_AGENT_ID == "task-dispatcher"
 
 
+def test_spawn_allowlist_excludes_dangerous_permissions() -> None:
+    """Verify spawn whitelist has been tightened per #378.
+
+    - Bash(python:*) removed (arbitrary code escape)
+    - Bash(gh:*) bare wildcard removed (destructive verbs)
+    - Only scoped gh verbs (read/create, no merge/delete) present
+    """
+    from agents.dispatcher import _SPAWN_ALLOWED_TOOLS
+
+    # Assert dangerous entries are NOT present
+    assert "Bash(python:*)" not in _SPAWN_ALLOWED_TOOLS, \
+        "Bash(python:*) must be removed — arbitrary code escape hatch (#378)"
+    assert "Bash(gh:*)" not in _SPAWN_ALLOWED_TOOLS, \
+        "bare Bash(gh:*) must be replaced with scoped verbs (#378)"
+
+    # Assert safe scoped gh verbs ARE present
+    safe_gh_verbs = {
+        "Bash(gh pr view:*)",
+        "Bash(gh pr create:*)",
+        "Bash(gh pr list:*)",
+        "Bash(gh issue view:*)",
+        "Bash(gh issue create:*)",
+        "Bash(gh issue list:*)",
+        "Bash(gh issue comment:*)",
+        "Bash(gh api repos/*/issues:*)",
+        "Bash(gh api repos/*/pulls:*)",
+    }
+    for verb in safe_gh_verbs:
+        assert verb in _SPAWN_ALLOWED_TOOLS, \
+            f"Missing safe gh verb '{verb}' — dispatcher cannot read/create issues/PRs"
+
+    # Assert no destructive gh verbs present
+    destructive_patterns = [
+        "merge",  # gh pr merge --admin
+        "delete",  # gh repo delete, gh api DELETE
+    ]
+    for pattern in destructive_patterns:
+        for tool in _SPAWN_ALLOWED_TOOLS:
+            assert pattern not in tool, \
+                f"Destructive pattern '{pattern}' found in allowlist entry '{tool}'"
+
+
 def test_sensitive_env_keys_cover_known_variants() -> None:
     """Env-sanitization must strip every historical Anthropic env name."""
     from agents.dispatcher import _SENSITIVE_ENV_KEYS


### PR DESCRIPTION
## Security Fix

Restrict spawned subagent permissions per PR #375 subagent review feedback.

### Changes

1. **Dropped Bash(python:*) entirely** — arbitrary code escape hatch. If a task genuinely needs to run a script, the agent can invoke Edit + commit instead; CI runs tests for us.

2. **Replaced bare Bash(gh:*) with scoped read/create verbs only:**
   - Allowed: gh pr/issue view/list/create/comment, gh api (read paths)
   - Denied: destructive verbs (merge --admin, repo delete, api DELETE)

### Test Coverage

Added `test_spawn_allowlist_excludes_dangerous_permissions()` to verify:
- Bare Bash(python:*) is not in the allowlist
- Bare Bash(gh:*) is not in the allowlist  
- All safe scoped gh verbs are present
- No destructive patterns are present

All 21 dispatcher tests pass.

Closes #378