### PR TITLE
docs(vision): Phase C — align docs with Phase B + apply 3 locked redesign edits + add C18

### DIFF
--- a/.claude-userlevel/skills/autonomous-loop/SKILL.md
+++ b/.claude-userlevel/skills/autonomous-loop/SKILL.md
@@ -74,7 +74,7 @@ Generate candidates:
 
 **Write-action permissions (enforced here):**
 - Repos under `Osasuwu/*` → all Low/Medium actions execute normally.
-- Repos under any other owner (e.g. `SergazyNarynov/redrobot`) → **flag-only**: record the finding in memory (`type=project, name=hygiene_sweep_proposals_<repo>_<date>, source_provenance="skill:autonomous-loop"`) and surface it in the output, but never execute the action. Owner acts manually or flips the repo to an owned org.
+- Repos under any other GitHub owner (e.g. `SergazyNarynov/redrobot`) → **flag-only**: record the finding in memory (`type=project, name=hygiene_sweep_proposals_<repo>_<date>, source_provenance="skill:autonomous-loop"`) and surface it in the output, but never execute the action. Principal acts manually or flips the repo to an owned org.
 
 **Dedup per-finding:** before closing a milestone / creating a retroactive one, check `outcome_list(task_type='autonomous', pattern_tags=['hygiene'])` for matching description from last 3 days. Skip if same finding already actioned.
 
@@ -108,7 +108,7 @@ Detect via `gh repo view <R> --json owner --jq .owner.login`:
 | 1 | N ≥ 1 | Memory exists | Memory exists |
 | 2 | N ≥ 2 or days_unaddressed ≥ 1 | `/status` surfaces `STALE FLAG` badge | Same |
 | 3 | N ≥ 3 | Emit `events` row, `severity=high`, `event_type=hygiene_stale` | Same |
-| 4 | N ≥ 5 | Create jarvis-side tracking issue (visibility on GitHub) | Emit `events` row, `severity=critical`, `event_type=hygiene_unaddressed_critical` — owner-facing nudge that auto-actionable findings are still untouched after 5 days; **no tracking issue** (would be paperwork) |
+| 4 | N ≥ 5 | Create jarvis-side tracking issue (visibility on GitHub) | Emit `events` row, `severity=critical`, `event_type=hygiene_unaddressed_critical` — principal-facing nudge that auto-actionable findings are still untouched after 5 days; **no tracking issue** (would be paperwork) |
 
 The own-repo critical-event payload should include `memory_names`, `detail`, and a one-line "next action" suggestion (e.g. "delegate to subagent" / "promote to next /implement cycle").
 
@@ -156,7 +156,7 @@ If empty → create:
 gh issue create --repo Osasuwu/jarvis \
   --title "Stale flag: <repo> findings unaddressed <N>d" \
   --label "process,autonomous-loop" \
-  --body "Autonomous-loop has flagged findings for \`<R>\` on <N> consecutive days without owner action. Memories: <list>. First flagged: <date>. Jarvis cannot open issues in \`<R>\` (flag-only repo), so tracking here for visibility. Close this when the upstream finding is resolved."
+  --body "Autonomous-loop has flagged findings for \`<R>\` on <N> consecutive days without principal action. Memories: <list>. First flagged: <date>. Jarvis cannot open issues in \`<R>\` (flag-only repo), so tracking here for visibility. Close this when the upstream finding is resolved."
 ```
 
 Record the issue URL in the event payload (`payload.jarvis_tracking_issue = <url>`) via an update to the event row.
@@ -194,7 +194,7 @@ VALUES (
 );
 ```
 
-Telegram-notify-hook.py picks this up at `severity=critical` and pings owner. Owner decides: action inline, /delegate, or mark the finding obsolete (which clears it from the next sweep).
+Telegram-notify-hook.py picks this up at `severity=critical` and pings principal. Principal decides: action inline, /delegate, or mark the finding obsolete (which clears it from the next sweep).
 
 **Ordering:** run Step 2b for every repo in `config/repos.conf` after Step 2a. Emitting an event here creates work the Low-risk batch will count (counts toward the 5-max limit).
 
@@ -302,7 +302,7 @@ If any action advances a goal → `goal_update(slug=..., progress=[...])` — ap
 
 ## Step 7.5 — Drain high-severity events to Telegram (#327)
 
