### PR TITLE
feat(security): principal-aware permissions for protected-files hook

### DIFF
--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -114,6 +114,7 @@ Follow the /implement skill pipeline (loaded in your session). Specifically:
 - §6 Record outcome — always record, pattern_tags=["delegation", "subagent", "<area>"]
 
 HARD RULES for you (subagent):
+- You operate as `JARVIS_PRINCIPAL=subagent` (#426). Hooks classify your tool calls as constrained — protected-file edits and protected-file mirrors will block. Do not try to bypass.
 - Do NOT merge the PR. Open it, push it, record outcome, stop.
 - Do NOT modify protected files (.mcp.json, CLAUDE.md, etc — see docs/security/agent-boundaries.md)
 - Do NOT send messages as the owner
@@ -122,6 +123,8 @@ HARD RULES for you (subagent):
 
 Report back: PR URL + 2-line summary of what you did.
 ```
+
+**Principal env propagation note (#426)**: The Agent tool inherits parent env, so `JARVIS_PRINCIPAL` set in the parent session carries to the subagent. Auto-injection of `JARVIS_PRINCIPAL=subagent` is deferred — the parent is `live` (owner-driven dispatch), and subagents are already constrained by the worktree isolation and skill-level rules above. If a future code path runs `/delegate` autonomously (e.g. dispatcher hands work to a subagent), revisit and inject `JARVIS_PRINCIPAL=subagent` explicitly via the spawn wrapper.
 
 ### 4a. Worktree-isolation caveat
 

--- a/docs/security/agent-boundaries.md
+++ b/docs/security/agent-boundaries.md
@@ -1,7 +1,34 @@
 # Agent Sandbox Boundaries
 
-Date: 2026-04-15 (revised 2026-04-23 for Pillar 7 Phase 0 federation — #341)
-Scope: Rules for subagents (current /delegate + future Pillar 7 agents)
+Date: 2026-04-15 (revised 2026-04-23 for Pillar 7 Phase 0 federation — #341; revised 2026-04-26 for principal-aware permissions — #426)
+Scope: Permission rules for **all principals** running Claude — interactive owner, autonomous loop, /delegate subagent, and the future dispatcher.
+
+## Principal model (#426)
+
+Permissions depend on **who is running Claude**. Four principals — detection lives in [`scripts/principal.py`](../../scripts/principal.py):
+
+| Principal | Signal | Trust |
+|---|---|---|
+| `live` | TTY + interactive harness, no `JARVIS_PRINCIPAL` override | Highest — owner watches, can correct in seconds |
+| `autonomous` | Scheduled task / cron / autonomous-loop (env or `not isatty()`) | Low — corrections take hours |
+| `subagent` | Dispatched by `/delegate` (Agent tool) | Medium — isolated worktree, parent reviews diff |
+| `supervised` | Future dispatcher (Pillar 7 Sprint 2) running Claude headless under a granted scope | Delegated — permissions ⊆ supervisor's grant |
+
+Detection is **default-safe**: a missing `JARVIS_PRINCIPAL` falls through `headless env → not isatty() → live`, so a future autonomous launcher that forgets to set the env still classifies as `autonomous`, never `live`.
+
+### Permission matrix (action × principal)
+
+Action tier model is shared with `agents/safety.py` (T0 = AUTO, T1 = OWNER_QUEUE, T2 = BLOCKED).
+
+| Action ↓ × Principal → | **live** | **autonomous** | **subagent** | **supervised** |
+|---|---|---|---|---|
+| **T0** narrow GitHub labels (`priority:*`, `area:*`, `needs-*`, `status:ready`); status updates; memory_store with `tag=auto-generated`; comment own PR; close issue with evidence; open jarvis tracking issue | ✅ act | ✅ act | ✅ act | ✅ act |
+| **T1** code edit own repo; open PR; merge LOW-risk own PR per skill policy; `/implement` work; workflow files; drive-by fixes | ✅ act | ⚠️ enqueue `task_queue` *(future, lands with dispatcher)* | ✅ in worktree, no merge | ✅ within dispatcher grant *(future)* |
+| **T2-canonical** repo-side sources of truth — see "Repo-level" table below | ⚠️ harness asks (hook exits 0) | ❌ block | ❌ block, escalate to `/implement` | ❌ block |
+| **T2-mirror** `~/.claude/*` files installed by `install.ps1` — see "User-level" table below | ❌ block (use installer) | ❌ block | ❌ block | ❌ block |
+| **T2-secret** `.env*` values; force push to main/master; impersonation; outbound to other humans (PR comments to others, Telegram, email) | ❌ always block | ❌ block | ❌ block | ❌ block |
+
+Currently enforced in code: only **T2** rows, via [`scripts/protected-files.py`](../../scripts/protected-files.py). T1 routing (autonomous-enqueue, supervised-grant) lands when the dispatcher ships; until then T1 work is owner-driven through `/implement` and `/delegate`.
 
 ## Protected Files
 
@@ -38,7 +65,7 @@ Editing these changes behaviour for **every Claude Code session on the device**,
 
 The source of truth for these files lives in the jarvis repo (`config/SOUL.md`, `.claude-userlevel/settings.json`, `.claude-userlevel/.mcp.json`, `.claude-userlevel/skills/*/SKILL.md`). The installer copies or templates them into `~/.claude/`. Direct edits to `~/.claude/` drift from source and are lost on the next `install.ps1 --apply`.
 
-Enforced via PreToolUse hook: `scripts/protected-files.py` (covers both surfaces; user-level paths anchored to `Path.home() / ".claude"` or `$JARVIS_CLAUDE_HOME` override).
+Enforced via PreToolUse hook: `scripts/protected-files.py` (covers both surfaces; user-level paths anchored to `Path.home() / ".claude"` or `$JARVIS_CLAUDE_HOME` override). The hook is principal-aware (#426): `live` principal can edit canonical sources directly (the harness asks for one-off approval), but mirror files always block — the canonical source + installer flow is the only sanctioned path to update them.
 
 ## Branch Rules
 

--- a/scripts/install/install-scheduler-service.ps1
+++ b/scripts/install/install-scheduler-service.ps1
@@ -360,6 +360,12 @@ Invoke-Nssm "set", $ServiceName, "AppRestartDelay", "5000"
 Invoke-Nssm "set", $ServiceName, "Description", "$ServiceDescription"
 Invoke-Nssm "set", $ServiceName, "DisplayName", "$ServiceDisplayName"
 
+# Principal (#426): scheduler service runs autonomously — no human in the loop.
+# Hooks (scripts/protected-files.py + future principal-aware hooks) read this
+# env var to apply constrained permissions vs interactive owner sessions.
+# AppEnvironmentExtra appends to the inherited service env; NUL-separated string.
+Invoke-Nssm "set", $ServiceName, "AppEnvironmentExtra", "JARVIS_PRINCIPAL=autonomous"
+
 # Service account configuration (issue #410)
 if ($ServiceAccount) {
     Write-Status "`nConfiguring service account: $ServiceAccount" $InfoColor

--- a/scripts/principal.py
+++ b/scripts/principal.py
@@ -1,0 +1,95 @@
+"""Principal detection — who is running the current Claude session?
+
+Hooks (PreToolUse and friends) read this to apply principal-aware policy.
+See ``docs/security/agent-boundaries.md`` for the full permission matrix.
+
+Detection chain (belt + suspenders, default-safe):
+
+1. Explicit env ``JARVIS_PRINCIPAL`` — primary signal.
+   Accepted values: ``live``, ``autonomous``, ``subagent``, ``supervised``.
+2. Claude Code headless / non-interactive env vars → ``autonomous``.
+3. ``not sys.stdin.isatty()`` → ``autonomous``.
+4. Default → ``live``.
+
+Default-safe property: forgetting to set ``JARVIS_PRINCIPAL`` in a future
+autonomous launch path falls to ``autonomous`` (no human attached, narrow
+permissions), never to ``live``. The dispatcher (Pillar 7 Sprint 2) and any
+other future entry point inherit this safety net for free.
+
+Tier model is shared with ``agents.safety`` (T0=AUTO, T1=OWNER_QUEUE,
+T2=BLOCKED). This module covers the orthogonal "principal" axis; concrete
+permission decisions are ``(action_tier, principal)`` lookups documented
+in the agent-boundaries doc.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Literal
+
+Principal = Literal["live", "autonomous", "subagent", "supervised"]
+
+VALID_PRINCIPALS: frozenset[str] = frozenset(
+    {"live", "autonomous", "subagent", "supervised"}
+)
+
+# Claude Code env vars that signal headless / non-interactive execution. The
+# exact name has shifted across releases; treat any of them being set (to a
+# truthy value) as a "no human attached" signal. This is the suspenders that
+# back up an explicit ``JARVIS_PRINCIPAL`` going missing.
+_HEADLESS_ENV_VARS: tuple[str, ...] = (
+    "CLAUDE_CODE_NON_INTERACTIVE",
+    "CLAUDE_CODE_HEADLESS",
+    "CLAUDE_HEADLESS",
+)
+
+
+def _explicit_env() -> str | None:
+    """Return the explicit principal from ``JARVIS_PRINCIPAL`` if valid, else None."""
+    raw = os.environ.get("JARVIS_PRINCIPAL")
+    if not raw:
+        return None
+    val = raw.strip().lower()
+    return val if val in VALID_PRINCIPALS else None
+
+
+def _is_headless_env() -> bool:
+    """True if any Claude Code headless / non-interactive env var is truthy."""
+    for name in _HEADLESS_ENV_VARS:
+        v = os.environ.get(name)
+        if v and v.strip() and v.strip().lower() not in {"0", "false", "no"}:
+            return True
+    return False
+
+
+def _is_tty() -> bool:
+    """Best-effort isatty() — returns False on detached stdin or errors."""
+    try:
+        return sys.stdin.isatty()
+    except (ValueError, AttributeError, OSError):
+        return False
+
+
+def detect() -> Principal:
+    """Return the active principal for the current process.
+
+    Resolution order:
+    1. ``JARVIS_PRINCIPAL`` env (explicit, primary)
+    2. Headless env var → ``autonomous``
+    3. Not a TTY → ``autonomous``
+    4. Default → ``live``
+    """
+    explicit = _explicit_env()
+    if explicit is not None:
+        return explicit  # type: ignore[return-value]
+    if _is_headless_env():
+        return "autonomous"
+    if not _is_tty():
+        return "autonomous"
+    return "live"
+
+
+if __name__ == "__main__":
+    # Ad-hoc inspection: ``python scripts/principal.py``
+    print(detect())

--- a/scripts/protected-files.py
+++ b/scripts/protected-files.py
@@ -1,13 +1,18 @@
-"""PreToolUse hook: block writes to protected files.
+"""PreToolUse hook: block writes to protected files (principal-aware).
 
 Checks Edit/Write tool inputs for file paths that match the protected list.
-Exits 2 to block if a protected file is targeted.
+Decision is principal-sensitive (#426):
 
-Covers two surfaces (kept in sync with ``docs/security/agent-boundaries.md``):
-- Repo-level files under the jarvis working copy (source of truth).
-- User-level files under ``~/.claude/`` installed by ``scripts/install/installer.py``.
-  Editing those affects every Claude Code session on the device, so they get
-  the same protection as the jarvis-repo source.
+- ``live`` (interactive owner) + repo-level canonical source → exit 0,
+  let the harness ask for permission. Owner can approve a one-off edit.
+- ``live`` + user-level mirror (``~/.claude/*``) → block. These are
+  installer-managed; direct edits drift from source on next ``install.ps1``.
+- ``autonomous`` / ``subagent`` / ``supervised`` + any protected file → block.
+  No human eye on these contexts; protected-file edits must be promoted
+  through the canonical PR + installer flow.
+
+See ``docs/security/agent-boundaries.md`` for the full action × principal
+matrix and ``scripts/principal.py`` for detection logic.
 """
 
 import json
@@ -15,8 +20,19 @@ import os
 import sys
 from pathlib import Path
 
-# Repo-level files that require owner review — agents must not modify these.
-PROTECTED_FILES = {
+# Wire in principal detection. Importing by relative name works because the
+# hook is invoked with cwd inside the repo and ``scripts/`` is the directory
+# this file lives in; for safety we also fall back to a path-based import.
+try:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import principal as _principal  # noqa: E402
+finally:
+    pass
+
+# Repo-level CANONICAL sources. Edits here flow to every device and project
+# via PR + installer. Live owner can approve one-off edits (harness asks);
+# autonomous / subagent / supervised must use the canonical PR flow.
+T2_CANONICAL = {
     ".mcp.json",
     "config/SOUL.md",
     "CLAUDE.md",
@@ -41,8 +57,14 @@ PROTECTED_FILES = {
     ".pre-commit-config.yaml",
 }
 
-# User-level paths (relative to ``~/.claude/``) that require owner review.
-# Expansion target matches installer.py — respects JARVIS_CLAUDE_HOME override.
+# Backwards-compat alias — older imports / docs may still reference this.
+PROTECTED_FILES = T2_CANONICAL
+
+# User-level MIRROR paths (relative to ``~/.claude/``). Canonical source for
+# these lives in the repo (``config/SOUL.md``, ``.claude-userlevel/...``);
+# the installer copies/templates them into ``~/.claude/``. Direct edits drift
+# from source on the next ``install.ps1 --apply``, so we block ALL principals
+# (including ``live``) and direct the user to the installer flow.
 _USER_LEVEL_PROTECTED_FILES = {
     "settings.json",
     "SOUL.md",
@@ -96,24 +118,79 @@ def _is_user_level_protected(normalized: str) -> bool:
     return len(parts) == 3 and parts[0] == "skills" and parts[2] == "SKILL.md"
 
 
-def is_protected(file_path: str) -> bool:
-    """Check if a file path matches any protected file (repo-level or user-level)."""
+def classify(file_path: str) -> str | None:
+    """Classify a path as ``"canonical"`` (repo-side T2), ``"mirror"``
+    (user-level T2 under ``~/.claude/``), or ``None`` (not protected).
+    """
     normalized = normalize_path(file_path)
-    if normalized in PROTECTED_FILES:
-        return True
-    return _is_user_level_protected(normalized)
+    if normalized in T2_CANONICAL:
+        return "canonical"
+    if _is_user_level_protected(normalized):
+        return "mirror"
+    return None
 
 
-def block(file_path: str):
-    """Output deny JSON and exit 2."""
+def is_protected(file_path: str) -> bool:
+    """Backwards-compat: True iff path matches any protected category."""
+    return classify(file_path) is not None
+
+
+def should_block(file_path: str, principal: str) -> bool:
+    """Principal-aware block decision.
+
+    Returns ``True`` iff the hook should block the write attempt for this
+    ``(path, principal)`` pair.
+
+    Policy (matches ``docs/security/agent-boundaries.md`` matrix):
+    - Not protected → never block.
+    - ``live`` + ``canonical`` → don't block (let harness ask owner).
+    - Any other combination of protected × principal → block.
+    """
+    classification = classify(file_path)
+    if classification is None:
+        return False
+    if principal == "live" and classification == "canonical":
+        return False
+    return True
+
+
+def _block_reason(file_path: str, classification: str, principal: str) -> str:
+    """Compose a human-readable reason for the block decision."""
+    if classification == "mirror":
+        return (
+            f"BLOCKED: '{file_path}' is a user-level mirror under ~/.claude/. "
+            "Edit the canonical source in the jarvis repo "
+            "(config/SOUL.md, .claude-userlevel/...), open a PR, then propagate "
+            "with `install.ps1 -Apply` (or `install.sh -a`). Direct edits drift "
+            "from source on next install."
+        )
+    # canonical, but principal != live
+    return (
+        f"BLOCKED: '{file_path}' is a protected canonical source and the "
+        f"current principal is '{principal}'. Only interactive (live) owner "
+        "sessions can edit canonical sources directly; autonomous loops, "
+        "subagents, and dispatched agents must document the change in the PR "
+        "description and leave the file for the owner to edit. See "
+        "docs/security/agent-boundaries.md for the full matrix."
+    )
+
+
+def block(file_path: str, classification: str | None = None, principal: str | None = None):
+    """Output deny JSON and exit 2.
+
+    ``classification`` and ``principal`` are optional for backwards
+    compatibility with the pre-#426 signature; main() always supplies them.
+    """
+    if classification is None:
+        classification = classify(file_path) or "canonical"
+    if principal is None:
+        principal = "unknown"
+    reason = _block_reason(file_path, classification, principal)
     result = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
-            "permissionDecisionReason": (
-                f"BLOCKED: '{file_path}' is a protected file. "
-                "Document the needed change in the PR description instead."
-            ),
+            "permissionDecisionReason": reason,
         }
     }
     json.dump(result, sys.stdout)
@@ -138,10 +215,17 @@ def main():
     if not file_path:
         sys.exit(0)
 
-    if is_protected(file_path):
-        block(file_path)
+    classification = classify(file_path)
+    if classification is None:
+        sys.exit(0)
 
-    sys.exit(0)
+    principal = _principal.detect()
+
+    # live + canonical → let the harness handle the permission ask.
+    if principal == "live" and classification == "canonical":
+        sys.exit(0)
+
+    block(file_path, classification, principal)
 
 
 if __name__ == "__main__":

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -1,0 +1,138 @@
+"""Tests for scripts/principal.py — principal detection (#426)."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import principal  # noqa: E402
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Strip JARVIS_PRINCIPAL and headless markers before each test so the
+    detection chain starts from a clean slate.
+    """
+    monkeypatch.delenv("JARVIS_PRINCIPAL", raising=False)
+    for name in principal._HEADLESS_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+class _FakeStdin:
+    """Stand-in for sys.stdin with a configurable isatty()."""
+
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+@pytest.fixture
+def fake_tty(monkeypatch):
+    """Force isatty()=True so default falls through to ``live``."""
+    monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
+
+
+@pytest.fixture
+def fake_no_tty(monkeypatch):
+    """Force isatty()=False so default falls through to ``autonomous``."""
+    monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=False))
+
+
+# ── Explicit env var (primary signal) ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["live", "autonomous", "subagent", "supervised"],
+)
+def test_explicit_env_each_valid_value(monkeypatch, fake_no_tty, value):
+    """Explicit JARVIS_PRINCIPAL wins over fallback detection."""
+    monkeypatch.setenv("JARVIS_PRINCIPAL", value)
+    assert principal.detect() == value
+
+
+def test_explicit_env_uppercase_normalized(monkeypatch, fake_no_tty):
+    monkeypatch.setenv("JARVIS_PRINCIPAL", "LIVE")
+    assert principal.detect() == "live"
+
+
+def test_explicit_env_whitespace_stripped(monkeypatch, fake_no_tty):
+    monkeypatch.setenv("JARVIS_PRINCIPAL", "  autonomous  ")
+    assert principal.detect() == "autonomous"
+
+
+def test_explicit_env_invalid_falls_through_to_autonomous(monkeypatch, fake_no_tty):
+    """An invalid value is ignored; chain continues — no TTY → autonomous.
+
+    Default-safe property: a typo doesn't escalate to ``live``.
+    """
+    monkeypatch.setenv("JARVIS_PRINCIPAL", "garbage")
+    assert principal.detect() == "autonomous"
+
+
+def test_explicit_env_invalid_falls_through_to_live(monkeypatch, fake_tty):
+    """Same chain with TTY available: invalid env → TTY check → live."""
+    monkeypatch.setenv("JARVIS_PRINCIPAL", "root")
+    assert principal.detect() == "live"
+
+
+def test_explicit_env_empty_treated_as_unset(monkeypatch, fake_tty):
+    monkeypatch.setenv("JARVIS_PRINCIPAL", "")
+    assert principal.detect() == "live"
+
+
+# ── Headless env (suspenders) ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("var_name", principal._HEADLESS_ENV_VARS)
+def test_headless_env_forces_autonomous_even_with_tty(monkeypatch, fake_tty, var_name):
+    """Headless env wins over a misleading TTY signal."""
+    monkeypatch.setenv(var_name, "1")
+    assert principal.detect() == "autonomous"
+
+
+@pytest.mark.parametrize("falsy", ["0", "false", "no", "FALSE", " "])
+def test_headless_env_falsy_values_ignored(monkeypatch, fake_tty, falsy):
+    """A headless env set to a falsy value isn't a real signal."""
+    monkeypatch.setenv("CLAUDE_CODE_NON_INTERACTIVE", falsy)
+    assert principal.detect() == "live"
+
+
+def test_explicit_env_overrides_headless(monkeypatch, fake_tty):
+    """Explicit JARVIS_PRINCIPAL still wins over headless env."""
+    monkeypatch.setenv("CLAUDE_CODE_NON_INTERACTIVE", "1")
+    monkeypatch.setenv("JARVIS_PRINCIPAL", "subagent")
+    assert principal.detect() == "subagent"
+
+
+# ── isatty fallback ──────────────────────────────────────────────────
+
+
+def test_no_tty_falls_back_to_autonomous(fake_no_tty):
+    assert principal.detect() == "autonomous"
+
+
+def test_tty_falls_back_to_live(fake_tty):
+    assert principal.detect() == "live"
+
+
+# ── Default-safe property check ──────────────────────────────────────
+
+
+def test_default_safe_no_signals_with_no_tty(fake_no_tty):
+    """No env, no TTY — must be ``autonomous``, never ``live``.
+
+    This is THE safety property of detect(): if a future entry-point launches
+    Claude headless and forgets to set JARVIS_PRINCIPAL, the principal must
+    fall to a constrained mode, not the wide-permissions live mode.
+    """
+    # No env vars set (clean_env fixture), no TTY.
+    assert principal.detect() == "autonomous"

