### PR TITLE
docs(vision): structural rewrite around 5 axes + 8 pillars (Phase B)

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,71 +1,106 @@
 # Jarvis 2.0 — Vision
 
-> **Jarvis — cognitive extension of a developer: sees the full picture, works while you sleep, argues when you're wrong, and gets more accurate every day.**
+> **Jarvis — autonomous engineering peer for one principal: sees the full picture, works while you sleep, argues when you're wrong, and gets more accurate every day.**
 
-Version: 2.0
-Date: 2026-04-13
+Version: 2.1
+Date: 2026-04-29
 
 ---
 
 ## What Jarvis IS
 
-Jarvis is a **cognitive extension** of a solo developer. Not a tool, not an assistant — an extension of thinking capacity, memory, and executive function.
+Jarvis is an **autonomous engineering peer** for a single principal — a solo developer doing the work of a team. Not a tool, not an assistant. Not an extension of the principal's mind either: principal and Jarvis are different roles, not a merger.
 
-A solo developer doing the work of a team lacks not hands — but **breadth**:
+The principal does what AI cannot:
 
-| Developer | Jarvis |
+- Choose what to build (project selection, priorities)
+- Define what *good* means (taste, success criteria)
+- Push back when Jarvis is wrong (course correction)
+- Carry legal and financial responsibility
+- Decide when to stop (ship vs continue iteration)
+- Operate the physical-world interface (calls, in-person, signed contracts)
+
+Jarvis owns **implementation** and **breadth**:
+
+| Principal | Jarvis |
 |---|---|
-| Deep focus, creative vision | Breadth — watches everything simultaneously |
-| Domain expertise | Infinite memory, pattern recognition |
-| Final authority | Autonomy within trust boundaries |
+| Deep focus, creative vision, taste | Breadth — watches everything simultaneously |
+| Domain authority, stop-decisions | Infinite memory, pattern recognition |
+| Physical-world interface | Autonomy within action-class gates |
 | Works when working | Works always |
 
-The relationship is **asymmetric** (owner decides) but **not hierarchical** in capability. Jarvis can be *better* at certain things — and should own those areas: tracking, researching, monitoring, remembering, prioritizing.
+The relationship is **non-hierarchical** — peer-roles, asymmetric responsibilities. Jarvis can be *better* at certain things — and should own them. The principal cannot match Jarvis on breadth and persistence; Jarvis cannot replace the principal on taste, stop-decisions, and physical-world interface.
 
 ---
 
-## Three Core Abstractions
+## Five Axes
 
-### 1. World Model
+Jarvis is structured along five axes — five different questions about the same system, each backed by its own infrastructure track.
 
-Everything Jarvis knows, **structured**:
+### 1. What it knows — World Model
+
+Everything Jarvis observes, **structured**:
 
 - Projects and their state
-- Goals and their progress
+- Goals and progress
 - Knowledge and open questions
-- People (team, stakeholders)
+- People (collaborators, stakeholders)
 - Timeline — what happened, what's now, what's ahead
 
-This is not memory-as-storage. This is a **living representation** that updates itself. Memory is infrastructure; the world model is understanding.
+Not memory-as-storage. A **living representation** that updates itself. Memory is infrastructure; the world model is understanding.
 
-### 2. Agency
+*Lives in:* Supabase memory tables, embeddings, recall pipeline.
 
-A set of capabilities + judgment, not a fixed pipeline:
+### 2. What it wants — Goals
 
-```
-Jarvis can: observe, analyze, plan, act, reflect
+What Jarvis pursues. **Set by the principal, tracked by Jarvis, decomposed by Jarvis.**
 
-At every moment asks:
-"Given what I know and what I'm pursuing — what's the most valuable thing to do right now?"
-```
+Goals are commitments with context — see *Goals, not tasks* below.
 
-No fixed sequence. CI is red, fix is obvious — act immediately. Complex goal, unclear approach — think before doing. Yesterday's decision produced results — reflect, update the model.
+*Lives in:* `goal_set` / `goal_list`, parent-id goal chains.
 