-Any `severity=high` events emitted this run (including Step 2b escalations) need to reach the owner outside of `/status`. Run the notifier as the final durable side effect:
+Any `severity=high` events emitted this run (including Step 2b escalations) need to reach the principal outside of `/status`. Run the notifier as the final durable side effect:
 
 ```bash
 python scripts/telegram-notify-hook.py --min-severity high
@@ -321,7 +321,7 @@ Skip silently if the script doesn't exist (older checkouts) — don't make this 
 - Create more than 1 PR per run (even in a batch)
 - Execute more than 5 Low-risk + 1 Medium-risk per run
 - Execute High-risk actions without explicit proposal
-- Execute write actions (close milestone, create milestone, delete branch, `gh issue/pr edit`) on repos outside `Osasuwu/*`. For other owners (e.g. `SergazyNarynov/redrobot`): flag-only — record the finding and surface in output, owner executes manually.
+- Execute write actions (close milestone, create milestone, delete branch, `gh issue/pr edit`) on repos outside `Osasuwu/*`. For other GitHub owners (e.g. `SergazyNarynov/redrobot`): flag-only — record the finding and surface in output, principal executes manually.
 
 **Always:**
 - Dedup: check `autonomous_loop_last_run` before acting

--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: delegate
-description: This skill should be used when the owner asks Jarvis to dispatch one or more GitHub issues to coding subagents (typically multiple issues in parallel), or says "делегируй #X #Y", "раскидай на агентов", "параллельно реализуй #X #Y #Z". Also used by autonomous-loop to hand off a single subagent-scoped job (e.g. CI debug). For a single issue the main session will do itself, use /implement instead. Jarvis's own judgment on task complexity OVERRIDES blind delegation — if a task is unfit for a subagent (needs session context, cross-cutting reasoning, safety review), keep it inline even if owner said "раскидай".
+description: This skill should be used when the principal asks Jarvis to dispatch one or more GitHub issues to coding subagents (typically multiple issues in parallel), or says "делегируй #X #Y", "раскидай на агентов", "параллельно реализуй #X #Y #Z". Also used by autonomous-loop to hand off a single subagent-scoped job (e.g. CI debug). For a single issue the main session will do itself, use /implement instead. Jarvis's own judgment on task complexity OVERRIDES blind delegation — if a task is unfit for a subagent (needs session context, cross-cutting reasoning, safety review), keep it inline even if principal said "раскидай".
 version: 1.0.0
 ---
 
@@ -26,9 +26,9 @@ The main session stays as orchestrator: it reviews each subagent's diff, resolve
 **Mixed batch — split the work:**
 - Keep context-heavy or safety-critical issues for yourself (inline via /implement flow)
 - Delegate the rest to subagents
-- Report the split reasoning briefly to the owner
+- Report the split reasoning briefly to the principal
 
-**Jarvis judgment overrides the owner's "параллельно":** The owner has explicitly delegated this call to Jarvis (memory: this decision). If a task looks deceptively complex or a subagent will struggle (needs memory context, cross-file reasoning, recent-decisions awareness), keep it inline even if asked to delegate. Don't silently downgrade — tell the owner "keeping #X inline because <reason>".
+**Jarvis judgment overrides the principal's "параллельно":** The principal has explicitly delegated this call to Jarvis (memory: this decision). If a task looks deceptively complex or a subagent will struggle (needs memory context, cross-file reasoning, recent-decisions awareness), keep it inline even if asked to delegate. Don't silently downgrade — tell the principal "keeping #X inline because <reason>".
 
 ## Pipeline
 
@@ -48,7 +48,7 @@ For each issue in the batch:
    - **Delegatable** → fresh subagent can handle it from the issue body alone
    - **Inline** → needs session context / safety review / cross-cutting peripheral vision
 
-Produce a short split plan for the owner before acting. Example:
+Produce a short split plan for the principal before acting. Example:
 
 > Batch: #604, #613, #617.
 > - #604 (uncertainty map) → **delegate** — self-contained, single module.
@@ -57,7 +57,7 @@ Produce a short split plan for the owner before acting. Example:
 
 ### 2. Claim all issues
 
-Claim *everything* in the batch up front (label `status:in-progress` + comment), even the ones staying inline. Prevents race with other Jarvis instances or owner forgetting to route.
+Claim *everything* in the batch up front (label `status:in-progress` + comment), even the ones staying inline. Prevents race with other Jarvis instances or principal forgetting to route.
 
 ```bash
 for N in <N1> <N2> ...; do
@@ -117,14 +117,14 @@ HARD RULES for you (subagent):
 - You operate as `JARVIS_PRINCIPAL=subagent` (#426). Hooks classify your tool calls as constrained — protected-file edits and protected-file mirrors will block. Do not try to bypass.
 - Do NOT merge the PR. Open it, push it, record outcome, stop.
 - Do NOT modify protected files (.mcp.json, CLAUDE.md, etc — see docs/security/agent-boundaries.md)
-- Do NOT send messages as the owner
+- Do NOT send messages as the principal
 - Do NOT change values, defaults, or constants that are not explicitly named as targets in the issue body. Centralization / refactoring tasks are structural only — IK seeds, default timeouts, magic numbers, tuple constants must be preserved exactly unless the issue says to change them. If the issue is unclear, preserve the value and flag in the PR body.
 - If you hit a blocker you can't resolve, record a "partial" outcome with a clear note about what's missing
 
 Report back: PR URL + 2-line summary of what you did.
 ```
 
-**Principal env propagation note (#426)**: The Agent tool inherits parent env, so `JARVIS_PRINCIPAL` set in the parent session carries to the subagent. Auto-injection of `JARVIS_PRINCIPAL=subagent` is deferred — the parent is `live` (owner-driven dispatch), and subagents are already constrained by the worktree isolation and skill-level rules above. If a future code path runs `/delegate` autonomously (e.g. dispatcher hands work to a subagent), revisit and inject `JARVIS_PRINCIPAL=subagent` explicitly via the spawn wrapper.
+**Principal env propagation note (#426)**: The Agent tool inherits parent env, so `JARVIS_PRINCIPAL` set in the parent session carries to the subagent. Auto-injection of `JARVIS_PRINCIPAL=subagent` is deferred — the parent is `live` (principal-driven dispatch), and subagents are already constrained by the worktree isolation and skill-level rules above. If a future code path runs `/delegate` autonomously (e.g. dispatcher hands work to a subagent), revisit and inject `JARVIS_PRINCIPAL=subagent` explicitly via the spawn wrapper.
 
 ### 4a. Worktree-isolation caveat
 
@@ -176,7 +176,7 @@ If issues found:
 
 Per each PR (subagent's or your own):
 - Tests green + Copilot clean + LOW/MEDIUM risk → **merge** (see /implement §7.5)
-- HIGH/CRITICAL or safety-critical → wait for owner
+- HIGH/CRITICAL or safety-critical → wait for principal
 - CI infra-blocked (billing, not failing tests) → merge if local tests pass + Copilot clean
 
 ### 8. Record outcomes
@@ -203,10 +203,10 @@ Stale worktrees and branches accumulate fast with multi-issue batches. Clean up 
 
 ## Safety rules
 - All /implement safety rules apply
-- **Subagents must NEVER**: merge PRs, force-push, modify protected files, send messages as owner
+- **Subagents must NEVER**: merge PRs, force-push, modify protected files, send messages as principal
 - Orchestrator reviews **every** subagent diff before merge
 - Parallelism > 3 concurrent → red flag; prefer sequential or smaller batches
-- If owner says "параллельно все" but one task is unfit → keep it inline and tell the owner why
+- If principal says "параллельно все" but one task is unfit → keep it inline and tell the principal why
 
 ## Recovery playbook
 

--- a/.claude-userlevel/skills/end-quick/SKILL.md
+++ b/.claude-userlevel/skills/end-quick/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: end-quick
-description: "Quick session close: checkpoint + commit only. ~30 sec. Use when owner needs to leave fast."
+description: "Quick session close: checkpoint + commit only. ~30 sec. Use when principal needs to leave fast."
 ---
 
 # End Session (Quick)

--- a/.claude-userlevel/skills/end/SKILL.md
+++ b/.claude-userlevel/skills/end/SKILL.md
@@ -63,7 +63,7 @@ Reconcile pre-existing records with anything surfaced in reflection:
   - If no → save it now via `record_decision` (or `memory_store` type=decision) **and flag in Step 7 output**: "Decision X was not recorded in real time — consider why". Real-time capture is the goal; post-hoc saves are a regression.
 - **User preferences** or profile updates → `user` memory (upsert existing, don't duplicate).
 - **Project state** changes → `project` memory.
-- **Feedback** given by owner → `feedback` memory.
+- **Feedback** given by principal → `feedback` memory.
 
 Upsert existing memories, don't create duplicates. Check name before creating new.
 

--- a/.claude-userlevel/skills/goals/SKILL.md
+++ b/.claude-userlevel/skills/goals/SKILL.md
@@ -23,7 +23,7 @@ Strategic goal management. Goals are NOT tasks — they are outcomes Jarvis purs
    - Title, project, priority, deadline (if any)
    - Accomplishment log (progress items marked done, with dates)
    - Risks (if any)
-   - Owner focus / Jarvis focus
+   - Principal focus / Jarvis focus (DB columns are still named `owner_focus`/`jarvis_focus` — schema rename is out of scope)
 3. If any goals have deadline within 7 days — highlight them
 4. If any P0 goals have no recent progress (no done items in last 14 days) — flag risk
 
@@ -100,7 +100,7 @@ Remaining (from success_criteria):
 - Scenario 3
 - UI polish
 Risks: #38 harder than expected
-Owner: Scenario 3 | Jarvis: Monitor #38, infra
+Principal: Scenario 3 | Jarvis: Monitor #38, infra
 
 ---
 
@@ -112,5 +112,5 @@ Done:
 Remaining:
 - Skill
 - Integration (CLAUDE.md, SOUL.md)
-Owner: Review | Jarvis: Implement
+Principal: Review | Jarvis: Implement
 ```

--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: This skill should be used when the owner asks Jarvis to implement a SINGLE GitHub issue directly in the current session, or says "реализуй #42", "сделай #42", "implement #X". For MULTIPLE issues that can run in parallel use /delegate instead. Do NOT trigger for viewing, triaging, or discussing issues — only for actual implementation requests.
+description: This skill should be used when the principal asks Jarvis to implement a SINGLE GitHub issue directly in the current session, or says "реализуй #42", "сделай #42", "implement #X". For MULTIPLE issues that can run in parallel use /delegate instead. Do NOT trigger for viewing, triaging, or discussing issues — only for actual implementation requests.
 version: 1.0.0
 ---
 
@@ -12,7 +12,7 @@ Use this when the work benefits from the full session context (memories just loa
 
 ## Usage
 
-Invoke when owner says "реализуй #42", "сделай #42", "implement #X".
+Invoke when principal says "реализуй #42", "сделай #42", "implement #X".
 Single-issue by default. If multiple issues arrive but only one needs session context → implement the context-heavy one here, hand the rest to `/delegate`.
 
 Target repo: determined from context (CWD, recent conversation, user mention). If ambiguous, ask. Read `config/repos.conf` for the full list of tracked repos.
@@ -50,7 +50,7 @@ Identify: files to change, acceptance criteria, safety implications.
 
 **Safety-critical zones** (`driver/`, `planning/`, `mujoco/`):
 - Post analysis + plan as comment
-- Wait for owner approval before implementing
+- Wait for principal approval before implementing
 - Do NOT dispatch to subagents (keep inline — this skill is the right tool)
 
 ### 3. Claim & branch
@@ -98,8 +98,8 @@ Pass `memories_used = [<uuids from step 0 recall>]` whenever recall surfaced som
 **Protected files — policy depends on who is editing.** The canonical list (repo-level + user-level `~/.claude/*`) lives in [`docs/security/agent-boundaries.md`](../../../docs/security/agent-boundaries.md). Don't duplicate it here — check that file before editing.
 
 - **Subagent dispatch (`/delegate`)** — never edits protected files. If the task requires it, escalate to inline `/implement`.
-- **Inline `/implement` with explicit owner approval in-session** — MAY edit protected files. Document the change prominently in the PR body (mark the file `[PROTECTED]` in the §Files Changed list + rationale) so the owner sees it before merge.
-- **Inline `/implement` without explicit approval** — document the needed change in the PR body and leave the file untouched for the owner.
+- **Inline `/implement` with explicit principal approval in-session** — MAY edit protected files. Document the change prominently in the PR body (mark the file `[PROTECTED]` in the §Files Changed list + rationale) so the principal sees it before merge.
+- **Inline `/implement` without explicit approval** — document the needed change in the PR body and leave the file untouched for the principal.
 
 #### 4a. Already-done audit (mandatory gate)
 
@@ -225,7 +225,7 @@ When implementing multiple related issues back-to-back:
 
 **The current session (the one running /implement) CAN merge — no permission needed for routine PRs:**
 - Tests green + Copilot review addressed + LOW/MEDIUM risk → **merge without asking**
-- HIGH/CRITICAL risk or safety-critical zone (`driver/`, `planning/`, `mujoco/`) → wait for owner explicit approval
+- HIGH/CRITICAL risk or safety-critical zone (`driver/`, `planning/`, `mujoco/`) → wait for principal explicit approval
 - CI infra-blocked (billing failure, empty `steps` array — not *failing* tests) → merge if local tests green AND Copilot review clean
 - Copilot findings are advisory — address substantive ones, ignore style nits
 
@@ -246,7 +246,7 @@ This prevents stale branch accumulation. If the branch has unmerged work, `-d` w
 - Never force-push to `master` / `main` or a shared branch
 - If change fails tests or breaks build, fix before pushing
 - Safety-critical code (`driver/`, `planning/`, `mujoco/`): analyze and comment, don't implement without approval
-- Merge policy: see §7.5 — LOW/MEDIUM routine merges are autonomous, HIGH/CRITICAL wait for owner
+- Merge policy: see §7.5 — LOW/MEDIUM routine merges are autonomous, HIGH/CRITICAL wait for principal
 
 ## Diff review (before marking done)
 

--- a/.claude-userlevel/skills/reflect/SKILL.md
+++ b/.claude-userlevel/skills/reflect/SKILL.md
@@ -122,7 +122,7 @@ Renders per-type Brier score (mean squared error of `confidence - actual_outcome
 - `brier > 0.25` AND `avg_predicted < avg_actual` → **underconfident**
 - `n < 20` → warning (insufficient data, skip calibration-based action)
 
-Surface flagged types in Step 9 output under "Calibration". Poor-calibration types become ideation seeds for `/self-improve` — the root cause is usually a specific pattern (e.g. "my `decision` memories in jarvis are overconfident when they rely on research memories without owner confirmation").
+Surface flagged types in Step 9 output under "Calibration". Poor-calibration types become ideation seeds for `/self-improve` — the root cause is usually a specific pattern (e.g. "my `decision` memories in jarvis are overconfident when they rely on research memories without principal confirmation").
 
 ## Step 6 — Extract lessons + patterns
 

--- a/.claude-userlevel/skills/status/SKILL.md
+++ b/.claude-userlevel/skills/status/SKILL.md
@@ -64,7 +64,7 @@ WHERE name LIKE 'hygiene_sweep_proposals_%'
 ORDER BY created_at ASC
 LIMIT 10;
 ```
-These are flag-only findings autonomous-loop recorded against foreign-owner repos (e.g. redrobot). Each day without owner action compounds — the `/status` prompt is the daily nudge. Compute `days_unaddressed = today - date(created_at)` per memory and group by repo (name format `hygiene_sweep_proposals_<repo>_<date>`).
+These are flag-only findings autonomous-loop recorded against foreign-owner repos (e.g. redrobot). Each day without principal action compounds — the `/status` prompt is the daily nudge. Compute `days_unaddressed = today - date(created_at)` per memory and group by repo (name format `hygiene_sweep_proposals_<repo>_<date>`).
 
 
 ## Step 3 — Analyze
@@ -105,7 +105,7 @@ Flag: N stale branches (remote gone), M unmerged branches, K stashes.
 
 ## Step 4 — Output
 
-**STALE FLAG section goes at the top of Alerts** — these compound daily and the owner needs to see them first. Group by repo; show oldest first so the most-ignored rises to the top:
+**STALE FLAG section goes at the top of Alerts** — these compound daily and the principal needs to see them first. Group by repo; show oldest first so the most-ignored rises to the top:
 
 ```
 [STALE FLAG] <repo> — <N>d unaddressed (<M> consecutive flags)
@@ -141,4 +141,4 @@ Omit the section if no stale flag-only findings were returned.
 3. <etc>
 ```
 
-Keep concise. Skip empty sections. Owner scans in 30 seconds.
+Keep concise. Skip empty sections. Principal scans in 30 seconds.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Personal AI agent built on [Claude Code](https://claude.ai/code) + [MCP](https://modelcontextprotocol.io/).
 
-> **Jarvis -- cognitive extension of a developer: sees the full picture, works while you sleep, argues when you're wrong, and gets more accurate every day.**
+> **Jarvis -- autonomous engineering peer for one principal: sees the full picture, works while you sleep, argues when you're wrong, and gets more accurate every day.**
 
-Not a tool, not an assistant -- an extension of thinking capacity, memory, and executive function. A solo developer lacks not hands but **breadth**. Jarvis compensates: tracking, researching, monitoring, remembering, prioritizing.
+Not a tool, not an assistant. A peer-role with asymmetric responsibilities: the principal owns taste, stop-decisions, and physical-world interface; Jarvis owns breadth, persistence, and implementation. A solo developer lacks not hands but **breadth** -- Jarvis compensates: tracking, researching, monitoring, remembering, prioritizing. See [`docs/VISION.md`](docs/VISION.md) for the full framing.
 
 > **Status:** v0.2.0 -- core memory + skills working. [Capability map below](#capabilities).
 
@@ -108,16 +108,20 @@ All devices connect to the same Supabase instance. No manual sync.
 
 ## Capabilities
 
-17 capabilities grouped into 6 pillars. (Internally the design doc also stratifies them into 4 layers + cross-cutting — Identity / Cognition / Action / Interface / Cross-cutting — but pillars are the stable user-facing grouping.) Live migration progress lives in GitHub milestones, not in this file (status text gets stale).
+The architecture has two complementary groupings:
 
-| Pillar | Capabilities |
-|--------|--------------|
-| Memory | C3 Memory store, C5 Reflection / learning, C17 Observability |
-| Identity & Strategy | C1 Identity & values, C2 Goals & priorities |
-| Cognition | C4 Reasoning & planning, C6 Decision gating |
-| Action | C7 Execution, C8 Sub-orchestration, C9 Tool / environment interface, C10 Research |
-| Interface | C11 Perception, C12 Communication with user |
-| Stewardship | C13 Budget, C14 Security & privacy, C15 Self-improvement, C16 Verification |
+- **Vision pillars** — 8 narrative tracks + Digital Twin mode, organized around the [Five Axes](docs/VISION.md#five-axes) (what it knows / wants / thinks / does / learns). Stable framing for «what Jarvis is».
+- **Capabilities (caps)** — 18 implementation units grouped into engineering layers (Identity / Cognition / Action / Interface / Cross-cutting). Stable framing for «what we build». This is the structural unit — sprints close caps, not pillars.
+
+The cap-to-axis grouping below is a quick map; pillar membership is intentionally narrative-only (per [pillars vs caps decision](docs/VISION.md#implementation-pillars)). Live migration progress lives in GitHub milestones, not here.
+
+| Axis (Vision) | Capabilities |
+|---|---|
+| What it knows — World Model | C3 Memory store, C11 Perception, C17 Observability |
+| What it wants — Goals | C2 Goals & priorities |
+| How it thinks — Judgment & Identity | C1 Identity & values, C4 Reasoning & planning, C6 Decision gating, C18 Proactive challenger |
+| How it acts — Execution | C7 Execution, C8 Sub-orchestration, C9 Tool / environment interface, C10 Research, C12 Communication, C13 Budget, C14 Security & privacy, C16 Verification |
+| How it learns — Outcomes & Reflection | C5 Reflection / learning, C15 Self-improvement |
 
 Full capability detail, migration order, and bootstrap protocol: [docs/design/jarvis-v2-redesign.md](docs/design/jarvis-v2-redesign.md). Vision: [docs/VISION.md](docs/VISION.md). Active sprint scope: [GitHub milestones](https://github.com/Osasuwu/jarvis/milestones).
 

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -9,7 +9,7 @@
 | What you need | Where to look |
 |---|---|
 | Vision / north-star | [`docs/VISION.md`](VISION.md) |
-| Architecture (17 capabilities, 5 layers, migration order, bootstrap) | [`docs/design/jarvis-v2-redesign.md`](design/jarvis-v2-redesign.md) |
+| Architecture (18 capabilities, 5 layers, migration order, bootstrap) | [`docs/design/jarvis-v2-redesign.md`](design/jarvis-v2-redesign.md) |
 | C4 diagrams (Context / Container / Component) | [`docs/design/jarvis-architecture-c4.md`](design/jarvis-architecture-c4.md) |
 | User / data-flow diagrams (8 scenarios) | [`docs/design/jarvis-flows.md`](design/jarvis-flows.md) |
 | Build-vs-buy library audit | [`docs/design/jarvis-build-vs-buy.md`](design/jarvis-build-vs-buy.md) |

--- a/docs/agents/dispatcher.md
+++ b/docs/agents/dispatcher.md
@@ -71,7 +71,7 @@ Failure modes surface as rows, not exceptions:
 | What fails | Surface |
 |-----------|---------|
 | `Popen` raises (e.g. `claude` not on PATH) | `audit_log` row with `outcome='failure:<ExceptionType>'`, FSM stays at `pending` |
-| `task_queue.update` fails (transient network) | `safety.audit` still records `success` (subprocess spawned); owner sees orphaned audit row + unchanged queue and can reconcile |
+| `task_queue.update` fails (transient network) | `safety.audit` still records `success` (subprocess spawned); principal sees orphaned audit row + unchanged queue and can reconcile |
 | Escalation check fires mid-flight | `evaluate_branch` routes to `escalate` — no subprocess spawned |
 
 ## Safety gate interpretation

--- a/docs/agents/escalation.md
+++ b/docs/agents/escalation.md
@@ -3,7 +3,7 @@
 Module: `agents/escalation.py`. Ships as **S2-4** (issue #299) — the
 guardrails dispatcher (S2-3, #298) calls before every live dispatch. If
 any trigger fires, the `task_queue` row flips to `escalated` and an
-`events` row (`severity=high`) tells the owner.
+`events` row (`severity=high`) tells the principal.
 
 ## Triggers
 
@@ -41,14 +41,14 @@ if check.should_escalate:
 
 `check_all` runs triggers in this priority order:
 
-1. **Stale approval** — owner needs to re-approve, cheapest fix.
+1. **Stale approval** — principal needs to re-approve, cheapest fix.
 2. **Scope drift** — files changed, approval is stale in a different way.
 3. **Limit near-exhaustion** — wait for budget, no config change needed.
 4. **Cross-task conflict** — another task is already touching these files.
-5. **Pattern repeat** — probable loop; owner should inspect the queue.
+5. **Pattern repeat** — probable loop; principal should inspect the queue.
 
 First-match wins — surfacing five simultaneous reasons would drown the
-owner in noise. If multiple fire, the earliest-fixable one shows up in
+principal in noise. If multiple fire, the earliest-fixable one shows up in
 the event.
 
 ## `escalate()` side effect

--- a/docs/agents/observability.md
+++ b/docs/agents/observability.md
@@ -90,8 +90,8 @@ Get-EventLog -LogName System -Source "Service Control Manager" -Newest 20 |
 
 ### 4. Telegram channels — escalations + dispatch reports
 
-Owner-facing Telegram channel receives:
-- Escalations from the escalation ladder ([#327](https://github.com/Osasuwu/jarvis/issues/327)) — owner action needed
+Principal-facing Telegram channel receives:
+- Escalations from the escalation ladder ([#327](https://github.com/Osasuwu/jarvis/issues/327)) — principal action needed
 - Dispatcher post-run reports (success/failure summaries)
 
 Silence in Telegram is **not** evidence of health — could mean dispatcher is down. Cross-reference with `audit_log`.
@@ -115,12 +115,12 @@ Outputs a text report: 24 h dispatch count per agent, failures, gaps, stale orph
 | `apscheduler_jobs` rows | matches registered set | unexpected id present | 0 rows on running service |
 | `Get-Service jarvis-scheduler` | Running | Stopped (service start pending) | Not found / Disabled |
 
-`> 2 hours` of silence on `task-dispatcher` = wake owner via Telegram (when escalation auto-pinging is wired) or page manually.
+`> 2 hours` of silence on `task-dispatcher` = wake principal via Telegram (when escalation auto-pinging is wired) or page manually.
 
 ## What this doc is NOT
 
-- Not real-time alerting — Phase 1 is reactive (owner queries on demand)
-- Not a dashboard — owner runs the morning check at their own cadence
+- Not real-time alerting — Phase 1 is reactive (principal queries on demand)
+- Not a dashboard — principal runs the morning check at their own cadence
 - Not exhaustive metrics — captures liveness + failure rate, nothing finer-grained
 
 If/when we want auto-alerts or dashboards, file a separate issue. This is the minimum viable observability.

--- a/docs/agents/perception.md
+++ b/docs/agents/perception.md
@@ -17,7 +17,7 @@ truth for `approved_by` namespace, `auto_dispatch` policy, and
 Sprint 5 gets spent unifying them. This doc settles the conventions
 **before** code lands.
 
-Owner decisions encoded here (resolved 2026-04-25, [#386
+Principal decisions encoded here (resolved 2026-04-25, [#386
 comment](https://github.com/Osasuwu/jarvis/issues/386)):
 
 1. Safety gate is **always** in the FSM. Strictness is a gradient over
@@ -53,8 +53,8 @@ mutation, regardless of source tier.
 | Source tier | `auto_dispatch` | Dispatcher behaviour |
 |-------------|-----------------|----------------------|
 | `tier:1-auto` | `true` | Picked up on next tick. Escalation triggers still apply. |
-| `tier:2-review` | `false` | Row sits in `pending`. Owner flips `auto_dispatch=true` after review (or runs `/implement` manually). |
-| `tier:3-human` | `false` | Row exists for tracking only. Dispatcher never touches it. Owner-driven from start to finish. |
+| `tier:2-review` | `false` | Row sits in `pending`. Principal flips `auto_dispatch=true` after review (or runs `/implement` manually). |
+| `tier:3-human` | `false` | Row exists for tracking only. Dispatcher never touches it. Principal-driven from start to finish. |
 
 `auto_dispatch=true` is the *only* signal `dispatcher.poll_queue_node`
 honours. The source tier label is metadata for humans and for
@@ -96,13 +96,13 @@ Caveat: as of Sprint 4, the dispatcher is fire-and-forget — it sets
 `dispatched_at` and never flips status to `done` itself ([dispatcher.md
 "Fire-and-forget semantics"](dispatcher.md)). The done-watcher in #388
 will idle until a result-collection path lands (future sprint) or until
-the owner flips status manually via `/verify`. Implementers: write the
+the principal flips status manually via `/verify`. Implementers: write the
 watcher, but expect zero firings until that upstream change.
 
 Open in flight: what happens if labels change post-ingest — re-tier the
 existing row, or freeze at ingest-time? **Decision: freeze at ingest.**
 Re-tier introduces a race where the dispatcher reads tier:1 but the row
-silently became tier:3. Owner can close + re-open the issue if a re-tier
+silently became tier:3. Principal can close + re-open the issue if a re-tier
 is needed; idempotency_key includes the label set, so re-applying labels
 produces a fresh key and a fresh row.
 
@@ -133,10 +133,10 @@ Listed so conventions don't shift when these land:
 
 | Source | `approved_by` prefix | `idempotency_key` formula | Default `auto_dispatch` |
 |--------|----------------------|----------------------------|--------------------------|
-| Telegram (deferred from #387) | `telegram:<owner_id>` | `sha256(chat_id \| message_id)` | `false` (owner classifies inline via bot) |
+| Telegram (deferred from #387) | `telegram:<principal_id>` | `sha256(chat_id \| message_id)` | `false` (principal classifies inline via bot) |
 | Email | `email:<from_address>` | `sha256(message_id)` | `false` |
 | Calendar | `calendar:<event_uid>` | `sha256(event_uid \| occurrence_start)` | varies — recurring events default `false` |
-| Voice | `voice:<owner>` | `sha256(audio_sha256)` | `false` (transcription happens before ingest) |
+| Voice | `voice:<principal>` | `sha256(audio_sha256)` | `false` (transcription happens before ingest) |
 
 Rule for adding a new source: extend this table in the same PR that adds
 the perception module. The `approved_by` prefix MUST be unique across
@@ -170,7 +170,7 @@ states; the existing FSM is sufficient.
               │ auto_dispatch=true           │ auto_dispatch=false
               ▼                              ▼
     ┌──────────────────┐         ┌──────────────────────┐
-    │ dispatcher       │         │ Owner / /implement   │
+    │ dispatcher       │         │ Principal / /implement│
     │ poll_queue_node  │         │ (manual)             │
     └────────┬─────────┘         └──────────┬───────────┘
              │                              │
@@ -193,13 +193,13 @@ Existing FSM transitions (from `task_queue` migration, unchanged):
 ```
 pending    → dispatched | escalated | rejected
 dispatched → done | escalated
-escalated  → pending           (owner re-approves)
+escalated  → pending           (principal re-approves)
 done       → (terminal)
 rejected   → (terminal)
 ```
 
 Perception adds *no* new state. Every transition still happens in the
-dispatcher / owner-driven path; perception's job ends the moment the row
+dispatcher / principal-driven path; perception's job ends the moment the row
 is INSERTed.
 
 ### Idempotency under retry
@@ -254,18 +254,18 @@ signature ([`safety.py`](../../agents/safety.py)). What changes is
 | Axis | Effect on strictness | Example |
 |------|---------------------|---------|
 | **Source** (`approved_by` prefix) | Trusted prefixes (`github:issue:` from allowlisted repo, `cron:morning_check` for own tasks) get the standard whitelist. Untrusted prefixes (`external:*` — future) get a narrower whitelist. | A `cron:` source can `audit_log:insert` (Tier 0); an `external:` source cannot. |
-| **Source tier** | Higher tier (1 → 2 → 3) → more checks. Tier 1 fires through the existing gate. Tier 2/3 don't reach the gate at all because `auto_dispatch=false`. | Tier 3 is owner-driven by definition; gate checks the owner's actions, not the tier. |
+| **Source tier** | Higher tier (1 → 2 → 3) → more checks. Tier 1 fires through the existing gate. Tier 2/3 don't reach the gate at all because `auto_dispatch=false`. | Tier 3 is principal-driven by definition; gate checks the principal's actions, not the tier. |
 | **Executor model** | Stronger model (e.g. Claude Opus) gets looser scope-file diffing tolerance; weaker (Haiku) gets tighter. *Implementation lives in `agents/dispatcher.py` when model selection is wired in — not Sprint 4.* | Future: dispatcher reads model hint from row metadata, picks gate config. |
 
 What this means concretely for Sprint 4 implementation:
 
 - **#388 (GitHub ingest)**: no gate changes. `tier:1-auto` rows go through the existing gate. The label is the human nod; the gate is the technical guardrail.
-- **#389 (self-perception)**: every row is tier:3 → `auto_dispatch=false` → never reaches dispatch path → gate not invoked. Owner triggers the actual fix manually.
+- **#389 (self-perception)**: every row is tier:3 → `auto_dispatch=false` → never reaches dispatch path → gate not invoked. Principal triggers the actual fix manually.
 - **Future sources**: extend the `_TIER0_*` / `_TIER2_*` constants in `agents/safety.py` with source-aware classifications (or add a new `_TIER0_PERCEPTION_*` set). Don't touch the `gate()` signature.
 
 ### Why source tier ≠ skip-gate
 
-Owner-stated principle: gate is always there. The intuition that pushed
+Principal-stated principle: gate is always there. The intuition that pushed
 back on "gate skip for cron-internal tasks" was correct — once you allow
 *any* source to skip the gate, the audit trail breaks and the
 single-bottleneck property goes away. The gate's job is to be the last

--- a/docs/agents/safety.md
+++ b/docs/agents/safety.md
@@ -8,7 +8,7 @@ Model memory: `action_agent_safety_gate_model_v1`.
 
 | Tier | Meaning | Examples |
 |------|---------|----------|
-| `0 AUTO` | Fires without owner involvement. | `priority:{high,medium,low}`, `area:*`, `needs-research`, `needs-triage`, `status:ready` labels. Insert into `events` / `audit_log`. `goals.progress` append. Memory store with tag `auto-generated`. |
+| `0 AUTO` | Fires without principal involvement. | `priority:{high,medium,low}`, `area:*`, `needs-research`, `needs-triage`, `status:ready` labels. Insert into `events` / `audit_log`. `goals.progress` append. Memory store with tag `auto-generated`. |
 | `1 OWNER_QUEUE` | Default. Gate refuses to fire and flags `queued=True`. | New issue comments, closing issues, merging PRs, `priority:critical`, `pillar:*` labels, any write to a table not on the Sprint-1 whitelist. |
 | `2 BLOCKED` | Never runs. `gate()` raises `GateError`. | `.env*`, `.claude/*`, destructive verbs (`delete`, `drop`, `force_push`), impersonation / `send_as_owner`, cross-repo writes, the whole `messaging` area. |
 
@@ -85,7 +85,7 @@ double-count.
 
 ## Changing tiers
 
-Owner-driven moves only. If the owner says "stop asking about X,
+Principal-driven moves only. If the principal says "stop asking about X,
 auto-apply it" → move the action to Tier 0 and narrow the rule as much
 as possible. If "this was too aggressive" → move to Tier 1. Each move
 is a decision memory with the reason. Never expand Tier 0 silently.

--- a/docs/design/jarvis-architecture-c4.md
+++ b/docs/design/jarvis-architecture-c4.md
@@ -1,4 +1,4 @@
-# Jarvis Architecture — C4 Views (revised 2026-04-28)
+# Jarvis Architecture — C4 Views (revised 2026-04-29)
 
 Four views: Context (system in environment), Container (runtime + storage), Component (18 capabilities in 5 layers + cross-cutting), Event-substrate dataflow (the load-bearing edge: `everything → C17`). Companion to [`jarvis-v2-redesign.md`](jarvis-v2-redesign.md). C18 (Proactive challenger) added in Phase C (2026-04-29) per `audit_3_main_changes_lock_2026_04_28`; mermaid sources below include c18, SVG outputs need re-render. Reflects L3 concrete adoptions folded in 2026-04-27/28 — see [`jarvis-build-vs-buy.md`](jarvis-build-vs-buy.md).
 

--- a/docs/design/jarvis-architecture-c4.md
+++ b/docs/design/jarvis-architecture-c4.md
@@ -1,6 +1,6 @@
 # Jarvis Architecture — C4 Views (revised 2026-04-28)
 
-Four views: Context (system in environment), Container (runtime + storage), Component (17 capabilities in 5 layers + cross-cutting), Event-substrate dataflow (the load-bearing edge: `everything → C17`). Companion to [`jarvis-v2-redesign.md`](jarvis-v2-redesign.md). Reflects L3 concrete adoptions folded in 2026-04-27/28 — see [`jarvis-build-vs-buy.md`](jarvis-build-vs-buy.md).
+Four views: Context (system in environment), Container (runtime + storage), Component (18 capabilities in 5 layers + cross-cutting), Event-substrate dataflow (the load-bearing edge: `everything → C17`). Companion to [`jarvis-v2-redesign.md`](jarvis-v2-redesign.md). C18 (Proactive challenger) added in Phase C (2026-04-29) per `audit_3_main_changes_lock_2026_04_28`; mermaid sources below include c18, SVG outputs need re-render. Reflects L3 concrete adoptions folded in 2026-04-27/28 — see [`jarvis-build-vs-buy.md`](jarvis-build-vs-buy.md).
 
 Rendered SVGs alongside each block: [c4-1.svg](c4-1.svg) Context · [c4-2.svg](c4-2.svg) Container · [c4-3.svg](c4-3.svg) Component · [c4-4.svg](c4-4.svg) Event dataflow. Re-render: `npx -p @mermaid-js/mermaid-cli mmdc -i jarvis-architecture-c4.md -o c4.svg` (writes `c4-1.svg`…`c4-4.svg`).
 
@@ -10,17 +10,17 @@ Rendered SVGs alongside each block: [c4-1.svg](c4-1.svg) Context · [c4-2.svg](c
 
 ```mermaid
 flowchart LR
-    owner((Owner))
+    principal((Principal))
     jarvis[Jarvis<br/>Personal AI agent<br/>Claude Code-native + Supabase]
 
-    owner -->|interactive + queue approvals| jarvis
+    principal -->|interactive + queue approvals| jarvis
 
     jarvis -->|inference Max sub| claude_api[Anthropic Claude]
     jarvis -->|different-provider review| other_llm[OpenAI / Gemini]
     jarvis -->|memory + events + queues| supabase[(Supabase Postgres<br/>pgvector + pg_cron)]
     jarvis -->|embeddings| voyage[VoyageAI]
     jarvis -->|repos + Actions| github[GitHub]
-    owner -->|issues + comments + corrections| github
+    principal -->|issues + comments + corrections| github
     jarvis -->|credential probes| hibp[HaveIBeenPwned]
     jarvis -->|fork base + install| plugin_eco[Anthropic plugins<br/>claude-plugins-official + skills]
 ```
@@ -31,7 +31,7 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-    owner((Owner))
+    principal((Principal))
 
     subgraph SURFACE[Claude Code surface]
         direction TB
@@ -69,7 +69,7 @@ flowchart LR
         hibp[HIBP]
     end
 
-    owner --> claude_code
+    principal --> claude_code
     claude_code --> hooks
     claude_code --> subagents
     claude_code --> PLUGINS
@@ -111,6 +111,7 @@ flowchart TB
         c4[C4 Reasoning]
         c5[C5 Reflection]
         c6[C6 Decision gating]
+        c18[C18 Proactive challenger]
     end
 
     subgraph ACT[Action]
@@ -141,6 +142,7 @@ flowchart TB
     c2 --> c6
     c5 --> c2
     c11 --> c17
+    c11 --> c18
     c6 --> c17
     c6 --> c3
     c5 --> c17
@@ -154,6 +156,7 @@ flowchart TB
     c15 --> c16
     c13 --> c17
     c12 --> c6
+    c18 --> c12
 ```
 
 ## C4 Level 4 — Event-substrate dataflow
@@ -200,7 +203,7 @@ sequenceDiagram
         Pg->>MV: last_run_by_actor_mv
     end
 
-    Note over Pg, C5h: pg LISTEN/NOTIFY on outcome_recorded, owner_correction, anomaly_flagged, recall_failed
+    Note over Pg, C5h: pg LISTEN/NOTIFY on outcome_recorded, principal_correction, anomaly_flagged, recall_failed
     Pg-->>C5h: trigger handler - synthesizer or stale-challenge or calibrator
     C5h->>C5h: pattern extraction with crepes Mondrian CP for sparse classes
     C5h->>C3w: candidate fact - auto-write if confidence above class threshold, else queue
@@ -218,10 +221,10 @@ sequenceDiagram
 
 ## Reading guide
 
-- **Identity layer** is owner-authored axioms — the alignment substrate. Never auto-mutated (M3). Drift detection delegated to `claude-md-management` plugin (C12).
+- **Identity layer** is principal-authored axioms — the alignment substrate. Never auto-mutated (M3). Drift detection delegated to `claude-md-management` plugin (C12).
 - **Cognition layer** is what Jarvis *thinks with*. C3 is the durable substrate (bi-temporal facts + episodic events); C4 sequences work on a LangGraph-backed plan store; C5 is the active loop that mutates C3 from C17 events with class-conditional calibration; C6 is the act/ask classifier consulted before every tool call.
 - **Action layer** is what Jarvis *does*. C7/C8/C9 are the runtime; C10 is the external info-gathering arm with GPT Researcher as primary engine.
-- **Interface layer** is the boundary with the owner — C11 ingests with a YAML noise filter; C12 communicates out via CLI + Anthropic plugins.
+- **Interface layer** is the boundary with the principal — C11 ingests with a YAML noise filter; C12 communicates out via CLI + Anthropic plugins.
 - **Cross-cutting** layer wraps everything: C17 is the substrate every event passes through; C13/C14/C16/C15 are governance/safety/quality/evolution functions that consume and gate.
 
 The single most load-bearing edge is **everything → C17** (visualized in Level 4): substrate-as-source-of-truth means audit, reflection, calibration, cost, and review all share the same data. Materialized projections per hot read path (per Q1 reframe — Honeycomb / Greptime "Observability 2.0" guidance) prevent read-amplification on long streams.

--- a/docs/design/jarvis-build-vs-buy.md
+++ b/docs/design/jarvis-build-vs-buy.md
@@ -4,7 +4,7 @@ Companion to [`jarvis-v2-redesign.md`](jarvis-v2-redesign.md). Two parallel scou
 
 ## Constraints (load-bearing)
 
-These are owner-locked decisions that pre-filter every adoption candidate:
+These are principal-locked decisions that pre-filter every adoption candidate:
 
 1. **`architecture_final` (2026-03-28, confirmed 2026-03-31):** *"Anthropic-native stack only. No custom Python services. Before writing Python for any feature: can Claude Code skills/MCP/hooks/subagents do it? If yes → don't write Python."*
    - Filters out: Cognee container, Letta runtime, LiteLLM proxy, Phoenix backend, OpenHands/Goose/Cline/Continue runtimes.
@@ -32,7 +32,7 @@ Three columns: **Adopt** (drop-in, integrates as MCP/plugin/hook/skill), **Patte
 |---|---|---|---|
 | **C3 Memory** | None (heavy runtimes filtered) | **Zep / Graphiti** ([arXiv:2501.13956](https://arxiv.org/abs/2501.13956)) — bi-temporal column shape (`t_valid`/`t_invalid`/transaction-time). **Cognee** schema — node/edge + embedding. **LangGraph PostgresStore** for namespace-tuple `(facts \| episodes)` indexing pattern. | Bi-temporal `valid_from`/`valid_to`/`superseded_by` migration on existing `mcp-memory/server.py`. Conflict classifier (Haiku ADD/UPDATE/SUPERSEDE/NOOP). Provenance-aware ranking. |
 | **C4 Reasoning** | **sequential-thinking MCP** (already installed). **LangGraph as one MCP server** (Federation & Delegation carveout) wrapping Postgres checkpointer pointing at Supabase. | **Magentic-One ledger** ([MS Agent Framework 1.0](https://github.com/microsoft/agent-framework), MIT) — verified-facts / derived-facts / guesses tri-ledger pattern for plan state. **Plan-and-Execute** template (LangGraph). | `applies_when` / `skip_if` template runtime. Replan-on-stall. Skills→templates migration glue. |
-| **C5 Reflection** | None | **Letta sleep-time agents** (Apache-2.0) — async secondary writer pattern. Implement as Routine. **Reflexion** (MIT) — verbal-feedback loop algorithm. **Cognee evolution pass** — synthesis-on-ingest reference. | Stale-belief challenger. LLM-as-judge Brier-score calibration. Owner-correction → label loop. |
+| **C5 Reflection** | None | **Letta sleep-time agents** (Apache-2.0) — async secondary writer pattern. Implement as Routine. **Reflexion** (MIT) — verbal-feedback loop algorithm. **Cognee evolution pass** — synthesis-on-ingest reference. | Stale-belief challenger. LLM-as-judge Brier-score calibration. Principal-correction → label loop. |
 | **C6 Decision gating** | **PreToolUse hooks + permissions** (Claude Code native). **Guardrails AI** (Apache-2.0) — Pydantic schemas for *output* validation only, called from hook. | — | **Everything substantive.** State-aware classification (git status, convergence counter, harness restrictions) has no library — confirmed by scout 2: all gating frameworks are stateless. Tier 1 queue table custom. Auto-emit decision events custom. |
 
 ### Action layer
@@ -121,11 +121,11 @@ Honest accounting (not the scout-1 70% number):
 
 **Aggregate: ~45% adoption + pattern coverage; ~55% custom-build.** Mainly because the substrate caps (C3/C6/C13/C17) and the project-specific safety caps (C8/C15) all skew custom under the "no Python services" filter.
 
-## Owner decisions 2026-04-27
+## Principal decisions 2026-04-27
 
 - **Q1 — fork Anthropic Code Review plugin: yes, first task next session.** Single biggest buy-win (~70-80% C16). Sprint shape: fork → adapt CLAUDE.md compliance reviewer → add 3 missing reviewers (diff-coherence subagent-fabrication, cross-device integrity, smoke-test) → wire into PR pipeline.
 - **Q2 — LangGraph carveout may expand** beyond plan-only. Still wrapped behind ONE MCP boundary, not used directly throughout codebase. Additional state-machine use cases acceptable when they fit.
-- **Q3 — `architecture_final` ("no Python services") rule stays.** Owner explicitly preferred custom-build over running Cognee/LiteLLM/Phoenix containers across 3 devices. The 55% custom-build remaining is acceptable.
+- **Q3 — `architecture_final` ("no Python services") rule stays.** Principal explicitly preferred custom-build over running Cognee/LiteLLM/Phoenix containers across 3 devices. The 55% custom-build remaining is acceptable.
 
 ## Action items (next-session priority order)
 
@@ -205,4 +205,4 @@ If the "no Python services" rule were relaxed (e.g., one shared cloud container 
 - **Phoenix** becomes adoptable (~40% of C17 covered).
 - Aggregate adoption rises to ~65-70%.
 
-Trade-off owner explicitly weighed and rejected: cross-device sync for the Python services creates a new pain class outweighing build savings.
+Trade-off principal explicitly weighed and rejected: cross-device sync for the Python services creates a new pain class outweighing build savings.

--- a/docs/design/jarvis-flows.md
+++ b/docs/design/jarvis-flows.md
@@ -6,25 +6,25 @@ Re-render: `npx -p @mermaid-js/mermaid-cli mmdc -i jarvis-flows.md -o flow.svg` 
 
 ## Index
 
-1. [Owner session userflow](#1--owner-session-userflow) — how a session starts, runs, and ends from owner's POV.
+1. [Principal session userflow](#1--principal-session-userflow) — how a session starts, runs, and ends from principal's POV.
 2. [Memory I/O — write + recall](#2--memory-io--write--recall) — the C3 canonical funnel.
 3. [C6 decision gate](#3--c6-decision-gate) — pre-action act/ask classifier with 6 outcomes.
 4. [C8 sub-orchestration dispatch](#4--c8-sub-orchestration-dispatch) — pre/post-dispatch gates around subagent worktree work.
 5. [C5 reflection triggers and handlers](#5--c5-reflection-triggers-and-handlers) — event-driven mutation arm.
 6. [C15 self-modification cycle](#6--c15-self-modification-cycle) — M0–M3 propose → safeguards → apply → measure.
-7. [C16 PR review pipeline](#7--c16-pr-review-pipeline) — reviewer triggers, aggregation, owner surface.
+7. [C16 PR review pipeline](#7--c16-pr-review-pipeline) — reviewer triggers, aggregation, principal surface.
 8. [C13 cost cap enforcement](#8--c13-cost-cap-enforcement) — event ledger → projection → soft/hard cap → gate.
 
 ---
 
-## 1 — Owner session userflow
+## 1 — Principal session userflow
 
 ![Session userflow](flow-1.svg)
 
 ```mermaid
 sequenceDiagram
     autonumber
-    actor Owner
+    actor Principal
     participant Sched as Scheduled task
     participant GHA as GitHub Action
     participant ALoop as autonomous-loop
@@ -34,8 +34,8 @@ sequenceDiagram
     participant Mem as Memory recall
     participant State as working_state_jarvis
 
-    alt Owner-initiated
-        Owner->>CC: claude (interactive start)
+    alt Principal-initiated
+        Principal->>CC: claude (interactive start)
     else Scheduled task fire
         Sched->>CC: spawn with task prompt
     else GHA event
@@ -50,23 +50,23 @@ sequenceDiagram
     Hook->>Pg: goal_list active
     Hook->>State: read working_state if present
     Hook-->>CC: inject context (compact, in window)
-    CC-->>Owner: ready prompt with one-line continuation offer if state found
+    CC-->>Principal: ready prompt with one-line continuation offer if state found
 
     loop interaction
-        Owner->>CC: message
+        Principal->>CC: message
         CC->>Mem: targeted memory_recall on topic
         CC->>CC: reasoning + plan
         CC->>CC: tool calls (each gated by C6)
-        CC-->>Owner: response
+        CC-->>Principal: response
     end
 
-    Note over Owner, CC: At natural breakpoint or /end:
+    Note over Principal, CC: At natural breakpoint or /end:
     CC->>State: working_state_jarvis save
     CC->>Pg: record_decision events flushed
-    CC-->>Owner: session close
+    CC-->>Principal: session close
 ```
 
-**Key points.** **Same bootstrap fires regardless of session origin** — owner-interactive, scheduled tasks, GHA-triggered, autonomous-loop tick all converge on the SessionStart hook. For autonomous origins, the interaction loop processes goal-derived queued prompts in place of owner messages; rest of the flow unchanged. Bootstrap context arrives via hook in one shot (no MCP calls during session start — already in window per CLAUDE.md). Targeted recall happens during interaction, not at session start. Working state is saved at natural breakpoints, not every tool call. After context compression, recall surfaces "working state" first.
+**Key points.** **Same bootstrap fires regardless of session origin** — principal-interactive, scheduled tasks, GHA-triggered, autonomous-loop tick all converge on the SessionStart hook. For autonomous origins, the interaction loop processes goal-derived queued prompts in place of principal messages; rest of the flow unchanged. Bootstrap context arrives via hook in one shot (no MCP calls during session start — already in window per CLAUDE.md). Targeted recall happens during interaction, not at session start. Working state is saved at natural breakpoints, not every tool call. After context compression, recall surfaces "working state" first.
 
 ---
 
@@ -131,19 +131,19 @@ flowchart TB
     probes --> classify{Classifier<br/>rule fast path + Haiku for ambiguous}
     classify --> outcome{6 outcomes}
 
-    outcome -->|low risk, owner preference known| allow[ALLOW]
+    outcome -->|low risk, principal preference known| allow[ALLOW]
     outcome -->|low risk, log-explicit| log[LOG_AND_PROCEED]
-    outcome -->|owner needs informing| explain[EXPLAIN_AND_PROCEED]
+    outcome -->|principal needs informing| explain[EXPLAIN_AND_PROCEED]
     outcome -->|state probe needs async work| defer[DEFER<br/>v2.1.89]
-    outcome -->|multiple viable, owner pick| queue[QUEUE]
+    outcome -->|multiple viable, principal pick| queue[QUEUE]
     outcome -->|destructive or convergence stall| block[BLOCK]
 
     defer --> resume[Pause headless, resume after probe] --> outcome
     queue --> qtbl[(decision_queue table)]
     qtbl --> brief[Batched morning/evening brief]
-    brief --> ownerd{Owner decides}
-    ownerd -->|approve| emit
-    ownerd -->|reject| emit
+    brief --> principald{Principal decides}
+    principald -->|approve| emit
+    principald -->|reject| emit
 
     allow --> emit
     log --> emit
@@ -157,7 +157,7 @@ flowchart TB
     calib -.->|threshold update| classify
 ```
 
-**Key points.** **Single canonical gate** consulted for every tool call across all lanes (interactive / scheduled / subagent). **State-aware** — `topic_hash` convergence counter catches 3-attempt stalls deterministically. `decision_queue` is a **separate table** (workflow with state), not the C17 events table (append-only). `record_decision` is auto-emitted by the gate — no manual call required, closes compliance gap. **DEFER** outcome added per Claude Code v2.1.89 PreToolUse `defer` decision. **Learning loop closed** — `gate_overpermissive` (owner reverts) and `gate_overcautious` (owner approves queued with annotation) feed C5 calibrator; per-class threshold auto-adjusts (redesign §C6 calibration).
+**Key points.** **Single canonical gate** consulted for every tool call across all lanes (interactive / scheduled / subagent). **State-aware** — `topic_hash` convergence counter catches 3-attempt stalls deterministically. `decision_queue` is a **separate table** (workflow with state), not the C17 events table (append-only). `record_decision` is auto-emitted by the gate — no manual call required, closes compliance gap. **DEFER** outcome added per Claude Code v2.1.89 PreToolUse `defer` decision. **Learning loop closed** — `gate_overpermissive` (principal reverts) and `gate_overcautious` (principal approves queued with annotation) feed C5 calibrator; per-class threshold auto-adjusts (redesign §C6 calibration).
 
 ---
 
@@ -211,7 +211,7 @@ flowchart TB
     subgraph TRIG[Triggers]
         direction TB
         ev_outcome[outcome_recorded]
-        ev_correct[owner_correction]
+        ev_correct[principal_correction]
         ev_anomaly[anomaly_flagged spike]
         ev_decision[N decisions accumulated]
         ev_recall_fail[recall_failed FoK]
@@ -232,7 +232,7 @@ flowchart TB
     subgraph APPLY[3-lane apply mirrors C3]
         lane1[Confidence above class threshold<br/>AND judge precision validated<br/>auto-write to C3]
         lane2[Below thresholds<br/>review queue]
-        lane3[Owner correction<br/>ground-truth label<br/>feeds calibrator]
+        lane3[Principal correction<br/>ground-truth label<br/>feeds calibrator]
     end
 
     ev_outcome --> disp
@@ -256,14 +256,14 @@ flowchart TB
     APPLY --> c3[(C3 Memory)]
     lane3 --> calib
 
-    synth --> goalcand[Candidate child goal<br/>from owner_message + decision_made]
+    synth --> goalcand[Candidate child goal<br/>from principal_message + decision_made]
     goalcand --> c6q[C6 Tier 1 queue]
-    c6q -->|owner approves| c2[(C2 Goals)]
+    c6q -->|principal approves| c2[(C2 Goals)]
 
     c3 --> events[(C17 events:<br/>judgment_made, mutation_proposed,<br/>stale_challenge_fired)]
 ```
 
-**Key points.** **Event-triggered primary, sweeps as backstop** — no pure cron. Per `Memory-driven autonomy` op policy. **Each handler narrow + independently calibratable** — synthesizer, stale-challenger, calibrator, FoK, anomaly investigator. **Cold-start: `crepes` Mondrian CP** does class-conditional calibration — partial-pooling across semantically-near classes when leaf class has no labels. Stale-challenger sweep deferred until first month of labels accumulates. **Goals as candidate output** — synthesizer also produces candidate child goals from `owner_message` + `decision_made` events; routed through C6 Tier 1 queue, owner-approved entries land in C2 (closes the C5 → C2 path per redesign §C2 proactive tracking).
+**Key points.** **Event-triggered primary, sweeps as backstop** — no pure cron. Per `Memory-driven autonomy` op policy. **Each handler narrow + independently calibratable** — synthesizer, stale-challenger, calibrator, FoK, anomaly investigator. **Cold-start: `crepes` Mondrian CP** does class-conditional calibration — partial-pooling across semantically-near classes when leaf class has no labels. Stale-challenger sweep deferred until first month of labels accumulates. **Goals as candidate output** — synthesizer also produces candidate child goals from `principal_message` + `decision_made` events; routed through C6 Tier 1 queue, principal-approved entries land in C2 (closes the C5 → C2 path per redesign §C2 proactive tracking).
 
 ---
 
@@ -278,7 +278,7 @@ sequenceDiagram
     participant C16 as Reviewer
     participant Bench as Empirical benchmark
     participant Sandbox
-    participant Owner
+    participant Principal
     participant Pg as Supabase
 
     C5->>Pg: emit improvement_proposed event
@@ -292,17 +292,17 @@ sequenceDiagram
         C16-->>C6: ok
         C6->>Pg: apply + emit self_modification_applied
     else M2 collaborative
-        C6->>Owner: queue for collaborative session
-        Owner-->>C6: applies during shared session
+        C6->>Principal: queue for collaborative session
+        Principal-->>C6: applies during shared session
     else M3 protected — SOUL, CLAUDE, .mcp.json, schema, .env, gate, reviewer, observability
-        C6->>Owner: explicit-only, never auto
+        C6->>Principal: explicit-only, never auto
     end
 
     Note over C5, Pg: For C6 / C16 / C17 changes — 4 safeguards stacked
     C6->>C16: prior-version review (frozen image)
     C6->>Bench: empirical benchmark (DGM-style)
     C6->>Sandbox: sandbox test
-    C6->>Owner: sign-off
+    C6->>Principal: sign-off
 
     Note over C5, Pg: Misimprovement detection — observation window
     loop window
@@ -314,11 +314,11 @@ sequenceDiagram
         C5->>Pg: improvement_inconclusive — no progression
     else regression suspected
         C5->>Pg: regression_suspected — auto-propose revert via M1
-        Pg->>Owner: owner decides
+        Pg->>Principal: principal decides
     end
 ```
 
-**Key points.** **Per-class trust ladder** — M0 → M1 unlocks per class only after K successful cycles. **M3 never unlocks autonomously** (SOUL, CLAUDE.md, .mcp.json, schema, .env, gate logic, reviewer, observability). **4 safeguards stacked for C6/C16/C17 changes** — prior-version review + empirical benchmark (per DGM) + sandbox + owner sign-off. Per-class precision unlocks/locks via `improvement_inconclusive` / `regression_suspected` events. **Compaction-aware**: state lives in artifacts (PR, issue, events), not session memory.
+**Key points.** **Per-class trust ladder** — M0 → M1 unlocks per class only after K successful cycles. **M3 never unlocks autonomously** (SOUL, CLAUDE.md, .mcp.json, schema, .env, gate logic, reviewer, observability). **4 safeguards stacked for C6/C16/C17 changes** — prior-version review + empirical benchmark (per DGM) + sandbox + principal sign-off. Per-class precision unlocks/locks via `improvement_inconclusive` / `regression_suspected` events. **Compaction-aware**: state lives in artifacts (PR, issue, events), not session memory.
 
 ---
 
@@ -346,9 +346,9 @@ flowchart TB
     xdev --> agg
 
     agg[Aggregator<br/>summary comment via gh API]
-    agg --> owner_view{Owner reads}
-    owner_view -->|merge| merged([Merged])
-    owner_view -->|drill in| dr[Owner reads concern]
+    agg --> principal_view{Principal reads}
+    principal_view -->|merge| merged([Merged])
+    principal_view -->|drill in| dr[Principal reads concern]
     dr -->|override block| merged
     dr -->|reject| closed([Closed])
 
@@ -356,11 +356,11 @@ flowchart TB
     smoke -->|fails| incident[(Incident events)]
     smoke -->|ok| done([Done])
 
-    merged --> labels[Reviewer FP/FN labels<br/>via owner action + post-merge incidents]
+    merged --> labels[Reviewer FP/FN labels<br/>via principal action + post-merge incidents]
     labels --> calib[Feed C5 calibrator]
 ```
 
-**Key points.** **Diff coherence runs FIRST and gates everything else** — claimed-edits vs `git diff` mismatch → `subagent_fabrication_detected` BLOCK, no further review attempted. Cheap to implement, high-leverage. **Mechanical reviewers (deterministic)** alongside LLM ones — diff coherence + test coverage are facts, not judgment. **Different-provider mandatory** for high-leverage class (schema / cross-project / C6/C16/C17 / security / API contract). **Owner sees aggregator summary**, never individual reviewer outputs by default. FP/FN labels feed C5 — over-permissive vs over-cautious tracked symmetrically.
+**Key points.** **Diff coherence runs FIRST and gates everything else** — claimed-edits vs `git diff` mismatch → `subagent_fabrication_detected` BLOCK, no further review attempted. Cheap to implement, high-leverage. **Mechanical reviewers (deterministic)** alongside LLM ones — diff coherence + test coverage are facts, not judgment. **Different-provider mandatory** for high-leverage class (schema / cross-project / C6/C16/C17 / security / API contract). **Principal sees aggregator summary**, never individual reviewer outputs by default. FP/FN labels feed C5 — over-permissive vs over-cautious tracked symmetrically.
 
 ---
 
@@ -376,7 +376,7 @@ sequenceDiagram
     participant Views as Materialized views<br/>via pg_cron
     participant C13 as Budget gate
     participant C6 as Decision gate
-    participant Owner
+    participant Principal
 
     Tool->>PostHook: tool finished
     PostHook->>Events: emit tool_call event<br/>OTel GenAI: cost_usd, duration_ms
@@ -389,18 +389,18 @@ sequenceDiagram
         alt projected at most 20 USD soft cap
             C13->>C13: no action
         else 20 USD to 100 USD
-            C13->>Owner: warn via batched brief
+            C13->>Principal: warn via batched brief
             C13->>C6: deprioritize external LLM, prefer subscription/Haiku
         else above 100 USD hard cap
             C13->>C6: BLOCK non-essential external
-            C13->>Owner: critical alert
+            C13->>Principal: critical alert
         end
     end
 
     loop weekly
         C13->>C13: heartbeat probe per service<br/>Anthropic, Voyage, OpenAI, Gemini, GHA, Copilot
         alt probe fails
-            C13->>Owner: stale-credential or quota-out warning
+            C13->>Principal: stale-credential or quota-out warning
         end
     end
 
@@ -411,7 +411,7 @@ sequenceDiagram
         end
     end
 
-    Note over Tool, Owner: Pre-emptive structural guard
+    Note over Tool, Principal: Pre-emptive structural guard
     C6->>C13: routing intent check<br/>API key vs subscription
     alt API key path without allowlist entry
         C13-->>C6: routing_violation event, BLOCK

--- a/docs/design/jarvis-flows.md
+++ b/docs/design/jarvis-flows.md
@@ -257,13 +257,15 @@ flowchart TB
     lane3 --> calib
 
     synth --> goalcand[Candidate child goal<br/>from principal_message + decision_made]
-    goalcand --> c6q[C6 Tier 1 queue]
-    c6q -->|principal approves| c2[(C2 Goals)]
+    goalcand --> c2draft[C2 draft goal<br/>provenance:agent_extracted<br/>confidence:low<br/>status:draft]
+    c2draft --> brief[/status + batched brief<br/>accept / edit / dismiss]
+    c2draft -.->|7-day quiet auto-dismiss| dismiss[draft_auto_dismissed log]
+    brief -->|accept| c2[(C2 Goals)]
 
     c3 --> events[(C17 events:<br/>judgment_made, mutation_proposed,<br/>stale_challenge_fired)]
 ```
 
-**Key points.** **Event-triggered primary, sweeps as backstop** — no pure cron. Per `Memory-driven autonomy` op policy. **Each handler narrow + independently calibratable** — synthesizer, stale-challenger, calibrator, FoK, anomaly investigator. **Cold-start: `crepes` Mondrian CP** does class-conditional calibration — partial-pooling across semantically-near classes when leaf class has no labels. Stale-challenger sweep deferred until first month of labels accumulates. **Goals as candidate output** — synthesizer also produces candidate child goals from `principal_message` + `decision_made` events; routed through C6 Tier 1 queue, principal-approved entries land in C2 (closes the C5 → C2 path per redesign §C2 proactive tracking).
+**Key points.** **Event-triggered primary, sweeps as backstop** — no pure cron. Per `Memory-driven autonomy` op policy. **Each handler narrow + independently calibratable** — synthesizer, stale-challenger, calibrator, FoK, anomaly investigator. **Cold-start: `crepes` Mondrian CP** does class-conditional calibration — partial-pooling across semantically-near classes when leaf class has no labels. Stale-challenger sweep deferred until first month of labels accumulates. **Goals as candidate output** — synthesizer produces candidate child goals from `principal_message` + `decision_made` events; per Phase C redesign §C2, candidates **auto-create as drafts** (no C6 queue; rate-limited 3/week; 7-day quiet auto-dismiss). Principal accepts/edits/dismisses in `/status` or batched brief.
 
 ---
 
@@ -294,8 +296,12 @@ sequenceDiagram
     else M2 collaborative
         C6->>Principal: queue for collaborative session
         Principal-->>C6: applies during shared session
-    else M3 protected — SOUL, CLAUDE, .mcp.json, schema, .env, gate, reviewer, observability
-        C6->>Principal: explicit-only, never auto
+    else M2-strong — CLAUDE.md, .mcp.json, mcp-memory/server.py
+        C6->>C16: different-provider review + cross-device smoke
+        C16-->>C6: both gates pass
+        C6->>Pg: apply + emit self_modification_applied
+    else M3-hard — SOUL.md, schema.sql, .env, C6 logic, C16 logic, C17 schema
+        C6->>Principal: explicit-only, never auto, never auto-propose
     end
 
     Note over C5, Pg: For C6 / C16 / C17 changes — 4 safeguards stacked
@@ -318,7 +324,7 @@ sequenceDiagram
     end
 ```
 
-**Key points.** **Per-class trust ladder** — M0 → M1 unlocks per class only after K successful cycles. **M3 never unlocks autonomously** (SOUL, CLAUDE.md, .mcp.json, schema, .env, gate logic, reviewer, observability). **4 safeguards stacked for C6/C16/C17 changes** — prior-version review + empirical benchmark (per DGM) + sandbox + principal sign-off. Per-class precision unlocks/locks via `improvement_inconclusive` / `regression_suspected` events. **Compaction-aware**: state lives in artifacts (PR, issue, events), not session memory.
+**Key points.** **Per-class trust ladder** — M0 → M1 unlocks per class only after K successful cycles. **M3-hard never unlocks autonomously** (Phase C 6-item fixed list: SOUL.md, schema.sql, .env, C6 logic, C16 logic, C17 schema). **M2-strong** (CLAUDE.md, .mcp.json, mcp-memory/server.py) — autonomous OK with different-provider review + cross-device smoke per Phase C M3 split. **4 safeguards stacked for C6/C16/C17 changes** — prior-version review + empirical benchmark (per DGM) + sandbox + principal sign-off. Per-class precision unlocks/locks via `improvement_inconclusive` / `regression_suspected` events. **Compaction-aware**: state lives in artifacts (PR, issue, events), not session memory.
 
 ---
 

--- a/docs/design/jarvis-v2-redesign-review-pass2.md
+++ b/docs/design/jarvis-v2-redesign-review-pass2.md
@@ -83,6 +83,8 @@ Every L3 decision rests on Claude Code: PreToolUse, `isolation: worktree`, MCP, 
 
 Principal mentions "v2 reserved for paradigm shift (framework swap)" — implicit trade-off acceptance. Should be **explicit at L0**: *"harness lock-in accepted because cost of harness independence > benefit at this scale."* Otherwise future-self asks "why isn't this cap harness-independent?" and the answer stays implicit.
 
+**Resolved 2026-04-29 (Phase C):** explicit L0 §«Harness coupling — deliberate trade-off» added in `jarvis-v2-redesign.md`. Names what's locked (skills/hooks/auto-load/subagent isolation), what's portable (cap layer / schema / MCP / events substrate), the swap cost (~1–2 sprints rewrite of skills+hooks), and the reconsideration trigger.
+
 ---
 
 ## Pass-1/2 (implementation/realism — v1.x roadmap input, NOT architecture)

--- a/docs/design/jarvis-v2-redesign-review-pass2.md
+++ b/docs/design/jarvis-v2-redesign-review-pass2.md
@@ -1,6 +1,6 @@
 # Architecture review — pass 2 (2026-04-27)
 
-Critical-review companion to [`jarvis-v2-redesign.md`](jarvis-v2-redesign.md) and [`jarvis-architecture-c4.md`](jarvis-architecture-c4.md). Owner-invited two-pass critique (vacuum first, then memory-informed). Owner reframed mid-review: pass-1/2 findings are mostly realism/implementation, not architecture; pass-3 below collects the genuinely design-level concerns.
+Critical-review companion to [`jarvis-v2-redesign.md`](jarvis-v2-redesign.md) and [`jarvis-architecture-c4.md`](jarvis-architecture-c4.md). Principal-invited two-pass critique (vacuum first, then memory-informed). Principal reframed mid-review: pass-1/2 findings are mostly realism/implementation, not architecture; pass-3 below collects the genuinely design-level concerns.
 
 External SOTA validation in flight (2 parallel research agents, 2026-04-27) on memory architectures, event-substrate contracts, reviewer calibration, sparse-N calibration, self-modification recursion, Claude Code 2026 changes. This file gets updated when they return.
 
@@ -50,15 +50,15 @@ Architectural answer must be one of:
 
 1. Some classes don't need calibration (deterministic + universal threshold) — explicitly list which.
 2. Rare classes pool labels with semantically-near classes (transfer-shape).
-3. Rare classes are owner-only by design, no calibration loop attempted.
+3. Rare classes are principal-only by design, no calibration loop attempted.
 
 Doc applies the same calibration shape to all classes. Silent option 3 de-facto, but never written as architectural choice.
 
 ### Q5. C1 ↔ C3 boundary is syntactic, not semantic
 
-C1 = "owner-authored axioms"; C5 stale-challenge does NOT touch C1.
+C1 = "principal-authored axioms"; C5 stale-challenge does NOT touch C1.
 
-But C3 holds feedback memories (`quality_over_speed`, `step_back_after_3_failed_iterations`, `record_decision_when_what`) — axioms by content, in C3 only because owner didn't put them in SOUL.md by hand. Same content can live either side. Boundary is storage location, not semantics.
+But C3 holds feedback memories (`quality_over_speed`, `step_back_after_3_failed_iterations`, `record_decision_when_what`) — axioms by content, in C3 only because the principal didn't put them in SOUL.md by hand. Same content can live either side. Boundary is storage location, not semantics.
 
 If C5 doesn't touch identity but feedback-memories ARE de-facto identity → either C5 touches identity (via memory) or all feedback memories migrate to SOUL. Doc does neither, offers no semantic test "is this an axiom or a fact?".
 
@@ -81,7 +81,7 @@ Every L3 decision rests on Claude Code: PreToolUse, `isolation: worktree`, MCP, 
 - MCP auth changes → C9 dies.
 - `isolation: worktree` deprecates → C8 dies.
 
-Owner mentions "v2 reserved for paradigm shift (framework swap)" — implicit trade-off acceptance. Should be **explicit at L0**: *"harness lock-in accepted because cost of harness independence > benefit at this scale."* Otherwise future-self asks "why isn't this cap harness-independent?" and the answer stays implicit.
+Principal mentions "v2 reserved for paradigm shift (framework swap)" — implicit trade-off acceptance. Should be **explicit at L0**: *"harness lock-in accepted because cost of harness independence > benefit at this scale."* Otherwise future-self asks "why isn't this cap harness-independent?" and the answer stays implicit.
 
 ---
 
@@ -118,7 +118,7 @@ Owner mentions "v2 reserved for paradigm shift (framework swap)" — implicit tr
 
 ## Confirmed by memory (don't change)
 
-- **C5 stale-challenge as missing piece** — `reflection_driven_sprint_2026_04_23` proves owner hand-mined outcomes; no autonomous mutation arm exists.
+- **C5 stale-challenge as missing piece** — `reflection_driven_sprint_2026_04_23` proves the principal hand-mined outcomes; no autonomous mutation arm exists.
 - **Memory facts/episodes split** — `metacognition_sprint_plan_*`, `consolidation_plan_*` are real C3 abuse class.
 - **Subagent fabrication first-class** — `subagent_fabrication_commit_message_vs_diff` + worktree incidents validate.
 - **Single canonical recall API** — closes real cloud-bypass pain.
@@ -190,10 +190,10 @@ The doc was written 2026-04-27; relevant Claude Code / MCP changes since early 2
 |---|---|---|
 | Q1 (C17 vs C3 single-table inconsistency) | **Reframed, not invalidated.** Wide-event substrate is right; missing piece is materialized projections discipline. | Promote "views" → "materialized projections" with per-cap list. |
 | Q2 (event substrate contract) | **Stands.** OTel GenAI conventions still experimental; consistency/replay/ordering not standardized. | Define contract explicitly. |
-| Q3 (role-axis vs coupling cut) | Stands as opinion; no SOTA opinion either way. | Owner judgment call. |
+| Q3 (role-axis vs coupling cut) | Stands as opinion; no SOTA opinion either way. | Principal judgment call. |
 | Q4 (sparse-class calibration) | **Strongly validated + concrete fix available.** | Adopt Hierarchical CP + LLM-prior bootstrap. |
 | Q5 (C1↔C3 boundary) | **Stands** (ICLR 2026 MemAgents workshop names this as unsolved). | Open problem. |
-| Q6 (cross-project sync) | Stands. No SOTA prior art. | Owner judgment call. |
+| Q6 (cross-project sync) | Stands. No SOTA prior art. | Principal judgment call. |
 | Q7 (harness lock-in) | **Stands; resource exists.** | Reference Anthropic harness-design blog at L0; make trade-off explicit. |
 
 ### Sources

--- a/docs/design/jarvis-v2-redesign.md
+++ b/docs/design/jarvis-v2-redesign.md
@@ -108,6 +108,20 @@ Decision routing:
 
 This makes **memory of principal preferences** the lever that reduces interruptions — every captured preference shifts the line further into autonomy. Reinforces *Memory = 10*.
 
+### Harness coupling — deliberate trade-off
+
+Jarvis is built on Claude Code as the runtime harness. This is a deliberate trade-off, not an oversight:
+
+**What's locked to Claude Code:** skills (slash commands), hooks (PreToolUse / SessionStart / etc.), SOUL.md / CLAUDE.md auto-load, subagent `isolation:worktree`, plugin marketplace fork base.
+
+**What's harness-agnostic by design:** the cap layer (C1–C18 describe *what*, not *which runtime*); Supabase memory schema + bi-temporal periods; canonical events substrate (OTel GenAI conventions); MCP servers (`mcp-memory/server.py` works with any client speaking MCP); embeddings via VoyageAI; goals tables.
+
+**Why accepted:** Claude Code currently closes the largest set of pain points (memory + breadth + subagent isolation + native plugin ecosystem) for the smallest implementation cost at this scale. Building a "harness adapter" abstraction with one real implementation = indirection, not abstraction (per SOUL §«Abstractions need two real implementations»).
+
+**Cost of swap if a better harness ships:** rewrite ~12 skills + 4–5 hooks + subagent dispatch glue (~1–2 sprints). Data, schema, and cap layer survive.
+
+**Trigger to reconsider:** another runtime substantively better than Claude Code in our use case (not «new shiny release»). Until then, harness lock-in stands. Q7 in pass2 review tracks this; v2 (per Status table) is reserved for the framework-swap class of change.
+
 ---
 
 ## L1 — Capabilities

--- a/docs/design/jarvis-v2-redesign.md
+++ b/docs/design/jarvis-v2-redesign.md
@@ -1,6 +1,6 @@
 # Jarvis Architecture — Capability Roadmap
 
-> Top-down architectural design derived from owner goals. Structures the system into 17 capabilities across 5 layers, with membership rules, measurement plans, migration paths, and a bootstrap protocol. Maps to v1 stabilization + 1.x feature evolution; v2 is reserved for cardinal paradigm shifts (framework swap or equivalent).
+> Top-down architectural design derived from principal goals. Structures the system into 18 capabilities across 5 layers, with membership rules, measurement plans, migration paths, and a bootstrap protocol. Maps to v1 stabilization + 1.x feature evolution; v2 is reserved for cardinal paradigm shifts (framework swap or equivalent).
 
 ## How to read this doc
 
@@ -26,7 +26,7 @@ No intermediate diagrams. One C4 (Context → Container → Component) at the en
 | Level | State |
 |---|---|
 | L0 — mission, qualities, non-goals | **done** |
-| L1 — capabilities | **done** (17 caps, 5 layers, 3 ops policies) |
+| L1 — capabilities | **done** (18 caps, 5 layers, 3 ops policies) |
 | L2 — components per capability | **done** (Tier A: C3, C5, C6, C15, C16, C17; Tier B: C2, C4, C8, C13, C14; Tier C: C1, C7, C9, C10, C11, C12) |
 | Bootstrap protocol & migration order | **done** |
 | Critical review pass | **done** (high-severity addressed: bootstrap + cost reality + ~15 point fixes) |
@@ -41,32 +41,32 @@ No intermediate diagrams. One C4 (Context → Container → Component) at the en
 
 ### Mission
 
-Jarvis is an agentic system that takes the bulk of software-project work off the owner, helps with decisions, runs research, pushes back on bad ideas, and steers thinking — not just executing instructions, but actively shaping them.
+Jarvis is an agentic system that takes the bulk of software-project work off the principal, helps with decisions, runs research, pushes back on bad ideas, and steers thinking — not just executing instructions, but actively shaping them.
 
 ### Target user & scope
 
-**Personal-Jarvis for the owner only.** Not a product. Not multi-tenant. Tightly coupled to owner's repos, devices, identity, and SOUL.md.
+**Personal-Jarvis for the principal only.** Not a product. Not multi-tenant. Tightly coupled to principal's repos, devices, identity, and SOUL.md.
 
-A separate company-Jarvis variant may be developed in parallel by the owner's company, but it is a **separate project** with its own design, DB, and deployment (per `pillar7_personal_vs_company_separation`). Architecture design ignores company-variant requirements; shared code is extracted post-hoc when the company variant has concrete needs.
+A separate company-Jarvis variant may be developed in parallel by the principal's company, but it is a **separate project** with its own design, DB, and deployment (per `pillar7_personal_vs_company_separation`). Architecture design ignores company-variant requirements; shared code is extracted post-hoc when the company variant has concrete needs.
 
 Public-Jarvis open-source framework is also a **separate fork** with its own quality bar (per `open_source_quality_standard`); reformatted from private at release boundaries, not architected jointly.
 
 ### Problems solved
 
-Jarvis covers the work of an entire software development team, leaving the owner only as resource provider and strategic stakeholder:
+Jarvis covers the work of an entire software development team, leaving the principal only as resource provider and strategic stakeholder:
 - Code authoring & testing
 - Project management & progress tracking
 - Research & decision support
 - Deep code comprehension on demand
 - Managing other agents (sub-orchestration)
-- Catching owner errors / steering ideas
+- Catching principal errors / steering ideas
 
 ### Non-goals
 
 **This architecture explicitly excludes:**
 - Personal life management (smart home, shopping, calendar)
-- Email and messenger management on owner's behalf
-- Impersonating the owner — Jarvis drafts; owner sends
+- Email and messenger management on principal's behalf
+- Impersonating the principal — Jarvis drafts; principal sends
 - Telegram as a primary interface (chat-only role at most, see L1)
 - Designing for other developers / multi-tenancy (separate project)
 
@@ -74,7 +74,7 @@ Jarvis covers the work of an entire software development team, leaving the owner
 
 ### Quality attributes
 
-Owner-stated priorities (1–10), with tradeoff notes where they conflict:
+Principal-stated priorities (1–10), with tradeoff notes where they conflict:
 
 | Quality | Priority | Notes |
 |---|---|---|
@@ -85,7 +85,7 @@ Owner-stated priorities (1–10), with tradeoff notes where they conflict:
 | Multi-device | 8 | 3 devices baseline. Device-specific tasks (physical access) acceptable as exceptions. |
 | Personality | 7 | Has opinions, principles, thinks. SOUL.md-style is the baseline. |
 | Security + Privacy (merged) | 7 | Cloud storage OK. Threat model = external intruders / account takeover, not the cloud provider itself. Strong access control + recovery paths required. |
-| UX | 7 | Owner is the only user; doesn't need polish but must not be friction. |
+| UX | 7 | Principal is the only user; doesn't need polish but must not be friction. |
 | Flexibility (within work) | 7 | Wide range of work tasks; **does not** stretch beyond work scope. |
 | Offline tolerance | 3 | Acceptable to be unusable when offline (Claude API + Supabase + GitHub all need internet anyway). |
 
@@ -95,18 +95,18 @@ Owner-stated priorities (1–10), with tradeoff notes where they conflict:
 
 ### Autonomy / decision boundary
 
-Jarvis decides autonomously when it knows the owner's preference (from memory or SOUL); asks when it doesn't. **Long-term goal: digital-twin level — Jarvis knows the owner well enough to decide everything, only confirming critical/hard-to-reverse decisions.**
+Jarvis decides autonomously when it knows the principal's preference (from memory or SOUL); asks when it doesn't. **Long-term goal: digital-twin level — Jarvis knows the principal well enough to decide everything, only confirming critical/hard-to-reverse decisions.**
 
 Decision routing:
 
 | Situation | Behavior |
 |---|---|
-| Owner's view known (memory/SOUL) | Decide and act. |
-| Owner's view unknown, low-cost / reversible | Decide and act, log decision. |
-| Owner's view unknown, hard-to-reverse / high-cost | Research, propose, confirm. |
+| Principal's view known (memory/SOUL) | Decide and act. |
+| Principal's view unknown, low-cost / reversible | Decide and act, log decision. |
+| Principal's view unknown, hard-to-reverse / high-cost | Research, propose, confirm. |
 | Both don't know | Research, decide, confirm before acting. |
 
-This makes **memory of owner preferences** the lever that reduces interruptions — every captured preference shifts the line further into autonomy. Reinforces *Memory = 10*.
+This makes **memory of principal preferences** the lever that reduces interruptions — every captured preference shifts the line further into autonomy. Reinforces *Memory = 10*.
 
 ---
 
@@ -138,26 +138,27 @@ Filling these gaps is the deliberate differentiator vs the field.
 
 ### Final capability list
 
-Five layers, 17 capabilities:
+Five layers, 18 capabilities:
 
 **Identity layer** — what Jarvis *is*:
-- **C1. Identity & values** — SOUL-style personality and principles that shape every decision. Distinct from memory: identity is owner-authored axioms; memory is learned facts.
+- **C1. Identity & values** — SOUL-style personality and principles that shape every decision. Distinct from memory: identity is principal-authored axioms; memory is learned facts.
 - **C2. Goals & priorities** — active strategic context that prioritizes work. Kept separate from C3 because goals are *active* (drive ranking) while memory is *passive* (provides context). Analogous to SOUL.md vs CLAUDE.md.
 
 **Cognition layer** — how Jarvis *thinks*:
-- **C3. Memory** — durable cross-device store. Has two sub-types (detail in L2): *owner/preference memory* (durable, slow-changing) and *project/world knowledge* (volatile, refreshable). State/handoff between sessions lives here.
+- **C3. Memory** — durable cross-device store. Has two sub-types (detail in L2): *principal/preference memory* (durable, slow-changing) and *project/world knowledge* (volatile, refreshable). State/handoff between sessions lives here.
 - **C4. Reasoning & planning** — decompose tasks, sequence steps, replan on signals.
-- **C5. Reflection / learning** — periodic synthesis. Two roles: (a) raw episodes → lessons → new memory; (b) **challenge stale preferences** so Jarvis doesn't fossilize on outdated owner views.
+- **C5. Reflection / learning** — periodic synthesis. Two roles: (a) raw episodes → lessons → new memory; (b) **challenge stale preferences** so Jarvis doesn't fossilize on outdated principal views.
 - **C6. Decision gating** — escalation matrix:
   | Situation | Behavior |
   |---|---|
-  | Only one viable path | Act, log decision (owner is *informed* afterward). |
+  | Only one viable path | Act, log decision (principal is *informed* afterward). |
   | Multiple options, only one fits the work | Act, log decision + why others rejected. |
-  | Multiple genuinely viable options | Escalate — propose options, owner picks. |
+  | Multiple genuinely viable options | Escalate — propose options, principal picks. |
   | Destructive / hard-to-reverse | Always confirm regardless of ambiguity (SOUL rule). |
   | Low confidence in own analysis + high stakes | Escalate even when above says "act". |
 
-  Owner's only inputs: (a) be informed of decisions (low-effort read), or (b) pick among proposals. Owner never reads implementation by default.
+  Principal's only inputs: (a) be informed of decisions (low-effort read), or (b) pick among proposals. Principal never reads implementation by default.
+- **C18. Proactive challenger** — alongside C5: surfaces calibration drift, neglected goals, and contradictions between principal's stated direction and observed behavior. Triggers user-facing recalibration via C12 when the gap exceeds threshold. Distinct from C5 (which mutates memory) — C18 *only surfaces* without mutating.
 
 **Action layer** — what Jarvis *does*:
 - **C7. Execution** — perform individual tasks (code edit, test run, message draft).
@@ -165,29 +166,29 @@ Five layers, 17 capabilities:
 - **C9. Tool / environment interface** — connect to repos, filesystem, MCP servers, external APIs.
 - **C10. Research** — gather external info to inform reasoning. Tightly coupled to C4 but kept separate: research explores possibilities without choosing; reasoning chooses based on what research returned.
 
-**Interface layer** — how Jarvis *interacts with owner*:
-- **C11. Perception** — receive inputs from all sources: owner messages, repo/GitHub events, schedule triggers, file changes, external system events. Decision *when to act on a trigger* lives here, but is informed by C2 + C3 (autonomy is memory-driven, not pipeline-driven — see `no_deterministic_pipelines`).
-- **C12. Communication with owner** — strategic comms: push back, propose, confirm, report. Channels (chat / desktop / mobile / voice) are L2 detail.
+**Interface layer** — how Jarvis *interacts with principal*:
+- **C11. Perception** — receive inputs from all sources: principal messages, repo/GitHub events, schedule triggers, file changes, external system events. Decision *when to act on a trigger* lives here, but is informed by C2 + C3 (autonomy is memory-driven, not pipeline-driven — see `no_deterministic_pipelines`).
+- **C12. Communication with principal** — strategic comms: push back, propose, confirm, report. Channels (chat / desktop / mobile / voice) are L2 detail.
 
 **Cross-cutting** — properties applied across all layers:
 - **C13. Budget / cost governance** — track spend against $100–200/mo cap, refuse cap-blowing actions, optimize model selection (use lighter models for mechanical work).
 - **C14. Security & privacy** — secret protection, access control, recovery paths. Threat model = external intruders / account takeover; cloud provider is trusted.
-- **C15. Self-improvement** — Jarvis modifies itself. **Hybrid scope**: read-only self-analysis when running autonomously (proposes changes); write access only when owner is actively collaborating on Jarvis's own code.
-- **C16. Verification / QA** — automated review of Jarvis's own work. Owner does not code-review by default. Reviewer is a dedicated agent: a peer Jarvis instance, or a different model/provider for independence (different-model = no shared bias). Owner reviews vision/plan alignment only.
-- **C17. Observability & audit** — track-record for autonomous operation: action logs, decision logs, replay/diff, self-monitoring (rate-limit, memory write failures, suspicious tool calls). Enables: (a) trust-building over time, (b) post-hoc owner inspection, (c) self-detection of malfunction. Required for *Memory=10* and *Autonomy=8* to work safely.
+- **C15. Self-improvement** — Jarvis modifies itself. **Hybrid scope**: read-only self-analysis when running autonomously (proposes changes); write access only when principal is actively collaborating on Jarvis's own code.
+- **C16. Verification / QA** — automated review of Jarvis's own work. Principal does not code-review by default. Reviewer is a dedicated agent: a peer Jarvis instance, or a different model/provider for independence (different-model = no shared bias). Principal reviews vision/plan alignment only.
+- **C17. Observability & audit** — track-record for autonomous operation: action logs, decision logs, replay/diff, self-monitoring (rate-limit, memory write failures, suspicious tool calls). Enables: (a) trust-building over time, (b) post-hoc principal inspection, (c) self-detection of malfunction. Required for *Memory=10* and *Autonomy=8* to work safely.
 
 ### Operational policies (flow from L0+L1, not capabilities themselves)
 
 These are not blocks on the diagram but commitments that constrain L2:
 
 - **Trust ladder.** Autonomy scope expands by track record. Day 1 = safe-class actions only (reversible, low-cost, well-precedented). Categories unlock as Jarvis builds successful history in C17.
-- **Review topology.** Code review is fully delegated. Owner's review surface = vision/plan alignment only, never implementation diff. Different-provider reviewer is preferred over same-model peer for high-leverage changes.
+- **Review topology.** Code review is fully delegated. Principal's review surface = vision/plan alignment only, never implementation diff. Different-provider reviewer is preferred over same-model peer for high-leverage changes.
 - **Memory-driven autonomy, not pipelined.** No hardcoded execution order. Jarvis decides what to do based on judgment + memory + goals (`no_deterministic_pipelines`).
 - **Design-to-evaluate.** Every L2 capability decision must include "How measured" — a real-task quality signal, not unit-test sufficiency. Rationale: in-vacuum success ≠ in-task success; if a block isn't measurable in production, we cannot tell if our design works. **Benchmarks are built before implementation**, not after. Capabilities without a viable measurement plan get deferred until one exists.
 
 ### Decision
 
-L1 capability set locked: **17 capabilities in 5 layers + 3 operational policies.** Justification for going wider than competitor systems: every "extra" capability (C5 challenge-old, C13 budget, C15 self-improvement, C16 verification, C17 observability) addresses a gap explicitly identified in research as missing in the field but required by L0 priorities.
+L1 capability set locked: **18 capabilities in 5 layers + 3 operational policies.** Justification for going wider than competitor systems: every "extra" capability (C5 challenge-old, C13 budget, C15 self-improvement, C16 verification, C17 observability, C18 proactive challenger) addresses a gap explicitly identified in research as missing in the field but required by L0 priorities.
 
 ### Rejected during review
 
@@ -243,7 +244,7 @@ Order within Tier A: C3 Memory and C17 Observability first (other caps depend on
 Rules requiring subjective judgment (rare) stay in memory tagged as procedural-feedback for retrieval on related context.
 
 **Decision: memory becomes 2 sub-stores.**
-- **C3-F. Factual store** — owner preferences, project knowledge. Slow-changing, retrieval-driven, supersedable.
+- **C3-F. Factual store** — principal preferences, project knowledge. Slow-changing, retrieval-driven, supersedable.
 - **C3-E. Episodic store** — decisions, outcomes, incidents. Append-only, time-ordered.
 
 Both accessed through one recall API (caller doesn't pick a store).
@@ -260,7 +261,7 @@ Both accessed through one recall API (caller doesn't pick a store).
 
 **How measured — four signals, ALL built before any v2 memory code lands:**
 
-1. **Self-replay regression** (offline, CI) — owner's historical sessions as gold set; on every memory-subsystem change, replay and verify recall surfaces the memories the session actually used. Primary CI gate. Cheap (use existing logs). Strongest fit for N=1 personal agent.
+1. **Self-replay regression** (offline, CI) — principal's historical sessions as gold set; on every memory-subsystem change, replay and verify recall surfaces the memories the session actually used. Primary CI gate. Cheap (use existing logs). Strongest fit for N=1 personal agent.
 2. **Useful-injection rate** (sampled online) — LLM-as-judge scores a **10% sample of recalls** for whether the surfaced memory was load-bearing in the response. Sampling (not every recall) is the deliberate cost choice — judging every recall would be the single biggest unbounded cost (~$30+/mo at high recall volume). 10% gives a continuous signal at ~$0.50/mo.
 3. **Staleness / contradiction probe** (periodic, FAMA-style) — sample N memories weekly; pose questions whose answers reveal whether stale or fresh content surfaces. Catches beliefs that should have been superseded but weren't.
 4. **Decision-outcome linkage** (retrospective) — for `record_decision` episodes, after outcome is known, were the memories that informed the decision actually correct? Calibrates `confidence` values via real outcomes.
@@ -335,13 +336,13 @@ Implications:
 *Truth selection at recall:* canonical function returns only current heads (`valid_to IS NULL`) by default. History accessible via explicit `include_history=true` flag for audit/UI.
 
 *Supersession trigger* — three lanes:
-1. **Explicit declaration** (writer states `supersedes=<id>`): trusted, applied immediately. Used by classifier when confidence is high and by owner corrections.
+1. **Explicit declaration** (writer states `supersedes=<id>`): trusted, applied immediately. Used by classifier when confidence is high and by principal corrections.
 2. **Classifier proposal** (Haiku-style ADD/UPDATE/SUPERSEDE/NOOP): auto-applied only if **(a)** classifier confidence ≥ threshold AND **(b)** measured class-precision (from outcome labels) ≥ threshold. The second gate self-throttles when classifier quality drifts. **Bootstrap:** before N labeled outcomes accumulate per class (N defined in bootstrap protocol), gate (b) is *bypassed* — classifier auto-applies on confidence alone but with a **conservative initial threshold** (e.g., 0.95 instead of 0.85). As labels accumulate, gate (b) activates and threshold relaxes if precision is high.
-3. **Below thresholds**: goes to review queue with owner CLI loop. Queue throughput is itself a measured signal.
+3. **Below thresholds**: goes to review queue with principal CLI loop. Queue throughput is itself a measured signal.
 
 *Conflict detection ("same topic")*: hybrid — embedding similarity gives candidate set; LLM verifier confirms semantic overlap before triggering supersession classification. Prevents embedding-only false positives.
 
-*Owner correction*: `record_correction(memory_id, correct=<id_or_content>)` creates a high-trust ground-truth label, used both to (a) immediately fix recall, and (b) feed the classifier eval that gates lane 2.
+*Principal correction*: `record_correction(memory_id, correct=<id_or_content>)` creates a high-trust ground-truth label, used both to (a) immediately fix recall, and (b) feed the classifier eval that gates lane 2.
 
 **Why this not pure auto-classify** (current state): classifier without measured precision is a black box; failures are silent. Two-gate (confidence + class-precision) makes failures self-correcting.
 
@@ -350,12 +351,12 @@ Implications:
 **Rejected:**
 - *Last-write-wins* — destroys provenance, loses minority-but-correct view.
 - *Highest-confidence-wins ignoring time* — old confident-but-stale memory beats new less-confident-but-correct one.
-- *Owner-only supersession* — bottlenecks the owner; conflicts with "only stakeholder" mission.
+- *Principal-only supersession* — bottlenecks the principal; conflicts with "only stakeholder" mission.
 
 **How measured:**
 - **Classifier precision/recall by class** (ADD/UPDATE/SUPERSEDE/NOOP), labeled by `record_correction` events. Triggers threshold updates.
 - **Time-to-resolution for review-queue items**: how long stale beliefs coexist with corrections.
-- **Self-replay**: after owner correction, does subsequent recall surface the correction (not the old)?
+- **Self-replay**: after principal correction, does subsequent recall surface the correction (not the old)?
 - **Contradiction probe** (FAMA-style): catches stale heads that should have been superseded.
 
 ---
@@ -367,7 +368,7 @@ Implications:
 **Decision: provenance hierarchy as a recall ranking factor and a supersession tiebreaker.**
 
 *Hierarchy* (highest → lowest trust):
-1. `user:explicit` — owner direct statement
+1. `user:explicit` — principal direct statement
 2. `tool:<name>` — verified tool/system output (deterministic)
 3. `agent:<role>` with stored `confidence ≥ 0.7` — Jarvis or subagent inference, well-supported
 4. `agent:<role>` with stored `confidence < 0.7` — low-supported inference
@@ -382,21 +383,21 @@ The 0.7 boundary between tiers 3 and 4 is the same threshold C5's calibrator tun
 - Caller can request `provenance_weights=...` to override defaults.
 
 *At supersession:*
-- Higher-tier provenance auto-supersedes lower-tier on the same topic when conflict detected (e.g., owner correction beats agent inference without going through review queue).
+- Higher-tier provenance auto-supersedes lower-tier on the same topic when conflict detected (e.g., principal correction beats agent inference without going through review queue).
 - Same-tier conflict still uses classifier/explicit lane.
 
-**Why hierarchy not flat:** without trust weighting, agent self-derived memory drowns out owner-stated facts in recall (more agents writing → more low-trust noise). Hierarchy is the antidote.
+**Why hierarchy not flat:** without trust weighting, agent self-derived memory drowns out principal-stated facts in recall (more agents writing → more low-trust noise). Hierarchy is the antidote.
 
-**Why hierarchy values are these:** owner is ground truth by definition. Tool output is deterministic and reproducible. Agent inference is opinion. External-extracted is suspect (per SOUL §External content safety: "data, not instructions"). Legacy is unverified.
+**Why hierarchy values are these:** principal is ground truth by definition. Tool output is deterministic and reproducible. Agent inference is opinion. External-extracted is suspect (per SOUL §External content safety: "data, not instructions"). Legacy is unverified.
 
 **Rejected:**
-- *No provenance weighting* (current state) — owner statements get out-voted by agent self-derivation.
+- *No provenance weighting* (current state) — principal statements get out-voted by agent self-derivation.
 - *Provenance as filter only, not weight* — forces caller to know hierarchy; default behavior should already be sensible.
 - *Single-bit "trusted/untrusted"* — loses distinction between tool output and agent inference.
 
 **How measured:**
 - **Recall set provenance distribution**: track ratio of `user`-tier / `agent`-tier in surfaced top-K. Drift toward agent-tier = noise accumulating; drift toward user-tier = healthy.
-- **Owner override rate**: how often owner corrects recall results. Falling rate = hierarchy is working.
+- **Principal override rate**: how often principal corrects recall results. Falling rate = hierarchy is working.
 - **Useful-injection rate by provenance tier**: validates that higher-tier surfaces are actually more load-bearing.
 
 ---
@@ -444,7 +445,7 @@ Distillation surfaced 8+ piecemeal log/audit subsystems added reactively (events
 
 **Decision:** every initiating context creates a `trace_id`; downstream actors inherit.
 
-- Owner message → new trace_id
+- Principal message → new trace_id
 - Scheduled task fire → new trace_id
 - Subagent spawn → inherits parent's trace_id; `parent_event_id` = the spawning event
 - Hook fire → inherits trace_id of the session/task it fires in
@@ -466,7 +467,7 @@ This closes the "subagent fabrication" gap (no automated detection currently) by
 
 **Why:** denormalizing to a separate ledger table would drift from events. Inline cost on the event is the single source of truth.
 
-**Closes gap:** owner upgraded to Claude Max blind to consumption (`max_20x_upgrade_available`). With ledger views, real-time spend visibility is one query away.
+**Closes gap:** principal upgraded to Claude Max blind to consumption (`max_20x_upgrade_available`). With ledger views, real-time spend visibility is one query away.
 
 #### Self-detection
 
@@ -476,7 +477,7 @@ This closes the "subagent fabrication" gap (no automated detection currently) by
 - **Periodic anomaly checks** (sample over events) — emit `anomaly_flagged`.
 - **System events** — `compaction_event`, `rate_limited`, `api_failure` emitted by infrastructure when detected.
 
-**Why explicit event types:** owner-facing dashboards and reflection (C5) need to query failure modes by category, not text-search payloads.
+**Why explicit event types:** principal-facing dashboards and reflection (C5) need to query failure modes by category, not text-search payloads.
 
 #### Migration / what dies
 
@@ -494,14 +495,14 @@ This closes the "subagent fabrication" gap (no automated detection currently) by
 
 - **Trace coverage** — % of significant agent-actions with corresponding events. Target: ≥99%. Sampled audit cross-checks session jsonl against events.
 - **Trace-id propagation** — % of subagent events with parent's trace_id. Target: 100%. Orphaned trace_id = bug.
-- **Self-detection precision** — when `hallucination_suspected` / `tool_returned_empty` fires, validation rate (manual spot-check sample). Maintains owner trust in the signal.
+- **Self-detection precision** — when `hallucination_suspected` / `tool_returned_empty` fires, validation rate (manual spot-check sample). Maintains principal trust in the signal.
 - **Cost-ledger drift** — ledger total vs Anthropic billing reality. Target <2% drift. Monthly reconciliation.
 - **MTTR (Mean-Time-To-Reveal)** — interval between an actual malfunction and its surfacing as an event. Lower better. Critical for autonomy=8.
 
 #### Rejected
 
 - *Many specialized tables* (current state) — schema drift, query fragmentation, instrumentation gaps.
-- *Local-only session jsonl as primary log* — no cross-device replay, no aggregation, owner can't audit autonomous-while-sleeping work.
+- *Local-only session jsonl as primary log* — no cross-device replay, no aggregation, principal can't audit autonomous-while-sleeping work.
 - *Subagent transcripts harvested post-hoc* — too late for in-flight observability, lossy.
 - *Cost ledger as separate table* — denormalization cost > query simplicity benefit.
 - *Hand-rolled trace propagation per skill* — drift inevitable; OpenTelemetry-style ID inheritance is the established pattern.
@@ -521,38 +522,38 @@ C17 complete. Substrate, trace propagation, subagent visibility, cost ledger, se
 
 ### C5 — Reflection / learning
 
-Distillation: 5+ reflection mechanisms exist (/reflect skill, /end behavioral, A-MEM evolution, consolidation, FoK batch, calibration view), all uncoordinated. **None have an autonomous mutation arm** — /reflect renders markdown for owner to manually `memory_store`. The "challenge stale" role doesn't exist: Step 8 of /reflect lists 14d-untouched memories without challenging them. The most successful reflection event in 2 months (`reflection_driven_sprint_2026_04_23`) was *owner mining outcome logs by hand* — exactly what C5 must do autonomously.
+Distillation: 5+ reflection mechanisms exist (/reflect skill, /end behavioral, A-MEM evolution, consolidation, FoK batch, calibration view), all uncoordinated. **None have an autonomous mutation arm** — /reflect renders markdown for principal to manually `memory_store`. The "challenge stale" role doesn't exist: Step 8 of /reflect lists 14d-untouched memories without challenging them. The most successful reflection event in 2 months (`reflection_driven_sprint_2026_04_23`) was *principal mining outcome logs by hand* — exactly what C5 must do autonomously.
 
 **Question:** What is the structure of Jarvis's reflection/learning subsystem so the two L1-committed roles (synthesize new + challenge stale) actually happen autonomously?
 
 **Membership rule:** belongs in C5 iff *reads from C17 events* AND *proposes mutations to C3 memory* AND *operates on a population of memories/events, not single writes*. Single-memory direct writes from skills are C3 writes, not C5.
 
 **Things that don't belong here:**
-- Owner-facing markdown render of "what happened" → C12 reporting (separate from learning).
+- Principal-facing markdown render of "what happened" → C12 reporting (separate from learning).
 - Single-memory writes from skills → C3 direct API.
 - Outcome recording (event capture) → C7/C17.
 
 #### Substrate
 
-**Reads:** events (C17) — decision_made, error, owner_correction, outcome_recorded, anomaly_flagged, hallucination_suspected.
+**Reads:** events (C17) — decision_made, error, principal_correction, outcome_recorded, anomaly_flagged, hallucination_suspected.
 **Writes:** C3 memory (new facts, supersession links, confidence updates) via the canonical Postgres function (single funnel from C3-Q2). Also emits its own events to C17 (`judgment_made`, `mutation_proposed`, `stale_challenge_fired`, etc.) so reflection itself is observable.
 
 **No separate "reflection" tables.** Current `consolidation_plan_*` and `evolution_plan_*` memories abuse C3 as a planning store; v2 represents plans as events (ephemeral, audit-trailed, not facts).
 
 #### Triggering
 
-**Decision: event-triggered primary, sweeps as backstop, owner-invoked as override.**
+**Decision: event-triggered primary, sweeps as backstop, principal-invoked as override.**
 
 | Lane | Trigger | Handler |
 |---|---|---|
 | Event-triggered (primary) | `outcome_recorded` | Calibration handler (Brier update on judges) |
-| | `owner_correction` | Stale-challenge on related beliefs |
+| | `principal_correction` | Stale-challenge on related beliefs |
 | | `anomaly_flagged` rate spike | Policy re-examination |
 | | N decisions since last synthesis | Pattern extraction |
 | | `recall_failed` (FoK) | Known-unknown logging + sampling |
 | Sweep (backstop) | Weekly: memories not touched 30+ days | Sample-based stale-challenge |
 | | Quarterly: deeper re-examination on long-held beliefs | Full stale-challenge |
-| Owner-invoked | `/reflect` command | All handlers run on demand |
+| Principal-invoked | `/reflect` command | All handlers run on demand |
 
 **Why event-triggered primary:** pure cron is fragile (distillation: scheduler may not run; A-MEM gated on classifier UPDATE → if classifier never writes, evolution never fires). Event-triggering = `no_deterministic_pipelines` + `Memory-driven autonomy` op policies.
 
@@ -564,8 +565,8 @@ Events → pattern detection → candidate memories. LLM extracts patterns over 
 
 Three-lane apply (mirrors C3 supersession pattern):
 1. **Confidence ≥ threshold AND judge class-precision validated** → auto-write to C3.
-2. **Below thresholds** → review queue with owner CLI loop.
-3. **Owner correction** of an applied write = ground-truth label feeding the judge calibrator.
+2. **Below thresholds** → review queue with principal CLI loop.
+3. **Principal correction** of an applied write = ground-truth label feeding the judge calibrator.
 
 Per C17 migration, the standalone `episodes` table is folded into the canonical events table with `action='episode_*'`. C5 synthesizer reads these events on schedule; what's new in v2 is the *extractor* (currently absent) that turns episode events into candidate memory writes.
 
@@ -574,7 +575,7 @@ Per C17 migration, the standalone `episodes` table is folded into the canonical 
 **This is the role the current system entirely lacks.** Detection-only is not enough.
 
 Triggers (in priority order):
-1. **Owner statement on a topic similar to existing memory** — owner says Y, memory says X on topic T. Handler asks LLM: "compatible, evolved, or contradiction?" → propose update/supersession via Q3 conflict resolution.
+1. **Principal statement on a topic similar to existing memory** — principal says Y, memory says X on topic T. Handler asks LLM: "compatible, evolved, or contradiction?" → propose update/supersession via Q3 conflict resolution.
 2. **Decision failure** — `outcome_recorded` with negative outcome → trace back to memories that informed the decision (via `memories_used` in `record_decision`) → re-examine those memories against recent evidence.
 3. **Anomaly pattern** — repeated `hallucination_suspected` events on related actions → re-examine policies/heuristics that produced them.
 4. **Sweep backstop** — sample old (90+ day untouched) memories; LLM judges "still valid given recent events on this topic."
@@ -582,13 +583,13 @@ Triggers (in priority order):
 Outcomes from re-examination:
 - **Still valid** → update `last_examined`, no mutation.
 - **Evolved** → propose supersession with new memory.
-- **Contradicted** → propose supersession or owner-confirm.
+- **Contradicted** → propose supersession or principal-confirm.
 
-Closes the `reflection_driven_sprint` gap — owner-mined lessons should now surface autonomously.
+Closes the `reflection_driven_sprint` gap — principal-mined lessons should now surface autonomously.
 
 #### Judge calibration loop
 
-Every internal judge (Phase-2 classifier, FoK verdict, consolidation MERGE, evolution UPDATE, stale-challenge re-examination) emits a `judgment_made` event with claim + confidence. Ground-truth labels arrive later (owner override, decision outcome) and link back to the judgment.
+Every internal judge (Phase-2 classifier, FoK verdict, consolidation MERGE, evolution UPDATE, stale-challenge re-examination) emits a `judgment_made` event with claim + confidence. Ground-truth labels arrive later (principal override, decision outcome) and link back to the judgment.
 
 **Periodic Brier per judge.** Threshold updates auto-derived: judge whose precision drops below floor has its auto-apply threshold raised (or auto-apply suspended). Self-correcting — closes the `DEFAULT_CONFIDENCE_GATE = 0.85` symptom-fix (universal threshold without calibration data).
 
@@ -602,12 +603,12 @@ Why specialized handlers under one dispatcher (not monolithic /reflect): differe
 
 C13 allocates per-handler monthly budget. Handler hits cap → backs off (sample rate down, queue accumulates, or skip non-critical work). C13 enforces; C5 self-throttles via emitted events.
 
-Concrete: most handlers use Haiku (cheap); only stale-challenge re-examination of high-stakes beliefs may use Sonnet, **capped at 5 Sonnet escalations per week** for the stale-challenge handler (rest defer to next week or owner queue). C13 enforces.
+Concrete: most handlers use Haiku (cheap); only stale-challenge re-examination of high-stakes beliefs may use Sonnet, **capped at 5 Sonnet escalations per week** for the stale-challenge handler (rest defer to next week or principal queue). C13 enforces.
 
 #### Migration
 
-- `/reflect` skill → owner-invoked entry; **most logic moves to autonomous handlers**. Skill becomes "fire all handlers now + render summary."
-- `/end` behavioral reflection → owner-correction events trigger C5 stale-challenge directly. Skill becomes thinner.
+- `/reflect` skill → principal-invoked entry; **most logic moves to autonomous handlers**. Skill becomes "fire all handlers now + render summary."
+- `/end` behavioral reflection → principal-correction events trigger C5 stale-challenge directly. Skill becomes thinner.
 - A-MEM evolution → integrated into stale-challenge arm (tag/desc drift is one signal among many).
 - Consolidation → integrated into generation arm (cluster detection → merge proposal).
 - FoK batch → calibration arm with proper schedule (currently unregistered per distillation).
@@ -617,7 +618,7 @@ Concrete: most handlers use Haiku (cheap); only stale-challenge re-examination o
 #### How measured
 
 - **Mutation arm activity** — memories created / superseded / confidence-updated by C5 per week. Zero = mutation arm broken.
-- **Owner override rate** of C5 mutations. Falling = handlers calibrated. Rising = drift.
+- **Principal override rate** of C5 mutations. Falling = handlers calibrated. Rising = drift.
 - **Stale-challenge yield** — re-examined memories: update vs still-valid ratio. Indicates whether stale-challenge is finding real staleness or thrashing.
 - **Judge Brier trends** — per-judge precision over time. Should be flat or improving.
 - **Event coverage** — % of significant event types subscribed by at least one handler. Gaps = unmonitored failure modes.
@@ -625,7 +626,7 @@ Concrete: most handlers use Haiku (cheap); only stale-challenge re-examination o
 
 #### Rejected
 
-- *Owner-facing markdown only* (current /reflect) — no autonomous mutation = role unmet.
+- *Principal-facing markdown only* (current /reflect) — no autonomous mutation = role unmet.
 - *Pure cron triggers* — fragile (current pain).
 - *Monolithic reflection engine* — different roles have different needs; collapsing them produced the kitchen-sink /reflect.
 - *Auto-apply without calibration* — universal threshold without measurement was a symptom-fix.
@@ -637,9 +638,73 @@ C5 complete. Substrate, triggering, generation arm, stale-challenge arm, judge c
 
 ---
 
+### C18 — Proactive challenger
+
+**Question:** Who notices when Jarvis's calibration drifts, when goals go neglected, or when stated direction doesn't match observed behavior — and surfaces it before the principal has to catch it?
+
+**Membership rule:** belongs in C18 iff *detects gaps between stated and observed* AND *surfaces to the principal without mutating memory*. Memory mutation = C5. Surfacing = C12. C18 is the detection layer that decides *when surfacing is warranted*.
+
+**Why it's not C5:** C5 mutates state — synthesizer writes new memories, stale-challenger supersedes old ones. C18 only observes and routes to C12. Folding it into C5 conflated "fix the belief" with "tell the principal a recalibration is needed". Different blast radii: C5 changes the system; C18 changes what the principal sees.
+
+**Why it's not just C12:** C12 is the comm channel. C18 decides *which patterns are worth surfacing*. Putting the detection inside C12 makes C12 carry judgment that doesn't belong with a transport layer.
+
+#### Detection signals (input)
+
+C18 reads from C17 events and C2 goal state:
+
+| Signal | Source | What it indicates |
+|---|---|---|
+| Calibration drift | C5 calibrator outputs (Brier per memory type, per-class FP/FN) | Memory class confidence has decayed; principal's mental model may be stale |
+| Goal neglect | C2 `goal_stale` events crossed N day threshold without activity | Stated priority isn't matching observed work allocation |
+| Direction-vs-action gap | `decision_made` events grouped by `goal_slug` vs principal-stated priority | Jarvis is working on P2 while P0 is starving |
+| Repeated principal override | C16 `principal_override` events on a recurring class | Jarvis's classifier disagrees with the principal systematically — recalibration needed |
+| Stale assumption | Memory `confidence < 0.5` AND last-used > 90 days | Belief Jarvis still acts on but no longer has evidence for |
+
+#### Surfacing decision (output)
+
+C18 emits a `recalibration_proposed` event when the gap exceeds threshold. C12 picks it up and routes to the principal in the next batched brief — never as a real-time interrupt (this isn't urgent; this is "you should know").
+
+Surfacing format (rendered by C12):
+> Calibration check: `decision` memories in jarvis are overconfident (Brier 0.31, target <0.20). Pattern: heavy reliance on research memories without principal confirmation. Suggest: `/reflect` pass on last 10 decisions, or change the always-load rule.
+
+#### Interaction with C5
+
+- C5 detects pattern → mutates memory (e.g. supersede stale belief).
+- C18 detects pattern → surfaces to principal (e.g. "your stated P0 hasn't been touched in 14 days; either re-prioritize or update the goal").
+
+If both fire on the same signal, C5 mutates first, C18 surfaces the mutation to the principal. They share the input substrate but the outputs are orthogonal.
+
+#### Cost bounds
+
+Pure C17-event reads + threshold checks. No LLM calls in the hot path. Optional Sonnet pass to phrase the surfacing message readably; capped at 1 LLM call per `recalibration_proposed` event, max 5 events surfaced per batched brief.
+
+#### Migration
+
+- New code; no current implementation to migrate.
+- First version: pure SQL queries over C17 events + `goals` table, emitted via existing batched brief plumbing (C12 already aggregates).
+- L3 detail: detection thresholds tuned per signal class.
+
+#### How measured
+
+- **Surfacing acceptance rate** — % of `recalibration_proposed` events the principal acts on (re-prioritizes goal, runs `/reflect`, edits the rule) vs dismisses. Target: >50% (otherwise C18 is noise).
+- **Pattern-discovery latency** — time from drift signal first detectable in C17 to first `recalibration_proposed` event. Target: <7 days.
+- **False-surface rate** — `recalibration_proposed` dismissed as "not actionable" by principal. Rising = thresholds too sensitive.
+
+#### Rejected
+
+- *Fold into C5 stale-challenger* — conflates mutation with surfacing.
+- *Real-time interrupt on first signal* — drowns the principal in noise; calibration drift is slow, doesn't need real-time.
+- *No detection layer (let the principal notice)* — exactly the gap C18 closes; the principal *should not have to notice* drift in their own AI peer.
+
+---
+
+C18 complete. Detection signals, surfacing decision routed to C12, no memory mutation, calibration-loop-aware.
+
+---
+
 ### C6 — Decision gating
 
-Distillation: enforcement is **scattered across 3 places that drift** (SOUL prose, `agents/safety.py` Tier model, skill §7.5 prose). `safety.py` only covers action-agent paths (~5% of decisions); conversational lane is ungated. Stakes are state-dependent (`gh pr merge --delete-branch` is Tier 0 normally, irreversible on a stack root — hit twice). No convergence detector (6 iterations before owner stepped in). Tier 1 owner queue is documented but the table doesn't exist; "ask owner" today = unstructured chat message. `record_decision` is post-hoc, doesn't gate, has the same compliance problem as the rules it logs.
+Distillation: enforcement is **scattered across 3 places that drift** (SOUL prose, `agents/safety.py` Tier model, skill §7.5 prose). `safety.py` only covers action-agent paths (~5% of decisions); conversational lane is ungated. Stakes are state-dependent (`gh pr merge --delete-branch` is Tier 0 normally, irreversible on a stack root — hit twice). No convergence detector (6 iterations before principal stepped in). Tier 1 principal queue is documented but the table doesn't exist; "ask principal" today = unstructured chat message. `record_decision` is post-hoc, doesn't gate, has the same compliance problem as the rules it logs.
 
 L1 already committed to the escalation matrix. L2 specifies how it's implemented as one canonical gate that's actually called from every action path.
 
@@ -651,7 +716,7 @@ L1 already committed to the escalation matrix. L2 specifies how it's implemented
 - Post-hoc decision logging → C7 + C17 events (gate output emits these, but they're not C6).
 - Verification of completed work → C16.
 - Memory of past decisions → C3.
-- Owner notification UI → C12.
+- Principal notification UI → C12.
 
 #### Single canonical gate
 
@@ -671,8 +736,8 @@ Inputs to `gate()`:
 - Action: `(tool, action, target, payload)` — current narrow input
 - **Git state**: dirty worktree? stacked-PR root? protected branch? unmerged children?
 - **Convergence state**: N attempts on this topic in this session?
-- **Memory recall** on topic: owner preference known?
-- **Cost class**: token-expensive? blocks owner?
+- **Memory recall** on topic: principal preference known?
+- **Cost class**: token-expensive? blocks principal?
 - **Harness restrictions**: does the harness block this action class? (e.g., Claude Code blocks `.claude/*` edits — `claude_dir_edits_need_manual_confirm`)
 
 State queries are LIVE at gate time, not snapshots. Each state probe is itself an event in C17 (cheap; lets us audit *what the gate knew* when it decided).
@@ -687,7 +752,7 @@ State queries are LIVE at gate time, not snapshots. Each state probe is itself a
 
 Thresholds:
 - **3 attempts, no progress signal** → emit `convergence_stall` event → C5 stale-challenge handler fires (the rule isn't working — re-examine) AND C6 force-escalates next attempt.
-- **5 attempts** → BLOCK until owner intervenes.
+- **5 attempts** → BLOCK until principal intervenes.
 
 "No progress" = no `outcome_recorded(success=true)` linked to this topic since counter started.
 
@@ -699,10 +764,10 @@ Thresholds:
 
 Queue item: `(action_id, classification, payload, gated_at, decided_at, decision, reasoning)`. Status enum: `pending → approved | rejected | superseded | expired`.
 
-Owner-facing review:
+Principal-facing review:
 - Batched morning brief lists pending items, sorted by reversibility (irreversible first).
 - Bulk approve/reject with rationale (rationale becomes a feedback memory + classifier label).
-- Items expire if not decided in N days (configurable per-class). **Irreversible-class items NEVER expire silently** — when N elapses, the item gets re-flagged with higher urgency in the next batched brief and stays in queue. Owner explicit decline is the only way out.
+- Items expire if not decided in N days (configurable per-class). **Irreversible-class items NEVER expire silently** — when N elapses, the item gets re-flagged with higher urgency in the next batched brief and stays in queue. Principal explicit decline is the only way out.
 
 Closes the documented-but-unbuilt gap (`action_agent_safety_gate_model_v1` queue piece).
 
@@ -711,12 +776,12 @@ Closes the documented-but-unbuilt gap (`action_agent_safety_gate_model_v1` queue
 **Decision:** track BOTH failure modes of the gate, not just over-permissive.
 
 Two outcome types feed gate calibration:
-- **`gate_overpermissive`** — owner reverts/corrects an action the gate let through. Logged via owner-correction or revert detection.
-- **`gate_overcautious`** — owner approves a queued item with annotation. **Channel:** queue UI (the batched-brief item that owner reads to approve) presents two approve-buttons: "approve" and "approve + 'should have been autonomous'". Single-click labelling, no implementation review required. Owner provides label by their choice of approve action, not by reading code.
+- **`gate_overpermissive`** — principal reverts/corrects an action the gate let through. Logged via principal-correction or revert detection.
+- **`gate_overcautious`** — principal approves a queued item with annotation. **Channel:** queue UI (the batched-brief item that principal reads to approve) presents two approve-buttons: "approve" and "approve + 'should have been autonomous'". Single-click labelling, no implementation review required. Principal provides label by their choice of approve action, not by reading code.
 
 Both update per-class precision/recall. Threshold for that class auto-adjusts (more cautious if over-permissive trend; less cautious if over-cautious trend).
 
-**Closes:** `decision_shedding_via_open_questions` showed 5/6 questions were over-cautious — owner caught it manually. v2: tracked structurally, threshold self-corrects.
+**Closes:** `decision_shedding_via_open_questions` showed 5/6 questions were over-cautious — principal caught it manually. v2: tracked structurally, threshold self-corrects.
 
 #### Real-time gating, not post-hoc logging
 
@@ -730,7 +795,7 @@ Both update per-class precision/recall. Threshold for that class auto-adjusts (m
 
 When gate sees an action the harness will block, it pre-emptively `QUEUE`s rather than `PROCEED`s — saves the cost of a failed attempt. Config seeded from memories (`claude_dir_edits_need_manual_confirm`).
 
-**Discovery loop:** new harness blocks emerge dynamically. Gate emits `harness_block_observed` event when an action fails with a harness-rejection signal; the config update path is **C15 M2** (collaborative — owner present), not M3 (fully protected). Adding new entries does not require schema/SOUL touches, so it's not in the highest-protection class. This avoids the "config goes stale because it's protected" pitfall.
+**Discovery loop:** new harness blocks emerge dynamically. Gate emits `harness_block_observed` event when an action fails with a harness-rejection signal; the config update path is **C15 M2** (collaborative — principal present), not M3 (fully protected). Adding new entries does not require schema/SOUL touches, so it's not in the highest-protection class. This avoids the "config goes stale because it's protected" pitfall.
 
 #### Boundary with C16
 
@@ -741,7 +806,7 @@ C6 = before action (act/ask classifier). C16 = after action (review of completed
 - `agents/safety.py` Tier model → kept as the rule store; gate() consumes it. Tier definitions migrate from hardcoded Python to config (still rule-based, but inspectable).
 - SOUL.md autonomy section → documentation of gate behavior, not parallel rules.
 - Skill §7.5 risk policies → migrated into per-action-class entries in the rule store; skills consult the same gate.
-- `record_decision` MCP tool → kept for owner-explicit decisions; auto-emission from gate covers the rest.
+- `record_decision` MCP tool → kept for principal-explicit decisions; auto-emission from gate covers the rest.
 - Tier 1 queue → finally implemented as a real table (currently `queued=True` flag with no actual queue).
 
 #### How measured
@@ -749,7 +814,7 @@ C6 = before action (act/ask classifier). C16 = after action (review of completed
 - **Gate coverage** — % of tool calls that passed through `gate()`. Target: 100%. Gaps = unenforced lanes.
 - **Per-class precision/recall** — over_permissive vs over_cautious rates by action class. Calibration spine.
 - **Convergence-stall trigger rate** — how often the 3-attempt threshold fires. Drop in rate = topics resolving faster (or detector dead).
-- **Queue latency** — time from `QUEUE` to owner decision. Long latency = owner-bottleneck pain.
+- **Queue latency** — time from `QUEUE` to principal decision. Long latency = principal-bottleneck pain.
 - **Queue approval rate** — what fraction of queued items get approved. Low rate = gate is over-queueing.
 - **Drift detection** — periodic comparison of gate decisions on same `(action, state)` over time. Drift signals miscalibration.
 
@@ -758,7 +823,7 @@ C6 = before action (act/ask classifier). C16 = after action (review of completed
 - *Multiple parallel rule stores* (current state) — drift inevitable.
 - *Action-only classification (no state)* — can't catch state-dependent reversibility.
 - *Memory-based convergence detection* — probabilistic; deterministic counter wins.
-- *Chat-message-per-ask* (current state) — owner-bottleneck, unstructured.
+- *Chat-message-per-ask* (current state) — principal-bottleneck, unstructured.
 - *Manual `record_decision`* — compliance always degrades; auto-emit by gate is the fix.
 
 ---
@@ -773,7 +838,7 @@ Distillation: reviewer agent **doesn't exist** — L1 commitment is stated inten
 
 C16 is essentially build-from-scratch. The L2 design specifies what the reviewer subsystem looks like.
 
-**Question:** What is the structure of Jarvis's verification subsystem so that owner stays out of code review while quality holds?
+**Question:** What is the structure of Jarvis's verification subsystem so that principal stays out of code review while quality holds?
 
 **Membership rule:** belongs in C16 iff *evaluates produced work* AND *can block its acceptance* AND *operates independently of the producer*. The independence requirement is non-negotiable: orchestrator self-review fails it.
 
@@ -812,7 +877,7 @@ C16 is essentially build-from-scratch. The L2 design specifies what the reviewer
 - Security-tagged path (`scripts/secret-scanner.py`, `agents/safety.py`, credential registry, `.env*` adjacency).
 - API contract change (public function signature, MCP tool schema, exported types).
 
-For these, run logical correctness reviewer twice: once peer-Jarvis, once different-provider (OpenAI/Gemini). Disagreement = automatic owner escalation via C12. Expected rate: ~25% of PRs (C13 cost rehearsal anchor).
+For these, run logical correctness reviewer twice: once peer-Jarvis, once different-provider (OpenAI/Gemini). Disagreement = automatic principal escalation via C12. Expected rate: ~25% of PRs (C13 cost rehearsal anchor).
 
 **Why not always different-provider:** $100–200/mo cap. Per-PR different-provider review is too expensive for routine changes.
 
@@ -829,8 +894,8 @@ This closes the documented incident class (redrobot #640/#647, jarvis #688/#700)
 **Decision:** every reviewer can BLOCK merge by setting check status fail. Reviewer is not advisory.
 
 - Mechanical reviewers: block is final (deterministic facts).
-- LLM reviewers: block carries reasoning + confidence; owner can override via C12 (override is a calibration label).
-- Reviewer disagreement with orchestrator → C6 escalation lane (multiple viable interpretations → owner picks).
+- LLM reviewers: block carries reasoning + confidence; principal can override via C12 (override is a calibration label).
+- Reviewer disagreement with orchestrator → C6 escalation lane (multiple viable interpretations → principal picks).
 
 #### Triggers
 
@@ -843,14 +908,23 @@ This closes the documented incident class (redrobot #640/#647, jarvis #688/#700)
 | Post-merge | Smoke test (high-leverage only at first; broader as trust ladder permits) |
 | Periodic (weekly) | Cross-device integrity sweep across recent merges |
 
-#### Owner surface
+#### Principal surface — class-aware auto-merge
 
-**Decision:** reviewers aggregate into a single owner-facing summary; owner never sees individual reviewer outputs by default.
+**Decision:** PRs split into two classes by leverage; class determines whether the principal sees the PR at all.
 
-Summary shape:
-> PR #123 — feat: X. Linked: #100. ✅ aligned with goal. ✅ tests cover new symbols. ⚠️ logical-correctness flagged: <one-line concern>. Recommend: review concern OR merge.
+| Class | What | Principal surface |
+|---|---|---|
+| **Auto-merge** | Typo / doc-only changes, behavior changes in low-leverage scope | None by default. Merges automatically when **all three** hold: (a) C16 diff-coherence pass, (b) tests pass, (c) every triggered reviewer green. Surfaces in batched brief as a one-line "merged" entry, not as an action. |
+| **Principal gate** | High-leverage class — schema (`*.sql`), cross-project shared code (per C15 cross-project list), hook/gate/reviewer/observability code (C6/C16/C17), security-tagged PRs, ANY reviewer block (even warning) | Mandatory principal review. Aggregator summary + drill-in available. Merge blocked until explicit principal action. |
 
-Owner reads summary (vision/plan check), drills in only if needed. Routine merges have summary-only owner touch.
+**Classifier:** reuse C6 high-leverage classifier (already exists for different-provider review trigger). Don't create a parallel classification — one classifier, two consumers.
+
+Summary shape (for the principal-gate class):
+> PR #123 — feat: X. Linked: #100. Class: **principal-gate** (touches `mcp-memory/schema.sql`). ✅ aligned with goal. ✅ tests cover new symbols. ⚠️ logical-correctness flagged: <one-line concern>. Recommend: review concern OR merge.
+
+Auto-merge class produces a thinner summary (one line in batched brief). Routine work has zero principal touch by default; the principal sees high-leverage work and reviewer-flagged work.
+
+**Why class-aware:** flat "all PRs aggregate to principal" surface either bottlenecks on routine doc PRs or trains the principal to rubber-stamp. Class split means routine work shipped autonomously and the principal's attention reserves for the cases where it matters. Closes the principal-bottleneck side of `caution_vs_overconfirmation_principle`.
 
 #### Cost bounds
 
@@ -862,7 +936,7 @@ Owner reads summary (vision/plan check), drills in only if needed. Routine merge
 #### Calibration loop
 
 Tracked per reviewer:
-- **FP rate** — reviewer blocked, owner overrode → label.
+- **FP rate** — reviewer blocked, principal overrode → label.
 - **FN rate** — reviewer passed, post-merge incident traced back to PR → label (via C17 incident events linked to merge).
 
 Both feed C5 calibration arm. Per-reviewer Brier; thresholds adjust per reviewer.
@@ -880,10 +954,11 @@ When FP rate climbs on a reviewer → its block authority is downgraded to advis
 #### How measured
 
 - **Reviewer coverage** — % merged PRs that went through full reviewer pipeline. Target: 100%.
-- **Per-reviewer FP/FN** — calibration spine. Tracked via owner overrides and post-merge incident attribution.
+- **Per-reviewer FP/FN** — calibration spine. Tracked via principal overrides and post-merge incident attribution.
 - **Time-to-review** — PR-open to aggregated verdict latency.
 - **Subagent fabrication catch rate** — known-fabrication audit (sample post-merge for hidden cases) vs reviewer-flagged.
-- **Owner override frequency** — when owner overrides reviewer block. Should be rare; rising = miscalibration.
+- **Principal override frequency** — when principal overrides reviewer block. Should be rare; rising = miscalibration.
+- **Auto-merge class accuracy** — % of auto-merged PRs that the principal later flags as "should have been gated". Rising = classifier needs tightening; ~0 = classifier working. Symmetric metric for the gated class: % the principal merges without comment (overcautious classification).
 - **Cost per PR by class** — average $$ spend on review by leverage class; tracks against C13 cap.
 
 #### Rejected
@@ -893,17 +968,17 @@ When FP rate climbs on a reviewer → its block authority is downgraded to advis
 - *Copilot as primary gate* — quota-fragile, misses domain bugs.
 - *Advisory-only reviewers* — Copilot pattern, not effective at the act/ask level.
 - *Same-model on high-leverage* — shared blind spots between same-provider instances.
-- *Owner reviews diff* — contradicts L0 mission (owner = stakeholder, not reviewer).
+- *Principal reviews diff* — contradicts L0 mission (principal = stakeholder, not reviewer).
 
 ---
 
-C16 complete. Specialized reviewers (mechanical + LLM), same-vs-different-provider triggered by C6 high-leverage, subagent fabrication as first-class gate, block authority, owner-facing summary aggregation, FP/FN calibration via C5.
+C16 complete. Specialized reviewers (mechanical + LLM), same-vs-different-provider triggered by C6 high-leverage, subagent fabrication as first-class gate, block authority, principal-facing summary aggregation, FP/FN calibration via C5.
 
 ---
 
 ### C15 — Self-improvement
 
-Distillation: the highest-yield self-improvement path is *owner mining outcomes by hand* (`reflection_driven_sprint_2026_04_23`), not `/self-improve` — that skill exists but cadence and yield are unmeasured. The current protected-file whitelist (SOUL.md, CLAUDE.md, .mcp.json, mcp-memory/server.py, .env) substitutes for an absent reviewer (C16 didn't exist). Same low/medium/high tier classification lives in 3+ places and drifts (same C6 pain). Documented bootstrap incidents: `.claude/*` edit halting autonomous run; Jarvis-written CI guard silently passing because guard watched wrong path while Jarvis edited the right one; compaction-induced fabrication of "I implemented X" when nothing was done; `always_load` rules growing context until token diet was needed.
+Distillation: the highest-yield self-improvement path is *principal mining outcomes by hand* (`reflection_driven_sprint_2026_04_23`), not `/self-improve` — that skill exists but cadence and yield are unmeasured. The current protected-file whitelist (SOUL.md, CLAUDE.md, .mcp.json, mcp-memory/server.py, .env) substitutes for an absent reviewer (C16 didn't exist). Same low/medium/high tier classification lives in 3+ places and drifts (same C6 pain). Documented bootstrap incidents: `.claude/*` edit halting autonomous run; Jarvis-written CI guard silently passing because guard watched wrong path while Jarvis edited the right one; compaction-induced fabrication of "I implemented X" when nothing was done; `always_load` rules growing context until token diet was needed.
 
 C15 in v2 is mostly *composition* of C5 (proposals), C6 (tier classifier), C16 (independent review), C17 (modification audit). The new pieces are: **modification tiers**, **bootstrap protection**, **trust ladder for self-modification specifically**, **misimprovement detection**.
 
@@ -912,7 +987,7 @@ C15 in v2 is mostly *composition* of C5 (proposals), C6 (tier classifier), C16 (
 **Membership rule:** belongs in C15 iff *modifies Jarvis's own configuration / code / skills / hooks / schema* AND *operates as a deliberate self-improvement loop, not as side-effect of normal work*. Memory writes during task execution = C3 direct. Issue creation in workflow = C7/C12. Reflection-driven memory mutation = C5. C15 is reserved for changes to Jarvis itself.
 
 **Things that don't belong here:**
-- Hygiene/cleanup of owner repos (C7).
+- Hygiene/cleanup of principal repos (C7).
 - Memory consolidation/evolution (C5 handlers).
 - Issue creation as part of normal task flow (C12).
 - Reviewer-flagged auto-fixes on non-Jarvis PRs (C16).
@@ -925,10 +1000,31 @@ C15 in v2 is mostly *composition* of C5 (proposals), C6 (tier classifier), C16 (
 |---|---|---|---|
 | **M0** | Autonomous, read-only | Self-analysis, gap detection, friction logging, proposals (issues, design docs, memory) | Always available |
 | **M1** | Autonomous write | Doc-only changes, test additions, deletion of skills with measured zero-use, low-risk in non-protected scope | Trust-ladder unlocks after N successful M0 → M1 transitions |
-| **M2** | Collaborative write | Skill changes, code edits in Jarvis repo, hook changes, anything in `.claude/*` | Owner present in session OR explicit owner approval queued |
-| **M3** | Protected — always owner-explicit | Identity (SOUL.md), project instructions (CLAUDE.md), MCP config (.mcp.json), memory subsystem (mcp-memory/server.py + schema), gate logic (C6), reviewer logic (C16), observability substrate (C17), .env | Never auto-applied; never even auto-proposed without explicit owner ask |
+| **M2** | Collaborative or strong-reviewed | Skill changes, code edits in Jarvis repo, hook changes, anything in `.claude/*`. Plus the **M2-strong** subset (former M3 soft) — autonomous write OK only with C16 different-provider review + cross-device smoke | Principal present in session OR explicit principal approval queued (default M2). M2-strong adds the reviewer + smoke gates. |
+| **M3** | Protected — always principal-explicit, no auto-propose | The M3-hard list (below). Six items, fixed. | Never auto-applied; never even auto-proposed without explicit principal ask. |
 
-**Why M3 is fixed-protected:** these are the safety mechanisms that protect every other tier. Self-modifying them autonomously = self-validating safety. The schema-drift incident (Jarvis-written CI guard watching wrong path, silently passing) is exactly what M3 violations look like at scale.
+**M3-hard list (6 items, fixed-protected):**
+
+| Item | Why it's fixed M3 |
+|---|---|
+| `config/SOUL.md` | Identity axioms — self-modification = self-validating alignment. |
+| `mcp-memory/schema.sql` | Cross-project blast radius (redrobot uses the same Supabase). One wrong migration = both projects broken. |
+| `.env` (and `.env.*` secrets) | Secrets — never read, never write, ever. Absolute. |
+| C6 gate logic | The classifier deciding what's safe — self-modifying it = bypass mechanism for everything below. |
+| C16 reviewer logic | Quality gate. Self-modifying review = self-grading. |
+| C17 observability schema/projections | The audit substrate every other cap reports to. Tampering breaks reflection, calibration, cost tracking simultaneously. |
+
+**M2-strong (former M3 soft — 3 items, reclassified):**
+
+These were previously bundled with the M3-hard list under "always principal-explicit", but the cost was wrong: they're config/code, not safety mechanisms or secrets. Reclassified as M2 with **mandatory strong review** (different-provider per C16 + cross-device smoke per C16's cross-device sweep):
+
+| Item | Reason for reclassification |
+|---|---|
+| `CLAUDE.md` (project instructions) | Operational config. Routine edits (skill table updates, process clarifications) shouldn't bottleneck on principal touch. Wrong edits caught by reviewer + smoke. |
+| `.mcp.json` (MCP config) | Configuration, not gate logic. Misconfiguration = MCP server doesn't load = obvious failure mode (vs silent corruption). Cross-device smoke catches portability regressions. |
+| `mcp-memory/server.py` (code only — schema stays M3-hard) | Code with high test coverage and reviewer scrutiny. Schema migrations are the cross-project blast risk, not handler code. |
+
+**Why split M3:** flat M3 put `.mcp.json` (config) next to `.env` (secrets) — false equivalence. The schema-drift incident (Jarvis-written CI guard watching wrong path, silently passing) was a `mcp-memory/schema.sql` problem — that stays M3-hard. The CLAUDE.md/`.mcp.json`/server.py group was lumped in by association, not by blast radius. Real semantic distinction now applied.
 
 **Why M1 exists at all:** without M1 there's zero autonomous self-improvement and v2 mission ("Jarvis improves itself") fails. M1 is the only narrow autonomous lane; doc-only and zero-use deletion are genuinely safe.
 
@@ -945,9 +1041,10 @@ This blocks the class of failure where Jarvis modifies its gate/reviewer/observa
 **Decision:** progression specific to C15, narrower than the global trust ladder.
 
 - **Day 1:** M0 only. All self-modification proposals are issues/design docs/memory, no writes.
-- **After K successful M0 cycles** (proposal → owner review → owner-applied with no regression in N days) → M1 unlocks for the **specific class** that demonstrated reliability. Per-class unlock, not blanket.
-- **After M successful M1 applications with FP/FN within tolerance** → owner can manually elevate that class to M2 default. Not auto-elevated; M2 always remains a deliberate decision.
-- **M3 never unlocks.** New M3 items can only be added by owner.
+- **After K successful M0 cycles** (proposal → principal review → principal-applied with no regression in N days) → M1 unlocks for the **specific class** that demonstrated reliability. Per-class unlock, not blanket.
+- **After M successful M1 applications with FP/FN within tolerance** → principal can manually elevate that class to M2 default. Not auto-elevated; M2 always remains a deliberate decision.
+- **M3-hard never unlocks.** The 6-item list is fixed-protected. New M3-hard items can only be added by principal.
+- **M2-strong** (former M3-soft) follows normal M2 progression — the reviewer + smoke gates are the unlock condition, not a per-class trust counter.
 
 K and M are operational tunings (L3); the principle is per-class, evidence-based, monotonic-with-override.
 
@@ -958,7 +1055,7 @@ K and M are operational tunings (L3); the principle is per-class, evidence-based
 Outcomes:
 - **Benefit observed in metrics** → modification confirmed; class-precision label updated.
 - **No benefit observed** → modification flagged as `improvement_inconclusive` (not reverted, but no further M1→M2 progression for this class).
-- **Negative signal observed** (regression metrics, owner override frequency, reviewer FP/FN rises) → emit `regression_suspected` event; auto-propose revert via M1; owner decides.
+- **Negative signal observed** (regression metrics, principal override frequency, reviewer FP/FN rises) → emit `regression_suspected` event; auto-propose revert via M1; principal decides.
 
 **Closes:** current `/self-improve` produces PRs without measurement of whether they improved anything. Now every change has a measurable claim attached.
 
@@ -976,7 +1073,7 @@ This is enforced via a hook that triggers on compaction events for the C15 lane.
 
 #### Migration
 
-- `/self-improve` skill → kept as the C15 owner-invoked entry, but pipeline rebuilds: ideation = C5 generation arm; risk classification = C6; review = C16; apply = M1/M2 by tier; measurement = C17 + C5.
+- `/self-improve` skill → kept as the C15 principal-invoked entry, but pipeline rebuilds: ideation = C5 generation arm; risk classification = C6; review = C16; apply = M1/M2 by tier; measurement = C17 + C5.
 - Hard whitelist of protected files → kept but renamed *M3 list*; explicitly tied to safety semantics, not "files we're scared of".
 - Risk classifier (3-tier in 3 places) → consolidated under C6 (single canonical gate).
 - `/self-improve` Step 8 (orchestrator self-review of self-improvement PRs) → **deprecated**; C16 reviews instead, with bootstrap rule for C6/C16/C17 modifications.
@@ -986,7 +1083,7 @@ This is enforced via a hook that triggers on compaction events for the C15 lane.
 #### How measured
 
 - **Per-class M1 application precision** — `improvement_inconclusive` rate vs `confirmed` rate. Drives trust-ladder progression.
-- **Misimprovement detection rate** — `regression_suspected` flags raised before owner notices vs after. Lower-is-late = bad.
+- **Misimprovement detection rate** — `regression_suspected` flags raised before principal notices vs after. Lower-is-late = bad.
 - **Bootstrap-protection trigger frequency** — modifications that hit the prior-version-reviewer rule. Should be rare (most self-improvement avoids C6/C16/C17); spikes = something is wrong.
 - **M0 → M1 promotion latency** — how long it takes for a class to earn autonomous write. Unbounded latency = trust ladder dead.
 - **Compaction-induced fabrication catch rate** — instances where post-compaction verification rejected a fabricated "implemented" claim.
@@ -998,7 +1095,7 @@ This is enforced via a hook that triggers on compaction events for the C15 lane.
 - *Same C16 reviewer reviewing changes to itself* — fails the bootstrap protection rule.
 - *Hardcoded protected list as the only safety* — substitutes for review; new safety-critical files emerge and aren't covered.
 - *Trust ladder applied as one global policy* — self-modification has different risk profile than user-task autonomy.
-- *Auto-revert on regression suspicion* — too aggressive; owner-decision via M1 propose preserves judgment.
+- *Auto-revert on regression suspicion* — too aggressive; principal-decision via M1 propose preserves judgment.
 - *Allow M3 to unlock autonomously after enough successes* — the failure mode (autonomous gate self-modification) is catastrophic and rare; never trade it for cadence.
 
 ---
@@ -1019,7 +1116,7 @@ Distillation: schema is decent (11 real goals, lifecycle works); the bottleneck 
 
 - **`progress_pct` removed**; replaced with view `progress_ratio` = checked items / total in `success_criteria`. Auto-derived, can't lie.
 - **`jarvis_focus` split** into:
-  - `strategic_posture` — one short paragraph, current strategic stance (e.g., "blocked on owner review of v2 design").
+  - `strategic_posture` — one short paragraph, current strategic stance (e.g., "blocked on principal review of v2 design").
   - `progress_log` — moved out of the goal row entirely; goal-tagged events in C17 are the journal. The goal row stops being a write-amplification target.
 - **`direction` field** dropped as free-text. Multi-goal grouping handled by explicit `parent_id` chain (already in schema); no `directions` table. Free-text direction was rolled-up identical strings — chains do that semantically.
 
@@ -1028,7 +1125,7 @@ Distillation: schema is decent (11 real goals, lifecycle works); the bottleneck 
 Periodic checks run as SQL views over events:
 - P0 active goals with no events on `goal_slug` in 14d → emit `goal_stale` event.
 - Deadline within 7d → emit `goal_deadline_soon`.
-- Both feed **C12** (owner notification, batched, not interrupting) and **C5** (challenge handler — is this goal still relevant?).
+- Both feed **C12** (principal notification, batched, not interrupting) and **C5** (challenge handler — is this goal still relevant?).
 
 Closes the gap that `/goals review` text instructions never queried anything.
 
@@ -1036,20 +1133,25 @@ Closes the gap that `/goals review` text instructions never queried anything.
 
 - `goal_slug` becomes a **FK on every decision event** emitted by C6's gate. **Source at gate time:** gate runs a narrow C3 recall on the action's topic + active goals; if a single active goal matches semantically, it's bound automatically; if multiple match, the gate either picks the highest-priority active or escalates ambiguity. Default-required for decisions classified above a threshold (architectural / high-leverage); optional for trivial.
 - `outcome_record.goal_slug` validated against `goals.slug`; orphan slugs rejected.
-- `autonomous-loop` scoring formula: goal alignment becomes a **multiplier**, not one of N additive inputs. Work that doesn't align with any active goal is deprioritized by default — closes "owner forgets, Jarvis tracks" gap (`proactive_goal_tracking`) by making goal alignment structural.
+- `autonomous-loop` scoring formula: goal alignment becomes a **multiplier**, not one of N additive inputs. Work that doesn't align with any active goal is deprioritized by default — closes "principal forgets, Jarvis tracks" gap (`proactive_goal_tracking`) by making goal alignment structural.
 
 This makes "Goals drive priorities" a programmatic primitive instead of a SOUL.md aspiration.
 
 #### Hierarchy semantics
 
-- `parent_id` cascade: when all children of a parent are `status=achieved` → emit `parent_close_suggested` event. **Not auto-close** — owner judgment via C12 batched suggestion (a single goal closing is a strategic moment).
+- `parent_id` cascade: when all children of a parent are `status=achieved` → emit `parent_close_suggested` event. **Not auto-close** — principal judgment via C12 batched suggestion (a single goal closing is a strategic moment).
 - Progress rollup view: parent's effective progress = aggregate of children's `progress_ratio`. Surfaced in goal listing.
 
-#### Proactive tracking
+#### Proactive tracking — auto-create draft goals
 
-- C5 generation arm subscribes to `owner_message` and `decision_made` events; LLM extracts surfaced deadlines / commitments / time-bounded asks → candidate child goals.
-- Candidates go through C6 gate (Tier 1 queue) for owner approval. Owner accepts → child goal created with `parent_id`.
+- C5 generation arm subscribes to `principal_message` and `decision_made` events; LLM extracts surfaced deadlines / commitments / time-bounded asks → candidate child goals.
+- **Candidates auto-create as drafts**, not queued for approval. Goal row inserted with `provenance:agent_extracted`, `confidence:low`, `status:draft`. No C6 gate trip — these are extracted from the principal's own messages and decisions; treating them like risky autonomous actions adds friction without safety value.
+- Drafts surface to the principal in `/status` and the batched brief: "N draft goals — accept / edit / dismiss". Single-click triage; no approval ceremony.
+- **Quiet auto-dismiss after 7 days** of no principal action (with a `draft_auto_dismissed` log emit so the extractor's accuracy can still be measured).
+- **Rate limit: max 3 draft goals per week.** Prevents over-extraction noise; if the extractor is producing more than 3 useful candidates a week, that's a signal to revisit the formula.
 - Closes `university-degree` parent having 0 children despite 7 disciplines + 3 overdue.
+
+**Why auto-create vs queue:** worst case is a wrong draft sitting until dismiss — that's a UX issue, not a safety issue. The C6-queue route was wrong: it equated "agent extracts a candidate from the principal's own words" with "agent decides to fire a destructive action". Different blast radius, different gate.
 
 #### Migration
 
@@ -1062,8 +1164,8 @@ This makes "Goals drive priorities" a programmatic primitive instead of a SOUL.m
 
 - **Goal-tag coverage on decisions** — % decisions with valid `goal_slug`. Target rising.
 - **Stale-detection cadence** — `goal_stale` events fired, then resolved by activity within N days vs by abandonment.
-- **Proactive-extraction acceptance rate** — % LLM-proposed child goals accepted by owner. Calibrates the extractor.
-- **Parent-close-suggestion accuracy** — when owner accepts the suggestion (label).
+- **Proactive-extraction acceptance rate** — % LLM-proposed child goals accepted by principal. Calibrates the extractor.
+- **Parent-close-suggestion accuracy** — when principal accepts the suggestion (label).
 - **Goal-alignment multiplier effect** — ablation of autonomous-loop scoring with vs without multiplier.
 
 #### Rejected
@@ -1088,7 +1190,7 @@ Distillation surfaced deeper tensions than expected for a Tier B cap:
 - TodoWrite is optional, model-discretion. Plan state is transient or implicit.
 - Sprint plans live as freeform memories (`metacognition_sprint_plan_2026_04_20`, etc.) — same C3-abuse class we already retired in C5.
 - `sequential-thinking` MCP server is installed (`.mcp.json`) but **never used** in any skill or hook.
-- No mid-step replan — only post-compaction fresh-start or owner-pushback restart.
+- No mid-step replan — only post-compaction fresh-start or principal-pushback restart.
 - `Already-done audit` (`/implement §4a`) exists *because* planning routinely skips a "verify-not-done" step — symptom-fix bolted onto the pipeline.
 
 **Question:** What is the structure of C4 so that planning is judgment-driven (per op policy), plans are first-class observable artifacts, and replanning is incremental?
@@ -1124,7 +1226,7 @@ This commitment is **architectural** at L2; detailed template format is L3.
 | Trigger | Replan scope |
 |---|---|
 | Step outcome differs from `expected` (test fails, missing file, etc.) | Re-evaluate remaining steps that depended on the changed assumption |
-| Owner correction during execution | Re-evaluate from correction point |
+| Principal correction during execution | Re-evaluate from correction point |
 | Anomaly event in C17 (rate-limit, hallucination_suspected, error) | Re-evaluate against goal alignment |
 | `convergence_stall` from C6 | Force replan with broader template scope |
 | Compaction event | Re-ground premises (per `post_compaction_task_premise_verification`), preserve done steps |
@@ -1152,14 +1254,14 @@ This makes plan effectiveness measurable at the right level.
 
 Templates are not static. Each instantiation's outcome (success/partial/failure) attributes back to the template. C5 reflection arm:
 - High-success template → priority surface in planner
-- High-failure template → flagged for refinement (Tier 1 owner queue)
+- High-failure template → flagged for refinement (Tier 1 principal queue)
 - Stable, novel-task patterns → candidate for new templates
 
 Closes "skill not used in 2 weeks → merge or delete" rule that currently has no telemetry to enforce.
 
 #### Migration
 
-- TodoWrite usage → kept; writes also emit plan events. Owner UI unchanged.
+- TodoWrite usage → kept; writes also emit plan events. Principal UI unchanged.
 - /implement, /delegate, /research, /autonomous-loop → become templates over v2 development; pipeline behaviour kept until each is migrated.
 - Sprint plan memories (`*_sprint_plan_*`, `metacognition_sprint_plan_*`) → DEPRECATED as memory class; new sprints use plan events.
 - Sequential-thinking MCP → wired into reasoning mode for the triggers above.
@@ -1215,7 +1317,7 @@ Distillation: worktree isolation is **advisory, not enforced** — Edit/Write to
 
 **Decision:** three primitives, layered:
 
-- **GitHub labels + issue claim comment** — owner-visible status.
+- **GitHub labels + issue claim comment** — principal-visible status.
 - **Supabase lock with TTL + heartbeat** — fast intra-Jarvis claim. Initial values: heartbeat every **30s**, TTL **120s** (4× heartbeat — survives one missed beat). Auto-release on missed heartbeat. Concrete values tunable in config (L3); the rule is TTL ≥ 3× heartbeat. Closes stale-lock gap.
 - **Structured handoff event** (in C17) — subagent emits `subagent_complete(plan_id, branch, claimed_files[], claimed_changes_summary, test_results, blockers[])`. Orchestrator + C16 reviewer read this, not free-text summary. Trace_id propagated per C17.
 
@@ -1228,7 +1330,7 @@ Distillation: worktree isolation is **advisory, not enforced** — Edit/Write to
 - **Mandatory worktrees** for any parallel session — validated 2026-04-06; `git checkout` collisions destroy work otherwise. Not optional.
 - **Lock-before-work**: any session must acquire Supabase lock on the work item before touching files. TTL = work bound; heartbeat = liveness. No lock = no write.
 - **Stagger + lock acquisition order**: 10-second minimum stagger between session launches when both target same repo. Under contention (both still racing for same lock), Supabase `INSERT ... ON CONFLICT DO NOTHING` decides — first writer wins, second sees existing row and blocks/retries. Stagger reduces probability of contention; lock semantics resolves it deterministically when it happens.
-- **Crash recovery**: stale locks (heartbeat missed for 2× TTL) auto-released. Recovery emits event for owner audit.
+- **Crash recovery**: stale locks (heartbeat missed for 2× TTL) auto-released. Recovery emits event for principal audit.
 
 #### Cross-repo dispatch class
 
@@ -1242,7 +1344,7 @@ Orchestrator-worker only inside any delegated task (per `federated_architecture_
 
 - `/delegate` skill → kept as the dispatch entry, but pipeline gains the pre/post gates above.
 - "Always commit/stash before dispatch" memory rule → enforced by pre-dispatch gate, not relied on as discipline.
-- Free-text handoff summary → kept as owner-readable, but **canonical handoff** is the structured event.
+- Free-text handoff summary → kept as principal-readable, but **canonical handoff** is the structured event.
 - Supabase lock writes from skills → migrated to TTL+heartbeat schema.
 - Branch-naming convention `feat/<N>-<slug>` → enforced by gate, branch-race becomes structural-impossible (lock prevents two agents claiming same N).
 - `pm_dispatch_v1` (already retired) — no migration needed.
@@ -1272,7 +1374,7 @@ C8 complete.
 
 ### C13 — Budget / cost governance
 
-Distillation: no aggregated $/month dashboard across externals — owner is blind to cap proximity. Pain discovered via 400/422 errors (VoyageAI throttling, Anthropic API key empty, Copilot quota out, GHA minutes 50% in 5 days). One $1800 surprise bill when scheduled runs accidentally routed through `ANTHROPIC_API_KEY` instead of subscription auth (`max_20x_upgrade_available`). Dispatcher's `usage_probe` is the only live gate, single-agent only — undercount likely. Model selection is largely model-discretion; CLAUDE.md rules are prose.
+Distillation: no aggregated $/month dashboard across externals — principal is blind to cap proximity. Pain discovered via 400/422 errors (VoyageAI throttling, Anthropic API key empty, Copilot quota out, GHA minutes 50% in 5 days). One $1800 surprise bill when scheduled runs accidentally routed through `ANTHROPIC_API_KEY` instead of subscription auth (`max_20x_upgrade_available`). Dispatcher's `usage_probe` is the only live gate, single-agent only — undercount likely. Model selection is largely model-discretion; CLAUDE.md rules are prose.
 
 C17 already commits cost-on-event (inline `cost_tokens`/`cost_usd`). C13 is the consumer + enforcement layer + router.
 
@@ -1284,7 +1386,7 @@ C17 already commits cost-on-event (inline `cost_tokens`/`cost_usd`). C13 is the 
 **Routing rule** (closes the cost-ambiguity raised in cost rehearsal): the architecture supports two modes — *subscription-first* (current default) and *API-first* — and is designed to switch between them with config change, not refactor.
 
 - **Mode A — Subscription-first (current default while Max is active)**: C5 handlers, C16 LLM reviewers, classifiers, and recall judges run as Claude Code scheduled tasks under Max subscription wherever possible (free under Max). Only paths that *cannot* run on subscription — cloud Supabase scheduled tasks via `execute_sql` (no Python runtime), and C16 different-provider review — use API key. Pre-implementation cost rehearsal: ~$13/mo expected steady-state externals.
-- **Mode B — API-first (evaluation period, planned)**: same handlers route via API. Owner's interactive Claude Code usage joins the API-billed pool. Pre-implementation rehearsal at current usage tempo (~9.5M tokens/mo, Opus-favoured): ~$50–80/mo aggregate; well within hard cap.
+- **Mode B — API-first (evaluation period, planned)**: same handlers route via API. Principal's interactive Claude Code usage joins the API-billed pool. Pre-implementation rehearsal at current usage tempo (~9.5M tokens/mo, Opus-favoured): ~$50–80/mo aggregate; well within hard cap.
 
 **Operational plan**: run Mode A for the current Max period; collect real usage data; transition to Mode B for an equivalent observation window; final mode decided on actual data, not estimates. C13's cap enforcement and ledger work identically in both modes — only the routing default changes. No architectural rework required for the switch.
 
@@ -1305,7 +1407,7 @@ C17 already commits cost-on-event (inline `cost_tokens`/`cost_usd`). C13 is the 
 | GitHub Actions minutes | Per repo, monthly | gh API |
 | Copilot quota | Binary availability probe | gh API |
 
-Each service has a configured budget; sum constrained to owner's external cap.
+Each service has a configured budget; sum constrained to principal's external cap.
 
 #### Cap enforcement gate (soft + hard for externals)
 
@@ -1314,8 +1416,8 @@ Each service has a configured budget; sum constrained to owner's external cap.
 | Projected external spend | Behaviour |
 |---|---|
 | ≤ $20 (soft cap) | No action |
-| $20 – $100 (above soft, below hard) | Warn — event + owner notification (C12 batched); deprioritize non-essential external LLM use; prefer subscription/Haiku where possible |
-| > $100 (hard cap) | Block non-essential external calls; allow only critical (owner-tagged or hard-required) |
+| $20 – $100 (above soft, below hard) | Warn — event + principal notification (C12 batched); deprioritize non-essential external LLM use; prefer subscription/Haiku where possible |
+| > $100 (hard cap) | Block non-essential external calls; allow only critical (principal-tagged or hard-required) |
 
 Per-service projection inside the gate so one service hitting hard cap doesn't kill all others, but **aggregate hard cap** is the bottom line. Subscription usage tracked separately (units, throttling-based, not dollar gates).
 
@@ -1324,7 +1426,7 @@ Per-service projection inside the gate so one service hitting hard cap doesn't k
 **Decision:** silence-failure (key empty, quota out) is detected pre-emptively, not after a 400.
 
 - **Daily reconciliation**: C17-derived spend vs provider billing API (where available). Drift > N% → investigation event.
-- **Heartbeat probes**: weekly low-cost API call per external service to verify keys/quotas alive. Failed probe → owner notification (C12) before next action depending on it.
+- **Heartbeat probes**: weekly low-cost API call per external service to verify keys/quotas alive. Failed probe → principal notification (C12) before next action depending on it.
 
 Closes the "Anthropic API key empty discovered by 400 error" class.
 
@@ -1335,7 +1437,7 @@ Closes the "Anthropic API key empty discovered by 400 error" class.
 Rules (initial):
 - Mechanical / classifier / extraction → Haiku
 - Implementation / refactor / structured reasoning → Sonnet
-- Architectural decisions / cross-system reasoning / redrobot owner work → Opus (regular, not 1M unless owner-tagged)
+- Architectural decisions / cross-system reasoning / redrobot principal work → Opus (regular, not 1M unless principal-tagged)
 - Different-provider review (per C16 high-leverage) → OpenAI/Gemini per-class
 
 Router emits `model_routed` event with rule that fired. Calibration: if outcome of a class consistently underperforms with chosen model → C5 reflection proposes rule update.
@@ -1356,11 +1458,11 @@ Closes "default Opus / Opus 1M extra billing" prose-rule fragility (`opus_1m_ext
 - `agents/usage_probe.py` → kept; extended to all actors (not just dispatcher) by reading C17 cost events.
 - CLAUDE.md model-selection prose → migrated to router config; prose becomes documentation of router rules.
 - Scheduled-task subscription assumption (`scheduled_tasks_subscription_not_api`) → enforced by routing protection above, not behavioural memory.
-- Manual escalation Max → Max 20× → triggered by 4-week sustained throttling event from C17, surfaced via C12 to owner.
+- Manual escalation Max → Max 20× → triggered by 4-week sustained throttling event from C17, surfaced via C12 to principal.
 
 #### How measured
 
-- **Cap proximity** — projected month-end vs cap, per service. Owner-facing dashboard.
+- **Cap proximity** — projected month-end vs cap, per service. Principal-facing dashboard.
 - **Reconciliation drift** — C17 ledger vs provider billing. Should be near-zero.
 - **Heartbeat-failure lead time** — interval between heartbeat-detected exhaustion and the action that would have failed. Should be > 0 (i.e., we caught it early).
 - **Routing-violation events** — should be near-zero. Spike = something is bypassing routing.
@@ -1388,7 +1490,7 @@ Remaining gaps require structural treatment in v2; most are extensions of what s
 
 **Question:** What does C14 add to Sprint 1's foundation to close the audit-completeness, compromise-detection, and recovery-runbook gaps?
 
-**Membership rule:** belongs in C14 iff *protects credentials/access* OR *bounds blast radius of compromise* OR *enables forensic reconstruction*. Owner-stated out-of-scope (personal data, password hygiene, prompt injection on untrusted external content) stays out of scope unless owner re-decides at L0.
+**Membership rule:** belongs in C14 iff *protects credentials/access* OR *bounds blast radius of compromise* OR *enables forensic reconstruction*. Principal-stated out-of-scope (personal data, password hygiene, prompt injection on untrusted external content) stays out of scope unless principal re-decides at L0.
 
 #### Layered defense (preserved from Sprint 1)
 
@@ -1418,9 +1520,9 @@ C3's bi-temporal model preserves `memory_facts` history (no destructive overwrit
 
 **Decision:** active monitoring beyond passive scanners.
 
-- **HIBP-style breach probe**: weekly check of registered credential identifiers (emails, usernames where applicable) against haveibeenpwned API. Hit → emit `credential_potentially_compromised` event → C12 owner notification.
-- **Suspicious-activity heuristics**: anomaly events from C17 self-detection (rate-limited spikes, hallucinated tool calls, off-hours dispatcher activity) cross-checked against credential usage timestamps. Pattern match → flag for owner.
-- **Post-rotation verification**: when owner rotates a credential, registry's `last_rotated` updated; subsequent uses of old credential (failed auth events) → `stale_credential_in_use` event (a script somewhere wasn't updated).
+- **HIBP-style breach probe**: weekly check of registered credential identifiers (emails, usernames where applicable) against haveibeenpwned API. Hit → emit `credential_potentially_compromised` event → C12 principal notification.
+- **Suspicious-activity heuristics**: anomaly events from C17 self-detection (rate-limited spikes, hallucinated tool calls, off-hours dispatcher activity) cross-checked against credential usage timestamps. Pattern match → flag for principal.
+- **Post-rotation verification**: when principal rotates a credential, registry's `last_rotated` updated; subsequent uses of old credential (failed auth events) → `stale_credential_in_use` event (a script somewhere wasn't updated).
 
 #### Recovery runbook for credential compromise
 
@@ -1432,7 +1534,7 @@ C3's bi-temporal model preserves `memory_facts` history (no destructive overwrit
 3. Update credential in all storage locations (registry's `stored_in` field tracks them)
 4. Verify rotation via heartbeat probe (C13)
 5. Audit C17 events for the compromise window — what was accessed/modified
-6. Owner decides whether to rollback specific changes or accept
+6. Principal decides whether to rollback specific changes or accept
 
 Closes "no key-leaked runbook" gap.
 
@@ -1446,9 +1548,9 @@ v2: bootstrap reads launcher signature (process tree, env source) and verifies e
 
 #### Supabase RLS — defense in depth
 
-**Decision:** enable RLS even though single-user. Two roles: `owner` (full read/write) and `agent` (no read on `credential_registry.value-equivalents`, no DELETE on `memories`/`events`).
+**Decision:** enable RLS even though single-user. Two roles: `principal` (full read/write) and `agent` (no read on `credential_registry.value-equivalents`, no DELETE on `memories`/`events`).
 
-Single-user assumption is correct today, but RLS adds a guard if a leaked anon key ever happens. Cheap to add; matches owner's "восстановление если что-то всё-таки произойдёт" clarification at L0.
+Single-user assumption is correct today, but RLS adds a guard if a leaked anon key ever happens. Cheap to add; matches principal's "восстановление если что-то всё-таки произойдёт" clarification at L0.
 
 **Note:** RLS on the shared Supabase project is a **cross-project change** (per C15's cross-project shared-code class). Coordination with redrobot before applying — RLS rules must allow redrobot's existing access patterns or break it.
 
@@ -1475,7 +1577,7 @@ Single-user assumption is correct today, but RLS adds a guard if a leaked anon k
 - *No active breach monitoring* — discovers compromises by their consequences.
 - *Single recovery playbook for all classes* — credential-compromise has different steps than agent-broke-something.
 - *Reliance on principal env var without verification* — workshop scheduler class.
-- *Skip Supabase RLS because single-user* — cheap defense in depth that aligns with owner's recovery emphasis.
+- *Skip Supabase RLS because single-user* — cheap defense in depth that aligns with principal's recovery emphasis.
 - *Re-expanding scope to personal data / passwords / prompt injection* — explicitly out per L0; not re-decided here.
 
 ---
@@ -1490,9 +1592,9 @@ These caps inherit most structure from Tier A/B decisions. Each gets a single-pa
 
 #### C1 — Identity & values
 
-**Decision:** SOUL.md (owner-authored axioms) + CLAUDE.md (project-specific instructions) loaded at session start via the session-context hook. **Distinct storage from C3 memory** — identity is immutable-by-Jarvis (owner edits only, M3 in C15), retrieved by injection not query. C5 stale-challenge does NOT challenge identity (would break the alignment substrate); only owner does, via direct edits.
+**Decision:** SOUL.md (principal-authored axioms) + CLAUDE.md (project-specific instructions) loaded at session start via the session-context hook. **Distinct storage from C3 memory** — identity is immutable-by-Jarvis (principal edits only, M3 in C15), retrieved by injection not query. C5 stale-challenge does NOT challenge identity (would break the alignment substrate); only principal does, via direct edits.
 
-**How measured:** identity-drift detection — C5 reflection compares Jarvis's recent behavior pattern to SOUL.md rules; deviation flagged for owner review (not auto-corrected).
+**How measured:** identity-drift detection — C5 reflection compares Jarvis's recent behavior pattern to SOUL.md rules; deviation flagged for principal review (not auto-corrected).
 
 **Rejected:** identity learnable from outcomes (drift risk), identity stored in C3 (sub-type rule violation).
 
@@ -1516,29 +1618,29 @@ These caps inherit most structure from Tier A/B decisions. Each gets a single-pa
 
 #### C11 — Perception
 
-**Decision:** perception is the boundary where external events become C17 events. Sources: owner messages (CLI, future channels), GitHub events (via Actions → Supabase per `event_driven_perception_v1`), scheduled-task triggers, repo file-changes, MCP server signals. C11 does **not** decide what to act on — it converts external signals into structured events; **C2/C3/C5/C6 chain** decides response per `Memory-driven autonomy` op policy.
+**Decision:** perception is the boundary where external events become C17 events. Sources: principal messages (CLI, future channels), GitHub events (via Actions → Supabase per `event_driven_perception_v1`), scheduled-task triggers, repo file-changes, MCP server signals. C11 does **not** decide what to act on — it converts external signals into structured events; **C2/C3/C5/C6 chain** decides response per `Memory-driven autonomy` op policy.
 
 **Ingest gate:** raw signals from external sources can be high-volume (CI events, file watches). C11 has a thin filter — discards signals that match known-noise patterns (config) — but every accepted signal becomes an event regardless of whether anything acts on it. The decision *to act* is downstream (autonomous-loop / handlers query events); the decision *to record* is C11's only call, biased toward record-everything. Signals dropped by the noise filter emit a `signal_dropped` count event for audit (no payload).
 
-**How measured:** event-to-action latency for time-sensitive events (e.g., owner-message to first action), event drop rate (events that arrived but weren't ingested).
+**How measured:** event-to-action latency for time-sensitive events (e.g., principal-message to first action), event drop rate (events that arrived but weren't ingested).
 
-#### C12 — Communication with owner
+#### C12 — Communication with principal
 
 **Decision:** structured channels with priority semantics:
 - **Interactive** (CLI / future desktop) — primary, highest fidelity.
 - **Critical alerts** — interrupt-style; few, validated against false-positive rate. Examples: cap-breach (C13), credential compromise (C14), bootstrap fail (C15).
-- **Batched briefs** — morning/evening summary aggregator: pending C6 queue items, C16 reviewer summaries, C5 stale alerts, C2 deadline-soon, C13 cap proximity. **Single owner-facing surface**, not N notifications.
+- **Batched briefs** — morning/evening summary aggregator: pending C6 queue items, C16 reviewer summaries, C5 stale alerts, C2 deadline-soon, C13 cap proximity. **Single principal-facing surface**, not N notifications.
 - **Telegram** — chat-only role per L0 (dropped as primary interface).
 
-**Drafts vs sends:** Jarvis drafts; final send to other humans (PR comments, messages, emails) goes through owner approval per L0 non-goal "не пишет от моего лица". **Mechanism:** outgoing-message production is a separate C12 action class (not a tool call), gated by a `c12_send_intent` event that requires explicit owner-confirmed `c12_send_approval` before any tool actually emits text outward. Drafts written to a queue (visible to owner via batched brief) — sending = owner button-press = produces the approval event = unblocks the actual send tool call. Pre-confirmation tool calls don't fire.
+**Drafts vs sends:** Jarvis drafts; final send to other humans (PR comments, messages, emails) goes through principal approval per L0 non-goal "не пишет от моего лица". **Mechanism:** outgoing-message production is a separate C12 action class (not a tool call), gated by a `c12_send_intent` event that requires explicit principal-confirmed `c12_send_approval` before any tool actually emits text outward. Drafts written to a queue (visible to principal via batched brief) — sending = principal button-press = produces the approval event = unblocks the actual send tool call. Pre-confirmation tool calls don't fire.
 
-**How measured:** interrupt rate (should fall as autonomy + accuracy grows), batched-brief actionability (% of items in brief that owner acted on / dismissed).
+**How measured:** interrupt rate (should fall as autonomy + accuracy grows), batched-brief actionability (% of items in brief that principal acted on / dismissed).
 
-**Rejected:** Telegram as primary interface (L0); per-event owner notification (drowns owner); auto-send to other humans (L0 non-goal).
+**Rejected:** Telegram as primary interface (L0); per-event principal notification (drowns principal); auto-send to other humans (L0 non-goal).
 
 ---
 
-**L2 complete.** All 17 capabilities have membership rules, structural decisions, measurement plans, migration paths, and explicit rejections.
+**L2 complete.** All 18 capabilities have membership rules, structural decisions, measurement plans, migration paths, and explicit rejections.
 
 ---
 
@@ -1572,29 +1674,29 @@ Until enough labels accumulate, "calibrated" gates can't fire. Every such gate h
 | Capability | Seeded behavior until labels accumulate | What labels look like | N to mature |
 |---|---|---|---|
 | **C3 conflict classifier** | Auto-apply confidence threshold raised from 0.85 to 0.95 (conservative). Below queue. | `record_correction` events labeling classifier outcome. | ~30 labels per class |
-| **C5 generation arm** | Auto-write threshold 0.95; no super-aggressive synthesis until first 30 days of labels. | Owner override on synthesized memory. | ~50 labels global |
-| **C5 stale-challenge** | Triggers only on **owner correction** and **decision failure** (the strong signals); periodic sweep deferred until first quarter. | Owner override on superseded memory. | ~20 labels |
+| **C5 generation arm** | Auto-write threshold 0.95; no super-aggressive synthesis until first 30 days of labels. | Principal override on synthesized memory. | ~50 labels global |
+| **C5 stale-challenge** | Triggers only on **principal correction** and **decision failure** (the strong signals); periodic sweep deferred until first quarter. | Principal override on superseded memory. | ~20 labels |
 | **C5 judge calibrator** | Computed only on judges that have ≥10 ground-truth labels in last 90 days; below threshold, judge is reported "uncalibrated" and uses its seed threshold. | Outcome labels link back. | ≥10 per judge per 90 days |
-| **C6 gate per-class** | Action class with no calibration history: defaults to **escalate-on-uncertainty**. As classifier confidence + outcome data accumulate, threshold relaxes. | Owner override on queue items. | ~30 labels per class |
+| **C6 gate per-class** | Action class with no calibration history: defaults to **escalate-on-uncertainty**. As classifier confidence + outcome data accumulate, threshold relaxes. | Principal override on queue items. | ~30 labels per class |
 | **C6 convergence detector** | Counter active from Day 1 (deterministic, no calibration needed). | n/a | Immediate |
 | **C16 different-provider** | **Deferred to month 2.** Peer-Jarvis only in month 1; cost data from month 1 informs whether different-provider is affordable at planned cadence. | Cost reconciliation. | 30 days of operation |
-| **C13 cap enforcement** | **Warning only in month 1**, no blocking. Cost numbers vs cap inform whether caps are correctly set. Blocking starts month 2. | Owner observation of cost trends. | 30 days |
-| **C15 trust ladder** | All M1 classes start locked. Owner manually unlocks first class after first month of M0 success data. | Per-class regression / success counts. | Per-class threshold |
-| **C16 cross-device sweep** | Disabled until month 2. Manual cross-device test on owner-flagged config-touching changes only. | Cross-device incident reports. | 30 days |
-| **Bootstrap-protection rule (C15)** | On Day 1, **C6/C16/C17 modifications are owner-only** (no "previous version" to review against yet). After 30 days of stable operation, prior-version + different-provider review unlocks for these caps. | Operational stability of C6/C16/C17. | 30 days stable |
+| **C13 cap enforcement** | **Warning only in month 1**, no blocking. Cost numbers vs cap inform whether caps are correctly set. Blocking starts month 2. | Principal observation of cost trends. | 30 days |
+| **C15 trust ladder** | All M1 classes start locked. Principal manually unlocks first class after first month of M0 success data. | Per-class regression / success counts. | Per-class threshold |
+| **C16 cross-device sweep** | Disabled until month 2. Manual cross-device test on principal-flagged config-touching changes only. | Cross-device incident reports. | 30 days |
+| **Bootstrap-protection rule (C15)** | On Day 1, **C6/C16/C17 modifications are principal-only** (no "previous version" to review against yet). After 30 days of stable operation, prior-version + different-provider review unlocks for these caps. | Operational stability of C6/C16/C17. | 30 days stable |
 
 ### Cold-start month rules
 
-- **Cost cap**: warning thresholds active, no blocking. Owner sees real numbers before policy hardens.
-- **Autonomy default**: lower than mature target. Most decisions queue; owner approval rate informs C6 threshold tuning.
+- **Cost cap**: warning thresholds active, no blocking. Principal sees real numbers before policy hardens.
+- **Autonomy default**: lower than mature target. Most decisions queue; principal approval rate informs C6 threshold tuning.
 - **Mutation arm volume**: capped at ~5 autonomous writes/week from C5 to limit blast radius if calibration is wrong.
-- **Owner instrumentation**: weekly "cold-start readout" — cost, override rate, queue depth, per-cap volume — informs which thresholds to relax for month 2.
+- **Principal instrumentation**: weekly "cold-start readout" — cost, override rate, queue depth, per-cap volume — informs which thresholds to relax for month 2.
 
 Cold-start ends when each cap has its label budget met OR after 60 days, whichever comes first.
 
 ### Bootstrap caveat
 
-This protocol explicitly accepts **degraded autonomy in month 1** in exchange for safety + calibration data. The trade-off is owner-visible: more queueing, fewer auto-decisions, more manual labeling. By month 2 the system should be operating closer to design intent.
+This protocol explicitly accepts **degraded autonomy in month 1** in exchange for safety + calibration data. The trade-off is principal-visible: more queueing, fewer auto-decisions, more manual labeling. By month 2 the system should be operating closer to design intent.
 
 ---
 
@@ -1613,8 +1715,8 @@ After scout v2 (2026-04-27) — see [`jarvis-build-vs-buy.md`](jarvis-build-vs-b
 - **Stale detection**: pg view + scheduled query OR pg trigger on event insert. Lean: scheduled query (simpler, traceable).
 - **`goal_slug` resolution at gate**: pg function consulted by C6 gate hook OR LLM-judged matching. Lean: pg function with semantic-similarity over goal embeddings (cheap, deterministic), LLM fallback only on ambiguity.
 - **Goal embeddings**: VoyageAI on `description` at insert/update. Lean: pg trigger fires Voyage call via `mcp-memory/server.py` background worker; cached in `goals.embedding` column.
-- **Parent-close cascade**: pg trigger on `goal_status_change` vs scheduled query. Lean: scheduled query — closing a goal is a strategic moment requiring owner judgment, not auto-action; trigger only emits `parent_close_suggested` event.
-- **Proactive child goal extraction**: scheduled subagent vs event-triggered handler on `owner_message`/`decision_made`. Lean: event-triggered with Haiku — per `Memory-driven autonomy` op policy, not periodic sweep.
+- **Parent-close cascade**: pg trigger on `goal_status_change` vs scheduled query. Lean: scheduled query — closing a goal is a strategic moment requiring principal judgment, not auto-action; trigger only emits `parent_close_suggested` event.
+- **Proactive child goal extraction**: scheduled subagent vs event-triggered handler on `principal_message`/`decision_made`. Lean: event-triggered with Haiku — per `Memory-driven autonomy` op policy, not periodic sweep.
 
 ### C3 — Memory
 - **Tables**: PostgreSQL with pgvector (current). No real alternative under Cost=9 + Memory=10.
@@ -1641,6 +1743,12 @@ After scout v2 (2026-04-27) — see [`jarvis-build-vs-buy.md`](jarvis-build-vs-b
 - **Class-conditional calibration (closes Q4 sparse-class)**: bespoke vs `crepes` vs MAPIE. Lean: [`crepes`](https://github.com/henrikbostrom/crepes) — `pip install crepes`, Mondrian CP via `class_cond=True`, sklearn-compatible, CPU-only, ~10× faster than MAPIE on small data. Wires into `memory_calibration_summary` MCP tool. [`MAPIE`](https://github.com/scikit-learn-contrib/MAPIE) on watch list (2026 roadmap adds CP for LLM-as-judge).
 - **Calibration metrics**: bespoke vs `netcal`. Lean: [`netcal`](https://github.com/EFS-OpenSource/calibration-framework) (`pip install netcal`) — ECE/MCE/ACE/MMCE + reliability diagrams; pair with sklearn `brier_score_loss`.
 - **Judge prompt source**: bespoke strings vs published rubric prompts. Lean: [`prometheus-eval`](https://github.com/prometheus-eval/prometheus-eval) (`pip install prometheus-eval`) — `from prometheus_eval.prompts import ABSOLUTE_PROMPT, RELATIVE_PROMPT` for /reflect, /verify, calibrator. Removes bespoke prompt-engineering drift.
+
+### C18 — Proactive challenger
+- **Detection engine**: SQL queries over C17 events + `goals` table. No LLM in the hot detection path.
+- **Threshold tuning**: per-signal config in `recalibration_thresholds.yaml` (calibration-Brier, goal-stale-days, override-frequency-per-class). Editable as M2-strong (reviewer + smoke required) since wrong thresholds = surfacing storm.
+- **Surfacing renderer**: optional Haiku call to phrase the `recalibration_proposed` payload readably. Capped by C13 — max 5 surfacings per batched brief (1 LLM call each).
+- **Routing**: emit `recalibration_proposed` event; C12 batched-brief aggregator picks it up alongside other deferred items. No new transport.
 
 ### C6 — Decision gating
 - **Hook substrate**: Claude Code PreToolUse hook (interactive lane) + similar gate at MCP boundary (cloud lane). Lean: this; the canonical gate function is the same behind both.
@@ -1680,15 +1788,15 @@ After scout v2 (2026-04-27) — see [`jarvis-build-vs-buy.md`](jarvis-build-vs-b
 ### C11 — Perception
 - **External event ingest**: GitHub Actions → Supabase events table (`event_driven_perception_v1` already established).
 - **File-watch source**: native fs-watch vs polling vs git hooks. Lean: git hooks for repo-meaningful changes; fs-watch only for narrow needs.
-- **Owner-message channel**: Claude Code interactive (primary). Future: desktop notifications, mobile (1.x feature).
-- **Noise filter config**: bespoke YAML — pattern `(actor regex, action regex) → drop`. Lean: YAML edited by owner via PR; discovery loop = incident → owner adds entry. Reference: `event_dispatch_spam_fix` (136 CI Issue-Checks events).
-- **Dropped-signal audit**: count-only events (no payload, just `signal_dropped` action + matched-pattern attr) for trail of filter hits. Cheap; required for "owner can answer why X didn't trigger" forensics.
+- **Principal-message channel**: Claude Code interactive (primary). Future: desktop notifications, mobile (1.x feature).
+- **Noise filter config**: bespoke YAML — pattern `(actor regex, action regex) → drop`. Lean: YAML edited by principal via PR; discovery loop = incident → principal adds entry. Reference: `event_dispatch_spam_fix` (136 CI Issue-Checks events).
+- **Dropped-signal audit**: count-only events (no payload, just `signal_dropped` action + matched-pattern attr) for trail of filter hits. Cheap; required for "principal can answer why X didn't trigger" forensics.
 
-### C12 — Communication with owner
+### C12 — Communication with principal
 - **Interactive**: Claude Code CLI (primary). Future: native desktop app, voice (1.x).
 - **Critical alerts**: notification mechanism — desktop notifier vs Telegram message vs CLI banner-on-next-session. Lean: CLI banner-on-next-session as default; Telegram supplementary; desktop later.
-- **Batched briefs**: morning/evening summary written to a fixed file owner reads on session start vs sent via Telegram, OR using [`session-report`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report) plugin from `anthropics/claude-plugins-official`. Lean: `session-report` plugin as base, file output for cross-session continuity; Telegram optional.
-- **CLAUDE.md / SOUL drift management**: bespoke vs [`claude-md-management`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management) plugin. Lean: install the plugin to detect drift; SOUL.md changes still M3 (owner-only) per C15.
+- **Batched briefs**: morning/evening summary written to a fixed file principal reads on session start vs sent via Telegram, OR using [`session-report`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/session-report) plugin from `anthropics/claude-plugins-official`. Lean: `session-report` plugin as base, file output for cross-session continuity; Telegram optional.
+- **CLAUDE.md / SOUL drift management**: bespoke vs [`claude-md-management`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management) plugin. Lean: install the plugin to detect drift; SOUL.md changes still M3 (principal-only) per C15.
 
 ### C13 — Budget / cost governance
 - **Cost ledger**: SQL views over C17 events (already decided in L2). No alternative.
@@ -1712,7 +1820,7 @@ After scout v2 (2026-04-27) — see [`jarvis-build-vs-buy.md`](jarvis-build-vs-b
 - **Trust-ladder state**: stored in C3 facts (`self_improve_class_<name>` memories with maturity counters) or in a small `m1_unlocks` table. Lean: facts — they're the natural home, no schema overhead.
 - **Misimprovement detection**: SQL queries over C17 events comparing claimed-benefit metrics vs observed outcomes. Lean: this.
 - **Bootstrap-protection enforcement**: PR check workflow (GitHub Action) reading event substrate to confirm prior-version review. Lean: GHA — already established for CI.
-- **Safeguard layers (prior-version-review is novel — add parallel)**: per [Darwin-Gödel Machine (arXiv:2505.22954)](https://arxiv.org/abs/2505.22954) and [SiriuS](https://openreview.net/forum?id=Mz2JYufbg4g) — empirical benchmark + sandboxing + human oversight, not prior-version alone. Lean: stack all four for C6/C16/C17 modifications (prior-version + benchmark + sandbox + owner sign-off). DGM concedes "proving most changes net beneficial is impossible" — defense in depth required.
+- **Safeguard layers (prior-version-review is novel — add parallel)**: per [Darwin-Gödel Machine (arXiv:2505.22954)](https://arxiv.org/abs/2505.22954) and [SiriuS](https://openreview.net/forum?id=Mz2JYufbg4g) — empirical benchmark + sandboxing + human oversight, not prior-version alone. Lean: stack all four for C6/C16/C17 modifications (prior-version + benchmark + sandbox + principal sign-off). DGM concedes "proving most changes net beneficial is impossible" — defense in depth required.
 - **Tier-graduation alignment check**: per [biosecurity-agent lifecycle (bioRxiv 2025.09.17)](https://www.biorxiv.org/content/10.1101/2025.09.17.676717v1.full.pdf) — formal alignment check before each M-tier promotion. Lean: structured checklist (regression metrics + reviewer sign-off + SOUL alignment), not metric thresholds alone.
 
 ### C16 — Verification / QA
@@ -1756,7 +1864,7 @@ Before shifting effort to the new architecture's 1.x feature roll-out, the curre
 Required for v1 stable:
 - Memory contradictions visible to current recall do not actively mislead in daily ops (current pain class — bi-temporal + supersession in C3 fixes this, but interim is acceptable if it doesn't cause incidents).
 - Subagent fabrication rate ≤ 1 per 30 dispatches via existing manual-review discipline (until C16 ships).
-- Cost visibility — owner can answer "how much did Jarvis cost me last month" within 1 minute (precondition for any A/B routing experiment).
+- Cost visibility — principal can answer "how much did Jarvis cost me last month" within 1 minute (precondition for any A/B routing experiment).
 - No active blocker on cross-device usage (keys, MCP portability, principal env).
 - Critical security defenses (Sprint 1) operational on all 3 devices.
 
@@ -1770,9 +1878,9 @@ Pillars are long-lived capability groups (per `pillar_is_not_one_task` — they 
 |---|---|
 | Memory | C3 (Memory store), C5 (Reflection / learning), C17 (Observability — feeds episodic) |
 | Identity & Strategy | C1 (Identity & values), C2 (Goals & priorities) |
-| Cognition | C4 (Reasoning & planning), C6 (Decision gating) |
+| Cognition | C4 (Reasoning & planning), C6 (Decision gating), C18 (Proactive challenger) |
 | Action | C7 (Execution), C8 (Sub-orchestration), C9 (Tool / env interface), C10 (Research) |
-| Interface | C11 (Perception), C12 (Communication with owner) |
+| Interface | C11 (Perception), C12 (Communication with principal) |
 | Stewardship | C13 (Budget), C14 (Security & privacy), C15 (Self-improvement), C16 (Verification) |
 
 Pillars are how progress gets summarized; capabilities are how work gets sliced.
@@ -1782,7 +1890,7 @@ Pillars are how progress gets summarized; capabilities are how work gets sliced.
 Independent re-derivation compared to `jarvis_v2_vision` + `jarvis_v2_hybrid_agile`:
 
 - **Convergent on core** (10 themes): memory primacy, cloud-trust threat model, outcome-driven learning, autonomous loop, goals separate from memory, identity separate from memory, sub-orchestration, decisions outside memory, research-gated, security cloud-trust. Strong signal that the core direction is right.
-- **Scope divergence (deliberate per L0)**: prior framing was "universal personal AI agent" with personal life included; this architecture is owner-only, work-only. Personal life, TTS/STT, broader data ingestion, open-source split → 1.x feature backlog, not separate version.
+- **Scope divergence (deliberate per L0)**: prior framing was "universal personal AI agent" with personal life included; this architecture is principal-only, work-only. Personal life, TTS/STT, broader data ingestion, open-source split → 1.x feature backlog, not separate version.
 - **Structural additions in this design** (formalization, not scope creep): C6 single canonical gate, C13 budget governance, C15 modification tiers + bootstrap protection, C16 reviewer independence, C17 events as canonical substrate, "design-to-evaluate" op policy, bootstrap protocol.
 
 No findings forced re-decision. Prior vision's broader scope captured in 1.x backlog rather than in this architecture.

--- a/docs/design/jarvis-v2-redesign.md
+++ b/docs/design/jarvis-v2-redesign.md
@@ -27,7 +27,7 @@ No intermediate diagrams. One C4 (Context → Container → Component) at the en
 |---|---|
 | L0 — mission, qualities, non-goals | **done** |
 | L1 — capabilities | **done** (18 caps, 5 layers, 3 ops policies) |
-| L2 — components per capability | **done** (Tier A: C3, C5, C6, C15, C16, C17; Tier B: C2, C4, C8, C13, C14; Tier C: C1, C7, C9, C10, C11, C12) |
+| L2 — components per capability | **done** (Tier A: C3, C5, C6, C15, C16, C17, C18; Tier B: C2, C4, C8, C13, C14; Tier C: C1, C7, C9, C10, C11, C12) |
 | Bootstrap protocol & migration order | **done** |
 | Critical review pass | **done** (high-severity addressed: bootstrap + cost reality + ~15 point fixes) |
 | L3 — technologies/patterns | **done** (options marked + scout v2 adoption candidates folded in 2026-04-27 per [`jarvis-build-vs-buy.md`](jarvis-build-vs-buy.md); decisions deferred to implementation) |
@@ -236,11 +236,11 @@ For each capability we run two research streams and synthesize:
 2. **External research** — fresh subagent surveys current state of the art (no training-data trust).
 
 Stratification:
-- **Tier A** (deep): C3, C5, C6, C15, C16, C17 — novel or risky, full two-stream research.
+- **Tier A** (deep): C3, C5, C6, C15, C16, C17, C18 — novel or risky, full two-stream research.
 - **Tier B** (medium): C2, C4, C8, C13, C14 — discussion + targeted research.
 - **Tier C** (shallow): C1, C7, C9, C10, C11, C12 — single-line decision.
 
-Order within Tier A: C3 Memory and C17 Observability first (other caps depend on them), then C5/C6/C15/C16. After Tier A, Tier B, then Tier C.
+Order within Tier A: C3 Memory and C17 Observability first (other caps depend on them), then C5/C6/C15/C16/C18 (C18 sequenced after C5 — shares the calibration substrate). After Tier A, Tier B, then Tier C.
 
 ### C3 — Memory
 


### PR DESCRIPTION
Closes #469

## Summary

- Phase C of the Vision update — extends Phase B's framing into the rest of the docs, applies the 3 LOCKED redesign edits from `audit_3_main_changes_lock_2026_04_28`, adds **C18 Proactive challenger** (caps 17→18), and resolves pass2 §Q7 with an explicit L0 harness coupling trade-off.
- Bundled into one PR instead of 4+ sequential — design docs cross-reference each other, sequential PRs would cite stale unmerged peers + 4× CI cost.
- Tracking via post-factum issue-bucket #469 (per CLAUDE.md drive-by-without-parent pattern, #183). Phase B was #465; Phase A was #461.

## What changed

**C-2 README.md** — north-star line + capability table aligned with Vision's 5 axes.

**C-3 design docs** — jarvis-architecture-c4.md, jarvis-flows.md (8 flows), jarvis-build-vs-buy.md, jarvis-v2-redesign-review-pass2.md: terminology pass owner→principal.

**C-4 agents docs + skill prompts** — docs/agents/{dispatcher,observability,perception,safety,escalation}.md + 8 skills under .claude-userlevel/skills/: prose terminology only.

**C-1 redesign.md** (the big one):
- Bulk owner→principal (164 refs)
- §C16 → class-aware auto-merge taxonomy (auto-merge low-leverage; principal-gate high-leverage)
- §C15 M3 split: M3-hard (6 fixed: SOUL.md, schema.sql, .env, C6, C16, C17) + M2-strong (3 reclassified: CLAUDE.md, .mcp.json, server.py)
- §C2 → auto-create draft goals (no C6 queue; 7-day quiet dismiss; 3/week limit)
- **C18 added** in Cognition layer alongside C5 (full L2 §, L3 entry, pillar→cap mapping, C4 component diagram)

**Q7 resolution** (commit 1a3dc66) — added explicit L0 §«Harness coupling — deliberate trade-off» naming what's locked to Claude Code (skills/hooks/auto-load/subagent isolation), what's portable (cap layer, Supabase schema, events substrate, MCP, embeddings), the swap cost (~1-2 sprints rewrite of skills+hooks), and the reconsideration trigger. pass2 §Q7 marked Resolved.

## Explicitly NOT renamed (functional identifiers)

- GitHub <owner/repo> URL convention in skills
- OWNER_QUEUE Enum in agents/safety.py
- send_as_owner function name
- owner_focus/jarvis_focus DB columns — schema rename = cross-project with redrobot, separate issue
- Foreign-owner repo convention (GitHub repo ownership)
- Owner column header in scheduler.md (different sense)

## Follow-ups

- [ ] SVG re-render via mmdc for c4-*.svg + flow-*.svg
- [ ] Schema rename owner_focus→principal_focus (cross-project)
- [ ] Code Enum rename OWNER_QUEUE→PRINCIPAL_QUEUE

## Test plan

- [ ] CI green (docs-only)
- [ ] Visual diff review: README capability table, redesign.md §C16/§C15/§C2/§C18/§Harness coupling
- [ ] mermaid sources parse (re-render in follow-up)
- [ ] No broken anchor links in jarvis-flows.md after Owner→Principal rename