### PR TITLE
docs(skills): origin/master → origin/main + UUID guard in verify (#421)

### DIFF
--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -136,7 +136,7 @@ Report back: PR URL + 2-line summary of what you did.
 **Mitigations:**
 - Branch names are explicit, per-issue, and unique (`feat/<N>-<slug>`) — encode in the prompt
 - Cap parallelism: **2-3 agents concurrently** is the safe band; 5+ is a red flag
-- **Review the diff in the main repo tree as the authoritative check** — `cd <main repo> && git fetch && git diff origin/master...origin/feat/<N>-<slug>`. Treat the agent's worktree as a staging area, not a trusted sandbox.
+- **Review the diff in the main repo tree as the authoritative check** — `cd <main repo> && git fetch && git diff origin/main...origin/feat/<N>-<slug>`. Treat the agent's worktree as a staging area, not a trusted sandbox.
 - If you see contamination, abort and re-dispatch sequentially
 
 ### 5. Implement inline tasks (parallel with the subagents)
@@ -150,8 +150,8 @@ When a subagent reports done, review **in the main repo tree, not the agent's wo
 ```bash
 cd <main repo>
 git fetch origin
-git diff origin/master...origin/feat/<N>-<slug> --stat
-git diff origin/master...origin/feat/<N>-<slug>
+git diff origin/main...origin/feat/<N>-<slug> --stat
+git diff origin/main...origin/feat/<N>-<slug>
 ```
 
 Run the following checks in order — do NOT short-circuit:
@@ -214,4 +214,4 @@ See `docs/security/recovery-playbook.md`. Subagent-specific:
 - Subagent edited wrong files → revert in its worktree, re-prompt with stricter scope
 - Subagent broke its worktree → `git worktree remove --force <path>` + reclaim branch in fresh worktree
 - Two subagents raced on same file → abort both, re-dispatch sequentially
-- Subagent silently merged → revert merge on `master` immediately, open incident note, add to agent-boundaries.md
+- Subagent silently merged → revert merge on `main` immediately, open incident note, add to agent-boundaries.md

--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -269,7 +269,7 @@ If the diff looks wrong, fix it before pushing.
 ## Recovery playbook
 
 See `docs/security/recovery-playbook.md` for how to handle:
-- Broke a file → revert from master
+- Broke a file → revert from main
 - Corrupted memory → `memory_restore`
 - Created bad PR → close + delete branch
 - Committed to wrong branch → cherry-pick + reset

--- a/.claude-userlevel/skills/verify/SKILL.md
+++ b/.claude-userlevel/skills/verify/SKILL.md
@@ -66,6 +66,8 @@ outcome_update(
 
 **Enrich `memory_id` if the outcome row has it NULL**: look up the linked `decision_made` episode (same issue/PR) and pass `memory_id = payload.memories_used[0]`. Rule — primary informing memory = first entry (dominant basis). If the outcome already has `memory_id`, leave it alone; `/verify` is not where you rewrite attribution. If no decision episode references this issue, omit — the backfill script (`scripts/backfill-outcome-memories.py`) can handle historical rows in bulk.
 
+**Only backfill when `memories_used[0]` is a UUID** (matches `^[0-9a-f]{8}-`). Empirical audit per #325: of 33 historical `decision_made` episodes, 21 had empty `memories_used` and 12 stored memory NAMES, not UUIDs (zero matched the FK shape). Passing a name to `outcome_update.memory_id` writes a broken FK. If the first entry is a name, omit `memory_id` and leave the row for `scripts/backfill-outcome-memories.py`, which handles name→id resolution in bulk. If no decision episode references this issue, also omit.
+
 **Empty `memories_used` is valid** (per #334 expanded triggers: policy/schema/tag/config decisions may genuinely have no memory basis). If the matching decision episode exists but its `memories_used` list is empty, skip the enrichment — do NOT error, do NOT guess. Outcome stays `memory_id = NULL`; this is the correct representation for a decision that wasn't informed by prior memory.
 
 `verified_at` is set automatically when status changes from pending.


### PR DESCRIPTION
Closes #421

## Scope

Three mechanical fixes against \`.claude-userlevel/skills/\` (canonical post-federation source per #354):

| Skill | Change | Why |
|---|---|---|
| \`delegate/SKILL.md\` | 3× \`origin/master\` → \`origin/main\`; "revert merge on \`master\`" → "\`main\`" | Project default branch is \`main\`; \`master\` references would silently fail diffs |
| \`implement/SKILL.md\` | "revert from master" → "revert from main" | Same reason |
| \`verify/SKILL.md\` | Add UUID guard before backfilling \`memory_id\` | #325 root cause — historical \`decision_made\` episodes store memory NAMES (12/12 non-empty rows audited), not UUIDs. Passing a name writes a broken FK |

## Scope correction vs original PR #328

PR #328 (closed as superseded by federation tombstone #354) also claimed \`docs/security/recovery-playbook.md\` was a dead reference. **It is not** — the file exists (added by #163). Those reference-removals are dropped from this PR's scope; only the genuinely-stale \`origin/master\` and the genuinely-missing UUID guard land here.

## Test plan
- [x] \`grep -rn "origin/master" .claude-userlevel/skills/\` — clean
- [x] \`grep -rn "revert.*from\|merge on.*master" .claude-userlevel/skills/\` — clean
- [x] \`docs/security/recovery-playbook.md\` exists — references kept

After merge, next \`install.ps1\` propagates the fixes to \`~/.claude/skills/\` on each device.