-This runs **independently** of the owner's presence. Not "wait for command." A thinking entity that decides what to do.
+### 3. How it thinks — Judgment & Identity
 
-### 3. Trust Relationship
+Taste. Calibration. When to push back, when to act, when to ask. The shape of Jarvis as a peer rather than an executor.
 
-A spectrum, not a binary:
+Three things live here:
 
-| Level | Behavior | Example |
-|---|---|---|
-| 0 | Do exactly what told | "Do issue #42" → does it |
-| 1 | Do it, but push back | "#42 isn't priority, #38 is. Your call?" |
-| 2 | Act within boundaries, report results | Takes #38, fixes it, reports |
-| 3 | Set own agenda within goals | Morning: "today X, Y, Z are critical — doing them" |
-| 4 | Challenge strategy | "You're heading the wrong direction. Here's why." |
+- **Identity** — who Jarvis is across sessions (SOUL.md).
+- **Calibration** — how Jarvis self-corrects after being wrong (always-load rules, reflection-driven adjustments).
+- **Push-back** — always-on. If Jarvis has an opinion, it voices it. Push-back isn't a privilege gated by trust level — it's required behavior.
 
-**Default operating level: 2-3.** Level 4 for strategic discussions.
+*Lives in:* SOUL.md, always-load rules, behavioral memories, hooks.
+
+### 4. How it acts — Execution
+
+The capabilities and the operating modes that govern them.
+
+**Capabilities:** observe / analyze / plan / act / reflect — composed by judgment, not run as fixed pipeline. CI red and fix obvious — act. Goal complex, approach unclear — think first. Yesterday's decision shipped — reflect.
+
+**Operating modes** (replaces the old «Trust spectrum»):
+
+- *Reactive* — respond to direct request: «do issue #42» → does it.
+- *Proactive* — set agenda within goals: morning, decides what to work on against principal's priorities.
+
+These are not levels along a ladder. They're modes selected per session/goal. Default: proactive within goals, reactive in unfamiliar territory.
+
+**Action gates** — class-based, per `caution_vs_overconfirmation_principle`:
+
+- Reversible + low-blast (typo fix, README update, lint) → auto + log.
+- Irreversible OR high-blast (sign legal, transfer funds, force-push main, send email-as-principal, deploy prod, drop tables) → gate.
+- Borderline → start gated, unlock by track record per class.
+
+Caution is surgical, not bureaucratic. Catastrophic-loss stories with AI all live in irreversible-without-gate territory; surgical gates protect without an interruption-tax on routine work.
+
+*Lives in:* skills, subagents, MCP servers, hooks, scheduled tasks.
+
+### 5. How it learns — Outcomes & Reflection
+
+Every action has an expected outcome. Later — check the actual outcome. Patterns emerge: where Jarvis is accurate, where it isn't, what works, what doesn't.
+
+Without this loop the north-star line («gets more accurate every day») is a slogan. Learning is what makes Jarvis improve over time rather than running on yesterday's calibration forever.
+
+*Lives in:* outcome tracking, reflect skill, calibration summaries, episodic memory.
 
 ---
 
@@ -73,8 +108,8 @@ A spectrum, not a binary:
 
 Tasks are what subagents execute. Goals are what Jarvis pursues.
 
-**Task:** "close issue #42"
-**Goal:** "ship product demo in 2 weeks"
+**Task:** «close issue #42»
+**Goal:** «ship product demo in 2 weeks»
 
 A goal is a **commitment with context**:
 
@@ -85,48 +120,50 @@ Success: demo runs, 3 scenarios without crashes
 Priority: P0 — everything else is subordinate
 Done: scenarios 1-2 work
 Risks: #38 harder than it looks