--- a/tests/test_protected_files.py
+++ b/tests/test_protected_files.py
@@ -1,4 +1,8 @@
-"""Tests for scripts/protected-files.py — protected file detection."""
+"""Tests for scripts/protected-files.py — protected file detection.
+
+#426 added principal-aware decisions (classify + should_block); legacy
+``is_protected`` kept for backwards compat and still tested below.
+"""
 
 import sys
 import os
@@ -13,6 +17,8 @@ protected_files = importlib.import_module("protected-files")
 
 is_protected = protected_files.is_protected
 normalize_path = protected_files.normalize_path
+classify = protected_files.classify
+should_block = protected_files.should_block
 
 
 @pytest.fixture
@@ -144,3 +150,101 @@ def test_allows_user_level_non_protected(fake_claude_home):
 def test_allows_user_level_skill_subresource(fake_claude_home):
     # Only SKILL.md itself is protected — co-located scripts or resources aren't.
     assert not is_protected(f"{fake_claude_home}/skills/implement/helper.py")
+
+
+# ── #426: classification (canonical vs mirror vs none) ──────────────
+
+
+def test_classify_repo_canonical():
+    """Repo-side protected files classify as ``canonical``."""
+    assert classify("config/SOUL.md") == "canonical"
+    assert classify("CLAUDE.md") == "canonical"
+    assert classify(".mcp.json") == "canonical"
+    assert classify("mcp-memory/server.py") == "canonical"
+    assert classify(".pre-commit-config.yaml") == "canonical"
+
+
+def test_classify_user_level_mirror(fake_claude_home):
+    """User-level ``~/.claude/*`` files classify as ``mirror``."""
+    assert classify(f"{fake_claude_home}/SOUL.md") == "mirror"
+    assert classify(f"{fake_claude_home}/settings.json") == "mirror"
+    assert classify(f"{fake_claude_home}/.mcp.json") == "mirror"
+    assert classify(f"{fake_claude_home}/skills/delegate/SKILL.md") == "mirror"
+
+
+def test_classify_unprotected_returns_none():
+    """Files not on either list classify as None."""
+    assert classify("scripts/secret-scanner.py") is None
+    assert classify("docs/PROJECT_PLAN.md") is None
+    assert classify("tests/test_secret_scanner.py") is None
+
+
+# ── #426: should_block(path, principal) — the matrix ────────────────
+
+
+@pytest.mark.parametrize(
+    "principal", ["live", "autonomous", "subagent", "supervised"]
+)
+def test_unprotected_never_blocks(principal):
+    """Files outside the protected list never block, regardless of principal."""
+    assert not should_block("scripts/secret-scanner.py", principal)
+    assert not should_block("docs/PROJECT_PLAN.md", principal)
+    assert not should_block("config/device.json", principal)
+
+
+def test_canonical_allows_live_principal():
+    """Live owner can edit canonical sources — harness asks one-off."""
+    assert not should_block("config/SOUL.md", "live")
+    assert not should_block("CLAUDE.md", "live")
+    assert not should_block(".mcp.json", "live")
+    assert not should_block("mcp-memory/server.py", "live")
+
+
+@pytest.mark.parametrize(
+    "principal", ["autonomous", "subagent", "supervised"]
+)
+def test_canonical_blocks_non_live_principals(principal):
+    """Anything but live blocks canonical sources."""
+    assert should_block("config/SOUL.md", principal)
+    assert should_block("CLAUDE.md", principal)
+    assert should_block(".mcp.json", principal)
+    assert should_block("mcp-memory/server.py", principal)
+
+
+@pytest.mark.parametrize(
+    "principal", ["live", "autonomous", "subagent", "supervised"]
+)
+def test_mirror_blocks_all_principals(principal, fake_claude_home):
+    """User-level mirrors block ALL principals — even live owner uses installer flow.
+
+    Source of truth lives in the repo; direct edits to ``~/.claude/*`` drift
+    on the next ``install.ps1 --apply``. Hook directs everyone to the
+    installer rather than letting the harness ask owner to drift the mirror.
+    """
+    paths = [
+        f"{fake_claude_home}/SOUL.md",
+        f"{fake_claude_home}/settings.json",
+        f"{fake_claude_home}/.mcp.json",
+        f"{fake_claude_home}/skills/delegate/SKILL.md",
+    ]
+    for path in paths:
+        assert should_block(path, principal), (
+            f"{path} should block {principal} (mirror — use installer flow)"
+        )
+
+
+def test_block_reason_mentions_installer_for_mirror(fake_claude_home):
+    """Mirror block message must point users at the installer flow."""
+    reason = protected_files._block_reason(
+        f"{fake_claude_home}/SOUL.md", "mirror", "live"
+    )
+    assert "install" in reason.lower()
+
+
+def test_block_reason_mentions_principal_for_canonical():
+    """Canonical block message must explain the principal-side constraint."""
+    reason = protected_files._block_reason(
+        "config/SOUL.md", "canonical", "autonomous"
+    )
+    assert "autonomous" in reason.lower()
+    assert "owner" in reason.lower() or "live" in reason.lower()


