### PR TITLE
feat(setup): batch install 5 Anthropic plugins via setup-device.py

### DIFF
--- a/.claude/marketplace/.claude-plugin/marketplace.json
+++ b/.claude/marketplace/.claude-plugin/marketplace.json
@@ -19,6 +19,86 @@
         "ref": "main"
       },
       "homepage": "https://github.com/Osasuwu/claude-plugins-official/tree/main/plugins/code-review"
+    },
+    {
+      "name": "pr-review-toolkit",
+      "description": "Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification.",
+      "author": {
+        "name": "Anthropic",
+        "email": "support@anthropic.com"
+      },
+      "category": "productivity",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/anthropics/claude-plugins-official.git",
+        "path": "plugins/pr-review-toolkit",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/anthropics/claude-plugins-public/tree/main/plugins/pr-review-toolkit"
+    },
+    {
+      "name": "session-report",
+      "description": "Generate an explorable HTML report of Claude Code session usage — tokens, cache efficiency, subagents, skills, and the most expensive prompts — from local ~/.claude/projects transcripts.",
+      "author": {
+        "name": "Anthropic",
+        "email": "support@anthropic.com"
+      },
+      "category": "productivity",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/anthropics/claude-plugins-official.git",
+        "path": "plugins/session-report",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report"
+    },
+    {
+      "name": "hookify",
+      "description": "Easily create custom hooks to prevent unwanted behaviors by analyzing conversation patterns or from explicit instructions. Define rules via simple markdown files.",
+      "author": {
+        "name": "Anthropic",
+        "email": "support@anthropic.com"
+      },
+      "category": "productivity",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/anthropics/claude-plugins-official.git",
+        "path": "plugins/hookify",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/anthropics/claude-plugins-public/tree/main/plugins/hookify"
+    },
+    {
+      "name": "claude-md-management",
+      "description": "Tools to maintain and improve CLAUDE.md files — audit quality, capture session learnings, and keep project memory current.",
+      "author": {
+        "name": "Anthropic",
+        "email": "support@anthropic.com"
+      },
+      "category": "productivity",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/anthropics/claude-plugins-official.git",
+        "path": "plugins/claude-md-management",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management"
+    },
+    {
+      "name": "mcp-server-dev",
+      "description": "Skills for designing and building MCP servers that work seamlessly with Claude. Guides you through deployment models (remote HTTP, MCPB, local), tool design patterns, auth, and interactive MCP apps.",
+      "author": {
+        "name": "Anthropic",
+        "email": "support@anthropic.com"
+      },
+      "category": "development",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/anthropics/claude-plugins-official.git",
+        "path": "plugins/mcp-server-dev",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/anthropics/claude-plugins-official/tree/main/plugins/mcp-server-dev"
     }
   ]
 }

--- a/scripts/setup-device.py
+++ b/scripts/setup-device.py
@@ -413,12 +413,46 @@ def setup_sibling_repos():
             warn(f"  could not add upstream remote: {upstream_result.stderr.strip()[:120]}")
 
 
+# NB: marketplace name is `jarvis-fork-plugins` for historical reasons —
+# only `code-review` is actually a fork (Osasuwu/claude-plugins-official).
+# The other 5 are upstream Anthropic plugins consumed via git-subdir directly.
+# Kept the name to avoid forcing an opt-in re-add on existing devices.
 CLAUDE_PLUGINS = [
     {
         "plugin": "code-review",
         "marketplace": "jarvis-fork-plugins",
         "marketplace_path": ".claude/marketplace",
         "purpose": "C16 PR code-review (forked + adapted)",
+    },
+    {
+        "plugin": "pr-review-toolkit",
+        "marketplace": "jarvis-fork-plugins",
+        "marketplace_path": ".claude/marketplace",
+        "purpose": "Specialized PR review agents (comments / tests / errors / types / quality / simplification)",
+    },
+    {
+        "plugin": "session-report",
+        "marketplace": "jarvis-fork-plugins",
+        "marketplace_path": ".claude/marketplace",
+        "purpose": "HTML report of session usage — tokens / cache / subagents / skills / costly prompts",
+    },
+    {
+        "plugin": "hookify",
+        "marketplace": "jarvis-fork-plugins",
+        "marketplace_path": ".claude/marketplace",
+        "purpose": "Author custom hooks via markdown rules (conversation pattern detection)",
+    },
+    {
+        "plugin": "claude-md-management",
+        "marketplace": "jarvis-fork-plugins",
+        "marketplace_path": ".claude/marketplace",
+        "purpose": "Audit + improve CLAUDE.md files; capture session learnings",
+    },
+    {
+        "plugin": "mcp-server-dev",
+        "marketplace": "jarvis-fork-plugins",
+        "marketplace_path": ".claude/marketplace",
+        "purpose": "Skills for designing/building MCP servers (deployment, tool patterns, auth, interactive apps)",
     },
 ]
 
@@ -431,36 +465,59 @@ def install_claude_plugins():
         warn("claude CLI not found -- skipping plugin install")
         return
 
+    # Group entries by (marketplace_name, marketplace_path) so we register +
+    # refresh each marketplace once, regardless of how many plugins it serves.
+    marketplaces = {}  # name -> (path, [entries])
     for entry in CLAUDE_PLUGINS:
+        mp_name = entry["marketplace"]
         mp_path = ROOT / entry["marketplace_path"]
+        marketplaces.setdefault(mp_name, (mp_path, []))[1].append(entry)
+
+    for mp_name, (mp_path, entries) in marketplaces.items():
         if not mp_path.exists():
