### PR TITLE
fix(mcp-memory): alias __main__ -> server to unbreak script launch (#436)

### DIFF
--- a/mcp-memory/server.py
+++ b/mcp-memory/server.py
@@ -28,6 +28,15 @@ Usage in .mcp.json:
 
 from __future__ import annotations
 
+import sys
+
+# Alias __main__ -> 'server' so that handler modules' `import server`
+# (used to reach shared utilities via this module for test monkeypatch
+# propagation) doesn't re-execute this file when launched as a script
+# (`python mcp-memory/server.py`) and recursively re-enter the handler
+# imports below. No-op when already imported as `server` (pytest path).
+sys.modules.setdefault("server", sys.modules[__name__])
+
 import asyncio
 from pathlib import Path
 

--- a/tests/test_memory_server_script_launch.py
+++ b/tests/test_memory_server_script_launch.py
@@ -1,0 +1,56 @@
+"""Smoke test: launch mcp-memory/server.py as a script (the way MCP clients do).
+
+The pytest path imports server.py as module `server`, which masks the
+circular-import class of bug — handlers do `import server` at module top to
+reach shared utilities, and that resolves trivially when `server` is already
+in sys.modules. When MCP launches the file as a script, Python sets
+`__name__='__main__'` and handlers' `import server` triggers a fresh re-execution
+that re-enters the partially-loaded handler chain → ImportError.
+
+This test reproduces the script launch and asserts: process survives import +
+no traceback on stderr.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SERVER = REPO_ROOT / "mcp-memory" / "server.py"
+
+
+def test_server_script_launch_does_not_crash_on_import():
+    proc = subprocess.Popen(
+        [sys.executable, str(SERVER)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(REPO_ROOT),
+    )
+    try:
+        time.sleep(3)
+        if proc.poll() is not None:
+            stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+            stdout = proc.stdout.read().decode("utf-8", errors="replace") if proc.stdout else ""
+            pytest.fail(
+                f"server.py exited during import (rc={proc.returncode})\n"
+                f"--- stderr ---\n{stderr}\n--- stdout ---\n{stdout}"
+            )
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+    assert "ImportError" not in stderr, f"ImportError on script launch:\n{stderr}"
+    assert "Traceback" not in stderr, f"Unexpected traceback on script launch:\n{stderr}"


### PR DESCRIPTION
## Summary
- `mcp-memory/server.py` crashes during import when launched as a script (the way `.mcp.json` runs it). All 6 handlers do `import server` at module top to reach shared utilities; that re-executes server.py recursively under `__name__='__main__'` and re-enters partially-loaded `handlers.goal` → ImportError on `GOAL_FIELDS`.
- Fix: alias `__main__` → `'server'` in `sys.modules` at the top of `server.py`. Handlers' `import server` becomes a no-op. Pytest path unchanged (`server` is already in `sys.modules` there).
- Add `tests/test_memory_server_script_launch.py` — subprocesses the server and asserts no `ImportError`/`Traceback` on stderr. The existing 269 unit tests all pass even WITH the bug because they import server as a module, not a script — this was the test gap that let the regression land.

## Why it was invisible

The pytest harness (`tests/conftest.py`) adds `mcp-memory/` to `sys.path` and tests do `from server import ...`. So `server` is in `sys.modules` before any handler is touched, and handlers' `import server` resolves trivially. Only the script-launch path ever exercises the `__main__` vs `server` distinction — and nothing in CI was actually launching the file that way.

## Test plan
- [x] `python mcp-memory/server.py` stays alive past 5s and produces no traceback on stderr (manual + new pytest smoke).
- [x] `claude mcp list` shows `memory: ... ✓ Connected`.
- [x] Existing 269 unit tests + 1 skipped still pass under `tests/test_memory_server.py` and the goal/memory handler suites.
- [ ] Verify on Linux/Mac after merge — cross-platform but only tested on Windows in this PR.

## Follow-up

Cross-impact: `mcp-memory/` is shared with redrobot per `CLAUDE.md`. Same fix lands there once they pull.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)