### PR DESCRIPTION
Closes #426

## Summary

Adds the **principal axis** to hook permissions. `scripts/protected-files.py` now classifies each blocked target as `T2_CANONICAL` (repo source) or `T2_MIRROR` (`~/.claude/*` install mirror) and applies a different policy per principal. Live owner can edit canonical sources directly (harness asks one-off); autonomous loops, subagents, and the future dispatcher stay constrained.

Surfaced from a real-world friction: merging #329 (`fcf3425`), the canonical install flow `install.ps1 -Apply` ran into the same hook that's supposed to protect against ad-hoc edits.

## Design (decided in chat 2026-04-26)

Detection — `scripts/principal.py` (belt + suspenders, default-safe):

1. Explicit env `JARVIS_PRINCIPAL` ∈ {live, autonomous, subagent, supervised}
2. Fallback: Claude Code headless env vars → `autonomous`
3. Fallback: `not sys.stdin.isatty()` → `autonomous`
4. Default → `live`

A future autonomous launcher that forgets to set the env still classifies as `autonomous`, never escalates to `live`. That is THE safety property.

Permission matrix lives as single source of truth in `docs/security/agent-boundaries.md`. Currently enforced: T2 only (this hook). T1 routing (autonomous-enqueue, supervised-grant) lands with the dispatcher.