-            warn(f"marketplace path missing: {entry['marketplace_path']}")
+            warn(f"marketplace path missing: {mp_path}")
             continue
 
-        # marketplace add (idempotent — claude reports "already on disk")
+        # add: idempotent — first run registers, subsequent runs are no-op
+        # ("already on disk"). Absolute path required so claude doesn't
+        # mis-treat it as a Git source.
         add_result = subprocess.run(
-            ["claude", "plugins", "marketplace", "add", str(mp_path)],
+            ["claude", "plugins", "marketplace", "add", str(mp_path.resolve())],
             capture_output=True, text=True,
         )
         if add_result.returncode != 0:
-            warn(f"marketplace add failed for {entry['marketplace']}: "
+            warn(f"marketplace add failed for {mp_name}: "
                  f"{add_result.stderr.strip()[:200]}")
             continue
 
-        # plugin install (idempotent — re-install is a no-op success)
-        install_result = subprocess.run(
-            [
-                "claude", "plugins", "install",
-                f"{entry['plugin']}@{entry['marketplace']}",
-                "--scope", "user",
-            ],
+        # update: re-reads marketplace.json from disk so newly-added plugin
+        # entries become visible to install. Without this step, plugins added
+        # to an already-registered marketplace would be invisible until the
+        # user manually ran `claude plugins marketplace update`.
+        update_result = subprocess.run(
+            ["claude", "plugins", "marketplace", "update", mp_name],
             capture_output=True, text=True,
         )
-        if install_result.returncode == 0:
-            ok(f"{entry['plugin']}@{entry['marketplace']} -- {entry['purpose']}")
-        else:
-            err = (install_result.stderr or install_result.stdout or "").strip()
-            warn(f"install failed for {entry['plugin']}: {err[:200]}")
+        if update_result.returncode != 0:
+            warn(f"marketplace update failed for {mp_name}: "
+                 f"{update_result.stderr.strip()[:200]}")
+            # don't `continue` — install may still work if marketplace
+            # already had the entry from a prior run
+
+        for entry in entries:
+            install_result = subprocess.run(
+                [
+                    "claude", "plugins", "install",
+                    f"{entry['plugin']}@{mp_name}",
+                    "--scope", "user",
+                ],
+                capture_output=True, text=True,
+            )
+            if install_result.returncode == 0:
+                ok(f"{entry['plugin']}@{mp_name} -- {entry['purpose']}")
+            else:
+                err = (install_result.stderr or install_result.stdout or "").strip()
+                warn(f"install failed for {entry['plugin']}: {err[:200]}")
 
 
 def verify_skills():


### PR DESCRIPTION
Closes #462

## Summary

Extends `CLAUDE_PLUGINS` with 5 official Anthropic plugins consumed direct from upstream (no forks needed). Per build-vs-buy §190 in [jarvis-v2-redesign-review-pass2.md](docs/design/jarvis-v2-redesign-review-pass2.md).

| Plugin | Purpose |
|---|---|
| `pr-review-toolkit` | Specialized PR review agents (comments / tests / errors / types / quality / simplification) |
| `session-report` | HTML report of session usage — tokens / cache / subagents / skills / costly prompts |
| `hookify` | Author custom hooks via markdown rules |
| `claude-md-management` | Audit + improve CLAUDE.md files; capture session learnings |
| `mcp-server-dev` | Skills for designing/building MCP servers |

## Drive-by fix in `install_claude_plugins()`

While extending the plugin list I noticed a latent bug: `claude plugins marketplace add` is a no-op for already-registered marketplaces (reports «already on disk») and does **not** reload `marketplace.json`. Net effect: any new plugin entry added to an existing marketplace would be invisible to the install step on a re-run.

Fix:
1. Insert `claude plugins marketplace update <name>` between `add` and `install` — re-reads JSON from disk.
2. Dedupe the per-entry marketplace setup (was running `add` 6 times for 6 entries that share one marketplace).

Also switched `add` to use absolute path (`mp_path.resolve()`) — without it, claude tried to clone `.claude/marketplace` as a Git source.

## Marketplace name

Kept as `jarvis-fork-plugins` for migration friction (renaming would force every device to manually re-add). Misnomer noted in a code comment — only `code-review` is actually a fork. Acceptable tradeoff.

## End-to-end verification (this device)

```
$ python -c "import importlib.util; spec = importlib.util.spec_from_file_location('s','scripts/setup-device.py'); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m); m.install_claude_plugins()"
[7] Claude Code plugins
  [OK] code-review@jarvis-fork-plugins -- C16 PR code-review (forked + adapted)
  [OK] pr-review-toolkit@jarvis-fork-plugins -- ...
  [OK] session-report@jarvis-fork-plugins -- ...
  [OK] hookify@jarvis-fork-plugins -- ...
  [OK] claude-md-management@jarvis-fork-plugins -- ...
  [OK] mcp-server-dev@jarvis-fork-plugins -- ...
```

`claude plugins list` now shows all 6 enabled at user scope.

Idempotent — re-run yields the same `[OK]` lines, no errors.

## Cross-device

Other 2 devices pick up the new plugins on next `python scripts/setup-device.py` run. Same idempotency guarantees apply.

## Test plan

- [x] Local end-to-end on Main PC (Windows 11)
- [x] Idempotent re-run verified
- [x] All 6 plugins enumerated by `claude plugins list`
- [ ] code-review plugin runs on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)