### PR TITLE
fix(install): two MCP migration fixes (shadow + register-via-CLI)

### DIFF
--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -55,13 +55,17 @@ groups:
         merge: true
 
   - id: mcp_config
-    description: ".mcp.json — MCP server config with absolute paths (M3 #338)"
+    description: "MCP servers — registered at user scope via `claude mcp add` (M3 #338)"
     enabled: true
     files:
+      # Source listing read by installer; each entry becomes a
+      # `claude mcp add -s user` call (writes to ~/.claude.json's mcpServers).
+      # Earlier revisions copied the file to ~/.claude/.mcp.json — Claude Code
+      # never reads that path, so the install was inert. The dead file is
+      # auto-quarantined on next apply.
       - source: ".claude-userlevel/.mcp.json"
-        dest: ".mcp.json"
+        install_as: "user_mcp_registrations"
         template: true
-        merge: true  # preserve user-added mcpServers entries on re-apply
 
   - id: skills
     description: "Core skills (M2 #337) — universal, not project-specific"

--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -36,7 +36,7 @@ DEFAULT_MANIFEST = "install-manifest.yaml"
 class Action:
     """One planned filesystem action."""
 
-    kind: str  # "copy_file" | "copy_dir" | "merge_json" | "write_version" | "set_env"
+    kind: str  # "copy_file" | "copy_dir" | "merge_json" | "quarantine_file" | "write_version" | "set_env"
     source: str | None
     dest: str
     template: bool = False
@@ -122,6 +122,16 @@ def detect_state(target_root: Path, current_sha: str) -> tuple[str, str | None]:
 _POSIX_PATH_PATTERN = re.compile(r"(?<!\S)(scripts|config)/")
 
 