## Files changed

- `scripts/principal.py` *(new)* — `detect()` + valid principal enum
- `scripts/protected-files.py` — split T2_CANONICAL / T2_MIRROR, principal-aware `should_block()`. Backwards-compat: `PROTECTED_FILES` alias + `is_protected()` kept.
- `scripts/install/install-scheduler-service.ps1` — NSSM `AppEnvironmentExtra=JARVIS_PRINCIPAL=autonomous` for the scheduler service.
- `.claude-userlevel/skills/delegate/SKILL.md` — documents subagent principal expectation. **[PROTECTED]** — but the source under `.claude-userlevel/` is editable; user-level mirror gets propagated by `install.ps1` next sync.
- `docs/security/agent-boundaries.md` — adds action × principal matrix.
- `tests/test_principal.py` *(new, 21 cases)* — env explicit/headless/tty/default chain, default-safe property check.
- `tests/test_protected_files.py` — extends 28 → 44 cases with classify + should_block matrix.

## Out of scope (future work)

- T1 enqueue/worker mechanism — lands with dispatcher (Pillar 7 Sprint 2).
- T0/T1 enforcement in other hooks — only T2 enforced now via this hook.
- `supervised` T1 routing differentiation from `autonomous` — collapses to same behavior under T2.
- Auto-injecting `JARVIS_PRINCIPAL=subagent` into Agent tool dispatch — Agent tool inherits parent env; parent is `live` for owner-driven dispatch and skill-level rules already constrain. Revisit if dispatcher hands work to subagents.

