### PR TITLE
doc(perception): seed smoke-test trace section (smoke #1)

### DIFF
--- a/docs/agents/perception.md
+++ b/docs/agents/perception.md
@@ -291,3 +291,14 @@ When writing `agents/perception_<source>.py`, hit every one:
 - [`escalation.md`](escalation.md) — what fires after perception INSERTs and dispatcher picks up
 - [`mcp-memory/schema.sql`](../../mcp-memory/schema.sql) + [`supabase/migrations/20260422134442_create_task_queue.sql`](../../supabase/migrations/20260422134442_create_task_queue.sql) — `task_queue` columns and FSM check constraint
 - [`agents/README.md`](../../agents/README.md) — agent module index
+
+## Smoke test trace
+
+End-to-end smoke iterations of #390. Each row is one autonomous run:
+issue → perception tick → task_queue → dispatcher → claude -p → PR.
+
+### Iteration 1
+
+- Source issue: #399
+- Outcome: PR opened by autonomous dispatcher
+- Timestamps and PR link filled in by orchestrator post-merge


### PR DESCRIPTION
Appends a new `## Smoke test trace` section to the end of `docs/agents/perception.md`, after `## Cross-references`.

This is iteration 1 of the Sprint 4 end-to-end smoke (#390) — exercising the full producer → FSM → dispatcher → `claude -p` → PR loop.

## Changes

- One file modified: `docs/agents/perception.md`
- New section appended only (no existing sections touched)

Closes #399