### PR TITLE
feat(observability): first-week checklist (#380)

### DIFF
--- a/docs/agents/observability.md
+++ b/docs/agents/observability.md
@@ -1,0 +1,126 @@
+# Observability — first-week checklist
+
+Purpose: when the dispatcher runs unattended (workshop PC, NSSM service installed via [#368](https://github.com/Osasuwu/jarvis/pull/382)), we need to answer in under a minute: *did it work overnight, did it spam, did it silently break?*
+
+**Phase 1 = readable text.** No Grafana, no Prometheus. Supabase queries + a thin Python script + Windows event log.
+
+## What to watch
+
+### 1. `audit_log` — primary signal
+
+Every dispatcher tick (success or failure) writes one row. Schema (from `agents/supabase_client.py::audit`):
+
+| Column | Meaning |
+|---|---|
+| `agent_id` | `task-dispatcher` for the dispatcher; other agents have their own ids |
+| `tool_name` | What was invoked (e.g. `claude`, `safety_gate`, `dispatch`) |
+| `action` | Specific verb (`spawn`, `tick`, `check`) |
+| `target` | Issue/task being handled (when applicable) |
+| `details` | JSONB — full context |
+| `outcome` | `success` or `failure:<ExceptionType>` |
+| `timestamp` | UTC, when row was written |
+
+**Queries (Supabase SQL editor or via `mcp__supabase__execute_sql`):**
+
+Last 24 h activity per agent:
+```sql
+SELECT agent_id, count(*) AS rows, min(timestamp) AS first, max(timestamp) AS last
+FROM audit_log
+WHERE timestamp > now() - interval '24 hours'
+GROUP BY agent_id
+ORDER BY last DESC;
+```
+
+Failures in last 24 h:
+```sql
+SELECT timestamp, agent_id, action, target, outcome, details
+FROM audit_log
+WHERE timestamp > now() - interval '24 hours'
+  AND outcome NOT LIKE 'success%'
+ORDER BY timestamp DESC;
+```
+
+Gap detection — where did the heartbeat stop:
+```sql
+WITH lagged AS (
+  SELECT timestamp,
+         lag(timestamp) OVER (ORDER BY timestamp) AS prev_timestamp
+  FROM audit_log
+  WHERE agent_id = 'task-dispatcher'
+    AND timestamp > now() - interval '7 days'
+)
+SELECT timestamp,
+       extract(epoch FROM (timestamp - prev_timestamp))/60 AS gap_minutes
+FROM lagged
+WHERE timestamp - prev_timestamp > interval '5 minutes'
+ORDER BY gap_minutes DESC
+LIMIT 10;
+```
+
+### 2. `apscheduler_jobs` — what the scheduler thinks it should run
+
+Persisted job rows. After [#383](https://github.com/Osasuwu/jarvis/pull/383) the startup reaper deletes orphans automatically — if you see unexpected ids, something registered them post-startup.
+
+```sql
+SELECT id, next_run_time
+FROM apscheduler_jobs
+ORDER BY next_run_time;
+```
+
+Expected rows in production: `task-dispatcher` only. With `--placeholder` flag also `_pickle_canary_tick`. Anything else = red flag.
+
+### 3. NSSM service state on workshop PC
+
+```powershell
+Get-Service jarvis-scheduler
+# Status should be Running, StartType Automatic
+```
+
+Service stdout / stderr (live tail):
+```powershell
+Get-Content "C:\path\to\jarvis\logs\scheduler\stdout.log" -Tail 50 -Wait
+Get-Content "C:\path\to\jarvis\logs\scheduler\stderr.log" -Tail 50 -Wait
+```
+
+Windows event log for service crashes / restarts:
+```powershell
+Get-EventLog -LogName System -Source "Service Control Manager" -Newest 20 |
+  Where-Object { $_.Message -like "*jarvis*" }
+```
+
+### 4. Telegram channels — escalations + dispatch reports
+
+Owner-facing Telegram channel receives:
+- Escalations from the escalation ladder ([#327](https://github.com/Osasuwu/jarvis/issues/327)) — owner action needed
+- Dispatcher post-run reports (success/failure summaries)
+
+Silence in Telegram is **not** evidence of health — could mean dispatcher is down. Cross-reference with `audit_log`.
+
+## Morning check — one shot
+
+Run on any host that has Supabase MCP credentials:
+
+```bash
+python scripts/observability/morning_check.py
+```
+
+Outputs a text report: 24 h dispatch count per agent, failures, gaps, stale orphans. If it prints nothing alarming and the audit_log row count matches expected ticks (≈ `86400 / interval_seconds`), things are fine.
+
+## Threshold rules — when does silence mean broken
+
+| Signal | Healthy | Concerning | Broken |
+|---|---|---|---|
+| Gap in `audit_log` for `task-dispatcher` | < 2× `--interval` | 2-4× | > 4× or > 2 hours |
+| Failure rate (24 h) | < 5 % of ticks | 5-25 % | > 25 % |
+| `apscheduler_jobs` rows | matches registered set | unexpected id present | 0 rows on running service |
+| `Get-Service jarvis-scheduler` | Running | Stopped (service start pending) | Not found / Disabled |
+
+`> 2 hours` of silence on `task-dispatcher` = wake owner via Telegram (when escalation auto-pinging is wired) or page manually.
+
+## What this doc is NOT
+
+- Not real-time alerting — Phase 1 is reactive (owner queries on demand)
+- Not a dashboard — owner runs the morning check at their own cadence
+- Not exhaustive metrics — captures liveness + failure rate, nothing finer-grained
+
+If/when we want auto-alerts or dashboards, file a separate issue. This is the minimum viable observability.

--- a/scripts/observability/morning_check.py
+++ b/scripts/observability/morning_check.py
@@ -1,0 +1,127 @@
+"""Morning check — read audit_log, surface what happened in the last 24h.
+
+Run on any host with Supabase credentials (SUPABASE_URL / SUPABASE_KEY in env
+or via agents.config.AgentConfig). Prints a text report; exits 0 on healthy,
+1 on alarms, 2 on connection failure.
+
+Usage:
+    python -m scripts.observability.morning_check
+    python -m scripts.observability.morning_check --hours 6
+    python -m scripts.observability.morning_check --agent task-dispatcher
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from agents.supabase_client import get_client
+
+
+def _fmt_ts(ts: str) -> str:
+    return ts.replace("T", " ").split("+")[0].split(".")[0]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--hours", type=int, default=24, help="Lookback window (default 24)")
+    parser.add_argument("--agent", default=None, help="Filter to specific agent_id")
+    parser.add_argument("--gap-minutes", type=int, default=10,
+                        help="Flag gaps in dispatcher heartbeat exceeding N minutes (default 10)")
+    args = parser.parse_args(argv)
+
+    try:
+        client = get_client()
+    except Exception as e:
+        print(f"FAILED to connect to Supabase: {e}", file=sys.stderr)
+        return 2
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=args.hours)
+    cutoff_iso = cutoff.isoformat()
+
+    q = (
+        client.table("audit_log")
+        .select("agent_id, tool_name, action, target, outcome, timestamp, details")
+        .gte("timestamp", cutoff_iso)
+        .order("timestamp", desc=False)
+    )
+    if args.agent:
+        q = q.eq("agent_id", args.agent)
+
+    rows = q.execute().data or []
+
+    if not rows:
+        print(f"No audit_log rows in the last {args.hours}h"
+              + (f" for agent {args.agent}" if args.agent else "")
+              + ".")
+        print("If the dispatcher should be running, this is a RED FLAG — service may be down.")
+        return 1
+
+    # Per-agent rollup
+    by_agent: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        by_agent[r["agent_id"] or "<null>"].append(r)
+
+    print(f"=== Morning check - last {args.hours}h ===")
+    print(f"Total rows: {len(rows)}")
+    print(f"Window: {_fmt_ts(cutoff_iso)} -> now")
+    print()
+    print(f"{'agent_id':<30} {'rows':>6} {'failures':>10} {'first':<20} {'last':<20}")
+    print("-" * 96)
+
+    alarms: list[str] = []
+
+    def _is_failure(outcome: str | None) -> bool:
+        # 'failure:<ExceptionType>' is the canonical failure marker (see
+        # agents/dispatcher.py docstring). 'success', 'dry_run', and any
+        # other domain-specific outcome are NOT failures.
+        return (outcome or "").startswith("failure")
+
+    for agent, agent_rows in sorted(by_agent.items()):
+        failures = [r for r in agent_rows if _is_failure(r["outcome"])]
+        first = _fmt_ts(agent_rows[0]["timestamp"])
+        last = _fmt_ts(agent_rows[-1]["timestamp"])
+        print(f"{agent:<30} {len(agent_rows):>6} {len(failures):>10} {first:<20} {last:<20}")
+        if len(agent_rows) >= 5:
+            failure_pct = 100.0 * len(failures) / len(agent_rows)
+            if failure_pct > 25:
+                alarms.append(f"{agent}: {failure_pct:.0f}% failure rate ({len(failures)}/{len(agent_rows)})")
+
+    print()
+
+    # Gap detection on dispatcher heartbeat
+    dispatcher_rows = by_agent.get("task-dispatcher", [])
+    if dispatcher_rows:
+        prev = None
+        for r in dispatcher_rows:
+            ts = datetime.fromisoformat(r["timestamp"].replace("Z", "+00:00"))
+            if prev is not None:
+                gap_min = (ts - prev).total_seconds() / 60
+                if gap_min > args.gap_minutes:
+                    alarms.append(
+                        f"task-dispatcher: {gap_min:.0f}min gap ending at {_fmt_ts(r['timestamp'])}"
+                    )
+            prev = ts
+
+    # Recent failures (full detail)
+    recent_failures = [r for r in rows if _is_failure(r["outcome"])][-10:]
+    if recent_failures:
+        print(f"Recent failures (last 10):")
+        for r in recent_failures:
+            print(f"  {_fmt_ts(r['timestamp'])} {r['agent_id']:<25} {r['action']:<15} {r['outcome']}")
+        print()
+
+    if alarms:
+        print("ALARMS:")
+        for a in alarms:
+            print(f"  - {a}")
+        return 1
+
+    print("All clear.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 1 observability for the unattended dispatcher — readable text reports, no Grafana/Prometheus yet.

- **docs/agents/observability.md** — first-week checklist:
  - What to watch: `audit_log`, `apscheduler_jobs`, NSSM service state, Telegram channels
  - Supabase SQL queries (24 h activity, failures, gap detection via `lag()`)
  - PowerShell snippets for `Get-Service jarvis-scheduler` + log tailing
  - Threshold table (gap `< 2× interval` = healthy, `> 4× or > 2 h` = broken)

- **scripts/observability/morning_check.py** — one-shot CLI:
  - Reads `audit_log` for last N hours (default 24), rolls up per-agent activity
  - Detects heartbeat gaps for `task-dispatcher`
  - Prints recent failures (last 10, with full outcome)
  - Exit codes: `0` healthy, `1` alarms found, `2` connection failure
  - `_is_failure()` helper canonicalises the outcome convention (`failure:<ExceptionType>` is failure; `success`, `dry_run`, etc. are not)

## Live test (Main PC)

Run against Supabase right now found 30 `task-dispatcher` rows in last 24 h and 7 real `failure:FileNotFoundError` — claude binary not in PATH for the unattended dispatcher. Will file as separate issue (out of Sprint 3 scope).

## Test plan

- [x] Lint clean (no new modules, only stdlib + existing supabase_client)
- [x] Smoke-tested live against Supabase from Main PC — exit code 1, alarms surfaced correctly
- [x] Verified `_is_failure()` does NOT flag `dry_run` / `success` (regression caught during development)
- [ ] Re-run on workshop PC after dispatcher service is installed (deferred — workshop offline)

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)