### PR TITLE
ci(pr-body-check): hotfix label escape + design-RFC policy (#424)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,14 @@
 
 Closes #
 
+<!--
+PR scope rules:
+  - Code change       → keep "Closes #NNN" above.
+  - Hotfix            → remove the line and apply the priority:critical label.
+  - Design / RFC      → wrong place. Use GitHub Discussions, not a PR.
+-->
+
+
 ## Decisions & Alternatives
 
 <!-- Key choices made during implementation. What alternatives were considered and why they were rejected. Non-obvious decisions that a reviewer would question. -->

--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -15,12 +15,22 @@ jobs:
         with:
           script: |
             const repo = { owner: context.repo.owner, repo: context.repo.repo };
-            const body = context.payload.pull_request.body || '';
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const labels = (pr.labels || []).map(l => l.name);
+
+            // Hotfix escape: priority:critical label bypasses the linked-issue requirement.
+            // Aligns with issue-checks.yml which treats priority:critical as hotfix.
+            if (labels.includes('priority:critical')) {
+              console.log('priority:critical label present — skipping linked-issue requirement (hotfix).');
+              return;
+            }
+
             const issueMatches = [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)];
             const issueNumbers = [...new Set(issueMatches.map(m => parseInt(m[1], 10)))];
 
             if (issueNumbers.length === 0) {
-              core.setFailed('PR body must include a linked issue reference, e.g. "Closes #123".');
+              core.setFailed('PR body must include a linked issue reference, e.g. "Closes #123". For hotfixes, apply the priority:critical label instead.');
               return;
             }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,11 @@ Project-specific addition — **transform tasks into verifiable goals**: "Fix bu
 
 ## Development process
 
-- Branches from `main`. One issue per PR; body includes `Closes #NNN`. Drive-by fixes without parent → create post-factum issue-bucket (see #183).
+- Branches from `main`. **PRs are for code, not for discussions.**
+  - Code change → one issue, one PR; body includes `Closes #NNN`. Drive-by fixes without parent → create post-factum issue-bucket (see #183).
+  - Hotfix → label `priority:critical` (PR Body Check honors the label per #424; no linked issue required); commit-msg uses `[no-issue]` when there's no parent issue (per `.pre-commit-config.yaml` regex from #329).
+  - Design RFC / proposal / debate → **GitHub Discussions, not an issue and not a PR.** Approval = thread resolution by the task initiator (owner if owner-started; orchestrator/PM if agent-started). Stable post-decision artifacts may land in `docs/design/` via direct commit; no PR ceremony.
+  - Final decisions go to memory (`record_decision` / `memory_store`) — that is the queryable source of truth, not a markdown file.
 - Check GitHub Copilot auto-review before merging.
 
 ### Fix > track for trivial reversible (#428)

--- a/tests/ci/test_pr_body_check_guard.py
+++ b/tests/ci/test_pr_body_check_guard.py
@@ -1,0 +1,96 @@
+"""Meta-test for .github/workflows/pr-body-check.yml.
+
+Reimplements the workflow's decision rule in Python and asserts the
+escape hatches behave as the workflow promises:
+
+  - Closes #NNN in body                → allowed
+  - priority:critical label             → allowed (hotfix bypass)
+  - neither                             → blocked
+
+Convention from CLAUDE.md §326 (path-filtered guards need meta-tests).
+PR Body Check isn't path-filtered, but the escape logic is non-trivial
+enough that a sibling test is worth keeping in lockstep with the YAML.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "pr-body-check.yml"
+)
+
+
+def evaluate(body: str, labels: list[str]) -> tuple[bool, str]:
+    """Mirror the workflow's decision rule. Returns (allowed, reason)."""
+    if "priority:critical" in labels:
+        return True, "hotfix"
+
+    matches = re.findall(r"(?:closes|fixes|resolves)\s+#(\d+)", body, re.IGNORECASE)
+    if matches:
+        return True, "linked"
+
+    return False, "no-link"
+
+
+def test_closes_marker_allows():
+    allowed, reason = evaluate("Closes #123\n\nSome body", [])
+    assert allowed
+    assert reason == "linked"
+
+
+def test_alt_markers_allow():
+    for marker in ("Closes", "Fixes", "Resolves", "closes", "FIXES"):
+        body = f"{marker} #42"
+        allowed, _ = evaluate(body, [])
+        assert allowed, f"{marker} should be accepted"
+
+
+def test_hotfix_label_bypasses():
+    allowed, reason = evaluate("urgent prod fix, no time to file", ["priority:critical"])
+    assert allowed
+    assert reason == "hotfix"
+
+
+def test_other_labels_do_not_bypass():
+    allowed, _ = evaluate("trivial change", ["priority:medium", "documentation"])
+    assert not allowed
+
+
+def test_empty_body_no_label_blocked():
+    allowed, _ = evaluate("", [])
+    assert not allowed
+
+
+def test_partial_keyword_blocked():
+    # "close to" should not match "closes"
+    allowed, _ = evaluate("This is close to done.", [])
+    assert not allowed
+
+
+def test_workflow_yaml_references_priority_critical():
+    """Config dimension: workflow file must mention the label name we test against."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "priority:critical" in text, (
+        "PR Body Check workflow no longer references the priority:critical "
+        "escape; this test (and CLAUDE.md hotfix rule) is now stale."
+    )
+
+
+def test_workflow_yaml_keeps_closes_regex():
+    """Config dimension: the regex used in the YAML must still recognize Closes/Fixes/Resolves."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "closes|fixes|resolves" in text.lower(), (
+        "PR Body Check regex changed shape — update this test to match."
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #424

## Summary

PRs are for code, not for discussions. This PR makes the policy executable:

| Change | File |
|---|---|
| Hotfix label escape on PR Body Check | \`.github/workflows/pr-body-check.yml\` |
| Template comment guiding hotfix vs design-RFC | \`.github/PULL_REQUEST_TEMPLATE.md\` |
| Meta-test for the workflow's decision rule | \`tests/ci/test_pr_body_check_guard.py\` (NEW) |
| §Development process rewrite | \`CLAUDE.md\` (now in this PR — was previously deferred to owner; #426 principal-aware hook landed and unblocked the edit) |

## Workflow change

Old: every PR must contain \`Closes #NNN\`.

New:
1. \`priority:critical\` label → check passes (hotfix bypass, mirrors issue-checks.yml hotfix detection).
2. Otherwise \`Closes/Fixes/Resolves #NNN\` regex check, same as before.

Failure message points at the label as the alternative.

## CLAUDE.md change

Replaces the §Development process two-bullet block with a four-carve-out structure:
- Code change → one issue, one PR (existing rule, restated).
- Hotfix → \`priority:critical\` label (PR Body Check honors per #424; commit-msg uses \`[no-issue]\` per #329).
- Design RFC → GitHub Discussions (not issue, not PR).
- Final decisions → memory (\`record_decision\`), not markdown files.

§Fix > track for trivial reversible (#428) is left untouched — it's complementary, not contradictory.

## Meta-test

\`tests/ci/test_pr_body_check_guard.py\` — 8 tests, all pass. Two dimensions per #326 convention:
- **Config**: assert the YAML references \`priority:critical\` and the regex shape.
- **Logic**: cover every escape path (closes-marker, alt markers, hotfix label, no-label, empty body, partial keyword false-match).

## Test plan
- [x] \`pytest tests/ci/test_pr_body_check_guard.py\` — 8/8 pass
- [x] CI meta-tests job picked up the new test on PR #425
- [x] \`require-linked-issue\` passes via the new escape against \`Closes #424\`