+# A pre-migration `.mcp.json` sitting in any parent dir of JARVIS_HOME (e.g.
+# `D:\Github\.mcp.json`) shadows the correctly-templated user-level file:
+# Claude Code walks up from CWD and binds the first `.mcp.json` it finds.
+# Pre-migration files reference `jarvis/scripts/...` as a *relative* path,
+# which only resolves when CWD == the legacy file's parent. From any other
+# project (redrobot, etc.) the server fails to launch. Detect by JSON content,
+# not just filename, so we don't quarantine unrelated parent-dir MCP configs.
+_LEGACY_RELATIVE_JARVIS_PATTERN = re.compile(r"^jarvis[\\/]")
+
+
 def _transform_json_paths(node: Any, repo_root_posix: str) -> Any:
     """Rewrite relative `scripts/...` and `config/...` references to
     absolute paths inside the jarvis repo. JSON-aware walk preserves
@@ -135,6 +145,53 @@ def _transform_json_paths(node: Any, repo_root_posix: str) -> Any:
     if isinstance(node, dict):
         return {k: _transform_json_paths(v, repo_root_posix) for k, v in node.items()}
     return node
+
+
+def _references_relative_jarvis(node: Any) -> bool:
+    """True if any string leaf is a relative path beginning with `jarvis/` or `jarvis\\`."""
+    if isinstance(node, str):
+        return bool(_LEGACY_RELATIVE_JARVIS_PATTERN.match(node))
+    if isinstance(node, list):
+        return any(_references_relative_jarvis(x) for x in node)
+    if isinstance(node, dict):
+        return any(_references_relative_jarvis(v) for v in node.values())
+    return False
+
+
+def find_legacy_parent_mcp(repo_root: Path, max_depth: int = 4) -> list[Path]:
+    """Return parent-dir `.mcp.json` files referencing jarvis with relative paths.
+
+    Walks up to `max_depth` parents from `repo_root` (typically JARVIS_HOME).
+    A file is flagged only when its JSON content contains a string starting
+    with `jarvis/` or `jarvis\\` — i.e. a path that resolves correctly when
+    CWD is the legacy file's parent dir but breaks elsewhere. Absolute paths
+    (already-templated by a prior install) are left alone.
+    """
+    found: list[Path] = []
+    parent = repo_root.parent
+    for _ in range(max_depth):
+        if parent == parent.parent:  # filesystem root
+            break
+        candidate = parent / ".mcp.json"
+        if candidate.is_file():
+            try:
+                data = json.loads(candidate.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                pass
+            else:
+                if _references_relative_jarvis(data):
+                    found.append(candidate)
+        parent = parent.parent
+    return found
+
+
+def _quarantine_dest(path: Path) -> Path:
+    """Compute non-clobbering `.bak.pre-jarvis-migration` destination for `path`."""
+    base = path.with_name(path.name + ".bak.pre-jarvis-migration")
+    if not base.exists():
+        return base
+    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    return path.with_name(f"{path.name}.bak.pre-jarvis-migration-{stamp}")
 
 
 def _substitute_placeholders(text: str, repo_root: Path, claude_home: Path) -> str:
@@ -230,6 +287,17 @@ def build_plan(
                     note=f"include={include}" if include else "",
                 )
             )
+
+    for legacy in find_legacy_parent_mcp(repo_root):
+        actions.append(
+            Action(
+                kind="quarantine_file",
+                source=str(legacy),
+                dest=str(_quarantine_dest(legacy)),
+                group="legacy_mcp",
+                note="parent-dir .mcp.json shadows ~/.claude/.mcp.json",
+            )
+        )
 
     actions.append(
         Action(
@@ -490,6 +558,12 @@ def apply_plan(
                 plan.repo_root,
                 plan.target_root,
             )
+        elif action.kind == "quarantine_file":
+            src = Path(action.source)
+            dst = Path(action.dest)
+            if src.exists():
+                src.rename(dst)
+                print(f"quarantined legacy {src} -> {dst}", file=sys.stderr)
         elif action.kind == "write_version":
             Path(action.dest).write_text(action.note + "\n", encoding="utf-8")
         elif action.kind == "set_env":
@@ -620,6 +694,11 @@ def format_plan(plan: Plan) -> str:
                 extra = f"  {a.note}" if a.note else ""
                 lines.append(
                     f"  copy_dir   [{a.group:>14}] {a.source} -> {a.dest}{extra}"
+                )
+            elif a.kind == "quarantine_file":
+                lines.append(
+                    f"  quarantine [{a.group:>14}] {a.source} -> {a.dest}"
+                    + (f"  ({a.note})" if a.note else "")
                 )
             elif a.kind == "write_version":
                 lines.append(f"  write_ver  -> {a.dest}  sha={a.note[:12]}")

--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -36,7 +36,7 @@ DEFAULT_MANIFEST = "install-manifest.yaml"
 class Action:
     """One planned filesystem action."""
 
-    kind: str  # "copy_file" | "copy_dir" | "merge_json" | "quarantine_file" | "write_version" | "set_env"
+    kind: str  # "copy_file" | "copy_dir" | "merge_json" | "quarantine_file" | "register_mcp_user" | "write_version" | "set_env"
     source: str | None
     dest: str
     template: bool = False
@@ -194,6 +194,86 @@ def _quarantine_dest(path: Path) -> Path:
     return path.with_name(f"{path.name}.bak.pre-jarvis-migration-{stamp}")
 
 
+def _plan_mcp_user_registrations(
+    source: Path,
+    repo_root: Path,
+    target_root: Path,
+) -> list[Action]:
+    """Generate a `register_mcp_user` action per server in `source` (.mcp.json).
+
+    Claude Code does NOT read `~/.claude/.mcp.json` as user-scope MCP config —
+    only project-scope (CWD walk) and the `mcpServers` block inside
+    `~/.claude.json` (managed by `claude mcp add -s user`). Earlier installer
+    revisions dropped the file under `target_root` where Claude Code never
+    looked. This helper reads that file and plans `claude mcp add -s user`
+    invocations that actually register servers in user scope.
+
+    Path templating (`scripts/...` → `<repo_root>/scripts/...`) and
+    `{{JARVIS_HOME}}` substitution are applied before serialising each spec
+    into the action note, so apply-time runs see absolute paths.
+
+    Also schedules a quarantine of any pre-existing `target_root/.mcp.json`
+    left over from the dead file-drop strategy.
+    """
+    rendered = template_content(source, repo_root, target_root).decode("utf-8")
+    data = json.loads(rendered)
+    actions: list[Action] = []
+    for name, spec in (data.get("mcpServers") or {}).items():
+        payload = json.dumps({"name": name, "spec": spec}, ensure_ascii=False)
+        actions.append(
+            Action(
+                kind="register_mcp_user",
+                source=str(source),
+                dest=name,
+                template=False,
+                group="mcp_config",
+                note=payload,
+            )
+        )
+    stale = target_root / ".mcp.json"
+    if stale.is_file():
+        actions.append(
+            Action(
+                kind="quarantine_file",
+                source=str(stale),
+                dest=str(_quarantine_dest(stale)),
+                group="mcp_config",
+                note="superseded by user-scope MCP registrations",
+            )
+        )
+    return actions
+
+
+def _register_mcp_user(name: str, spec: dict[str, Any]) -> None:
+    """Run `claude mcp add -s user` for one server, removing any prior entry first.
+
+    Idempotent: a stale entry is removed (errors swallowed — it may not exist)
+    before the add. Subprocess args are passed as a list so values containing
+    spaces or shell metacharacters survive intact.
+    """
+    subprocess.run(
+        ["claude", "mcp", "remove", "-s", "user", name],
+        check=False,
+        capture_output=True,
+    )
+    cmd: list[str] = ["claude", "mcp", "add", "-s", "user"]
+    transport = spec.get("type")
+    if transport in {"http", "sse"}:
+        cmd += ["--transport", transport]
+        for hk, hv in (spec.get("headers") or {}).items():
+            cmd += ["-H", f"{hk}: {hv}"]
+        cmd += [name, spec["url"]]
+    else:
+        for ek, ev in (spec.get("env") or {}).items():
+            cmd += ["-e", f"{ek}={ev}"]
+        cmd += [name, "--", spec["command"], *spec.get("args", [])]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude mcp add failed for {name!r}: {result.stderr.strip() or result.stdout.strip()}"
+        )
+
+
 def _substitute_placeholders(text: str, repo_root: Path, claude_home: Path) -> str:
     return (
         text.replace("{{JARVIS_HOME}}", repo_root.as_posix())
@@ -260,6 +340,16 @@ def build_plan(
         gid = group.get("id", "?")
         for entry in group.get("files") or []:
             src = repo_root / entry["source"]
+            install_as = entry.get("install_as")
+            if install_as == "user_mcp_registrations":
+                actions.extend(
+                    _plan_mcp_user_registrations(src, repo_root, target_root)
+                )
+                continue
+            if install_as is not None:
+                raise ValueError(
+                    f"manifest group {gid!r}: unknown install_as {install_as!r}"
+                )
             dest = target_root / entry["dest"]
             # `merge: true` → deep-merge JSON instead of plain overwrite.
             # Preserves user keys not owned by jarvis (M3 #338).
@@ -522,6 +612,7 @@ def apply_plan(
     plan: Plan,
     manifest: dict[str, Any],
     run_env: Callable[[str, str, str], None] | None = _set_env,
+    register_mcp: Callable[[str, dict[str, Any]], None] | None = _register_mcp_user,
 ) -> None:
     if plan.state == "current":
         return
@@ -564,6 +655,10 @@ def apply_plan(
             if src.exists():
                 src.rename(dst)
                 print(f"quarantined legacy {src} -> {dst}", file=sys.stderr)
+        elif action.kind == "register_mcp_user":
+            if register_mcp is not None:
+                payload = json.loads(action.note)
+                register_mcp(payload["name"], payload["spec"])
         elif action.kind == "write_version":
             Path(action.dest).write_text(action.note + "\n", encoding="utf-8")
         elif action.kind == "set_env":
@@ -699,6 +794,10 @@ def format_plan(plan: Plan) -> str:
                 lines.append(
                     f"  quarantine [{a.group:>14}] {a.source} -> {a.dest}"
                     + (f"  ({a.note})" if a.note else "")
+                )
+            elif a.kind == "register_mcp_user":
+                lines.append(
+                    f"  mcp_user   [{a.group:>14}] claude mcp add -s user {a.dest}"
                 )
             elif a.kind == "write_version":
                 lines.append(f"  write_ver  -> {a.dest}  sha={a.note[:12]}")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -775,3 +775,76 @@ def test_backup_tolerates_locked_file(
     assert plan2.backup_path.exists()
     assert not (plan2.backup_path / "debug" / "locked.log").exists()
     assert "locked.log" in capsys.readouterr().err
+
+
+# ---------- legacy parent-dir .mcp.json quarantine ----------
+
+
+def _legacy_mcp_payload(rel_path: str = "jarvis/scripts/run-memory-server.py") -> str:
+    return json.dumps(
+        {"mcpServers": {"memory": {"command": "python", "args": [rel_path]}}},
+        indent=2,
+    )
+
+
+def test_find_legacy_parent_mcp_detects_relative_jarvis_refs(tmp_path: Path) -> None:
+    repo = tmp_path / "Github" / "jarvis"
+    repo.mkdir(parents=True)
+    legacy = tmp_path / "Github" / ".mcp.json"
+    legacy.write_text(_legacy_mcp_payload(), encoding="utf-8")
+
+    found = installer.find_legacy_parent_mcp(repo)
+    assert legacy.resolve() in [p.resolve() for p in found]
+
+
+def test_find_legacy_parent_mcp_ignores_absolute_paths(tmp_path: Path) -> None:
+    repo = tmp_path / "Github" / "jarvis"
+    repo.mkdir(parents=True)
+    correct = tmp_path / "Github" / ".mcp.json"
+    correct.write_text(
+        _legacy_mcp_payload(rel_path=str(repo / "scripts" / "run-memory-server.py")),
+        encoding="utf-8",
+    )
+
+    assert installer.find_legacy_parent_mcp(repo) == []
+
+
+def test_find_legacy_parent_mcp_ignores_unrelated_mcp_configs(tmp_path: Path) -> None:
+    repo = tmp_path / "Github" / "jarvis"
+    repo.mkdir(parents=True)
+    unrelated = tmp_path / "Github" / ".mcp.json"
+    unrelated.write_text(
+        json.dumps({"mcpServers": {"foo": {"command": "npx", "args": ["foo-mcp"]}}}),
+        encoding="utf-8",
+    )
+
+    assert installer.find_legacy_parent_mcp(repo) == []
+
+
+def test_apply_plan_quarantines_legacy_parent_mcp(
+    manifest: Path, fake_repo: Path
+) -> None:
+    legacy = fake_repo.parent / ".mcp.json"
+    legacy.write_text(_legacy_mcp_payload(), encoding="utf-8")
+
+    m = installer.load_manifest(manifest)
+    plan = installer.build_plan(m, fake_repo)
+
+    quarantine = [a for a in plan.actions if a.kind == "quarantine_file"]
+    assert any(Path(a.source).resolve() == legacy.resolve() for a in quarantine)
+
+    installer.apply_plan(plan, m, run_env=None)
+
+    assert not legacy.exists()
+    assert (legacy.parent / ".mcp.json.bak.pre-jarvis-migration").exists()
+
+
+def test_quarantine_dest_avoids_clobbering_existing_bak(tmp_path: Path) -> None:
+    legacy = tmp_path / ".mcp.json"
+    legacy.write_text("{}", encoding="utf-8")
+    existing_bak = tmp_path / ".mcp.json.bak.pre-jarvis-migration"
+    existing_bak.write_text("{}", encoding="utf-8")
+
+    dest = installer._quarantine_dest(legacy)
+    assert dest != existing_bak
+    assert dest.name.startswith(".mcp.json.bak.pre-jarvis-migration-")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -345,7 +345,7 @@ def test_real_manifest_m4_all_groups_enabled() -> None:
     assert by_id["mcp_config"]["enabled"] is True
     mcp_entry = by_id["mcp_config"]["files"][0]
     assert mcp_entry["source"] == ".claude-userlevel/.mcp.json"
-    assert mcp_entry["merge"] is True
+    assert mcp_entry["install_as"] == "user_mcp_registrations"
     assert mcp_entry["template"] is True
 
     # M4: soul flipped on. Source stays at config/SOUL.md (canonical git-tracked).
@@ -848,3 +848,178 @@ def test_quarantine_dest_avoids_clobbering_existing_bak(tmp_path: Path) -> None:
     dest = installer._quarantine_dest(legacy)
     assert dest != existing_bak
     assert dest.name.startswith(".mcp.json.bak.pre-jarvis-migration-")
+
+
+# ---------- user-scope MCP registration ----------
+
+
+def _user_mcp_manifest(fake_repo: Path, target_root: Path) -> Path:
+    """Manifest variant that registers MCPs via `claude mcp add` instead of copying."""
+    data = {
+        "version": 1,
+        "target_root": str(target_root),
+        "version_marker": ".jarvis-version",
+        "groups": [
+            {
+                "id": "mcp_config",
+                "enabled": True,
+                "files": [
+                    {
+                        "source": ".mcp.json",
+                        "install_as": "user_mcp_registrations",
+                        "template": True,
+                    }
+                ],
+            },
+        ],
+        "env_vars": [],
+        "health_check": {"enabled": False},
+        "backup": {"prefix": ".claude.backup-", "retain": 3},
+    }
+    path = fake_repo / "install-manifest-user-mcp.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def test_plan_user_mcp_registrations_emits_action_per_server(
+    fake_repo: Path, tmp_path: Path
+) -> None:
+    target = tmp_path / "claude_home"
+    manifest_path = _user_mcp_manifest(fake_repo, target)
+    m = installer.load_manifest(manifest_path)
+    plan = installer.build_plan(m, fake_repo)
+
+    regs = [a for a in plan.actions if a.kind == "register_mcp_user"]
+    assert len(regs) == 1
+    payload = json.loads(regs[0].note)
+    assert payload["name"] == "memory"
+    assert payload["spec"]["command"] == "python"
+    # Path templating applied — relative `scripts/...` rewritten to absolute.
+    assert payload["spec"]["args"][0].startswith(fake_repo.as_posix() + "/scripts/")
+
+
+def test_plan_user_mcp_registrations_quarantines_stale_target_file(
+    fake_repo: Path, tmp_path: Path
+) -> None:
+    target = tmp_path / "claude_home"
+    target.mkdir()
+    stale = target / ".mcp.json"
+    stale.write_text("{}", encoding="utf-8")
+
+    manifest_path = _user_mcp_manifest(fake_repo, target)
+    m = installer.load_manifest(manifest_path)
+    plan = installer.build_plan(m, fake_repo)
+
+    quarantine = [a for a in plan.actions if a.kind == "quarantine_file"]
+    assert any(Path(a.source).resolve() == stale.resolve() for a in quarantine)
+
+
+def test_apply_register_mcp_user_calls_injected_runner(
+    fake_repo: Path, tmp_path: Path
+) -> None:
+    target = tmp_path / "claude_home"
+    manifest_path = _user_mcp_manifest(fake_repo, target)
+    m = installer.load_manifest(manifest_path)
+    plan = installer.build_plan(m, fake_repo)
+
+    calls: list[tuple[str, dict]] = []
+
+    def fake_register(name: str, spec: dict) -> None:
+        calls.append((name, spec))
+
+    installer.apply_plan(plan, m, run_env=None, register_mcp=fake_register)
+
+    assert calls and calls[0][0] == "memory"
+    assert calls[0][1]["command"] == "python"
+
+
+def test_register_mcp_user_stdio_command_shape(monkeypatch) -> None:
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    installer._register_mcp_user(
+        "memory",
+        {"command": "python", "args": ["/abs/run.py"], "env": {"K": "V"}},
+    )
+
+    # First call: idempotent remove. Second: add with -e then `--` then command.
+    assert captured[0][:5] == ["claude", "mcp", "remove", "-s", "user"]
+    add = captured[1]
+    assert add[:5] == ["claude", "mcp", "add", "-s", "user"]
+    assert "-e" in add and "K=V" in add
+    assert "--" in add
+    dd = add.index("--")
+    assert add[dd + 1 :] == ["python", "/abs/run.py"]
+
+
+def test_register_mcp_user_http_command_shape(monkeypatch) -> None:
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    installer._register_mcp_user(
+        "remote",
+        {
+            "type": "http",
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer xxx"},
+        },
+    )
+
+    add = captured[1]
+    assert "--transport" in add and "http" in add
+    assert "-H" in add and "Authorization: Bearer xxx" in add
+    assert add[-2:] == ["remote", "https://example.com/mcp"]
+
+
+def test_register_mcp_user_raises_on_add_failure(monkeypatch) -> None:
+    seq = iter([0, 1])  # remove succeeds, add fails
+
+    def fake_run(cmd, **kwargs):
+        class R:
+            returncode = next(seq)
+            stdout = ""
+            stderr = "boom"
+        return R()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="claude mcp add failed"):
+        installer._register_mcp_user("x", {"command": "y", "args": []})
+
+
+def test_unknown_install_as_raises(fake_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "claude_home"
+    bad = {
+        "version": 1,
+        "target_root": str(target),
+        "version_marker": ".jarvis-version",
+        "groups": [
+            {
+                "id": "mcp_config",
+                "enabled": True,
+                "files": [
+                    {"source": ".mcp.json", "install_as": "bogus", "template": True}
+                ],
+            }
+        ],
+    }
+    path = fake_repo / "bad-manifest.yaml"
+    path.write_text(yaml.safe_dump(bad), encoding="utf-8")
+    m = installer.load_manifest(path)
+    with pytest.raises(ValueError, match="unknown install_as"):
+        installer.build_plan(m, fake_repo)


### PR DESCRIPTION
Two related fixes to the M3 user-level MCP migration. Both surfaced together when memory MCP failed silently on VividFormsPC4Workshop today.

---

## Fix 1 -- Quarantine legacy parent-dir .mcp.json (commit 1)

A pre-migration .mcp.json left in any parent dir of JARVIS_HOME (e.g. D:/Github/.mcp.json) silently shadows the templated user-level file: Claude Code walks up from CWD and binds the first hit. Pre-migration files reference jarvis/scripts/... as a relative path that only resolves when CWD == the legacy file parent, breaking from any other project.

Installer now scans up to 4 parent dirs of JARVIS_HOME for .mcp.json files whose JSON contains a string starting with jarvis/ and quarantines them to .bak.pre-jarvis-migration. Detection is by content, not filename, so unrelated parent-dir MCP configs are left alone. Reversible -- rename, not delete.

## Fix 2 -- Register MCPs via claude mcp add -s user (commit 2)

The original mcp_config strategy copied .mcp.json to ~/.claude/.mcp.json on the assumption Claude Code reads user-home as a config location. It does not -- only project-scope (CWD walk) and ~/.claude.json mcpServers block (managed by claude mcp add -s user) are honoured. The drop was therefore inert: every install left memory + tg-messenger + the rest unregistered.

Installer now reads the source .mcp.json and emits one register_mcp_user action per server. Apply runs claude mcp remove -s user <name> then claude mcp add -s user ... (idempotent). Path templating still applies. Stale ~/.claude/.mcp.json from prior installs is auto-quarantined.

Manifest change: mcp_config group switches from merge: true (file copy) to install_as: user_mcp_registrations.

## Test plan

- pytest tests/test_installer.py -- 46 passed (12 new across both fixes)
- Dry-run on real env: 16 actions including 10 mcp_user registrations and quarantine of stale ~/.claude/.mcp.json
- Existing fresh / outdated / idempotent / rollback / health-check tests still green
- HTTP transport coverage, stdio + env-var coverage, failure-path coverage, manifest schema rejection

## Migration impact for existing devices

After merge, next install.ps1 -Apply will:
1. Quarantine any legacy <parent>/.mcp.json shadowing the install (Fix 1)
2. Quarantine the now-superseded ~/.claude/.mcp.json (Fix 2)
3. Register every server in .claude-userlevel/.mcp.json to user scope via claude mcp add (Fix 2)
4. Restart of Claude Code required for new registrations to load