### PR TITLE
fix(install): PS 5.1 compat for Join-Path + Split-Path nesting (#391)

### DIFF
--- a/scripts/install/install-scheduler-service.ps1
+++ b/scripts/install/install-scheduler-service.ps1
@@ -38,8 +38,12 @@ Write-Status "Reading configuration..." $InfoColor
 $repoPath = $null
 $pythonPath = $null
 
-# Try config/device.json first
-$configPath = Join-Path (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))) "config" "device.json"
+# Try config/device.json first.
+# Repo root = parent of parent of $PSScriptRoot (script lives at <repo>/scripts/install/).
+# Note: Windows PowerShell 5.1's Join-Path takes only -Path and -ChildPath, so multi-segment
+# paths must be chained: Join-Path (Join-Path A "config") "device.json".
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$configPath = Join-Path (Join-Path $repoRoot "config") "device.json"
 if (Test-Path $configPath) {
     try {
         $config = Get-Content $configPath | ConvertFrom-Json
@@ -62,7 +66,7 @@ if (-not $repoPath) {
     $repoPath = $env:JARVIS_REPO_PATH
     if (-not $repoPath) {
         Write-Status "config/device.json not found and JARVIS_REPO_PATH not set. Assuming current script directory." $WarningColor
-        $repoPath = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+        $repoPath = $repoRoot
     }
 }
 
@@ -118,7 +122,7 @@ catch {
 $ServiceName = "jarvis-scheduler"
 $ServiceDisplayName = "Jarvis Scheduler"
 $ServiceDescription = "Persistent task dispatcher via APScheduler (Jarvis issue #368)"
-$LogDir = Join-Path $repoPath "logs" "scheduler"
+$LogDir = Join-Path (Join-Path $repoPath "logs") "scheduler"
 $StdoutLog = Join-Path $LogDir "stdout.log"
 $StderrLog = Join-Path $LogDir "stderr.log"
 

--- a/tests/install/test_install_script_portable.py
+++ b/tests/install/test_install_script_portable.py
@@ -117,3 +117,47 @@ def test_install_script_sets_proper_logging():
 
     # Should not hardcode an absolute log path like C:\logs
     assert "c:\\logs" not in content.lower(), "Script should not hardcode absolute log path"
+
+
+def test_no_multiarg_join_path_in_ps_scripts():
+    """Windows PowerShell 5.1's Join-Path takes only -Path/-ChildPath; 3+ positional args throw.
+
+    Caught a real bug: install-scheduler-service.ps1 had `Join-Path X "config" "device.json"`
+    which crashed with "Не удается найти позиционный параметр" on workshop install. PS 7+
+    accepts the multi-arg form via -AdditionalChildPath, but the default Windows shell is 5.1.
+
+    Multi-segment paths must be chained: Join-Path (Join-Path A "config") "device.json".
+
+    Detection strategy: only flag the broken shape — three or more *simple* arguments
+    (variable, double/single-quoted string, or bareword). Parenthesized expressions are
+    skipped, which means a chained `Join-Path (Join-Path A B) C` reads as "first arg is `(`"
+    and falls through. Trade-off: false negatives on exotic invocations are acceptable;
+    false positives would block correct code.
+    """
+    repo_root = Path(__file__).parent.parent.parent
+    ps_scripts = list((repo_root / "scripts").rglob("*.ps1"))
+    assert ps_scripts, "Expected at least one .ps1 script under scripts/"
+
+    simple_token = r'(?:\$\w+|"[^"]*"|\'[^\']*\'|\w+)'
+    bad_pattern = re.compile(
+        r'Join-Path\s+'
+        + simple_token + r'\s+'
+        + simple_token + r'\s+'
+        + simple_token + r'(?:\s|$|\))'
+    )
+
+    violations = []
+    for script in ps_scripts:
+        content = script.read_text(encoding="utf-8")
+        for line_num, line in enumerate(content.split("\n"), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if bad_pattern.search(line):
+                violations.append((script.relative_to(repo_root), line_num, stripped))
+
+    assert not violations, (
+        "Multi-arg Join-Path X Y Z is not supported in Windows PowerShell 5.1.\n"
+        "Chain it: Join-Path (Join-Path X Y) Z\n\n"
+        + "\n".join(f"  {path}:{line_num}  {body}" for path, line_num, body in violations)
+    )


### PR DESCRIPTION
## Summary
- Chain multi-arg `Join-Path X Y Z` → `Join-Path (Join-Path X Y) Z`. Windows PowerShell 5.1 (default Windows shell) only takes `-Path` and `-ChildPath`; PS 7+ accepts 3+ args via `-AdditionalChildPath`. Two call sites: configPath resolution (L42→L46) and `$LogDir` (L121→L125).
- Drop one level of `Split-Path -Parent` nesting. Script lives at `<repo>/scripts/install/`, so 2 parents of `$PSScriptRoot` is the repo root. Three parents resolved to `D:\Github` on workshop, which has no `agents/` directory and bailed. Now stored in `$repoRoot` and reused for the env-var fallback path.
- Add `test_no_multiarg_join_path_in_ps_scripts` — regex meta-test that catches the simple `Join-Path X "y" "z"` shape across all `.ps1` scripts under `scripts/`. Parenthesized chained form is accepted.

## Test plan
- [x] `python -m pytest tests/install/ -v` passes (5/5).
- [x] PowerShell smoke-test from workshop simulates path resolution: `$repoRoot=D:\Github\jarvis`, `$configPath=D:\Github\jarvis\config\device.json` exists, JSON parses.
- [ ] Re-run `scripts/install/install-scheduler-service.ps1` from elevated PS on workshop after merge → service installs, `Get-Service jarvis-scheduler` reports state.

## Notes
- A full `pwsh` smoke-test that runs the script in dry-run mode would be more robust than the regex; left as follow-up if the bug class recurs.
- Doesn't touch dispatcher PATH resolution — that's #385, separate PR.

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)