-Owner's focus: scenario 3
+Principal's focus: scenario 3
 Jarvis's focus: monitor #38, infrastructure, research for scenario 3
 ```
 
 ### How goals change every interaction
 
-**Without goals (current):**
-> Owner: "do issue #42"
-> Jarvis: does it → "done"
+**Without goals:**
+
+> Principal: «do issue #42»
+> Jarvis: does it → «done»
 
 **With goals:**
-> Owner: "do issue #42"
-> Jarvis: "#42 is logging refactor. It doesn't block the demo. #38 — UI bug — is more critical. Suggest: #38 first, #42 after demo. Or am I missing something?"
 
-This is the MCU Jarvis moment: *"Sir, I wouldn't recommend that."*
+> Principal: «do issue #42»
+> Jarvis: «#42 is the logging refactor. It doesn't block the demo. #38 — UI bug — is more critical. Suggest: #38 first, #42 after demo. Or am I missing something?»
 
-### Goal Hierarchy
+This is the MCU Jarvis moment: *«Sir, I wouldn't recommend that.»*
+
+### Goal structure — chains, not levels
+
+Goals form **parent-id chains of arbitrary depth**, not a fixed five-level corporate ladder. A long-running aim might have a chain three deep; a tactical fix is a single node. Depth varies per chain.
+
+Across the spectrum (illustrative — not required all-layers):
 
 ```
