### PR TITLE
fix(dispatcher): resolve claude binary explicitly for LocalSystem (#385)

### DIFF
--- a/agents/dispatcher.py
+++ b/agents/dispatcher.py
@@ -40,6 +40,7 @@ import argparse
 import hashlib
 import logging
 import os
+import shutil
 import subprocess
 from datetime import UTC, datetime
 from typing import Any, TypedDict
@@ -134,6 +135,78 @@ class DispatcherState(TypedDict):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+# Documented Windows install locations to probe when neither override, env
+# var, nor PATH lookup yields a binary. Templates expand against ``os.environ``
+# so absent vars (e.g. running under a service account) are skipped silently.
+# Order matters: official installer first, then common alt locations seen in
+# the wild (`.local/bin/claude.exe`, npm shim, pipx).
+_CLAUDE_DEFAULT_WINDOWS_PATHS: tuple[str, ...] = (
+    r"{LOCALAPPDATA}\Programs\claude\claude.exe",
+    r"{USERPROFILE}\.local\bin\claude.exe",
+    r"{APPDATA}\npm\claude.exe",
+)
+
+
+def _resolve_claude_binary(override: str | None = None) -> str:
+    """Resolve the absolute path to the ``claude`` executable.
+
+    Resolution chain — earlier sources win and are validated against the
+    filesystem before being returned:
+
+    1. ``override`` argument — for tests and programmatic callers that need
+       to inject a known path. None / empty string skips this layer.
+    2. ``JARVIS_CLAUDE_BIN`` env var — operator override for unattended
+       contexts (NSSM service, cron, CI) where PATH is sparse. Set via
+       ``nssm set jarvis-scheduler AppEnvironmentExtra JARVIS_CLAUDE_BIN=...``.
+    3. :func:`shutil.which` — works in interactive shells where ``claude``
+       is on the user PATH but breaks under ``LocalSystem`` (issue #385,
+       7× ``failure:FileNotFoundError`` over 24 h before this fix).
+    4. Documented Windows install paths — covers official and common alt
+       installs without forcing the operator to set an env var on every box.
+
+    Raises :class:`FileNotFoundError` when nothing resolves to an existing
+    file, with a message that lists each step that was tried so operators
+    can see at a glance which override slot to fill.
+    """
+    if override:
+        if os.path.exists(override):
+            return override
+        raise FileNotFoundError(
+            f"claude binary override does not exist: {override!r}"
+        )
+
+    env_path = os.environ.get("JARVIS_CLAUDE_BIN")
+    if env_path:
+        if os.path.exists(env_path):
+            return env_path
+        raise FileNotFoundError(
+            f"JARVIS_CLAUDE_BIN points to a missing file: {env_path!r}"
+        )
+
+    found = shutil.which("claude")
+    if found:
+        return found
+
+    if os.name == "nt":
+        for tmpl in _CLAUDE_DEFAULT_WINDOWS_PATHS:
+            try:
+                candidate = tmpl.format(**os.environ)
+            except KeyError:
+                continue
+            if os.path.exists(candidate):
+                return candidate
+
+    tried = ["override arg", "JARVIS_CLAUDE_BIN", "shutil.which('claude')"]
+    if os.name == "nt":
+        tried.append(f"Windows defaults {_CLAUDE_DEFAULT_WINDOWS_PATHS}")
+    raise FileNotFoundError(
+        "claude binary not found. Tried: "
+        + ", ".join(tried)
+        + ". Set JARVIS_CLAUDE_BIN to the absolute path; under NSSM, "
+        "'nssm set jarvis-scheduler AppEnvironmentExtra JARVIS_CLAUDE_BIN=...'."
+    )
 
 
 def _sanitize_env(env: dict[str, str] | None = None) -> dict[str, str]:
@@ -318,7 +391,7 @@ def dispatch_node(
     try:
         env = _sanitize_env()
         argv = [
-            "claude",
+            _resolve_claude_binary(),
             "-p",
             goal,
             "--permission-mode",

--- a/docs/agents/scheduler.md
+++ b/docs/agents/scheduler.md
@@ -119,6 +119,29 @@ Start-Service -Name jarvis-scheduler
 
 Or restart Windows to auto-start.
 
+### Resolving the `claude` binary under LocalSystem (issue #385)
+
+The dispatcher spawns `claude -p` for each tier-1 auto-dispatch row. NSSM
+runs the service as `LocalSystem`, whose PATH is sparse — `shutil.which`
+fails and every tick records `failure:FileNotFoundError` in `audit_log`.
+
+`agents.dispatcher._resolve_claude_binary` resolves the executable in this
+order: explicit override arg → `JARVIS_CLAUDE_BIN` env var → `shutil.which` →
+documented Windows install paths (`%LOCALAPPDATA%\Programs\claude\`,
+`%USERPROFILE%\.local\bin\`, `%APPDATA%\npm\`). Set the env var on the
+service if your install lives elsewhere or if you want a hard pin:
+
+```powershell
+# Locate claude on this device, then attach to the service:
+$claudeBin = (Get-Command claude).Source
+nssm set jarvis-scheduler AppEnvironmentExtra "JARVIS_CLAUDE_BIN=$claudeBin"
+Restart-Service jarvis-scheduler
+```
+
+Verify with `python -m scripts.observability.morning_check` after a few
+ticks — `task-dispatcher` should report `success` outcomes, not
+`failure:FileNotFoundError`.
+
 ### View logs
 
 Logs are written to `<repo>/logs/scheduler/stdout.log` and `stderr.log`:

--- a/tests/test_agents_dispatcher.py
+++ b/tests/test_agents_dispatcher.py
@@ -281,6 +281,155 @@ def test_spawn_allowlist_excludes_dangerous_permissions() -> None:
                 f"Destructive pattern '{pattern}' found in allowlist entry '{tool}'"
 
 
+# ---------------------------------------------------------------------------
+# _resolve_claude_binary — issue #385
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_claude_binary_override_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """Explicit override beats env var, PATH lookup, and Windows defaults."""
+    import shutil as _shutil
+
+    from agents import dispatcher
+
+    real = tmp_path / "real-claude.exe"
+    real.write_text("")
+    fake_env = tmp_path / "env-claude.exe"
+    fake_env.write_text("")
+
+    monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake_env))
+    monkeypatch.setattr(_shutil, "which", lambda _name: "/never/used")
+
+    assert dispatcher._resolve_claude_binary(override=str(real)) == str(real)
+
+
+def test_resolve_claude_binary_override_must_exist(tmp_path: Any) -> None:
+    """A non-existent override surfaces immediately, not at spawn time."""
+    from agents import dispatcher
+
+    missing = tmp_path / "does-not-exist.exe"
+    with pytest.raises(FileNotFoundError, match="override does not exist"):
+        dispatcher._resolve_claude_binary(override=str(missing))
+
+
+def test_resolve_claude_binary_env_var_wins_over_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """``JARVIS_CLAUDE_BIN`` is the operator-controlled override for NSSM/cron."""
+    import shutil as _shutil
+
+    from agents import dispatcher
+
+    fake = tmp_path / "claude.exe"
+    fake.write_text("")
+
+    monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake))
+    monkeypatch.setattr(_shutil, "which", lambda _name: "/should/not/win")
+
+    assert dispatcher._resolve_claude_binary() == str(fake)
+
+
+def test_resolve_claude_binary_env_var_must_exist(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A misconfigured ``JARVIS_CLAUDE_BIN`` raises rather than silently falling through."""
+    from agents import dispatcher
+
+    monkeypatch.setenv("JARVIS_CLAUDE_BIN", "/no/such/file")
+    with pytest.raises(FileNotFoundError, match="JARVIS_CLAUDE_BIN"):
+        dispatcher._resolve_claude_binary()
+
+
+def test_resolve_claude_binary_falls_through_to_shutil_which(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Without override or env, PATH lookup wins."""
+    import shutil as _shutil
+
+    from agents import dispatcher
+
+    fake = tmp_path / "from-which.exe"
+    fake.write_text("")
+
+    monkeypatch.delenv("JARVIS_CLAUDE_BIN", raising=False)
+    monkeypatch.setattr(
+        _shutil, "which", lambda name: str(fake) if name == "claude" else None
+    )
+
+    assert dispatcher._resolve_claude_binary() == str(fake)
+
+
+def test_resolve_claude_binary_falls_back_to_windows_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Last resort: documented Windows install location.
+
+    Skipped on non-Windows because the module-level path templates only
+    expand under ``os.name == 'nt'``.
+    """
+    import shutil as _shutil
+
+    from agents import dispatcher
+
+    if os.name != "nt":
+        pytest.skip("Windows-default fallback only fires when os.name == 'nt'")
+
+    fake = tmp_path / "Programs" / "claude" / "claude.exe"
+    fake.parent.mkdir(parents=True)
+    fake.write_text("")
+
+    monkeypatch.delenv("JARVIS_CLAUDE_BIN", raising=False)
+    monkeypatch.setattr(_shutil, "which", lambda _name: None)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+    assert dispatcher._resolve_claude_binary() == str(fake)
+
+
+def test_resolve_claude_binary_raises_with_actionable_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Final failure must name JARVIS_CLAUDE_BIN so operators can see the fix."""
+    import shutil as _shutil
+
+    from agents import dispatcher
+
+    monkeypatch.delenv("JARVIS_CLAUDE_BIN", raising=False)
+    monkeypatch.setattr(_shutil, "which", lambda _name: None)
+    # Point Windows defaults at an empty directory so none resolve.
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "nope"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "nope"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "nope"))
+
+    with pytest.raises(FileNotFoundError, match="JARVIS_CLAUDE_BIN"):
+        dispatcher._resolve_claude_binary()
+
+
+def test_dispatch_argv_uses_resolved_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """End-to-end: spawn receives an absolute path, not the bare string ``claude``."""
+    from agents import dispatcher, usage_probe
+
+    fake = tmp_path / "resolved-claude.exe"
+    fake.write_text("")
+
+    monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake))
+    monkeypatch.setattr(usage_probe, "read_usage", _healthy_reading)
+    monkeypatch.setattr(dispatcher.usage_probe, "read_usage", _healthy_reading)
+
+    client = _StubClient()
+    client.seed("task_queue", [_queue_row(id="resolve-test")])
+    popen = _CapturedPopen()
+
+    app = _compile_graph(client, popen)
+    result = app.invoke({"dry_run": False, "row": None, "outcome": "", "reason": ""})
+
+    assert result["outcome"] == "dispatched"
+    assert len(popen.calls) == 1
+    argv = popen.calls[0]["argv"]
+    assert argv[0] == str(fake), (
+        "dispatcher must spawn the resolved binary path, not the bare 'claude' string"
+    )
+
+
 def test_sensitive_env_keys_cover_known_variants() -> None:
     """Env-sanitization must strip every historical Anthropic env name."""
     from agents.dispatcher import _SENSITIVE_ENV_KEYS
@@ -409,9 +558,17 @@ def test_graph_builds_with_expected_nodes() -> None:
     assert {"poll_queue", "evaluate", "escalate", "dispatch"} <= set(graph.nodes)
 
 
-def test_full_flow_dispatches_healthy_row(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_full_flow_dispatches_healthy_row(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
     """Happy path: healthy budget, fresh approval, no drift → subprocess spawned + row dispatched."""
     from agents import dispatcher, usage_probe
+
+    # Pin claude binary so this test stays deterministic regardless of host PATH
+    # (issue #385 — argv[0] is now the resolved absolute path, not the bare name).
+    fake_claude = tmp_path / "claude.exe"
+    fake_claude.write_text("")
+    monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake_claude))
 
     monkeypatch.setattr(usage_probe, "read_usage", _healthy_reading)
     # Dispatcher imports usage_probe at module load; monkeypatch the
@@ -429,10 +586,11 @@ def test_full_flow_dispatches_healthy_row(monkeypatch: pytest.MonkeyPatch) -> No
     assert result["outcome"] == "dispatched"
     assert result["reason"].startswith("idem=")
 
-    # Subprocess was invoked with claude -p <goal>.
+    # Subprocess was invoked with <resolved-claude-path> -p <goal>.
     assert len(popen.calls) == 1
     call = popen.calls[0]
-    assert call["argv"][0:2] == ["claude", "-p"]
+    assert call["argv"][0] == str(fake_claude)
+    assert call["argv"][1] == "-p"
 
     # Permission flags present — without these, headless Claude hangs
     # on approval prompts (#372). acceptEdits + narrow allowedTools,
@@ -540,10 +698,15 @@ def test_stale_approval_escalates(monkeypatch: pytest.MonkeyPatch) -> None:
     assert popen.calls == []
 
 
-def test_dispatch_passes_sanitized_env_to_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dispatch_passes_sanitized_env_to_subprocess(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
     """Integration-level leak test: ANTHROPIC_API_KEY in parent must NOT reach child env."""
     from agents import dispatcher, usage_probe
 
+    fake_claude = tmp_path / "claude.exe"
+    fake_claude.write_text("")
+    monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake_claude))
     monkeypatch.setenv("ANTHROPIC_API_KEY", "leak-sentinel-xyz")
     monkeypatch.setenv("CLAUDE_API_KEY", "leak-sentinel-claude")
     monkeypatch.setenv("PATH_FROM_PARENT", "keep-me")
@@ -565,10 +728,19 @@ def test_dispatch_passes_sanitized_env_to_subprocess(monkeypatch: pytest.MonkeyP
     assert env.get("PATH_FROM_PARENT") == "keep-me", "non-sensitive env must survive"
 
 
-def test_dispatch_failure_audits_and_returns_failed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Popen raising (e.g. claude not on PATH) must audit failure, not crash the tick."""
+def test_dispatch_failure_audits_and_returns_failed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Popen raising must audit failure, not crash the tick.
+
+    Pin ``JARVIS_CLAUDE_BIN`` so resolution succeeds and the failure path under
+    test is the spawn itself, not the resolver (issue #385).
+    """
     from agents import dispatcher, usage_probe
 
+    fake_claude = tmp_path / "claude.exe"
+    fake_claude.write_text("")
+    monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake_claude))
     monkeypatch.setattr(usage_probe, "read_usage", _healthy_reading)
     monkeypatch.setattr(dispatcher.usage_probe, "read_usage", _healthy_reading)
 


### PR DESCRIPTION
## Summary
- Add `agents.dispatcher._resolve_claude_binary` with a 4-step resolution chain — override arg → `JARVIS_CLAUDE_BIN` env → `shutil.which("claude")` → documented Windows install paths (`%LOCALAPPDATA%\Programs\claude\`, `%USERPROFILE%\.local\bin\`, `%APPDATA%\npm\`). Each layer validates `os.path.exists` before returning; misconfigured override or env raises with the offending value rather than falling through.
- `dispatch_node` calls the resolver in `argv[0]` instead of the bare string `"claude"` — eliminates the `FileNotFoundError` class observed under NSSM `LocalSystem` (sparse PATH).
- 7 new tests cover each chain step including the actionable failure message. Two existing dispatch tests now pin `JARVIS_CLAUDE_BIN` so their argv assertions stay deterministic regardless of host PATH.
- Doc note in `docs/agents/scheduler.md` walks operators through `nssm set ... AppEnvironmentExtra JARVIS_CLAUDE_BIN=...` and the morning_check verification step.

## Why this matters
`morning_check.py` (#380) surfaced 7× `failure:FileNotFoundError` for `task-dispatcher` over 24h on Main PC. The same failure mode will hit the workshop NSSM service the moment it picks up its first `auto_dispatch=true` row. This PR removes that class of failure and gives operators a single env var to pin the binary across all 3 devices (different install paths per host: workshop uses `~/.local/bin/claude.exe`, others may use `%LOCALAPPDATA%\Programs\claude\`).

## Test plan
- [x] `pytest tests/test_agents_dispatcher.py -v` → 29/29 pass (with langgraph installed); resolver chain tests cover override, env-var override, env-var-must-exist, shutil.which fallthrough, Windows defaults (Windows-only), and final FileNotFoundError with actionable message.
- [x] Smoke test on workshop: `python -c "from agents.dispatcher import _resolve_claude_binary; print(_resolve_claude_binary())"` → `C:\Users\PC4_v\.local\bin\claude.EXE` (resolved via `shutil.which` since claude is on user PATH).
- [ ] After merge: re-attach to the NSSM service on workshop with `nssm set jarvis-scheduler AppEnvironmentExtra "JARVIS_CLAUDE_BIN=$((Get-Command claude).Source)"`, start service, run `morning_check` after a few ticks → expect zero `failure:FileNotFoundError` for `task-dispatcher`.

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)