### PR TITLE
doc(agents): perception architecture + FSM map (#386)

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -12,6 +12,7 @@ detail. Per-module contents:
 |--------|-----|------|
 | `config.py` | — | `load_config()` — Postgres/Supabase URLs from env |
 | `dispatcher.py` | [`docs/agents/dispatcher.md`](../docs/agents/dispatcher.md) | Task dispatcher (S2-3) — polls `task_queue`, spawns `claude -p <goal>` with sanitized env |
+| `perception_*.py` (S4, planned) | [`docs/agents/perception.md`](../docs/agents/perception.md) | Producer side — `task_queue` ingest from GitHub issues, morning_check alarms, future sources |
 | `escalation.py` | [`docs/agents/escalation.md`](../docs/agents/escalation.md) | First-match triggers (S2-4) used by the dispatcher |
 | `event_monitor.py` | [`docs/agents/langgraph-setup.md`](../docs/agents/langgraph-setup.md) | GitHub event monitor — fetch → classify → store |
 | `github_client.py` | — | Thin wrapper over `gh` CLI / GitHub Events API |

--- a/docs/agents/dispatcher.md
+++ b/docs/agents/dispatcher.md
@@ -10,6 +10,7 @@ Sprint 2 (issue #298, S2-3). Wires together every other S2 primitive:
 | **S2-2** `agents/usage_probe.py` | Pre-dispatch budget check |
 | **S2-4** `agents/escalation.py` | First-match triggers: stale / drift / limit / conflict / pattern |
 | **S2-5** `agents/scheduler.py` | Run-loop engine (APScheduler, 60s interval + jitter) |
+| **S4** `agents/perception_*.py` | Producer side — turns external signals into `pending` rows ([`perception.md`](perception.md)) |
 
 ## Graph
 

--- a/docs/agents/perception.md
+++ b/docs/agents/perception.md
@@ -1,0 +1,275 @@
+# Perception → task_queue ingest
+
+Modules: `agents/perception_*.py` (one per source). Pillar 7 Sprint 4
+(milestone #32). Architecture-doc issue: #386. Implementation issues:
+#388 (GitHub), #389 (self-perception via morning_check). Telegram (#387)
+deferred — see "Future sources" below.
+
+The dispatcher (S2-3, [`dispatcher.md`](dispatcher.md)) consumes
+`task_queue` rows. Sprint 1–3 wired the **consume** side. Sprint 4 wires
+the **produce** side: external signals → rows → dispatcher's existing FSM.
+
+## Why this doc lands first
+
+Three implementations are about to be written. Without a single source of
+truth for `approved_by` namespace, `auto_dispatch` policy, and
+`idempotency_key` shape, three subagents will pick three conventions and
+Sprint 5 gets spent unifying them. This doc settles the conventions
+**before** code lands.
+
+Owner decisions encoded here (resolved 2026-04-25, [#386
+comment](https://github.com/Osasuwu/jarvis/issues/386)):
+
+1. Safety gate is **always** in the FSM. Strictness is a gradient over
+   `(source, tier, executor model)` — never on/off.
+2. Telegram ingest deferred — covered by Claude Code Channels (live
+   session) + GitHub ingest (autonomous).
+3. GitHub `tier:1-auto` label **is** the human nod — no second approval
+   gate.
+
+## Vocabulary — the three "tiers"
+
+The word "tier" appears in three distinct registers in this codebase.
+Mixing them is the single biggest source of confusion when wiring
+perception. Keep them separate.
+
+| Concept | Where it lives | Values | Purpose |
+|---------|---------------|--------|---------|
+| **Source tier** | Perception modules + GitHub issue labels (`tier:1-auto`, `tier:2-review`, `tier:3-human`) | 1, 2, 3 | Classifies an *incoming signal*: how autonomous can dispatch be? |
+| **`safety.Tier`** | `agents/safety.py` (IntEnum: `AUTO`, `OWNER_QUEUE`, `BLOCKED`) | 0, 1, 2 | Classifies an *outgoing action* in `gate(tool_name, action, target, area)`. |
+| **`task_queue.auto_dispatch`** | DB column (boolean) | true / false | Filters what dispatcher's `poll_queue_node` picks up. |
+
+Source tier and `safety.Tier` are independent dimensions: source tier is
+"how trusted is the input," `safety.Tier` is "how dangerous is the
+output." A `tier:1-auto` GitHub issue can still produce a Tier-2 BLOCKED
+action (e.g. an issue body that asks the agent to delete `.env`).
+
+The bridge: perception modules translate **source tier → `auto_dispatch`
+boolean** at ingest time. The safety gate runs later, on the actual
+mutation, regardless of source tier.
+
+## Mapping table — source tier → row shape
+
+| Source tier | `auto_dispatch` | Dispatcher behaviour |
+|-------------|-----------------|----------------------|
+| `tier:1-auto` | `true` | Picked up on next tick. Escalation triggers still apply. |
+| `tier:2-review` | `false` | Row sits in `pending`. Owner flips `auto_dispatch=true` after review (or runs `/implement` manually). |
+| `tier:3-human` | `false` | Row exists for tracking only. Dispatcher never touches it. Owner-driven from start to finish. |
+
+`auto_dispatch=true` is the *only* signal `dispatcher.poll_queue_node`
+honours. The source tier label is metadata for humans and for
+post-hoc reporting; it does not change dispatcher behaviour beyond the
+boolean.
+
+## Sources
+
+Every perception source produces a `task_queue` row with the same
+columns. The columns differ in *content* (where the values come from),
+not in *shape* (every row has all the columns).
+
+### GitHub ingest (#388, Sprint 4)
+
+| Column | Value |
+|--------|-------|
+| `goal` | Issue title + body, capped at N chars |
+| `scope_files[]` | Files referenced in issue body via fenced code or backtick paths; empty if none parsed |
+| `approved_by` | `github:issue:<owner>/<repo>#<N>` |
+| `approved_at` | Timestamp the `status:ready` label was applied (best-effort: poll-tick time if API doesn't give it cheaply) |
+| `approved_scope_hash` | sha256 of sorted `scope_files[]` (matches dispatcher's `_hash_scope_files`) |
+| `auto_dispatch` | `true` iff `tier:1-auto` label present; `false` for `tier:2-review` and `tier:3-human` |
+| `idempotency_key` | `sha256(repo \| issue_number \| sorted_label_set)` |
+
+Trigger: poll-tick scans `gh issue list --label status:ready --label tier:*`
+on each repo in the per-repo allowlist. Webhook is a stretch goal.
+
+Allowlist: `Osasuwu/jarvis` initially. `SergazyNarynov/redrobot` after
+the GitHub-ingest path soaks for a sprint. Cross-repo writes stay Tier
+2 BLOCKED in `safety.gate` regardless — perception just ingests, the
+gate decides whether the resulting action fires.
+
+Loop closure: when row transitions to `done`, perception module posts a
+comment on the source issue with the PR link. (Implementation note for
+#388: hook on `task_queue` UPDATE where status=done and approved_by
+prefix=`github:issue:`.)
+
+Open in flight: what happens if labels change post-ingest — re-tier the
+existing row, or freeze at ingest-time? **Decision: freeze at ingest.**
+Re-tier introduces a race where the dispatcher reads tier:1 but the row
+silently became tier:3. Owner can close + re-open the issue if a re-tier
+is needed; idempotency_key includes the label set, so re-applying labels
+produces a fresh key and a fresh row.
+
+### Self-perception via morning_check (#389, Sprint 4)
+
+| Column | Value |
+|--------|-------|
+| `goal` | Human-readable alarm description from `morning_check.py` |
+| `scope_files[]` | `[]` — alarms describe symptoms, not file scope |
+| `approved_by` | `cron:morning_check` |
+| `approved_at` | Cron tick time |
+| `approved_scope_hash` | sha256 of empty list (so drift checks pass trivially — there's no scope to drift from) |
+| `auto_dispatch` | `false` always — every self-perception row is `tier:3-human` |
+| `idempotency_key` | `sha256(YYYY-MM-DD \| alarm_category \| sha256(details_summary))` |
+
+Trigger: `morning_check.py --enqueue-on-alarm` (default off interactive,
+on under cron). Each distinct alarm category produces one row per day.
+Same alarm next day → new key (date is in the formula) → new row.
+
+Why all tier:3: an agent that auto-fixes its own observability alarms
+is one config bug away from making things worse silently. Self-modify
+is human-only this sprint. (A future "self-heal Tier 1" surface needs
+its own design issue and its own audit trail.)
+
+### Future sources (slot reserved, not implemented)
+
+Listed so conventions don't shift when these land:
+
+| Source | `approved_by` prefix | `idempotency_key` formula | Default `auto_dispatch` |
+|--------|----------------------|----------------------------|--------------------------|
+| Telegram (deferred from #387) | `telegram:<owner_id>` | `sha256(chat_id \| message_id)` | `false` (owner classifies inline via bot) |
+| Email | `email:<from_address>` | `sha256(message_id)` | `false` |
+| Calendar | `calendar:<event_uid>` | `sha256(event_uid \| occurrence_start)` | varies — recurring events default `false` |
+| Voice | `voice:<owner>` | `sha256(audio_sha256)` | `false` (transcription happens before ingest) |
+
+Rule for adding a new source: extend this table in the same PR that adds
+the perception module. The `approved_by` prefix MUST be unique across
+sources — that's how downstream tooling (escalation, reporting, audit)
+filters by source.
+
+## FSM integration
+
+Perception is a producer of `pending` rows. It does not introduce new
+states; the existing FSM is sufficient.
+
+```
+                    ┌──────────────────┐
+                    │  Source signal   │  (Telegram message, GitHub label,
+                    │                  │   morning_check alarm, …)
+                    └────────┬─────────┘
+                             │
+                             ▼
+                    ┌──────────────────┐
+                    │ Perception module│  classify(source) → source_tier
+                    │ agents/perception_*│ build row, sha256 idempotency_key
+                    └────────┬─────────┘
+                             │ INSERT (ON CONFLICT idempotency_key DO NOTHING)
+                             ▼
+                ┌────────────────────────┐
+                │ task_queue (pending)   │
+                │ auto_dispatch=…        │
+                └────────────┬───────────┘
+                             │
+              ┌──────────────┴──────────────┐
+              │ auto_dispatch=true           │ auto_dispatch=false
+              ▼                              ▼
+    ┌──────────────────┐         ┌──────────────────────┐
+    │ dispatcher       │         │ Owner / /implement   │
+    │ poll_queue_node  │         │ (manual)             │
+    └────────┬─────────┘         └──────────┬───────────┘
+             │                              │
+             ▼                              ▼
+    ┌──────────────────┐         ┌──────────────────────┐
+    │ evaluate_node    │         │ /implement skill     │
+    │ + escalate (S2-4)│         │ (PR pipeline)        │
+    └────────┬─────────┘         └──────────┬───────────┘
+             │                              │
+       (existing dispatcher FSM →           │
+        dispatched / escalated /            │
+        rejected / done)                    │
+                                            ▼
+                                  (status: done | rejected
+                                   via /implement + merge)
+```
+
+Existing FSM transitions (from `task_queue` migration, unchanged):
+
+```
+pending    → dispatched | escalated | rejected
+dispatched → done | escalated
+escalated  → pending           (owner re-approves)
+done       → (terminal)
+rejected   → (terminal)
+```
+
+Perception adds *no* new state. Every transition still happens in the
+dispatcher / owner-driven path; perception's job ends the moment the row
+is INSERTed.
+
+### Idempotency under retry
+
+Perception modules are expected to crash, restart, run twice in
+parallel during NSSM service swap, and otherwise misbehave. The
+DB-level UNIQUE constraint on `idempotency_key` is the only thing
+guaranteeing at-most-once enqueue.
+
+Every perception module MUST:
+
+1. Compute the key before the INSERT (deterministic from source payload
+   alone — no timestamps, no random salt).
+2. Use `INSERT ... ON CONFLICT (idempotency_key) DO NOTHING`. A retry
+   sees zero rows affected and exits the tick clean.
+3. Log the key prefix on every tick (first 12 chars) so the morning
+   check can grep for re-enqueue patterns.
+
+### Crash recovery
+
+Perception modules are stateless across ticks. State lives in the
+upstream source (GitHub issue labels, Telegram message ids, cron run
+timestamps). A perception module that crashes mid-tick and restarts
+re-reads the source, recomputes keys, and re-attempts the INSERT — the
+unique constraint absorbs the duplicate.
+
+## Safety gate policy
+
+The gate is **always in the FSM**. It does not skip for any source.
+Strictness varies along three axes:
+
+```
+gate_strictness = f(source, source_tier, executor_model)
+```
+
+This is not a binary "on/off" — it's a parameterisation of the existing
+`safety.gate()` rules. The gate today reads `(tool_name, action, target,
+area, scope_hash)`. Sprint 4 does not extend this signature. What changes
+is *which actions* a perception-spawned dispatch is allowed to attempt:
+
+| Axis | Effect on strictness | Example |
+|------|---------------------|---------|
+| **Source** (`approved_by` prefix) | Trusted prefixes (`github:issue:` from allowlisted repo, `cron:morning_check` for own tasks) get the standard whitelist. Untrusted prefixes (`external:*` — future) get a narrower whitelist. | A `cron:` source can `audit_log:insert` (Tier 0); an `external:` source cannot. |
+| **Source tier** | Higher tier (1 → 2 → 3) → more checks. Tier 1 fires through the existing gate. Tier 2/3 don't reach the gate at all because `auto_dispatch=false`. | Tier 3 is owner-driven by definition; gate checks the owner's actions, not the tier. |
+| **Executor model** | Stronger model (e.g. Claude Opus) gets looser scope-file diffing tolerance; weaker (Haiku) gets tighter. *Implementation lives in `agents/dispatcher.py` when model selection is wired in — not Sprint 4.* | Future: dispatcher reads model hint from row metadata, picks gate config. |
+
+What this means concretely for Sprint 4 implementation:
+
+- **#388 (GitHub ingest)**: no gate changes. `tier:1-auto` rows go through the existing gate. The label is the human nod; the gate is the technical guardrail.
+- **#389 (self-perception)**: every row is tier:3 → `auto_dispatch=false` → never reaches dispatch path → gate not invoked. Owner triggers the actual fix manually.
+- **Future sources**: extend `safety._RULES` with source-aware classifications. Don't touch `gate()` signature.
+
+### Why source tier ≠ skip-gate
+
+Owner-stated principle: gate is always there. The intuition that pushed
+back on "gate skip for cron-internal tasks" was correct — once you allow
+*any* source to skip the gate, the audit trail breaks and the
+single-bottleneck property goes away. The gate's job is to be the last
+line; perception does not get a back door.
+
+## Conventions checklist (for #388 / #389 implementers)
+
+When writing `agents/perception_<source>.py`, hit every one:
+
+- [ ] Module-level constant `SOURCE = "<source>"` (matches `approved_by` prefix without the colon)
+- [ ] Pure `_build_row(payload) -> dict` function — no DB, no I/O. Unit-testable.
+- [ ] Pure `_idempotency_key(payload) -> str` — sha256 hex of the formula in this doc's table. Use `agents.safety.idempotency_key` if the formula matches its `(agent_id, action, target, scope_hash)` shape; otherwise compute directly with `hashlib.sha256(...).hexdigest()`.
+- [ ] `INSERT ... ON CONFLICT (idempotency_key) DO NOTHING` — never raw INSERT
+- [ ] Per-source allowlist as a module constant (chat ids, repos, etc.); reject unknown principals before computing the key
+- [ ] Source tier classification (`tier:1-auto` / `tier:2-review` / `tier:3-human`) — translate to `auto_dispatch` boolean per the mapping table above
+- [ ] Tests: idempotency (running the tick twice produces zero new rows), allowlist rejection, row shape correctness
+- [ ] Doc cross-link: extend the relevant "Sources" subsection in this file with anything source-specific
+
+## Cross-references
+
+- [`dispatcher.md`](dispatcher.md) — what consumes the rows perception produces
+- [`safety.md`](safety.md) — `safety.Tier` (the *other* tier vocabulary) and the gate model
+- [`escalation.md`](escalation.md) — what fires after perception INSERTs and dispatcher picks up
+- [`mcp-memory/schema.sql`](../../mcp-memory/schema.sql) + [`supabase/migrations/20260422134442_create_task_queue.sql`](../../supabase/migrations/20260422134442_create_task_queue.sql) — `task_queue` columns and FSM check constraint
+- [`agents/README.md`](../../agents/README.md) — agent module index

--- a/docs/agents/perception.md
+++ b/docs/agents/perception.md
@@ -92,6 +92,13 @@ comment on the source issue with the PR link. (Implementation note for
 #388: hook on `task_queue` UPDATE where status=done and approved_by
 prefix=`github:issue:`.)
 
+Caveat: as of Sprint 4, the dispatcher is fire-and-forget — it sets
+`dispatched_at` and never flips status to `done` itself ([dispatcher.md
+"Fire-and-forget semantics"](dispatcher.md)). The done-watcher in #388
+will idle until a result-collection path lands (future sprint) or until
+the owner flips status manually via `/verify`. Implementers: write the
+watcher, but expect zero firings until that upstream change.
+
 Open in flight: what happens if labels change post-ingest — re-tier the
 existing row, or freeze at ingest-time? **Decision: freeze at ingest.**
 Re-tier introduces a race where the dispatcher reads tier:1 but the row
@@ -206,8 +213,19 @@ Every perception module MUST:
 
 1. Compute the key before the INSERT (deterministic from source payload
    alone — no timestamps, no random salt).
-2. Use `INSERT ... ON CONFLICT (idempotency_key) DO NOTHING`. A retry
-   sees zero rows affected and exits the tick clean.
+2. Use the supabase-py upsert idiom — never raw insert that lets the
+   unique-constraint violation propagate as an exception:
+   ```python
+   client.table("task_queue").upsert(
+       row,
+       on_conflict="idempotency_key",
+       ignore_duplicates=True,
+   ).execute()
+   ```
+   PostgREST translates this to `INSERT ... ON CONFLICT
+   (idempotency_key) DO NOTHING` server-side; a retry sees zero rows
+   affected and exits the tick clean. (Precedent in-repo:
+   `scripts/pre-compact-backup.py` uses the same pattern for memories.)
 3. Log the key prefix on every tick (first 12 chars) so the morning
    check can grep for re-enqueue patterns.
 
@@ -229,9 +247,9 @@ gate_strictness = f(source, source_tier, executor_model)
 ```
 
 This is not a binary "on/off" — it's a parameterisation of the existing
-`safety.gate()` rules. The gate today reads `(tool_name, action, target,
-area, scope_hash)`. Sprint 4 does not extend this signature. What changes
-is *which actions* a perception-spawned dispatch is allowed to attempt:
+`safety.gate()` rules. Sprint 4 does not extend the gate's call
+signature ([`safety.py`](../../agents/safety.py)). What changes is
+*which actions* a perception-spawned dispatch is allowed to attempt:
 
 | Axis | Effect on strictness | Example |
 |------|---------------------|---------|
@@ -243,7 +261,7 @@ What this means concretely for Sprint 4 implementation:
 
 - **#388 (GitHub ingest)**: no gate changes. `tier:1-auto` rows go through the existing gate. The label is the human nod; the gate is the technical guardrail.
 - **#389 (self-perception)**: every row is tier:3 → `auto_dispatch=false` → never reaches dispatch path → gate not invoked. Owner triggers the actual fix manually.
-- **Future sources**: extend `safety._RULES` with source-aware classifications. Don't touch `gate()` signature.
+- **Future sources**: extend the `_TIER0_*` / `_TIER2_*` constants in `agents/safety.py` with source-aware classifications (or add a new `_TIER0_PERCEPTION_*` set). Don't touch the `gate()` signature.
 
 ### Why source tier ≠ skip-gate
 


### PR DESCRIPTION
## Summary

New `docs/agents/perception.md` — single source of truth for Sprint 4 perception modules (#387 deferred / #388 GitHub / #389 self-perception via morning_check). Defines the `task_queue` row contract every source must produce: `approved_by` namespace, `auto_dispatch` policy, `idempotency_key` formula, source-tier classification scheme. Cross-links from `dispatcher.md` and `agents/README.md`.

## Why

#386 is the gate for the rest of milestone #32. The issue body called out the failure mode explicitly: "Without this, three subagents will pick three different conventions for `approved_by`, `auto_dispatch`, and `idempotency_key` shape, and we'll spend Sprint 5 unifying them." Three sibling implementations are about to land — this doc ships first so they have settled conventions to follow.

Closes #386

## Decisions & Alternatives

Owner-resolved questions (recorded in [#386 comment](https://github.com/Osasuwu/jarvis/issues/386#issuecomment-4318569771)):

- **Safety gate strictness — gradient, not on/off.** Gate is *always* in the FSM. Strictness varies along `(source, source_tier, executor_model)`. Rejected alternative: "skip gate for cron-internal tasks" — once any source skips, the audit trail breaks.
- **Telegram ingest deferred** (#387 → backlog, label cleared, deferral comment posted). Covered by Claude Code Channels (live session) + GitHub ingest (autonomous, three taps in gh mobile app). Slot reserved in "Future sources" so the convention doesn't shift later. Rejected alternative: keep #387 in scope — would add a poll loop and failure surface for a niche neither Channels nor #388 leaves uncovered.
- **GitHub `tier:1-auto` label IS the human nod.** No second approval gate. Rejected alternative: require human to flip a flag after labelling — would make tier:1 redundant with tier:2.

Disambiguation work the doc does:

- The word "tier" appears in three registers in this codebase (perception-source-tier label, `safety.Tier` IntEnum, `task_queue.auto_dispatch` boolean). Doc puts them in one table at the top so reviewers don't conflate them.
- Bridge: perception modules translate **source tier → `auto_dispatch` boolean** at ingest. Safety gate runs later on the actual mutation, regardless of source tier.

## Risk Assessment

- **LOW** — documentation only. No code touched, no schema migrated, no CI affected. Cross-links are additive. Worst-case: a future implementer disagrees with a convention and the doc gets updated.

## Testing

- `git diff main...HEAD --stat` — only the three documented files modified
- Doc cross-references checked: every linked file exists in-repo
- Mermaid-free ASCII diagram (no rendering tooling required)
- Spell-check by re-reading; structure-check by re-reading the issue acceptance criteria against the rendered doc

## Files Changed

- `docs/agents/perception.md` — new file, ~270 lines. Sources, FSM diagram, vocabulary disambiguation, safety-gate-strictness model, conventions checklist for #388/#389 implementers.
- `docs/agents/dispatcher.md` — one-line addition to the upstream table pointing at perception as the producer side.
- `agents/README.md` — one-line addition to the per-module table noting `perception_*.py` (planned) with link to the doc.