### PR TITLE
feat(install): -ServiceAccount + SeServiceLogonRight grant (#410)

### DIFF
--- a/docs/agents/scheduler.md
+++ b/docs/agents/scheduler.md
@@ -186,6 +186,45 @@ Verify with `python -m scripts.observability.morning_check` after a few
 ticks — `task-dispatcher` should report `success` outcomes, not
 `failure:FileNotFoundError`.
 
+### Running under a non-default account (issue #410)
+
+LocalSystem cannot read user-scoped Claude Max session credentials at
+`%USERPROFILE%\.claude\.credentials.json`. If the dispatcher needs them
+(every tier-1 row that spawns `claude -p` does), the service has to run
+under the user account that owns those credentials.
+
+Switching the service account on Windows hits a sharp edge: even with
+the **correct** password, `sc.exe config` and NSSM return error 1326
+("logon failure for .\username with current password") when the
+account is missing the **SeServiceLogonRight** privilege ("Log on as a
+service"). The services.msc GUI grants it implicitly when you re-enter
+the password through the Log On tab; `sc.exe` does not. This bit
+workshop deploy on 2026-04-25.
+
+The install script handles both halves of the dance via two opt-in
+parameters:
+
+```powershell
+# Grant the right, set NSSM ObjectName, password handled in-process.
+$pw = Read-Host -Prompt "Password for .\PC4_v" -AsSecureString
+.\scripts\install\install-scheduler-service.ps1 `
+    -ServiceAccount '.\PC4_v' `
+    -ServicePassword $pw
+
+# Or grant the right only; set the password later via services.msc:
+.\scripts\install\install-scheduler-service.ps1 -ServiceAccount '.\PC4_v'
+# Then: services.msc -> jarvis-scheduler -> Log On tab -> enter password.
+```
+
+Both forms are idempotent: if the account already has the right, the
+secedit round-trip detects it and no-ops. The script must run from an
+elevated PowerShell session so secedit can read/write the local
+security policy. `-DryRun` extends to the secedit operations and
+prints what it would do without mutating the policy.
+
+LocalSystem stays the default. Don't pass `-ServiceAccount` unless you
+specifically want the dispatcher to run under a user account.
+
 ### View logs
 
 Logs are written to `<repo>/logs/scheduler/stdout.log` and `stderr.log`:

--- a/scripts/install/install-scheduler-service.ps1
+++ b/scripts/install/install-scheduler-service.ps1
@@ -7,7 +7,18 @@ param(
     [switch]$SkipNssmCheck = $false,
 
     [Parameter(HelpMessage = "Validate resolution end-to-end without calling nssm install/set")]
-    [switch]$DryRun = $false
+    [switch]$DryRun = $false,
+
+    # Workshop incident 2026-04-25 (memory workshop_scheduler_logon_failure_real_cause):
+    # sc.exe config and NSSM cannot grant SeServiceLogonRight, so a correct password
+    # yields error 1326 when the account lacks the right. services.msc UI auto-grants
+    # on password re-entry; this script does the same explicitly via secedit.
+    # Format: '.\username' for local accounts, 'DOMAIN\username' for domain.
+    [Parameter(HelpMessage = "Run service as this user account; grants SeServiceLogonRight. Pair with -ServicePassword to also set NSSM ObjectName.")]
+    [string]$ServiceAccount = "",
+
+    [Parameter(HelpMessage = "Password for ServiceAccount (SecureString). Omit to set password manually after install.")]
+    [System.Security.SecureString]$ServicePassword
 )
 
 # Colors for output
@@ -33,6 +44,99 @@ function Exit-Script {
     param([int]$ExitCode = 1, [string]$Message = "")
     if ($Message) { Write-Error-Message $Message }
     exit $ExitCode
+}
+
+function Grant-SeServiceLogonRight {
+    # Idempotent grant of "Log on as a service" via secedit. See issue #410 +
+    # memory workshop_scheduler_logon_failure_real_cause.
+    param(
+        [Parameter(Mandatory = $true)][string]$Account,
+        [switch]$DryRun
+    )
+
+    $sid = $null
+    try {
+        $ntAccount = New-Object System.Security.Principal.NTAccount($Account)
+        $sid = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier]).Value
+    }
+    catch {
+        Exit-Script 1 "Cannot resolve account '$Account' to SID. Verify spelling and (for local accounts) the '.\' prefix."
+    }
+
+    Write-Status "Account $Account resolved to SID $sid" $InfoColor
+
+    $tempInf = [System.IO.Path]::GetTempFileName() + ".inf"
+    $tempSdb = [System.IO.Path]::GetTempFileName() + ".sdb"
+
+    if ($DryRun) {
+        Write-Status "[DRY-RUN] Would call: secedit /export /cfg $tempInf /areas USER_RIGHTS" $WarningColor
+        Write-Status "[DRY-RUN] Would patch SeServiceLogonRight to include *$sid (no-op if already present)" $WarningColor
+        Write-Status "[DRY-RUN] Would call: secedit /configure /db $tempSdb /cfg $tempInf /areas USER_RIGHTS" $WarningColor
+        return
+    }
+
+    & secedit /export /cfg $tempInf /areas USER_RIGHTS | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Remove-Item $tempInf -ErrorAction SilentlyContinue
+        Exit-Script $LASTEXITCODE "secedit /export failed (exit $LASTEXITCODE). Script must run elevated."
+    }
+
+    $content = Get-Content $tempInf -Encoding Unicode
+    $newContent = New-Object System.Collections.Generic.List[string]
+    $rightFound = $false
+    $alreadyGranted = $false
+
+    foreach ($line in $content) {
+        if ($line -match '^\s*SeServiceLogonRight\s*=\s*(.+)$') {
+            $rightFound = $true
+            $accounts = $Matches[1].Trim()
+            if ($accounts -match [regex]::Escape("*$sid")) {
+                $alreadyGranted = $true
+                $newContent.Add($line) | Out-Null
+            }
+            else {
+                $newContent.Add("SeServiceLogonRight = $accounts,*$sid") | Out-Null
+            }
+        }
+        else {
+            $newContent.Add($line) | Out-Null
+        }
+    }
+
+    if (-not $rightFound) {
+        $insertIdx = -1
+        for ($i = 0; $i -lt $newContent.Count; $i++) {
+            if ($newContent[$i] -match '^\[Privilege Rights\]') {
+                $insertIdx = $i + 1
+                break
+            }
+        }
+        if ($insertIdx -gt 0) {
+            $newContent.Insert($insertIdx, "SeServiceLogonRight = *$sid")
+        }
+        else {
+            $newContent.Add("[Privilege Rights]") | Out-Null
+            $newContent.Add("SeServiceLogonRight = *$sid") | Out-Null
+        }
+    }
+
+    if ($alreadyGranted) {
+        Write-Status "SeServiceLogonRight already granted to $Account; no change needed" $SuccessColor
+        Remove-Item $tempInf -ErrorAction SilentlyContinue
+        return
+    }
+
+    Set-Content -Path $tempInf -Value $newContent -Encoding Unicode
+
+    & secedit /configure /db $tempSdb /cfg $tempInf /areas USER_RIGHTS | Out-Null
+    $configureExit = $LASTEXITCODE
+    Remove-Item $tempInf, $tempSdb -ErrorAction SilentlyContinue
+
+    if ($configureExit -ne 0) {
+        Exit-Script $configureExit "secedit /configure failed (exit $configureExit); grant not applied."
+    }
+
+    Write-Status "SeServiceLogonRight granted to $Account" $SuccessColor
 }
 
 # Resolve repository path and Python interpreter
