### PR TITLE
doc(perception-github): add CLI usage example to module docstring (smoke #3)

### DIFF
--- a/agents/perception_github.py
+++ b/agents/perception_github.py
@@ -16,6 +16,10 @@ Architecture:
 
 Safety: per-repo allowlist prevents ingesting from arbitrary sources.
 Idempotency: upsert with ON CONFLICT (idempotency_key) DO NOTHING.
+
+CLI usage:
+    python -m agents.perception_github --once
+    python -m agents.perception_github --loop 60 --notify
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Extends the module-level docstring in `agents/perception_github.py` with a concrete CLI usage example, placed after the existing `Idempotency:` line.

Closes #390