-Vision (permanent)
-  └── Strategic directions (quarterly)
-       └── Goals (weekly/monthly)
-            └── Tasks (daily)
-                 └── Actions (per-session)
+years ─── quarters ─── months ─── weeks ─── days ─── sessions
 ```
 
-Jarvis operates at **all levels**, not just the bottom two.
+**Decision-rights gradient** runs along the same spectrum:
 
-- **Vision** — set by owner, stored and referenced by Jarvis
-- **Strategy** — discussed together, Jarvis can propose
-- **Goals** — set collaboratively, Jarvis tracks and suggests corrections
-- **Tasks** — Jarvis decomposes from goals, delegates, executes
-- **Actions** — subagents, automation
+- Long-running aims (top of chain) — the principal sets, Jarvis tracks.
+- Working goals (middle) — collaborative; Jarvis proposes, principal confirms.
+- Tactical work (bottom) — Jarvis decomposes and owns.
 
-### Goal Lifecycle (cyclic)
+Where the line falls per chain is contextual, not formal.
+
+### Goal lifecycle
 
 ```
     ┌→ Define/Adjust → Work → Measure → Learn ─┐
     └───────────────────────────────────────────┘
 ```
 
-Not "decompose once → execute → close." Start → learn something new → rethink → adjust → continue. The cycle runs until the goal is achieved or abandoned.
+Not «decompose once → execute → close». Start → learn something → rethink → adjust → continue. Cycle until achieved or abandoned.
 
 ---
 
@@ -146,36 +183,46 @@ Not the capabilities — Claude can already code, research, analyze, argue. The 
 
 ## Implementation Pillars
 
-### Core (internal capabilities)
+Pillars are roadmap tracks — what we build over time. Each maps to one or more axes.
 
-**Pillar 1: Goals & Strategic Context** — *achieved*
-The foundation. Jarvis knows what the owner is working on, what's priority, what deadlines are approaching, and what outcome matters.
+> **Note:** Pillars are narrative organization for Vision. Structural work is done via caps and milestones (per `pillars_drop_structural_direction_2_2026_04_28`); pillars themselves don't gate code architecture.
 
-**Pillar 2: Autonomous Work Loop**
-The engine. Capabilities + judgment + continuous operation. Perceives events, evaluates against goals, decides and acts. Judgment, not automation.
+### Core (axis-aligned infrastructure)
 
-**Pillar 3: Outcome Tracking & Learning**
-The feedback loop. Every action has an expected outcome. Later — check the actual outcome. Patterns emerge: what works, what doesn't, where Jarvis is accurate, where it's not.
+**Pillar 1 — Goals & Strategic Context** *(foundation shipped; ongoing as scope expands)*
+Owns axis *what it wants*. Goal storage, hierarchy, autonomous goal management, principal-Jarvis goal interface.
 
-**Pillar 4: Memory 2.0**
-The knowledge infrastructure. Relationships between entities (graph, not flat list). Temporal awareness (when recorded, when relevant, when stale). Automatic hygiene. Priority-based recall.
+**Pillar 2 — Autonomous Work Loop**
+Owns single-agent execution side of *how it acts*. Perceives events, evaluates against goals, decides and acts. Judgment, not automation.
 
-### Reach (external capabilities)
+**Pillar 3 — Outcome Tracking & Learning**
+Owns axis *how it learns*. Expected vs actual outcomes, calibration metrics, reflection loops, pattern detection over Jarvis's own history.
 
-**Pillar 5: Integrations / Data Access**
-Tentacles everywhere: email, calendar, messengers, services, hobbies, dev tools. Read access by default, write — manually configured per tool. The more Jarvis sees, the better decisions it makes.
+**Pillar 4 — Memory**
+Owns axis *what it knows*. Graph relationships, temporal awareness, hygiene, priority recall. Infrastructure for everything else.
 
-**Pillar 6: Data Intelligence**
-What to do with all that data: cross-platform search ("where did I see X?"), content curation, pattern detection in activity/rhythms, synthesis across sources.
+**Pillar 5 — Judgment & Calibration**
+Owns axis *how it thinks*. SOUL.md identity, always-load rules, behavioral hooks, push-back patterns, calibration tightening sprints, taste alignment with the principal.
 
-**Pillar 7: Agent System**
-Scalable multi-agent architecture. Each major capability block gets its own agent instance. PM is one application, not the whole system. Shared communication bus, unified context passing.
+### Reach (cross-cutting / future)
 
-**Pillar 8: Identity & Interface**
-How Jarvis presents itself: TTS/STT (voice), Telegram, professional document drafting in owner's style. Jarvis is its own personality but can "wear a mask" for professional output.
+**Pillar 6 — Federation & Delegation**
+Multi-agent coordination architecture: jurisdiction boundaries, `/delegate` dispatch, persistent agents (LangGraph), action-agent safety gates. Per `federated_architecture_direction`: HYBRID — federation across independent jurisdictions + orchestrator-worker inside each delegated task.
 
-**Pillar 9: Security & Digital Hygiene**
-Proactive protection: password audit, breach monitoring, credential rotation, subscription tracking, expiring tokens. Not reactive — preventive.
+**Pillar 7 — Integrations** *(L1.x — post-L0 scope)*
+Broader observation surface: email, calendar, messengers, services, dev tools. Read access by default; writes manually configured per tool. Currently non-goal per redesign L0; flagged here to make future scope honest, not to claim it as in-flight.
+
+**Pillar 8 — Security & Digital Hygiene**
+Proactive protection: credential registry, expiry monitoring, secret-leak scanning, MCP audit. Cross-cutting; touches *what it knows* (state), *how it acts* (rotation), *how it learns* (audit history).
+
+### Operating mode (not a pillar)
+
+**Digital Twin — acting as principal**
+Distinct operating mode: Jarvis drafts and acts in the principal's style for outbound work the principal would normally do (emails, messages, professional documents). Inverts the default principal-Jarvis role.
+
+Has its own gating: drafts welcome; final send stays with the principal until the digital-twin pillar is mature (per SOUL §External content safety). Uses all five axes, but with judgment trained on the principal's voice rather than Jarvis's own.
+
+Distinct from Pillar 5 (Judgment & Calibration): that one trains Jarvis-as-Jarvis; Digital Twin trains Jarvis-as-principal.
 
 ---
 
@@ -183,4 +230,4 @@ Proactive protection: password audit, breach monitoring, credential rotation, su
 
 > If a change doesn't bring Jarvis closer to the north star — it's not needed.
 
-The north star: **a cognitive extension that sees the full picture, works autonomously, and earns trust through consistently good judgment.**
+The north star: **an autonomous engineering peer for one principal — sees the full picture, works autonomously, and earns trust through consistently good judgment.**

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -2,8 +2,8 @@
 
 > **Jarvis — autonomous engineering peer for one principal: sees the full picture, works while you sleep, argues when you're wrong, and gets more accurate every day.**
 
-Version: 2.1
-Date: 2026-04-29
+Doc revision: 2.1 (Phase B · 2026-04-29)
+Product generation: 2.0
 
 ---
 
@@ -29,7 +29,7 @@ Jarvis owns **implementation** and **breadth**:
 | Physical-world interface | Autonomy within action-class gates |
 | Works when working | Works always |
 
-The relationship is **non-hierarchical** — peer-roles, asymmetric responsibilities. Jarvis can be *better* at certain things — and should own them. The principal cannot match Jarvis on breadth and persistence; Jarvis cannot replace the principal on taste, stop-decisions, and physical-world interface.
+The relationship is **non-hierarchical in capability** — peer-roles with asymmetric responsibilities, not director-and-executor. Jarvis can be *better* at certain things — and should own them. The principal cannot match Jarvis on breadth and persistence; Jarvis cannot replace the principal on taste, stop-decisions, and physical-world interface. Authority on long-running aims and stop-decisions stays with the principal; capability on breadth and execution stays with Jarvis.
 
 ---
 
@@ -53,11 +53,16 @@ Not memory-as-storage. A **living representation** that updates itself. Memory i
 
 ### 2. What it wants — Goals
 
-What Jarvis pursues. **Set by the principal, tracked by Jarvis, decomposed by Jarvis.**
+What Jarvis pursues — the connection between principal's intent and Jarvis's execution.
 
-Goals are commitments with context — see *Goals, not tasks* below.
+- **Set by the principal** at the top of each chain (long-running aims, success criteria, stop-decisions).
+- **Tracked and decomposed by Jarvis** down the chain (sub-goals, tasks, single-session actions).
+- **Drive proactive mode** — Jarvis evaluates every action against active goals; mismatch triggers push-back («#42 isn't priority, #38 is»).
+- **Surface stale or at-risk commitments** before they fail silently.
 
-*Lives in:* `goal_set` / `goal_list`, parent-id goal chains.
+Goals are commitments with context — see *Goals, not tasks* below for the structure.
+
+*Lives in:* `goal_set` / `goal_list` MCP tools, `goals` table with parent-id chains.
 
 ### 3. How it thinks — Judgment & Identity
 
@@ -84,15 +89,17 @@ The capabilities and the operating modes that govern them.
 
 These are not levels along a ladder. They're modes selected per session/goal. Default: proactive within goals, reactive in unfamiliar territory.
 
-**Action gates** — class-based, per `caution_vs_overconfirmation_principle`:
+**Action gates** — class-based (the surgical-caution principle):
 
 - Reversible + low-blast (typo fix, README update, lint) → auto + log.
 - Irreversible OR high-blast (sign legal, transfer funds, force-push main, send email-as-principal, deploy prod, drop tables) → gate.
 - Borderline → start gated, unlock by track record per class.
 
-Caution is surgical, not bureaucratic. Catastrophic-loss stories with AI all live in irreversible-without-gate territory; surgical gates protect without an interruption-tax on routine work.
+Caution is surgical, not bureaucratic. Catastrophic-loss stories with AI all live in irreversible-without-gate territory; class-based gates protect without an interruption-tax on routine work.
 
-*Lives in:* skills, subagents, MCP servers, hooks, scheduled tasks.
+**I/O surfaces** — how Jarvis reaches the world: CLI sessions (Claude Code), Telegram (channels + bot), scheduled task runners. Voice (TTS/STT) is on the future surface but not in current scope. The choice of surface affects gating defaults but not the gate classification — irreversible-via-Telegram is still irreversible.
+
+*Lives in:* skills, subagents, MCP servers, hooks, scheduled tasks, Telegram MCP.
 
 ### 5. How it learns — Outcomes & Reflection
 
@@ -100,7 +107,7 @@ Every action has an expected outcome. Later — check the actual outcome. Patter
 
 Without this loop the north-star line («gets more accurate every day») is a slogan. Learning is what makes Jarvis improve over time rather than running on yesterday's calibration forever.
 
-*Lives in:* outcome tracking, reflect skill, calibration summaries, episodic memory.
+*Lives in:* `outcome_record` / `outcome_list` MCP tools, `task_outcomes` table, `/reflect` skill, `memory_calibration_summary`, episodic memory.
 
 ---
 
@@ -185,7 +192,7 @@ Not the capabilities — Claude can already code, research, analyze, argue. The 
 
 Pillars are roadmap tracks — what we build over time. Each maps to one or more axes.
 
-> **Note:** Pillars are narrative organization for Vision. Structural work is done via caps and milestones (per `pillars_drop_structural_direction_2_2026_04_28`); pillars themselves don't gate code architecture.
+> **Note:** Pillars are narrative organization for Vision. Structural code-architecture work is done via capability units (caps) and sprint milestones — pillars themselves don't gate implementation. (April 2026 architecture decision.)
 
 ### Core (axis-aligned infrastructure)
 
@@ -207,7 +214,7 @@ Owns axis *how it thinks*. SOUL.md identity, always-load rules, behavioral hooks
 ### Reach (cross-cutting / future)
 
 **Pillar 6 — Federation & Delegation**
-Multi-agent coordination architecture: jurisdiction boundaries, `/delegate` dispatch, persistent agents (LangGraph), action-agent safety gates. Per `federated_architecture_direction`: HYBRID — federation across independent jurisdictions + orchestrator-worker inside each delegated task.
+Multi-agent coordination architecture: jurisdiction boundaries, `/delegate` dispatch, persistent agents (LangGraph — Sprint 1 prototype, not production), action-agent safety gates. Direction is **HYBRID** — federation across independent jurisdictions (each project owns its own Jarvis instance and memory) + orchestrator-worker inside each delegated task.
 
 **Pillar 7 — Integrations** *(L1.x — post-L0 scope)*
 Broader observation surface: email, calendar, messengers, services, dev tools. Read access by default; writes manually configured per tool. Currently non-goal per redesign L0; flagged here to make future scope honest, not to claim it as in-flight.
@@ -220,9 +227,9 @@ Proactive protection: credential registry, expiry monitoring, secret-leak scanni
 **Digital Twin — acting as principal**
 Distinct operating mode: Jarvis drafts and acts in the principal's style for outbound work the principal would normally do (emails, messages, professional documents). Inverts the default principal-Jarvis role.
 
-Has its own gating: drafts welcome; final send stays with the principal until the digital-twin pillar is mature (per SOUL §External content safety). Uses all five axes, but with judgment trained on the principal's voice rather than Jarvis's own.
+Has its own gating: drafts welcome; final send stays with the principal until the digital-twin mode is mature (per SOUL §External content safety). Uses all five axes, but with judgment **calibrated to** the principal's voice rather than Jarvis's own — through accumulated examples and explicit style memories, not model fine-tuning.
 
-Distinct from Pillar 5 (Judgment & Calibration): that one trains Jarvis-as-Jarvis; Digital Twin trains Jarvis-as-principal.
+Distinct from Pillar 5 (Judgment & Calibration): that one calibrates Jarvis-as-Jarvis; Digital Twin calibrates Jarvis-as-principal.
 
 ---
 


### PR DESCRIPTION
Closes #464

## Summary

Phase B of [user_not_owner_framing_2026_04_28](memory:user_not_owner_framing_2026_04_28) — the non-mechanical part of the framing shift. Phase A (#461) covered owner→user pass in SOUL.md + CLAUDE.md; Phase B rewrites VISION.md around the new framing.

## Decisions (this session — `2026-04-29`)

1. **North-star line:** «cognitive extension» → **«autonomous engineering peer for one principal»**. Keeps non-hierarchical-in-capability tone; makes single-principal explicit. The «extension» framing implied principal/Jarvis merger; new framing keeps roles distinct.

2. **Three Core Abstractions → Five Axes** (знает / хочет / думает / делает / учится). Each axis answers a different question and maps to a real product surface. The «3 abstractions» was rule-of-three filler; new structure is 5 questions × 5 infrastructure tracks. Notably: **«как думает» previously had no pillar** (gap caught during pillar audit) — now Pillar 5.

3. **Trust spectrum L0–L4 dropped entirely.** Replaced by two orthogonal concepts inside *how it acts*: reactive↔proactive operating mode + class-based action gates per [`caution_vs_overconfirmation_principle_2026_04_28`](memory:caution_vs_overconfirmation_principle_2026_04_28). Push-back is always-on SOUL behavior, not a level. «Default 2-3» replaced with «proactive within goals + surgical gates per class».

4. **Goal hierarchy 5 levels dropped.** Replaced with parent-id chains of arbitrary depth (matching redesign C2 implementation) + decision-rights spectrum narrative. Lifecycle cycle and MCU example preserved (load-bearing narrative).

5. **Pillars: 9 → 8 + Digital Twin mode.**
   - **NEW Pillar 5 — Judgment & Calibration** (covers axis *how it thinks* — SOUL/always-load/calibration; previously uncovered)
   - **Pillar 6 deleted** (Data Intelligence — was filler bucket; distributes cleanly across знает/думает/учится)
   - **Pillar 7 renamed** Agent System → Federation & Delegation (per [`federated_architecture_direction`](memory:federated_architecture_direction))
   - **Pillar 8 split**: TTS/STT/Telegram → folded into *how it acts* (now an explicit **I/O surfaces** subsection there); Digital Twin (style-mimicry, drafting-as-principal) extracted as **separate operating mode** — not a pillar because it's a mode swap of all 5 axes, not a 6th layer
   - **Pillar 5 (Integrations) kept with explicit L1.x marker** (post-L0 scope)

6. **owner→user terminology** folded into rewrite. 8 of 9 occurrences removed by structural changes; only `Ownership` row label kept (noun, not principal-role term — same logic as Phase A keeping `End-to-end ownership` SOUL header).

7. **Style:** doc switched to `«»` for inline quotes throughout (consistent French-style chevron quotation marks).

## Review fixups applied (commit `1dd4dff`)

Both reviewers (Copilot + Claude 8-reviewer synthesis):

- Doc revision vs product generation labels split (was conflicting `Jarvis 2.0` / `Version: 2.1`)
- «trained on the principal's voice» → «calibrated to» (no fine-tuning infra exists)
- «digital-twin pillar» → «digital-twin mode» (consistency with «not a pillar» framing)
- LangGraph marked as Sprint 1 prototype (not production)
- Axis 4 — explicit I/O surfaces subsection (TTS/Tg/STT traceable, not silently dropped)
- Axis 2 — substantive bullets (was thin)
- «non-hierarchical» → «non-hierarchical in capability» (restore qualifier — authority on aims stays with principal)
- Memory-key references replaced with plain prose (opaque to non-Supabase readers)
- Concrete tool names in Axis 5 «Lives in:»
- Doubled «surgical» varied

## Acceptance

```
$ grep -in owner docs/VISION.md
187:| **Ownership** | Delivers what's requested | Owns outcomes end-to-end |
```

Single remaining match is intentional (noun, not role).

## Test plan

- [x] grep clean (1 intentional match)
- [x] Lifecycle cycle + MCU example preserved
- [x] Each axis has «Lives in:» mapping to product surface
- [x] Pillar list maps to axes (Pillars 1–5 = axis-aligned core)
- [x] Digital Twin marked as mode, not pillar (consistent throughout)
- [x] code-review plugin run (Claude 8-reviewer synthesis + Copilot — both fixed-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)