@@ -255,6 +359,30 @@ Invoke-Nssm "set", $ServiceName, "AppRestartDelay", "5000"
 # Set service description
 Invoke-Nssm "set", $ServiceName, "Description", "$ServiceDescription"
 Invoke-Nssm "set", $ServiceName, "DisplayName", "$ServiceDisplayName"
+
+# Service account configuration (issue #410)
+if ($ServiceAccount) {
+    Write-Status "`nConfiguring service account: $ServiceAccount" $InfoColor
+    Grant-SeServiceLogonRight -Account $ServiceAccount -DryRun:$DryRun
+
+    if ($ServicePassword) {
+        $plainPassword = [System.Net.NetworkCredential]::new("", $ServicePassword).Password
+        if ($DryRun) {
+            Write-Status "[DRY-RUN] Would call: & $nssmPath set $ServiceName ObjectName $ServiceAccount <password>" $WarningColor
+        }
+        else {
+            Invoke-Nssm "set", $ServiceName, "ObjectName", $ServiceAccount, $plainPassword
+            Write-Status "NSSM ObjectName set to $ServiceAccount" $SuccessColor
+        }
+        # Scrub plaintext from this scope; GC will reclaim later.
+        $plainPassword = $null
+    }
+    else {
+        Write-Status "ServicePassword not supplied. Set the password manually before starting:" $WarningColor
+        Write-Host "  sc.exe config $ServiceName obj=`"$ServiceAccount`" password=<password>"
+        Write-Host "  OR services.msc -> $ServiceName -> Properties -> Log On -> Set password"
+    }
+}
 
 if ($DryRun) {
     Write-Status "`n[DRY-RUN] All validations passed. Actual service installation would proceed." $SuccessColor

--- a/tests/install/test_install_script_portable.py
+++ b/tests/install/test_install_script_portable.py
@@ -267,3 +267,81 @@ def test_install_scheduler_supports_dryrun():
     assert "[DRY-RUN]" in content or "DRY-RUN" in content, (
         "Script should indicate DryRun mode in output (prefix with [DRY-RUN])"
     )
+
+
+def test_install_scheduler_service_account_param():
+    """Assert install script exposes -ServiceAccount and -ServicePassword parameters.
+
+    Regression test for issue #410: workshop deploy needed a one-command path
+    to grant SeServiceLogonRight to a non-default service account.
+    """
+    script_path = Path(__file__).parent.parent.parent / "scripts" / "install" / "install-scheduler-service.ps1"
+    content = script_path.read_text(encoding="utf-8")
+
+    # -ServiceAccount must be declared as a string parameter
+    assert "[string]$ServiceAccount" in content, (
+        "Script should expose -ServiceAccount as a [string] parameter"
+    )
+
+    # -ServicePassword must be a SecureString — never plain string
+    assert "[System.Security.SecureString]$ServicePassword" in content, (
+        "Script should expose -ServicePassword as [System.Security.SecureString] "
+        "(never plain string — passwords must not appear in shell history)"
+    )
+
+    # Service account block must be conditional — LocalSystem default is unchanged
+    assert "if ($ServiceAccount)" in content, (
+        "ServiceAccount logic must be gated on $ServiceAccount being set; "
+        "LocalSystem default flow must remain unchanged"
+    )
+
+
+def test_install_scheduler_grants_seservicelogon_right():
+    """Assert install script grants SeServiceLogonRight via secedit when -ServiceAccount is set.
+
+    Regression test for issue #410: workshop incident — sc.exe and NSSM cannot
+    grant the right; without it Windows returns 1326 even on correct password.
+    """
+    script_path = Path(__file__).parent.parent.parent / "scripts" / "install" / "install-scheduler-service.ps1"
+    content = script_path.read_text(encoding="utf-8")
+
+    # Function must exist
+    assert "function Grant-SeServiceLogonRight" in content, (
+        "Script should define Grant-SeServiceLogonRight function"
+    )
+
+    # Must use secedit (the issue body proposes secedit OR LSA P/Invoke; secedit is simpler)
+    assert "secedit /export" in content and "secedit /configure" in content, (
+        "Grant function should use 'secedit /export' + 'secedit /configure' "
+        "to round-trip the USER_RIGHTS area"
+    )
+
+    # Must reference the right by name
+    assert "SeServiceLogonRight" in content, (
+        "Script should reference SeServiceLogonRight by name"
+    )
+
+    # Must resolve account to SID before patching the policy
+    assert "NTAccount" in content and "SecurityIdentifier" in content, (
+        "Grant function should resolve the account name to a SID via NTAccount.Translate"
+    )
+
+    # Must be invoked from the ServiceAccount block, not unconditionally
+    # (find the if-block and assert the call is inside it)
+    sa_block_start = content.find("if ($ServiceAccount)")
+    assert sa_block_start != -1, "Expected 'if ($ServiceAccount)' guard"
+    sa_block_end = content.find("\n}\n", sa_block_start)
+    sa_block = content[sa_block_start:sa_block_end] if sa_block_end != -1 else ""
+    assert "Grant-SeServiceLogonRight" in sa_block, (
+        "Grant call must be inside the 'if ($ServiceAccount)' block, not unconditional"
+    )
+
+    # Idempotency: must detect existing grant before re-applying
+    assert "alreadyGranted" in content, (
+        "Grant function should detect existing right and no-op (avoid mutating policy each run)"
+    )
+
+    # DryRun extends to secedit operations
+    assert "[DRY-RUN] Would call: secedit" in content, (
+        "DryRun mode should print the secedit operations it would perform"
+    )


### PR DESCRIPTION
## Summary

- Adds opt-in `-ServiceAccount` parameter that resolves the account to a SID and grants `SeServiceLogonRight` via `secedit` round-trip on USER_RIGHTS. Idempotent: detects existing grant by SID and no-ops.
- Adds optional `-ServicePassword` (SecureString — never plain string) that, when paired with `-ServiceAccount`, also sets NSSM ObjectName via the existing Invoke-Nssm helper. When omitted, prints the manual sc.exe / services.msc instructions and exits cleanly.
- LocalSystem default unchanged: nothing fires unless `-ServiceAccount` is passed.
- `-DryRun` extends to print the secedit operations without mutating the policy.

## Why

Workshop incident 2026-04-25: even with the correct password, Windows returns 1326 ("logon failure for .\username with current password") when the account lacks SeServiceLogonRight. `sc.exe config` and NSSM cannot grant the right; the services.msc UI implicitly grants on password re-entry. Memory `workshop_scheduler_logon_failure_real_cause` has the full incident.

## Acceptance

- [x] `-ServiceAccount <user>` parameter on `install-scheduler-service.ps1` — when supplied, configures NSSM `ObjectName` (gated on `-ServicePassword` for the password)
- [x] Grants `SeServiceLogonRight` via `secedit /export` -> patch -> `secedit /configure`. No-op when account already has the right.
- [x] `pwsh -File install-scheduler-service.ps1 -ServiceAccount '.\PC4_v' -DryRun` prints the secedit operations
- [x] `tests/install/test_install_script_portable.py` extended with two new tests asserting the right-grant code path exists and is gated on `-ServiceAccount`
- [x] `docs/agents/scheduler.md` documents the flag with workshop pattern

11/11 portability tests pass locally. Smoke test on Main PC: `... -DryRun -SkipNssmCheck -ServiceAccount '.\nonexistent'` produces the expected SID-resolution error message.

## Out of scope

- Switching the production service to run under a user account is a separate decision; this PR only fixes the install-script ergonomics so that switch is one command instead of services.msc-poking.
- Replacing every existing `Invoke-Nssm` quoting style with a more robust form: untouched. Only the new ObjectName call is added.

Closes #410

## Test plan

- [x] `pytest tests/install/test_install_script_portable.py -x -q` (11 passed)
- [x] PowerShell parser: zero errors
- [x] `pwsh -File install-scheduler-service.ps1 -DryRun -SkipNssmCheck -ServiceAccount '.\<bad-account>'` errors out with clear "Cannot resolve account" message
- [ ] Real workshop smoke (deferred — owner runs at workshop visit per session context; covered by DryRun + tests until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)