### PR TITLE
docs(readme): correct skill counts + owner→user framing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ Use skills — don't reinvent with raw tools.
 | "исследуй", "research", "сравни" | `/research` |
 | "улучши себя", self-improvement | `/self-improve` |
 | "цели", "приоритеты" | `/goals` |
+| New device bootstrap, "scheduled tasks setup" | `/setup-tasks` |
+| Daily scheduled tick, "запусти автономный цикл" | `/autonomous-loop` |
 | End of sprint in redrobot | `/sprint-report` |
 | "end" / "end quick" | `/end` / `/end-quick` |
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ User-level Jarvis is seeded from `.claude-userlevel/` in this repo by
 | `/status` | Session start, "what's happening" | Project dashboard: git, PRs, issues, CI, risks, goals |
 | `/implement` | "реализуй #42", "implement #X" | Issue → branch → inline implementation → PR (main session does the work) |
 | `/delegate` | "делегируй #X #Y", "раскидай на агентов" | Multiple issues → parallel coding subagents, orchestrator reviews each diff + decides merge |
-| `/verify` | "проверь результаты", post-delegation | Closes outcome loop: PR merge status, test results, lessons extracted |
+| `/verify` | "проверь результаты", "post-delegation" | Closes outcome loop: PR merge status, test results, lessons extracted |
 | `/reflect` | "что сработало", "уроки" | Reviews recent decisions + outcomes, extracts lessons as feedback memories |
 | `/research` | "research X", "compare A vs B" | Web research with source validation |
 | `/self-improve` | "improve yourself" | Gap analysis -> ideation -> research -> implementation |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ User-level Jarvis is seeded from `.claude-userlevel/` in this repo by
 | Component | Description |
 |-----------|-------------|
 | **Cross-device memory** | MCP server syncs memories, goals, events via Supabase. Vector search (Voyage AI) + keyword fallback |
-| **8 skills** | `/status`, `/implement`, `/delegate`, `/research`, `/self-improve`, `/goals`, `/end`, `/end-quick` |
+| **12 skills** | `/status`, `/implement`, `/delegate`, `/verify`, `/reflect`, `/research`, `/self-improve`, `/goals`, `/setup-tasks`, `/autonomous-loop`, `/end`, `/end-quick` |
 | **SOUL.md personality** | Auto-loaded every session via hook. Opinionated, direct, bilingual (RU/EN) |
 | **Goal-aware decisions** | Jarvis knows priorities and pushes back when a task conflicts with active goals |
 | **Delegation pipeline** | Issue -> branch -> coding agent -> PR, with verification |
@@ -79,9 +79,13 @@ User-level Jarvis is seeded from `.claude-userlevel/` in this repo by
 | `/status` | Session start, "what's happening" | Project dashboard: git, PRs, issues, CI, risks, goals |
 | `/implement` | "реализуй #42", "implement #X" | Issue → branch → inline implementation → PR (main session does the work) |
 | `/delegate` | "делегируй #X #Y", "раскидай на агентов" | Multiple issues → parallel coding subagents, orchestrator reviews each diff + decides merge |
+| `/verify` | "проверь результаты", post-delegation | Closes outcome loop: PR merge status, test results, lessons extracted |
+| `/reflect` | "что сработало", "уроки" | Reviews recent decisions + outcomes, extracts lessons as feedback memories |
 | `/research` | "research X", "compare A vs B" | Web research with source validation |
 | `/self-improve` | "improve yourself" | Gap analysis -> ideation -> research -> implementation |
 | `/goals` | "goals", "priorities" | View, set, update strategic goals in Supabase |
+| `/setup-tasks` | New device bootstrap | Registers all scheduled tasks (idempotent) |
+| `/autonomous-loop` | Daily scheduled tick or manual | Perceives events, evaluates against goals, acts within safety bounds |
 | `/end` | End of session | Behavioral reflection, decision log, memory save, commit |
 | `/end-quick` | Quick exit | Checkpoint + commit only |
 
@@ -112,7 +116,7 @@ All devices connect to the same Supabase instance. No manual sync.
 | Identity & Strategy | C1 Identity & values, C2 Goals & priorities |
 | Cognition | C4 Reasoning & planning, C6 Decision gating |
 | Action | C7 Execution, C8 Sub-orchestration, C9 Tool / environment interface, C10 Research |
-| Interface | C11 Perception, C12 Communication with owner |
+| Interface | C11 Perception, C12 Communication with user |
 | Stewardship | C13 Budget, C14 Security & privacy, C15 Self-improvement, C16 Verification |
 
 Full capability detail, migration order, and bootstrap protocol: [docs/design/jarvis-v2-redesign.md](docs/design/jarvis-v2-redesign.md). Vision: [docs/VISION.md](docs/VISION.md). Active sprint scope: [GitHub milestones](https://github.com/Osasuwu/jarvis/milestones).
@@ -127,7 +131,7 @@ jarvis/
     SOUL.md              <- personality definition
     repos.conf           <- repos to scan
   .claude/
-    skills/              <- 7 custom slash commands
+    skills/              <- project-scoped slash commands (sprint-report)
     agents/              <- subagent definitions (coding)
     settings.json        <- project hooks
   mcp-memory/


### PR DESCRIPTION
Closes #458

## Summary

README staleness pass after C16 milestone. Three drift areas closed:

- **Skill count drift**: README claimed "8 skills"; actual `ls .claude-userlevel/skills/` shows **12** (added since: `/verify`, `/reflect`, `/setup-tasks`, `/autonomous-loop`). Both the inline component table row and the dedicated `## Skills` table updated.
- **Project-level skill count drift**: project structure tree said `.claude/skills/ <- 7 custom slash commands`; actual is **1** (`sprint-report` only). Replaced the count with the actual contents.
- **Terminology**: C12 "Communication with owner" → "Communication with user" per [user_not_owner_framing_2026_04_28](memory:user_not_owner_framing_2026_04_28) decision (today). Only one occurrence in README.

## Iteration 2 (after /code-review feedback)

- **CLAUDE.md routing table**: added missing rows for `/setup-tasks` and `/autonomous-loop`. Routing table was at 10 rows for 12 actual skills — behavioral gap, Jarvis wouldn't route bootstrap or autonomous-tick correctly.
- **README `/verify` row**: quoted `"post-delegation"` for consistency with all other multi-phrase trigger cells.

## Follow-ups (filed)

- **#459** — `pr-body-check.yml` has no `[no-issue]` escape, blocking fix-inline drive-bys. Plugin flagged this as a 🔴 systemic gap on this PR. Already worked around here via tracker issue #458; #459 proposes the proper fix.

## Deferred (not filed — owner decision)

- **owner→user terminology pass** for SOUL.md, CLAUDE.md, VISION.md per [user_not_owner_framing_2026_04_28](memory:user_not_owner_framing_2026_04_28). Larger refactor; needs owner alignment on scope. Plugin correctly flagged the lack of a tracker — leaving the decision to the owner rather than auto-filing.

## Test plan

- [x] `git diff README.md CLAUDE.md` reviewed
- [x] Skill counts cross-checked: `ls .claude-userlevel/skills/` → 12 dirs, `ls .claude/skills/` → 1 dir
- [x] commit-msg hook accepted `[no-issue]` tag on both commits
- [x] `/code-review` ran on PR open (organic plugin validation) — verdict: Approve with one blocking fix (the no-issue gap, now tracked separately as #459)

🤖 Generated with [Claude Code](https://claude.com/claude-code)