### PR TITLE
fix(install): claude mcp add arg order — variadic flags after positionals

### DIFF
--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -254,6 +254,19 @@ def _register_mcp_user(name: str, spec: dict[str, Any]) -> None:
     Idempotent: a stale entry is removed (errors swallowed — it may not exist)
     before the add. Subprocess args are passed as a list so values containing
     spaces or shell metacharacters survive intact.
+
+    Argument order matters (#432). The Claude Code CLI declares variadic
+    options:
+        -e, --env <env...>
+        -H, --header <header...>
+    A variadic flag eats every following token until the next flag (or `--`),
+    including positional arguments. Putting `-H`/`-e` BEFORE the positional
+    `<name>` causes the parser to consume `<name>` as a header/env value and
+    fail with `error: missing required argument 'name'`.
+
+    Fix: place positionals first, then the variadic flags. For stdio, the
+    `--` separator marks the end of options, so `-e` between `<name>` and
+    `--` is safe.
     """
     subprocess.run(
         ["claude", "mcp", "remove", "-s", "user", name],
@@ -263,14 +276,19 @@ def _register_mcp_user(name: str, spec: dict[str, Any]) -> None:
     cmd: list[str] = ["claude", "mcp", "add", "-s", "user"]
     transport = spec.get("type")
     if transport in {"http", "sse"}:
-        cmd += ["--transport", transport]
+        # Order: --transport <t> <name> <url> -H ... -H ...
+        # Headers AFTER positionals so the -H variadic doesn't swallow them.
+        cmd += ["--transport", transport, name, spec["url"]]
         for hk, hv in (spec.get("headers") or {}).items():
             cmd += ["-H", f"{hk}: {hv}"]
-        cmd += [name, spec["url"]]
     else:
+        # Order: <name> -e ... -- <command> <args...>
+        # Env flags AFTER name so the -e variadic doesn't swallow it; the
+        # `--` separator then marks the boundary before the inner command.
+        cmd += [name]
         for ek, ev in (spec.get("env") or {}).items():
             cmd += ["-e", f"{ek}={ev}"]
-        cmd += [name, "--", spec["command"], *spec.get("args", [])]
+        cmd += ["--", spec["command"], *spec.get("args", [])]
     result = subprocess.run(cmd, check=False, capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -950,14 +950,44 @@ def test_register_mcp_user_stdio_command_shape(monkeypatch) -> None:
         {"command": "python", "args": ["/abs/run.py"], "env": {"K": "V"}},
     )
 
-    # First call: idempotent remove. Second: add with -e then `--` then command.
+    # First call: idempotent remove. Second: add — name BEFORE -e to avoid
+    # the variadic -e swallowing the positional (#432).
     assert captured[0][:5] == ["claude", "mcp", "remove", "-s", "user"]
     add = captured[1]
     assert add[:5] == ["claude", "mcp", "add", "-s", "user"]
+    # Layout: ... -s user <name> -e K=V -- <command> <args...>
+    name_idx = add.index("memory")
     assert "-e" in add and "K=V" in add
+    e_idx = add.index("-e")
+    assert name_idx < e_idx, "name must come BEFORE -e (variadic eats positional)"
     assert "--" in add
     dd = add.index("--")
+    assert e_idx < dd, "-e must come BEFORE -- separator"
     assert add[dd + 1 :] == ["python", "/abs/run.py"]
+
+
+def test_register_mcp_user_stdio_command_shape_no_env(monkeypatch) -> None:
+    """Stdio without env vars — name still goes before `--` boundary."""
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    installer._register_mcp_user("simple", {"command": "uvx", "args": ["foo-mcp"]})
+
+    add = captured[1]
+    dd = add.index("--")
+    # No -e flag should appear when env is absent.
+    assert "-e" not in add
+    # Layout: ... -s user simple -- uvx foo-mcp
+    assert add[dd - 1] == "simple"
+    assert add[dd + 1 :] == ["uvx", "foo-mcp"]
 
 
 def test_register_mcp_user_http_command_shape(monkeypatch) -> None:
@@ -984,7 +1014,35 @@ def test_register_mcp_user_http_command_shape(monkeypatch) -> None:
     add = captured[1]
     assert "--transport" in add and "http" in add
     assert "-H" in add and "Authorization: Bearer xxx" in add
-    assert add[-2:] == ["remote", "https://example.com/mcp"]
+    # Layout: ... --transport http <name> <url> -H "..." (#432)
+    # Headers AFTER positionals so variadic -H doesn't eat <name>.
+    name_idx = add.index("remote")
+    url_idx = add.index("https://example.com/mcp")
+    h_idx = add.index("-H")
+    assert name_idx < url_idx < h_idx, "positionals must come BEFORE -H (variadic)"
+
+
+def test_register_mcp_user_http_no_headers(monkeypatch) -> None:
+    """HTTP server without auth headers — clean positional layout."""
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    installer._register_mcp_user(
+        "open-mcp",
+        {"type": "http", "url": "https://example.com/mcp"},
+    )
+
+    add = captured[1]
+    assert "-H" not in add
+    assert add[-2:] == ["open-mcp", "https://example.com/mcp"]
 
 
 def test_register_mcp_user_raises_on_add_failure(monkeypatch) -> None:


### PR DESCRIPTION
Closes #432

## Summary

\`pwsh ./install.ps1 -Apply\` aborted on the github MCP registration with \`"claude mcp add failed for 'github': error: missing required argument 'name'"\` and rolled back. Blocks propagation of #428's behavior-calibration changes (and any future installer run).

## Root cause

Claude Code CLI declares variadic options:
- \`-e, --env <env...>\`
- \`-H, --header <header...>\`

A variadic flag consumes every following token until the next flag or \`--\` — including the positional \`<name>\` argument. Putting \`-H\` (or \`-e\`) BEFORE the positional means the parser eats \`name\` as a header value and exits.

## Repro

\`\`\`
$ claude mcp add -s user --transport http -H "Authorization: Bearer t" github URL
error: missing required argument 'name'

$ claude mcp add -s user --transport http github URL -H "Authorization: Bearer t"
Added HTTP MCP server github  ✓
\`\`\`

Same shape for stdio + \`-e\`.

## Fix

\`scripts/install/installer.py::_register_mcp_user\` — place positionals BEFORE variadic flags:
- HTTP: \`--transport <t> <name> <url> -H ... -H ...\`
- stdio: \`<name> -e ... -- <command> <args>\`

## Test changes

- Extended both shape tests with index-ordering assertions (regression guard)
- Two new tests for no-flag paths (stdio without env, http without headers)
- All 6 mcp_user tests green

Live smoke: invoked \`_register_mcp_user('github', {...})\` directly — registers without error (subsequent CLI \`mcp list\` shows it; connection then fails because fake bearer token, expected).

## After merge

Re-run \`pwsh ./install.ps1 -Apply\` to propagate #428's SOUL.md / settings.json / skills mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)