## Test plan

- [x] `pytest tests/test_principal.py tests/test_protected_files.py` — 65/65 pass
- [x] Full suite (excluding unrelated pre-existing `test_apply_plan_creates_files_and_version_marker` failure on main): 1014 pass / 7 skipped / 0 fail
- [x] Smoke-tested 3 scenarios manually:
  - `JARVIS_PRINCIPAL=live` + `config/SOUL.md` → exit 0 (allow harness)
  - `JARVIS_PRINCIPAL=autonomous` + `config/SOUL.md` → exit 2 with principal-aware message
  - `JARVIS_PRINCIPAL=live` + `~/.claude/SOUL.md` → exit 2 with installer-flow message
- [ ] After merge: re-run `install.ps1 -Apply` on each device to propagate updated `delegate/SKILL.md` mirror
- [ ] After merge: confirm scheduler service picks up new env on next reinstall (existing services need `install-scheduler-service.ps1` re-run)

## Risks

- Pre-existing flake on `test_apply_plan_creates_files_and_version_marker` — fails on `main` independent of this PR. Filing separately is one option.
- `live` + canonical ⇒ exit 0 means the harness's own permission UI will ask owner. If the harness silently approves canonical edits, this PR weakens the canonical-source guard. Mitigation: harness defaults to ask on Edit; owner approval is one-off, not durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)