### PR TITLE
docs: drop pillar numbers from operational language (#466 Option B)

### DIFF
--- a/.claude-userlevel/skills/autonomous-loop/SKILL.md
+++ b/.claude-userlevel/skills/autonomous-loop/SKILL.md
@@ -14,7 +14,7 @@ Implements the perceive→evaluate→decide→act→record loop from the Autonom
 
 - `/autonomous-loop` — manual invocation (full run)
 - Scheduled: daily 09:00 (after morning-brief)
-- Part of: Jarvis Pillar 2 — Autonomous Work Loop
+- Part of: Jarvis Autonomous Work Loop pillar
 
 ## Architecture
 
@@ -271,7 +271,7 @@ Never execute — save to memory:
 
 ## Step 7 — Record Outcomes
 
-**Each action** gets its own `outcome_record` (Pillar 3):
+**Each action** gets its own `outcome_record` (Outcome Tracking & Learning pillar):
 
 ```
 outcome_record(

--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -191,7 +191,7 @@ EOF
 
 ### 6. Record outcome
 
-After PR creation (or failure at any step), record the outcome for Pillar 3 tracking:
+After PR creation (or failure at any step), record the outcome for the Outcome Tracking & Learning pillar:
 
 ```
 outcome_record(

--- a/.claude-userlevel/skills/reflect/SKILL.md
+++ b/.claude-userlevel/skills/reflect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reflect
-description: "Learning loop: review recent decisions, check outcomes via GitHub PRs, extract lessons, update memory. Integrates with outcome tracking (Pillar 3)."
+description: "Learning loop: review recent decisions, check outcomes via GitHub PRs, extract lessons, update memory. Integrates with the Outcome Tracking & Learning pillar."
 ---
 
 # Reflect

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,6 @@
 # agents/
 
-Pillar 7 persistent LangGraph agents. Each module is a standalone agent
+Federation & Delegation pillar — persistent LangGraph agents. Each module is a standalone agent
 that runs alongside Claude Code (not as a replacement), uses Ollama as
 the local LLM, and persists state in PostgreSQL via LangGraph's
 `PostgresSaver` checkpointer.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -38,3 +38,25 @@ Semver discipline (per redesign): v2 is reserved for cardinal paradigm shifts (e
 ---
 
 History: this file used to hold pillar-by-pillar status and full scope (v7.0, 2026-04-13). Replaced with pointer 2026-04-28 after the [redesign](design/jarvis-v2-redesign.md) consolidated scope/architecture and live work moved to GitHub milestones. VISION.md restructured 2026-04-29 (Phase B, PR #465) — five axes + 8 pillars + Digital Twin mode.
+
+## Pillar names → numbers (transition table)
+
+Phase B (2026-04-29, PR #465) renumbered pillars in VISION.md. **Operational language now uses pillar names**, not numbers — numbers are narrative anchors only and exist solely in `docs/VISION.md`. Old EPIC issue titles, milestone names, and memory keys keep their original numbering as historical identifiers; new operational refs use names.
+
+| Pillar (current name) | Old number (pre-Phase-B) | New number (VISION.md v2.1) | Status |
+|---|---|---|---|
+| Goals & Strategic Context | 1 | 1 | unchanged |
+| Autonomous Work Loop | 2 | 2 | unchanged |
+| Outcome Tracking & Learning | 3 | 3 | unchanged |
+| Memory | 4 | 4 | unchanged |
+| Judgment & Calibration | — | 5 | **NEW Phase B** |
+| Federation & Delegation *(was Agent System)* | 7 | 6 | renamed + renumbered |
+| Integrations | 5 | 7 | renumbered, marked L1.x |
+| Security & Digital Hygiene | 9 | 8 | renumbered |
+| Digital Twin | *(part of 8: Identity & Interface)* | mode, not pillar | extracted |
+| ~~Data Intelligence~~ | 6 | *(deleted)* | distributed across other axes |
+
+Examples of historical identifiers that **stay as-is**:
+- Memory key `pillar9_sprint1_self_security` (= Security & Digital Hygiene Sprint 1)
+- EPIC #335 «Pillar 7 Phase 0: Federation» (= Federation & Delegation Phase 0)
+- Milestone titles «Pillar 4 Sprint: feeling-of-knowing» (= Memory Sprint: feeling-of-knowing)

--- a/docs/agents/dispatcher.md
+++ b/docs/agents/dispatcher.md
@@ -1,7 +1,6 @@
 # Task dispatcher agent
 
-Module: `agents/dispatcher.py`. First federation jurisdiction in Pillar 7
-Sprint 2 (issue #298, S2-3). Wires together every other S2 primitive:
+Module: `agents/dispatcher.py`. First federation jurisdiction (Federation & Delegation Sprint 2 — issue #298, S2-3). Wires together every other S2 primitive:
 
 | Upstream | Role |
 |----------|------|

--- a/docs/agents/e2e-test.md
+++ b/docs/agents/e2e-test.md
@@ -1,4 +1,4 @@
-# Pillar 7 End-to-End Test (issue #175)
+# Federation & Delegation End-to-End Test (issue #175)
 
 Validates the full event pipeline:
 

--- a/docs/agents/langgraph-setup.md
+++ b/docs/agents/langgraph-setup.md
@@ -1,6 +1,6 @@
 # LangGraph Agents — Dev Setup
 
-Pillar 7 persistent agents run alongside Claude Code. LangGraph handles the lifecycle (graph definition, state, checkpointing), Ollama handles inference, local Postgres stores checkpoints.
+Federation & Delegation pillar — persistent agents run alongside Claude Code. LangGraph handles the lifecycle (graph definition, state, checkpointing), Ollama handles inference, local Postgres stores checkpoints.
 
 This document covers the Sprint 1 foundation (issue #172). Agent implementations live in later sprints.
 

--- a/docs/agents/ollama-setup.md
+++ b/docs/agents/ollama-setup.md
@@ -1,4 +1,4 @@
-# Ollama Setup for Pillar 7 Agents
+# Ollama Setup for Federation & Delegation Agents
 
 Local LLM runtime for LangGraph persistent agents. Ollama handles cheap, always-on decisions (routing, classification) without burning Claude tokens.
 

--- a/docs/agents/perception.md
+++ b/docs/agents/perception.md
@@ -1,6 +1,6 @@
 # Perception → task_queue ingest
 
-Modules: `agents/perception_*.py` (one per source). Pillar 7 Sprint 4
+Modules: `agents/perception_*.py` (one per source). Federation & Delegation Sprint 4
 (milestone #32). Architecture-doc issue: #386. Implementation issues:
 #388 (GitHub), #389 (self-perception via morning_check). Telegram (#387)
 deferred — see "Future sources" below.

--- a/docs/agents/safety.md
+++ b/docs/agents/safety.md
@@ -1,7 +1,7 @@
 # Action-agent safety gate
 
 Module: `agents/safety.py`. Ships as **S2-0** (issue #295), the foundation
-every Pillar 7 Sprint 2+ action agent must route its mutations through.
+every Federation & Delegation Sprint 2+ action agent must route its mutations through.
 Model memory: `action_agent_safety_gate_model_v1`.
 
 ## Three tiers

--- a/docs/design/autonomous-loop.md
+++ b/docs/design/autonomous-loop.md
@@ -1,6 +1,6 @@
 # Autonomous Work Loop — Architecture
 
-> Source of truth for Jarvis Pillar 2: Autonomous Work Loop.
+> Source of truth for the Jarvis Autonomous Work Loop pillar.
 > Created: 2026-04-08. Status: implementing.
 
 ## Overview

--- a/docs/design/jarvis-build-vs-buy.md
+++ b/docs/design/jarvis-build-vs-buy.md
@@ -31,7 +31,7 @@ Three columns: **Adopt** (drop-in, integrates as MCP/plugin/hook/skill), **Patte
 | Cap | Adopt | Pattern | Custom |
 |---|---|---|---|
 | **C3 Memory** | None (heavy runtimes filtered) | **Zep / Graphiti** ([arXiv:2501.13956](https://arxiv.org/abs/2501.13956)) — bi-temporal column shape (`t_valid`/`t_invalid`/transaction-time). **Cognee** schema — node/edge + embedding. **LangGraph PostgresStore** for namespace-tuple `(facts \| episodes)` indexing pattern. | Bi-temporal `valid_from`/`valid_to`/`superseded_by` migration on existing `mcp-memory/server.py`. Conflict classifier (Haiku ADD/UPDATE/SUPERSEDE/NOOP). Provenance-aware ranking. |
-| **C4 Reasoning** | **sequential-thinking MCP** (already installed). **LangGraph as one MCP server** (Pillar 7 carveout) wrapping Postgres checkpointer pointing at Supabase. | **Magentic-One ledger** ([MS Agent Framework 1.0](https://github.com/microsoft/agent-framework), MIT) — verified-facts / derived-facts / guesses tri-ledger pattern for plan state. **Plan-and-Execute** template (LangGraph). | `applies_when` / `skip_if` template runtime. Replan-on-stall. Skills→templates migration glue. |
+| **C4 Reasoning** | **sequential-thinking MCP** (already installed). **LangGraph as one MCP server** (Federation & Delegation carveout) wrapping Postgres checkpointer pointing at Supabase. | **Magentic-One ledger** ([MS Agent Framework 1.0](https://github.com/microsoft/agent-framework), MIT) — verified-facts / derived-facts / guesses tri-ledger pattern for plan state. **Plan-and-Execute** template (LangGraph). | `applies_when` / `skip_if` template runtime. Replan-on-stall. Skills→templates migration glue. |
 | **C5 Reflection** | None | **Letta sleep-time agents** (Apache-2.0) — async secondary writer pattern. Implement as Routine. **Reflexion** (MIT) — verbal-feedback loop algorithm. **Cognee evolution pass** — synthesis-on-ingest reference. | Stale-belief challenger. LLM-as-judge Brier-score calibration. Owner-correction → label loop. |
 | **C6 Decision gating** | **PreToolUse hooks + permissions** (Claude Code native). **Guardrails AI** (Apache-2.0) — Pydantic schemas for *output* validation only, called from hook. | — | **Everything substantive.** State-aware classification (git status, convergence counter, harness restrictions) has no library — confirmed by scout 2: all gating frameworks are stateless. Tier 1 queue table custom. Auto-emit decision events custom. |
 
@@ -69,7 +69,7 @@ Three columns: **Adopt** (drop-in, integrates as MCP/plugin/hook/skill), **Patte
 2. **GPT Researcher MCP** → C10 primary engine. Apache-2.0, MCP-native; config: Claude model, Supabase store for promoted facts. **Estimated: 60% of C10 covered.**
 3. **sequential-thinking MCP** → C4 novel/high-stakes reasoning. Already installed; finally wire it.
 4. **firecrawl + context7 MCP** → C10 scrape/docs tier (already adopted).
-5. **LangGraph as one MCP server** → C4 plan-as-event + Postgres checkpointer to Supabase. Pillar 7 carveout pre-approved. Wrap behind ONE MCP boundary (not used directly throughout codebase).
+5. **LangGraph as one MCP server** → C4 plan-as-event + Postgres checkpointer to Supabase. Federation & Delegation carveout pre-approved. Wrap behind ONE MCP boundary (not used directly throughout codebase).
 6. **Guardrails AI (library, called from hook)** → C6 *output* validation only. Not flow control.
 7. **HIBP API** (free tier) → C14 breach probes. Scheduled task.
 

--- a/docs/design/jarvis-v2-redesign.md
+++ b/docs/design/jarvis-v2-redesign.md
@@ -1382,7 +1382,7 @@ C13 complete.
 
 ### C14 — Security & privacy
 
-Distillation: significantly more mature than other caps — Pillar 9 Sprint 1 shipped (`pillar9_sprint1_self_security`). Existing layered defense: secret scanner PreToolUse hook (12 regex families + 8 bash-exfil patterns, heredoc-aware), credential registry (metadata-only, DB CHECK rejecting raw values), protected-files hook with principal-aware tiering, action gate Tier 0/1/2 in `safety.py`, gitleaks pre-commit + CI, soft-delete with 30-day retention, recovery playbook. Threat model = external intruders / cloud-provider-trusted / single-user / GitHub-public-repo. Owner deliberately accepts: prompt injection via web/issues, personal-data leakage, password hygiene blindness.
+Distillation: significantly more mature than other caps — Security & Digital Hygiene Sprint 1 shipped (memory key: `pillar9_sprint1_self_security` — historical identifier from pre-Phase-B numbering). Existing layered defense: secret scanner PreToolUse hook (12 regex families + 8 bash-exfil patterns, heredoc-aware), credential registry (metadata-only, DB CHECK rejecting raw values), protected-files hook with principal-aware tiering, action gate Tier 0/1/2 in `safety.py`, gitleaks pre-commit + CI, soft-delete with 30-day retention, recovery playbook. Threat model = external intruders / cloud-provider-trusted / single-user / GitHub-public-repo. Principal deliberately accepts: prompt injection via web/issues, personal-data leakage, password hygiene blindness.
 
 Remaining gaps require structural treatment in v2; most are extensions of what shipped, not rebuilds.
 

--- a/docs/design/memory-fok.md
+++ b/docs/design/memory-fok.md
@@ -1,4 +1,4 @@
-# Feeling-of-Knowing (Pillar 4 Phase 5.3) — Design
+# Feeling-of-Knowing (Memory Phase 5.3) — Design
 
 **Status:** 5.3-α approved — six decisions ratified via Discussion [#439](https://github.com/Osasuwu/jarvis/discussions/439) (2026-04-27). 5.3-β/γ/δ may proceed.
 **Closes:** #420.

--- a/docs/design/memory-overhaul.md
+++ b/docs/design/memory-overhaul.md
@@ -1,7 +1,7 @@
 # Memory overhaul — research synthesis + design proposal
 
 **Status:** research complete, design pending owner review.
-**Context:** Pillar 4 (memory). Current system has measurable lifecycle bugs; before fixing ad-hoc, owner asked for research on (a) how production LLM agent systems solve the same problems, (b) theory of agent memory. Two parallel research agents ran; this doc consolidates findings with our local audit.
+**Context:** Memory pillar. Current system has measurable lifecycle bugs; before fixing ad-hoc, principal asked for research on (a) how production LLM agent systems solve the same problems, (b) theory of agent memory. Two parallel research agents ran; this doc consolidates findings with our local audit.
 
 ## 1. Local audit — what's actually broken
 

--- a/docs/design/memory-overhaul.md
+++ b/docs/design/memory-overhaul.md
@@ -1,6 +1,6 @@
 # Memory overhaul — research synthesis + design proposal
 
-**Status:** research complete, design pending owner review.
+**Status:** research complete, design pending principal review.
 **Context:** Memory pillar. Current system has measurable lifecycle bugs; before fixing ad-hoc, principal asked for research on (a) how production LLM agent systems solve the same problems, (b) theory of agent memory. Two parallel research agents ran; this doc consolidates findings with our local audit.
 
 ## 1. Local audit — what's actually broken
@@ -17,7 +17,7 @@ Verified against live Supabase state (2026-04-18):
 | 6 | Archive is a dirty hack (`type = type \|\| '_archived'`) | `archive_memories` RPC | Breaks type-filtered recall; abuses type column |
 | 7 | `deleted_at` column exists, most RPCs don't check it | Schema alter + RPC grep | Soft-delete is inconsistent |
 | 8 | `find_consolidation_clusters` RPC exists, never invoked | No scheduled task calls it | Consolidation capability idle |
-| 9 | No provenance on memories | No `source` column | Can't tell owner-stated from tool-output |
+| 9 | No provenance on memories | No `source` column | Can't tell principal-stated from tool-output |
 | 10 | No confidence / entrenchment ordering | No column | Contraction undefined when conflicts exist |
 
 Two concrete contradicting memories observed: `jarvis_stays_goals_not_agile` (Jan) and `jarvis_v2_hybrid_agile` (Mar). Description of the latter explicitly says "replaces" the former. They're linked as `related` (strength 0.757), both surface in recall, no supersession marker.
@@ -33,8 +33,8 @@ Items flagged by **both** research streams — strongest evidence, should be in 
 
 ### 2b. Provenance / justification on every fact
 - **Theory (Doyle, JTMS):** beliefs without justifications cannot be revised correctly. Revision needs source chain.
-- **Production (memory-poisoning lit, 2025):** `MemoryGraft`, `AgentPoison` — stored-memory injection is a real attack class. Defense starts from provenance tagging (`owner_stated` / `tool_output` / `web_ingested` / `subagent_reported`).
-- **Us:** no source column. Web-research output and owner statements are indistinguishable.
+- **Production (memory-poisoning lit, 2025):** `MemoryGraft`, `AgentPoison` — stored-memory injection is a real attack class. Defense starts from provenance tagging (`principal_stated` / `tool_output` / `web_ingested` / `subagent_reported`).
+- **Us:** no source column. Web-research output and principal statements are indistinguishable.
 
 ### 2c. ACT-R-style retrieval scoring (not raw cosine)
 - **Theory (Anderson-Schooler, ACT-R):** rank by `relevance × recency-weighted usage frequency × context match × entrenchment / interference penalty`. Cosine alone is a category error.
@@ -70,11 +70,11 @@ Items flagged by **both** research streams — strongest evidence, should be in 
 
 **Production-only:**
 - **Embedding model migration hazard.** Voyage-3-lite → next model = whole corpus becomes incomparable. Store `embedding_model` + `embedding_version`, support dual columns during migration. (Our single biggest unnoticed production risk.) **Status (#242):** foundation shipped — `embedding_v2` column + `match_memories_v2` RPC, `EMBEDDING_MODEL_PRIMARY`/`SECONDARY` env vars drive dual-write + read-path selection. Zero behavior change while SECONDARY unset. Corpus backfill + episode_extractor dual-write are separate follow-ups.
-- **Collections vs Profiles split.** Some memories should be overwrite-single-row (`owner_preferences`, `device_config`); others append (`decisions`). Without the distinction, you fight supersession bugs forever on the overwrite ones. One column: `single_instance BOOLEAN`.
+- **Collections vs Profiles split.** Some memories should be overwrite-single-row (`principal_preferences`, `device_config`); others append (`decisions`). Without the distinction, you fight supersession bugs forever on the overwrite ones. One column: `single_instance BOOLEAN`.
 - **Task-aware recall = query rewriting.** Cheap LLM call turns `{user_prompt, recent_turns}` into `{intent, entities, type_filter, tag_filter, timeframe}` *before* vector search. Don't embed the raw prompt — biggest quality win on relevance.
 - **A-MEM memory evolution (second step).** New memory arrives → LLM also rewrites context/tags of linked neighbors. We have auto-linking; we don't have the in-place rewrite. Without it: linked graph of frozen interpretations.
 - **Evaluation set.** 20 hand-written `(query, expected_memory_ids)` pairs, re-run weekly, track recall@5 and MRR. Without this, every "improvement" is vibes.
-- **Cross-session actor namespacing.** Memory written in autonomous mode ("I decided X because no one was around") ≠ owner-stated. Namespace by actor, not just project.
+- **Cross-session actor namespacing.** Memory written in autonomous mode ("I decided X because no one was around") ≠ principal-stated. Namespace by actor, not just project.
 - **Embed canonical form not raw content** (Cognee, A-MEM). Embed `{name, type, tags, one_line_description}` not raw note text — survives rewrites and model upgrades.
 
 **Theory-only:**
@@ -114,7 +114,7 @@ ALTER TABLE memories
   ADD COLUMN expired_at timestamptz,              -- when we stopped believing it
   ADD COLUMN superseded_by uuid REFERENCES memories(id),
   ADD COLUMN confidence real DEFAULT 0.5,         -- [0, 1]
-  ADD COLUMN source_provenance text,              -- owner_stated / tool_output / web_ingested / subagent_reported / autonomous_agent
+  ADD COLUMN source_provenance text,              -- principal_stated / tool_output / web_ingested / subagent_reported / autonomous_agent
   ADD COLUMN single_instance boolean DEFAULT false,
   ADD COLUMN embedding_model text DEFAULT 'voyage-3-lite',
   ADD COLUMN embedding_version text DEFAULT 'v1';
@@ -136,7 +136,7 @@ Gates everything else. Without this, no amount of write-side sophistication help
 1. Replace append-on-write with Mem0-style ADD/UPDATE/DELETE/NOOP classifier. Haiku-class model, sees top-5 neighbors. Cost: ~$0.001/write, budget-negligible.
 2. Lower `SUPERSEDE_SIM_THRESHOLD` from 0.85 to ~0.75; remove `type=decision` gate (all types can supersede).
 3. On UPDATE/DELETE decision: set `superseded_by` + `valid_to` + `expired_at` on old, not `type='…_archived'` rename.
-4. Provenance required on every write (default `owner_stated` if unset — but log warnings to force callers to be explicit).
+4. Provenance required on every write (default `principal_stated` if unset — but log warnings to force callers to be explicit).
 5. Embed canonical form `"{name}\n{description}\n{tags}"` not raw content.
 
 ### Phase 3 — task-aware recall
@@ -153,7 +153,7 @@ Gates everything else. Without this, no amount of write-side sophistication help
 
 ### Phase 5 — consolidation + metacognition
 
-1. Wire up `find_consolidation_clusters` to a real weekly job. Haiku groups by `(type, tag)`, detects pairwise contradictions, emits merge/supersede plan. Auto-apply above confidence 0.9; else queue for owner review.
+1. Wire up `find_consolidation_clusters` to a real weekly job. Haiku groups by `(type, tag)`, detects pairwise contradictions, emits merge/supersede plan. Auto-apply above confidence 0.9; else queue for principal review.
 2. A-MEM evolution second step: on UPDATE, also rewrite linked-neighbor context/tags if meaning shifted.
 3. Confidence self-monitor: after each recall, store feeling-of-knowing judgment (did answer sufficiency hit). Feeds entrenchment over time.
 4. Known-unknowns table: propositions the agent knows it *should* know but can't retrieve — surfaced proactively.
@@ -162,7 +162,7 @@ Gates everything else. Without this, no amount of write-side sophistication help
 
 First step shipped as `scripts/evolve-neighbors.py` (#230, #231). Offline batch: scans recent `memory_review_queue` rows where `decision='UPDATE' AND status='auto_applied'`, fetches each target's 1-hop live neighbors via `get_linked_memories`, and asks Haiku-4.5 per neighbor whether its tags/description drifted after the (target → candidate) swap. Output is a KEEP / UPDATE_TAGS / UPDATE_DESC / UPDATE_BOTH proposal with confidence — rendered as markdown (default) or JSON (`--json`), upserted as `evolution_plan_YYYY-MM-DD` on `--save-memory`. Fallback pattern matches the Phase 2 classifier: any Haiku/parse/HTTP failure collapses to KEEP with confidence 0, and `new_tags`/`new_description` are required only when the action commits to them — missing payload downgrades to the nearest safe action.
 
-**5.2-β (#232) wires the apply path.** `memory_review_queue.decision` CHECK gains `'EVOLVE'`; new column `evolution_payload jsonb` holds per-neighbor `old_tags`/`old_description` snapshots + parent lineage (`update_queue_id`, `candidate_id`, `target_id`). RPCs `apply_evolution_plan(plan, queue_meta)` and `rollback_evolution(queue_id)` parallel the 5.1b-β consolidation pair — same provenance/load-bearing-field guards, same `auto_applied → rolled_back` lifecycle. The script's `--apply` flag routes plans by **plan-level min confidence**: all proposals ≥ gate (default 0.85) auto-applies with a queue audit row; any below gate queues the whole plan as `pending` for owner review. KEEP-only plans are skipped (no-op). A functional index `idx_review_queue_update_queue_id` on `evolution_payload->>'update_queue_id'` drives the planner's dedup pre-filter. Rollback re-bumps `content_updated_at` via the existing trigger — deliberate tradeoff, rollback is rare and the column is a soft decay signal.
+**5.2-β (#232) wires the apply path.** `memory_review_queue.decision` CHECK gains `'EVOLVE'`; new column `evolution_payload jsonb` holds per-neighbor `old_tags`/`old_description` snapshots + parent lineage (`update_queue_id`, `candidate_id`, `target_id`). RPCs `apply_evolution_plan(plan, queue_meta)` and `rollback_evolution(queue_id)` parallel the 5.1b-β consolidation pair — same provenance/load-bearing-field guards, same `auto_applied → rolled_back` lifecycle. The script's `--apply` flag routes plans by **plan-level min confidence**: all proposals ≥ gate (default 0.85) auto-applies with a queue audit row; any below gate queues the whole plan as `pending` for principal review. KEEP-only plans are skipped (no-op). A functional index `idx_review_queue_update_queue_id` on `evolution_payload->>'update_queue_id'` drives the planner's dedup pre-filter. Rollback re-bumps `content_updated_at` via the existing trigger — deliberate tradeoff, rollback is rare and the column is a soft decay signal.
 
 **5.2-γ (#234)** wires the cadence. `scripts/evolve-run.py` is the scheduler wrapper paralleling `consolidation-run.py`: subprocess-calls `evolve-neighbors.py --apply --json --save-memory`, parses `apply_outcomes[]`, emits one `evolve_run` event to Supabase, prints a JSON recap for the scheduled-task session. Registered as `memory-evolve-weekly` via the scheduled-tasks MCP with cron `0 11 * * 0` — Sundays 11:00 Astana, one hour after `memory-consolidation-weekly` so the two jobs don't contend for the same DB txn slots or Haiku budget. Review threshold is lower than consolidation's (severity `medium` at `queued_pending >= 1`, not `>= 3`): evolution plans are smaller-grain than consolidation clusters, so a single queued EVOLVE plan is already worth a review pass. The sync in-request trigger inside `_apply_classifier_decision` stays deferred — offline batch keeps write-path latency bounded while we calibrate the Haiku confidence distribution from the first few weeks of `evolve_run` events.
 
@@ -188,10 +188,10 @@ The scheduler runs `scripts/consolidation-run.py` every Sunday at 10:00 Astana �
 - Ontology canonicalization (Cognee). Only when entity dedup becomes a pain.
 - Dual-embedding migration machinery. When we actually upgrade models.
 
-## 6. Open questions for owner
+## 6. Open questions for principal
 
 1. **Phase ordering.** Above is cost-ordered. Alternative: do Phase 6 (eval) first so we can measure Phase 1-2 quantitatively. Adds ~half-day upfront. Recommend: eval first.
-2. **Classifier model.** Mem0 uses GPT-4o at write. We'd use Haiku-4.5. Risk: classifier errors become silent corruption. Mitigation: low-confidence decisions require owner review (above a threshold, auto-apply; below, queue).
+2. **Classifier model.** Mem0 uses GPT-4o at write. We'd use Haiku-4.5. Risk: classifier errors become silent corruption. Mitigation: low-confidence decisions require principal review (above a threshold, auto-apply; below, queue).
 3. **Migration strategy for existing corpus.** ~600 memories currently. Options: (a) leave as-is with defaults, rely on Phase 1 filters to gate the worst cases; (b) run one-off backfill through classifier to tag provenance, detect chains; (c) wipe and restart. Recommend: (a). (c) loses decision history.
 4. **Scope.** Phases 0-3 + eval is ~a week's work. Phases 4-5 are another week. Stop after Phase 3 and measure, or commit to the whole stack?
 5. **The `jarvis_stays_goals_not_agile` / `jarvis_v2_hybrid_agile` concrete pair.** Manually set `superseded_by` now (one-line SQL), or wait for Phase 2 auto-detection. Recommend: manual now, it's a known live bug poisoning recall today.

--- a/docs/security/agent-boundaries.md
+++ b/docs/security/agent-boundaries.md
@@ -1,7 +1,7 @@
 # Agent Sandbox Boundaries
 
 Date: 2026-04-15 (revised 2026-04-23 for Federation & Delegation Phase 0 — #341; revised 2026-04-26 for principal-aware permissions — #426; isatty fallback removed in #429)
-Scope: Permission rules for **all principals** running Claude — interactive owner, autonomous loop, /delegate subagent, and the future dispatcher.
+Scope: Permission rules for **all principals** running Claude — interactive principal (`live`), autonomous loop, /delegate subagent, and the future dispatcher.
 
 ## Principal model (#426, #429)
 
@@ -9,7 +9,7 @@ Permissions depend on **who is running Claude**. Four principals — detection l
 
 | Principal | Signal | Trust |
 |---|---|---|
-| `live` | Default when no `JARVIS_PRINCIPAL` and no headless env | Highest — owner watches, can correct in seconds |
+| `live` | Default when no `JARVIS_PRINCIPAL` and no headless env | Highest — principal watches, can correct in seconds |
 | `autonomous` | `JARVIS_PRINCIPAL=autonomous` (set by scheduler/cron launchers) **or** `CLAUDE_CODE_NON_INTERACTIVE`/`CLAUDE_CODE_HEADLESS` | Low — corrections take hours |
 | `subagent` | `JARVIS_PRINCIPAL=subagent` (auto-injection in /delegate is future work) | Medium — isolated worktree, parent reviews diff |
 | `supervised` | `JARVIS_PRINCIPAL=supervised` (future dispatcher launcher will set this) | Delegated — permissions ⊆ supervisor's grant |
@@ -35,11 +35,11 @@ Action tier model is shared with `agents/safety.py` (T0 = AUTO, T1 = OWNER_QUEUE
 | **T2-mirror** `~/.claude/*` files installed by `install.ps1` — see "User-level" table below | ❌ block (use installer) | ❌ block | ❌ block | ❌ block |
 | **T2-secret** `.env*` values; force push to main/master; impersonation; outbound to other humans (PR comments to others, Telegram, email) | ❌ always block | ❌ block | ❌ block | ❌ block |
 
-Currently enforced in code: only **T2** rows, via [`scripts/protected-files.py`](../../scripts/protected-files.py). T1 routing (autonomous-enqueue, supervised-grant) lands when the dispatcher ships; until then T1 work is owner-driven through `/implement` and `/delegate`.
+Currently enforced in code: only **T2** rows, via [`scripts/protected-files.py`](../../scripts/protected-files.py). T1 routing (autonomous-enqueue, supervised-grant) lands when the dispatcher ships; until then T1 work is principal-driven through `/implement` and `/delegate`.
 
 ## Protected Files
 
-These files must NEVER be modified by subagents. Changes require owner review in the main session. This table is the **single source of truth** — skills reference it rather than redefining their own lists.
+These files must NEVER be modified by subagents. Changes require principal review in the main session. This table is the **single source of truth** — skills reference it rather than redefining their own lists.
 
 ### Repo-level (jarvis working copy)
 
@@ -83,13 +83,13 @@ Enforced via PreToolUse hook: `scripts/protected-files.py` (covers both surfaces
 ## Memory Rules
 
 - Agents CAN: store project/decision memories, record outcomes
-- Agents CANNOT: delete memories without owner confirmation (soft delete provides safety net)
+- Agents CANNOT: delete memories without principal confirmation (soft delete provides safety net)
 - Secret scanner blocks credential values in memory_store
 
 ## Scope Rules
 
 - Agent should only modify files relevant to its assigned issue
-- If an agent needs to change a protected file, it must document the needed change in the PR description and leave it for the owner
+- If an agent needs to change a protected file, it must document the needed change in the PR description and leave it for the principal
 - Cross-project changes (jarvis ↔ redrobot) require explicit mention in the issue
 
 ## Escalation

--- a/docs/security/agent-boundaries.md
+++ b/docs/security/agent-boundaries.md
@@ -1,6 +1,6 @@
 # Agent Sandbox Boundaries
 
-Date: 2026-04-15 (revised 2026-04-23 for Pillar 7 Phase 0 federation — #341; revised 2026-04-26 for principal-aware permissions — #426; isatty fallback removed in #429)
+Date: 2026-04-15 (revised 2026-04-23 for Federation & Delegation Phase 0 — #341; revised 2026-04-26 for principal-aware permissions — #426; isatty fallback removed in #429)
 Scope: Permission rules for **all principals** running Claude — interactive owner, autonomous loop, /delegate subagent, and the future dispatcher.
 
 ## Principal model (#426, #429)

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,7 +1,7 @@
 # Jarvis Threat Model
 
 Date: 2026-04-15
-Scope: Full system including multi-agent future (Pillar 7)
+Scope: Full system including multi-agent future (Federation & Delegation pillar)
 
 ## Data Classification
 
@@ -28,7 +28,7 @@ See `docs/security/mcp-audit.md` for per-server analysis. Summary:
 | Data corruption via memory writes | Medium | Soft delete with 30-day retention (#160) |
 | Obsidian vault data exposure | Low | Local only, no network |
 
-### 2. Subagents (current + Pillar 7)
+### 2. Subagents (current + Federation & Delegation pillar)
 
 | Vector | Risk | Current mitigation |
 |--------|------|--------------------|
@@ -36,7 +36,7 @@ See `docs/security/mcp-audit.md` for per-server analysis. Summary:
 | Agent modifies protected files | Medium | **Sprint 2: #162** |
 | Agent corrupts git state (wrong branch, conflict) | Medium | **Sprint 2: #163** |
 | Agent scope creep (edits unrelated files) | Low | CLAUDE.md rules (soft) |
-| Agent-to-agent data poisoning | Low | Not yet addressed (Pillar 7) |
+| Agent-to-agent data poisoning | Low | Not yet addressed (Federation & Delegation pillar) |
 | Agent infinite loop / resource waste | Low | Token budget awareness in CLAUDE.md |
 
 ### 3. External Integrations
@@ -89,7 +89,7 @@ Key flows to protect:
 | Prompt injection via web scrape | Low | Medium | Low | Accepted (Claude instruction hierarchy) |
 | Supply chain attack via dependency | Low | High | Medium | Partial (Dependabot) |
 | Prompt injection via GitHub issue | Low | Medium | Low | Accepted (trusted repo) |
-| Agent-to-agent poisoning | Low | Medium | Low | Deferred (Pillar 7) |
+| Agent-to-agent poisoning | Low | Medium | Low | Deferred (Federation & Delegation pillar) |
 
 ## Mitigations Summary
 
@@ -115,4 +115,4 @@ Key flows to protect:
 ### Accepted Risks
 - **Prompt injection via web/issues**: Claude's instruction hierarchy (system > user > tool output) is the defense. No additional mitigation planned unless incidents occur.
 - **Single-user assumption**: No RLS, no multi-tenant isolation. Acceptable for solo project.
-- **Agent-to-agent poisoning**: Deferred to Pillar 7 when multi-agent architecture is designed.
+- **Agent-to-agent poisoning**: Deferred to Federation & Delegation pillar when multi-agent architecture is designed.


### PR DESCRIPTION
Closes #466

## Summary

Phase B VISION rewrite (#465) renumbered pillars (e.g. old Pillar 7 = Agent System; new Pillar 7 = Integrations) — same number, different meaning across docs. Per the recommendation in #466, pillar **numbers** are now narrative-only in `docs/VISION.md`; everywhere else we use **names**.

This unblocks future renumbering without breaking operational refs, and makes existing docs readable without consulting a mapping table mid-paragraph.

## What changed

**Renamed in 18 files:**

| Was | Now |
|---|---|
| Pillar 7 persistent LangGraph agents | Federation & Delegation pillar — persistent LangGraph agents |
| Pillar 7 Sprint 2 / 4 | Federation & Delegation Sprint 2 / 4 |
| Pillar 7 End-to-End Test | Federation & Delegation End-to-End Test |
| Pillar 7 carveout | Federation & Delegation carveout |
| Ollama Setup for Pillar 7 Agents | Ollama Setup for Federation & Delegation Agents |
| Pillar 4 (memory) | Memory pillar |
| Pillar 4 Phase 5.3 | Memory Phase 5.3 |
| Pillar 9 Sprint 1 shipped | Security & Digital Hygiene Sprint 1 shipped |
| Pillar 2: Autonomous Work Loop | Autonomous Work Loop pillar |
| (Pillar 3) | (Outcome Tracking & Learning pillar) |

**Mapping table added** to `docs/PROJECT_PLAN.md` — name → old number → new number, plus list of historical identifiers that intentionally stay numbered.

## What stays numbered (intentional historical identifiers)

- `docs/VISION.md` Implementation Pillars list (narrative anchors)
- Memory keys: `pillar9_sprint1_self_security`, `pillar7_phase2_six_choices_2026_04_22`
- EPIC issue titles: #335 «Pillar 7 Phase 0: Federation»
- Milestone titles: «Pillar 4 Sprint: feeling-of-knowing»
- `docs/design/jarvis-v2-redesign-review-pass2.md` (historical analysis of the OLD pillar structure)
- `.claude/README.md` reference to EPIC #335 by its existing title

## Drive-by

`memory-overhaul.md` and `jarvis-v2-redesign.md` had `owner` on lines we already touched — fixed to `principal` per Phase A pattern (no separate phase needed; trivial reversible per `Fix > track` rule #428).

## Test plan

- [x] grep `Pillar [1-9]` returns only intentional matches (VISION narrative + EPIC titles + historical refs)
- [x] Mapping table renders correctly in PROJECT_PLAN.md
- [x] No memory keys / EPIC titles renamed
- [ ] code-review plugin runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)