### PR TITLE
hotfix: _upsert_known_unknown TypeError + morning_check brittle date

### DIFF
--- a/mcp-memory/handlers/memory.py
+++ b/mcp-memory/handlers/memory.py
@@ -367,24 +367,6 @@ async def _hybrid_recall(
         _enrich_with_confidence(client, merged)
         _apply_temporal_scoring(merged)
 
-        # Phase 5: gap detection — fire-and-forget so we don't add Supabase
-        # round-trips to the recall hot path on low-match queries.
-        top_sim = merged[0].get("similarity", 0.0) if merged else 0.0
-        top_mem_id = merged[0].get("id") if merged else None
-        if not show_history and top_sim < GAP_THRESHOLD:
-            asyncio.create_task(
-                asyncio.to_thread(
-                    _upsert_known_unknown,
-                    client,
-                    query_text,
-                    query_embedding,
-                    top_sim,
-                    top_mem_id,
-                    project,
-                    "recall",
-                )
-            )
-
         formatted = _format_memories(merged, brief=brief)
         search_type = "hybrid+temporal" if keyword_rows else "semantic+temporal"
         mode_tag = ", brief" if brief else ""
@@ -392,11 +374,16 @@ async def _hybrid_recall(
             "\n".join(formatted) if brief else "\n---\n".join(formatted)
         )
 
-        # Track known unknowns: if top similarity < 0.45, log as a potential gap
-        # (best-effort, non-blocking)
+        # Phase 5: gap detection — fire-and-forget so we don't add Supabase
+        # round-trips to the recall hot path on low-match queries. Single
+        # path; an earlier duplicate at GAP_THRESHOLD passed positional
+        # args that didn't match the kwarg-only signature and silently
+        # raised TypeError under asyncio.to_thread (audit 2026-04-26).
+        # FoK 5.3-γ removes this entirely once batch judge owns gap
+        # detection; until then it's the only path.
         if not show_history and merged:
             top_sim = merged[0].get("similarity", 0.0)
-            if top_sim < 0.45:
+            if top_sim < GAP_THRESHOLD:
                 top_mem_id = merged[0].get("id")
                 asyncio.create_task(
                     _upsert_known_unknown(
@@ -405,7 +392,7 @@ async def _hybrid_recall(
                         query_embedding,
                         top_sim,
                         top_mem_id,
-                        context={"project": project},
+                        context={"project": project, "source": "recall"},
                     )
                 )
 

--- a/tests/test_morning_check.py
+++ b/tests/test_morning_check.py
@@ -133,8 +133,18 @@ class _StubClient:
 
 
 def _now_utc() -> datetime:
-    """Fixed UTC now for testing."""
-    return datetime(2026, 4, 25, 14, 30, 0, tzinfo=UTC)
+    """UTC now for test seed timestamps.
+
+    Was previously a frozen 2026-04-25 14:30 UTC. That worked while the
+    repo's "today" was within 24h of that point, then silently broke
+    once two days had passed: morning_check filters audit_log by
+    `timestamp >= now() - 24h`, so seeds older than that disappeared
+    and the "healthy system" tests started seeing an empty result set
+    ("service may be down" path) → exit 1 instead of 0.
+
+    Use real now() so the seed always lands inside the lookback window.
+    """
+    return datetime.now(UTC)
 
 
 def _audit_row(**overrides: Any) -> dict[str, Any]:


### PR DESCRIPTION
Two bugs found by audit, fixing inline.

## 1. mcp-memory/handlers/memory.py — silent gap-recording failure

\`_hybrid_recall\` had two adjacent gap-detection blocks at the same effective threshold (top_sim < 0.45). The first called \`_upsert_known_unknown\` via \`asyncio.to_thread\` with positional \`project, "recall"\` args that **didn't match the function's kwarg-only \`context=\` signature** — every call silently raised \`TypeError\` inside the fire-and-forget task, never reaching the table. The second block used the correct kwarg pattern and was the only working path.

Net effect: looked like gap-recording at \`top_sim < GAP_THRESHOLD\` was firing twice per recall. Actually only fired once.

Fix: drop the broken block, keep the correct one, switch the surviving block's literal \`0.45\` to \`GAP_THRESHOLD\` constant for cohesion, fold the \`"source": "recall"\` tag into the \`context\` dict. FoK 5.3-γ will remove this entire inline path once the batch judge owns gap detection (per discussion #439 D5) — until then this is the single source of truth.

This is **mcp-memory/server.py shared with redrobot** — touched a protected file with owner-interactive principal-aware approval. Behavior preserved (same threshold, same dedup target, just minus the dead branch).

## 2. tests/test_morning_check.py — date drift

\`_now_utc()\` was hardcoded to \`2026-04-25 14:30 UTC\`. \`morning_check\` filters audit_log by \`timestamp >= now()-24h\`. Once two days passed, seeded rows fell outside the window and the "healthy system" branch tests started seeing empty result sets → "service may be down" path → exit 1 instead of 0. **3 tests silently failing on every run since 2026-04-26.**

Fix: \`_now_utc()\` returns real \`datetime.now(UTC)\` so seeds always land inside the lookback window regardless of when the test runs.

## Test plan
- [x] \`pytest tests/test_morning_check.py\` — 10/10 pass (was 7/10)
- [x] \`pytest tests/\` — full green
- [x] handlers/memory.py change preserves single-path behavior at GAP_THRESHOLD

## Hotfix scope
Per #424: \`priority:critical\` label, no issue. Both reversible, narrowly scoped, found by audit during one cleanup session.