### PR TITLE
docs(readme): refresh pillar table to match 17-cap architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ All devices connect to the same Supabase instance. No manual sync.
 
 ## Capabilities
 
-17 capabilities organized into 5 layers + cross-cutting concerns. Pillars are stable groupings; live migration progress lives in GitHub milestones, not in this file (status text gets stale).
+17 capabilities grouped into 6 pillars. (Internally the design doc also stratifies them into 4 layers + cross-cutting — Identity / Cognition / Action / Interface / Cross-cutting — but pillars are the stable user-facing grouping.) Live migration progress lives in GitHub milestones, not in this file (status text gets stale).
 
 | Pillar | Capabilities |
 |--------|--------------|

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Personal AI agent built on [Claude Code](https://claude.ai/code) + [MCP](https:/
 
 Not a tool, not an assistant -- an extension of thinking capacity, memory, and executive function. A solo developer lacks not hands but **breadth**. Jarvis compensates: tracking, researching, monitoring, remembering, prioritizing.
 
-> **Status:** v0.2.0 -- core memory + skills working. [Roadmap below](#roadmap).
+> **Status:** v0.2.0 -- core memory + skills working. [Capability map below](#capabilities).
 
 ## Quick Start
 
@@ -102,7 +102,7 @@ Memory types: `user`, `project`, `decision`, `feedback`, `reference`
 
 All devices connect to the same Supabase instance. No manual sync.
 
-## Architecture
+## Capabilities
 
 17 capabilities organized into 5 layers + cross-cutting concerns. Pillars are stable groupings; live migration progress lives in GitHub milestones, not in this file (status text gets stale).
 
@@ -110,8 +110,8 @@ All devices connect to the same Supabase instance. No manual sync.
 |--------|--------------|
 | Memory | C3 Memory store, C5 Reflection / learning, C17 Observability |
 | Identity & Strategy | C1 Identity & values, C2 Goals & priorities |
-| Cognition | C4 Reasoning & planning, C6 Decision gating, C10 Research |
-| Action | C7 Execution, C8 Sub-orchestration, C9 Tool / environment interface |
+| Cognition | C4 Reasoning & planning, C6 Decision gating |
+| Action | C7 Execution, C8 Sub-orchestration, C9 Tool / environment interface, C10 Research |
 | Interface | C11 Perception, C12 Communication with owner |
 | Stewardship | C13 Budget, C14 Security & privacy, C15 Self-improvement, C16 Verification |
 

--- a/README.md
+++ b/README.md
@@ -102,30 +102,20 @@ Memory types: `user`, `project`, `decision`, `feedback`, `reference`
 
 All devices connect to the same Supabase instance. No manual sync.
 
-## Roadmap
+## Architecture
 
-9 pillars, two layers. Core = how Jarvis thinks. Reach = how Jarvis interacts with the world.
+17 capabilities organized into 5 layers + cross-cutting concerns. Pillars are stable groupings; live migration progress lives in GitHub milestones, not in this file (status text gets stale).
 
-### Core
+| Pillar | Capabilities |
+|--------|--------------|
+| Memory | C3 Memory store, C5 Reflection / learning, C17 Observability |
+| Identity & Strategy | C1 Identity & values, C2 Goals & priorities |
+| Cognition | C4 Reasoning & planning, C6 Decision gating, C10 Research |
+| Action | C7 Execution, C8 Sub-orchestration, C9 Tool / environment interface |
+| Interface | C11 Perception, C12 Communication with owner |
+| Stewardship | C13 Budget, C14 Security & privacy, C15 Self-improvement, C16 Verification |
 
-| Pillar | Status | Description |
-|--------|--------|-------------|
-| 1. Goals & Strategic Context | Done | Goal-aware decisions, push-back, priority tracking |
-| 2. Autonomous Work Loop | ~90% | Event perception, judgment, continuous operation |
-| 3. Outcome Tracking & Learning | ~40% | Verify results, learn from patterns |
-| 4. Memory 2.0 | ~85% | Graph relations, temporal awareness, auto-hygiene |
-
-### Reach
-
-| Pillar | Status | Description |
-|--------|--------|-------------|
-| 5. Integrations / Data Access | Early | Read access to owner's accounts and services |
-| 6. Data Intelligence | Not started | Cross-platform search, pattern detection |
-| 7. Agent System | Prototype | Scalable multi-agent architecture |
-| 8. Identity & Interface | Partial | TTS/STT, Telegram, professional document drafting |
-| 9. Security & Digital Hygiene | Not started | Password audit, breach monitoring, proactive protection |
-
-Architecture detail (17 capabilities, 5 layers, migration order) — [docs/design/jarvis-v2-redesign.md](docs/design/jarvis-v2-redesign.md). Vision — [docs/VISION.md](docs/VISION.md). Active sprint scope — [GitHub milestones](https://github.com/Osasuwu/jarvis/milestones).
+Full capability detail, migration order, and bootstrap protocol: [docs/design/jarvis-v2-redesign.md](docs/design/jarvis-v2-redesign.md). Vision: [docs/VISION.md](docs/VISION.md). Active sprint scope: [GitHub milestones](https://github.com/Osasuwu/jarvis/milestones).
 
 ## Project Structure
 

--- a/docs/design/jarvis-v2-redesign.md
+++ b/docs/design/jarvis-v2-redesign.md
@@ -1770,8 +1770,8 @@ Pillars are long-lived capability groups (per `pillar_is_not_one_task` — they 
 |---|---|
 | Memory | C3 (Memory store), C5 (Reflection / learning), C17 (Observability — feeds episodic) |
 | Identity & Strategy | C1 (Identity & values), C2 (Goals & priorities) |
-| Cognition | C4 (Reasoning & planning), C6 (Decision gating), C10 (Research) |
-| Action | C7 (Execution), C8 (Sub-orchestration), C9 (Tool / env interface) |
+| Cognition | C4 (Reasoning & planning), C6 (Decision gating) |
+| Action | C7 (Execution), C8 (Sub-orchestration), C9 (Tool / env interface), C10 (Research) |
 | Interface | C11 (Perception), C12 (Communication with owner) |
 | Stewardship | C13 (Budget), C14 (Security & privacy), C15 (Self-improvement), C16 (Verification) |
 


### PR DESCRIPTION
Closes #455

## Summary

- Replace the 9-pillar status table (with stale percentages) with a 6-pillar capabilities table linking to the redesign doc.
- Rename section to `## Capabilities` to avoid clashing with the existing `## Architecture` heading; update the in-page anchor from `#roadmap` to `#capabilities`.
- Move C10 (Research) from Cognition to Action in **both** README and `docs/design/jarvis-v2-redesign.md` pillar map, so the pillar map matches L1's "Action layer — what Jarvis does: C7, C8, C9, C10" assignment. Inconsistency was flagged by the code-review plugin's architecture-consistency reviewer.
- Wording fix: intro now says "6 pillars" (matching the table) and explains the layer/pillar split, instead of saying "5 layers" while rendering 6 rows.
- State (live migration progress, sprint scope) moves to GitHub milestones — per `no_state_in_static_storage`.

## Test plan

- [x] code-review.yml workflow runs on this PR (real human PR — not skipped by step-1 eligibility check).
- [x] All 8 reviewers fan out and produce a posted comment.
- [x] Iteratively responded to plugin's findings (anchor / heading / C10 / intro count).
- [ ] Branch-naming nit (`chore/<issue-number>-<short-desc>` per copilot-instructions) — acknowledged but not fixed; branch already pushed and `Closes #455` linkage works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)