### PR TITLE
Phase 5.3-β: fok_judgments table migration + dual-write

### DIFF
--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2383,3 +2383,11 @@ create table if not exists fok_judgments (
 create index if not exists idx_fok_judgments_verdict ON fok_judgments(verdict, judged_at DESC);
 create index if not exists idx_fok_judgments_query_project ON fok_judgments(project, query);
 create index if not exists idx_fok_judgments_outcome ON fok_judgments(outcome_id) WHERE outcome_id IS NOT NULL;
+
+ALTER TABLE fok_judgments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow all for authenticated" ON fok_judgments
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "Allow all for anon" ON fok_judgments
+  FOR ALL TO anon USING (true) WITH CHECK (true);

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2352,3 +2352,34 @@ create policy "Allow all for anon" on task_queue
 -- scan becomes the bottleneck.
 -- =========================================================================
 drop index if exists public.memories_embedding_idx;
+
+
+-- =========================================================================
+-- #443 (Phase 5.3-β memory): FOK judgments table
+--
+-- Stores feeling-of-knowing verdicts for memory_recall events.
+-- Tracks sufficiency of returned memories against queries, confidence
+-- of the judgment, and optional linkage to task outcomes for calibration.
+-- =========================================================================
+
+create table if not exists fok_judgments (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recall_event_id uuid NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  query           text NOT NULL,
+  project         text,
+  verdict         text NOT NULL CHECK (verdict IN ('sufficient','partial','insufficient','unknown','skipped')),
+  confidence      real CHECK (confidence IS NULL OR confidence BETWEEN 0 AND 1),
+  rationale       text,
+  judge_model     text NOT NULL,
+  judge_version   text NOT NULL,
+  judged_at       timestamptz NOT NULL DEFAULT now(),
+  action_taken    text CHECK (action_taken IN ('pass_through','gap_recorded','widened') OR action_taken IS NULL),
+  action_at       timestamptz,
+  outcome_id      uuid REFERENCES task_outcomes(id) ON DELETE SET NULL,
+  outcome_correct boolean,
+  UNIQUE (recall_event_id)
+);
+
+create index if not exists idx_fok_judgments_verdict ON fok_judgments(verdict, judged_at DESC);
+create index if not exists idx_fok_judgments_query_project ON fok_judgments(project, query);
+create index if not exists idx_fok_judgments_outcome ON fok_judgments(outcome_id) WHERE outcome_id IS NOT NULL;

--- a/scripts/fok-batch.py
+++ b/scripts/fok-batch.py
@@ -252,11 +252,10 @@ def try_insert_known_unknown(client, event: dict, project: str) -> None:
         pass
 
 
-def format_judgment_for_display(event_id: str, verdict: dict, event: dict) -> dict:
+def format_judgment_for_display(
+    event_id: str, verdict: dict, payload: dict, judged_at: str
+) -> dict:
     """Format judgment data for dry-run display."""
-    payload = event.get("payload") or {}
-    now = datetime.now(timezone.utc).isoformat()
-
     return {
         "event_id": event_id,
         "query": payload.get("query", ""),
@@ -266,54 +265,51 @@ def format_judgment_for_display(event_id: str, verdict: dict, event: dict) -> di
         "rationale": verdict.get("reason", ""),
         "judge_model": "claude-3-5-haiku-20241022",
         "judge_version": "5.3-β",
-        "judged_at": now,
+        "judged_at": judged_at,
     }
 
 
-def write_verdict_to_event(client, event_id: str, verdict: dict, event: dict) -> None:
-    """Write FOK verdict back to event.payload AND insert into fok_judgments (dual-write).
+def write_verdict_to_event(client, event_id: str, verdict: dict) -> None:
+    """Write FOK verdict to event.payload (legacy) AND fok_judgments (canonical).
 
-    Legacy mirror: event.payload.fok_verdict is dropped in 5.3-δ.
-    Canonical: fok_judgments table.
+    Legacy mirror dropped in 5.3-δ.
     """
+    db_payload: dict = {}
+    judged_at = datetime.now(timezone.utc).isoformat()
+
     try:
         current_event = client.table("events").select("payload").eq("id", event_id).execute()
         if not current_event.data:
             return
+        db_payload = current_event.data[0].get("payload") or {}
 
-        # Legacy write: event.payload
-        payload = current_event.data[0].get("payload") or {}
-        payload.update(
+        new_payload = dict(db_payload)
+        new_payload.update(
             {
                 "fok_verdict": verdict.get("verdict"),
                 "fok_confidence": verdict.get("confidence"),
                 "fok_reason": verdict.get("reason", ""),
-                "fok_judged_at": datetime.now(timezone.utc).isoformat(),
+                "fok_judged_at": judged_at,
             }
         )
-
-        client.table("events").update({"payload": payload}).eq("id", event_id).execute()
+        client.table("events").update({"payload": new_payload}).eq("id", event_id).execute()
     except Exception:
         pass
 
-    # Canonical write: fok_judgments table
     try:
-        payload = event.get("payload") or {}
-        now = datetime.now(timezone.utc).isoformat()
-
         client.table("fok_judgments").upsert(
             {
                 "recall_event_id": event_id,
-                "query": payload.get("query", ""),
-                "project": payload.get("project", "Osasuwu/jarvis"),
+                "query": db_payload.get("query", ""),
+                "project": db_payload.get("project", "Osasuwu/jarvis"),
                 "verdict": verdict.get("verdict", "unknown"),
                 "confidence": verdict.get("confidence"),
                 "rationale": verdict.get("reason", ""),
                 "judge_model": "claude-3-5-haiku-20241022",
                 "judge_version": "5.3-β",
-                "judged_at": now,
+                "judged_at": judged_at,
             },
-            on_conflict="recall_event_id"
+            on_conflict="recall_event_id",
         ).execute()
     except Exception:
         pass
@@ -462,23 +458,23 @@ def main():
 
         # Collect dry-run output for both targets
         if args.dry_run:
-            judgment = format_judgment_for_display(event_id, verdict, event)
-            dry_run_writes.append({
-                "target": "fok_judgments",
-                "record": judgment
-            })
-            dry_run_writes.append({
-                "target": "events.payload (legacy mirror)",
-                "record": {
-                    "fok_verdict": verdict.get("verdict"),
-                    "fok_confidence": verdict.get("confidence"),
-                    "fok_reason": verdict.get("reason", ""),
-                    "fok_judged_at": judgment["judged_at"],
+            judged_at = datetime.now(timezone.utc).isoformat()
+            judgment = format_judgment_for_display(event_id, verdict, payload, judged_at)
+            dry_run_writes.append({"target": "fok_judgments", "record": judgment})
+            dry_run_writes.append(
+                {
+                    "target": "events.payload (legacy mirror)",
+                    "record": {
+                        "fok_verdict": verdict.get("verdict"),
+                        "fok_confidence": verdict.get("confidence"),
+                        "fok_reason": verdict.get("reason", ""),
+                        "fok_judged_at": judged_at,
+                    },
                 }
-            })
+            )
         else:
             # Write verdict
-            write_verdict_to_event(client, event_id, verdict, event)
+            write_verdict_to_event(client, event_id, verdict)
 
             # Try to insert into known_unknowns if applicable
             if verdict["verdict"] == "insufficient":

--- a/scripts/fok-batch.py
+++ b/scripts/fok-batch.py
@@ -252,13 +252,36 @@ def try_insert_known_unknown(client, event: dict, project: str) -> None:
         pass
 
 
-def write_verdict_to_event(client, event_id: str, verdict: dict) -> None:
-    """Write FOK verdict back to event.payload."""
+def format_judgment_for_display(event_id: str, verdict: dict, event: dict) -> dict:
+    """Format judgment data for dry-run display."""
+    payload = event.get("payload") or {}
+    now = datetime.now(timezone.utc).isoformat()
+
+    return {
+        "event_id": event_id,
+        "query": payload.get("query", ""),
+        "project": payload.get("project", "Osasuwu/jarvis"),
+        "verdict": verdict.get("verdict", "unknown"),
+        "confidence": verdict.get("confidence"),
+        "rationale": verdict.get("reason", ""),
+        "judge_model": "claude-3-5-haiku-20241022",
+        "judge_version": "5.3-β",
+        "judged_at": now,
+    }
+
+
+def write_verdict_to_event(client, event_id: str, verdict: dict, event: dict) -> None:
+    """Write FOK verdict back to event.payload AND insert into fok_judgments (dual-write).
+
+    Legacy mirror: event.payload.fok_verdict is dropped in 5.3-δ.
+    Canonical: fok_judgments table.
+    """
     try:
         current_event = client.table("events").select("payload").eq("id", event_id).execute()
         if not current_event.data:
             return
 
+        # Legacy write: event.payload
         payload = current_event.data[0].get("payload") or {}
         payload.update(
             {
@@ -270,6 +293,28 @@ def write_verdict_to_event(client, event_id: str, verdict: dict) -> None:
         )
 
         client.table("events").update({"payload": payload}).eq("id", event_id).execute()
+    except Exception:
+        pass
+
+    # Canonical write: fok_judgments table
+    try:
+        payload = event.get("payload") or {}
+        now = datetime.now(timezone.utc).isoformat()
+
+        client.table("fok_judgments").upsert(
+            {
+                "recall_event_id": event_id,
+                "query": payload.get("query", ""),
+                "project": payload.get("project", "Osasuwu/jarvis"),
+                "verdict": verdict.get("verdict", "unknown"),
+                "confidence": verdict.get("confidence"),
+                "rationale": verdict.get("reason", ""),
+                "judge_model": "claude-3-5-haiku-20241022",
+                "judge_version": "5.3-β",
+                "judged_at": now,
+            },
+            on_conflict="recall_event_id"
+        ).execute()
     except Exception:
         pass
 
@@ -361,6 +406,7 @@ def main():
 
     verdicts_by_type = defaultdict(int)
     start_time = time.time()
+    dry_run_writes = []
 
     for event in events:
         event_id = event.get("id")
@@ -414,9 +460,25 @@ def main():
             file=sys.stderr,
         )
 
-        # Write verdict
-        if not args.dry_run:
-            write_verdict_to_event(client, event_id, verdict)
+        # Collect dry-run output for both targets
+        if args.dry_run:
+            judgment = format_judgment_for_display(event_id, verdict, event)
+            dry_run_writes.append({
+                "target": "fok_judgments",
+                "record": judgment
+            })
+            dry_run_writes.append({
+                "target": "events.payload (legacy mirror)",
+                "record": {
+                    "fok_verdict": verdict.get("verdict"),
+                    "fok_confidence": verdict.get("confidence"),
+                    "fok_reason": verdict.get("reason", ""),
+                    "fok_judged_at": judgment["judged_at"],
+                }
+            })
+        else:
+            # Write verdict
+            write_verdict_to_event(client, event_id, verdict, event)
 
             # Try to insert into known_unknowns if applicable
             if verdict["verdict"] == "insufficient":
@@ -431,6 +493,9 @@ def main():
         "elapsed_seconds": elapsed,
         "dry_run": args.dry_run,
     }
+    if args.dry_run and dry_run_writes:
+        summary["would_write"] = dry_run_writes
+
     print(f"\nSummary: {json.dumps(summary, indent=2)}", file=sys.stdout)
 
     if not args.dry_run:

--- a/supabase/migrations/20260429065042_add_fok_judgments_table.sql
+++ b/supabase/migrations/20260429065042_add_fok_judgments_table.sql
@@ -1,4 +1,11 @@
-CREATE TABLE fok_judgments (
+-- Pillar 4 / Memory FOK Phase 5.3-β (issue #443)
+-- Canonical FOK (feeling-of-knowing) judgments store. Replaces the
+-- events.payload.fok_verdict legacy mirror (dropped in 5.3-δ).
+-- Paired with mcp-memory/schema.sql per CI gate (#326 / #289).
+-- RLS + allow-all policies live in a follow-up migration to keep this
+-- file scoped to the schema decision recorded in issue #443.
+
+CREATE TABLE IF NOT EXISTS fok_judgments (
   id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   recall_event_id uuid NOT NULL REFERENCES events(id) ON DELETE CASCADE,
   query           text NOT NULL,
@@ -16,6 +23,6 @@ CREATE TABLE fok_judgments (
   UNIQUE (recall_event_id)
 );
 
-CREATE INDEX idx_fok_judgments_verdict ON fok_judgments(verdict, judged_at DESC);
-CREATE INDEX idx_fok_judgments_query_project ON fok_judgments(project, query);
-CREATE INDEX idx_fok_judgments_outcome ON fok_judgments(outcome_id) WHERE outcome_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_fok_judgments_verdict ON fok_judgments(verdict, judged_at DESC);
+CREATE INDEX IF NOT EXISTS idx_fok_judgments_query_project ON fok_judgments(project, query);
+CREATE INDEX IF NOT EXISTS idx_fok_judgments_outcome ON fok_judgments(outcome_id) WHERE outcome_id IS NOT NULL;

--- a/supabase/migrations/20260429065042_add_fok_judgments_table.sql
+++ b/supabase/migrations/20260429065042_add_fok_judgments_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE fok_judgments (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recall_event_id uuid NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  query           text NOT NULL,
+  project         text,
+  verdict         text NOT NULL CHECK (verdict IN ('sufficient','partial','insufficient','unknown','skipped')),
+  confidence      real CHECK (confidence IS NULL OR confidence BETWEEN 0 AND 1),
+  rationale       text,
+  judge_model     text NOT NULL,
+  judge_version   text NOT NULL,
+  judged_at       timestamptz NOT NULL DEFAULT now(),
+  action_taken    text CHECK (action_taken IN ('pass_through','gap_recorded','widened') OR action_taken IS NULL),
+  action_at       timestamptz,
+  outcome_id      uuid REFERENCES task_outcomes(id) ON DELETE SET NULL,
+  outcome_correct boolean,
+  UNIQUE (recall_event_id)
+);
+
+CREATE INDEX idx_fok_judgments_verdict ON fok_judgments(verdict, judged_at DESC);
+CREATE INDEX idx_fok_judgments_query_project ON fok_judgments(project, query);
+CREATE INDEX idx_fok_judgments_outcome ON fok_judgments(outcome_id) WHERE outcome_id IS NOT NULL;

--- a/supabase/migrations/20260429070204_enable_fok_judgments_rls.sql
+++ b/supabase/migrations/20260429070204_enable_fok_judgments_rls.sql
@@ -1,0 +1,13 @@
+-- Pillar 4 / Memory FOK Phase 5.3-β (issue #443, follow-up to PR #470 review)
+-- Enable RLS + allow-all policies on fok_judgments to match the Pillar
+-- convention used by known_unknowns / task_queue. Without this, PostgREST
+-- access semantics for the table differ from the rest of the schema.
+-- Hardening to per-role policies is a separate sweep across the schema.
+
+ALTER TABLE fok_judgments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow all for authenticated" ON fok_judgments
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "Allow all for anon" ON fok_judgments
+  FOR ALL TO anon USING (true) WITH CHECK (true);

--- a/tests/test_fok_batch.py
+++ b/tests/test_fok_batch.py
@@ -235,17 +235,73 @@ def test_try_insert_known_unknown_above_similarity_threshold():
 
 
 def test_write_verdict_to_event():
-    """Test updating event.payload with FOK verdict."""
+    """Legacy mirror still updates events.payload with FOK verdict."""
     mock_client = MagicMock()
+    # Stub the events.payload fetch so write_verdict_to_event finds a row
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        Mock(data=[{"payload": {"query": "test", "project": "Osasuwu/jarvis"}}])
+    )
     event_id = "evt-001"
     verdict = {"verdict": "partial", "confidence": 0.7, "reason": "Some info present."}
 
     fok_batch.write_verdict_to_event(mock_client, event_id, verdict)
 
-    # Verify update was called
-    mock_client.table.assert_called_with("events")
-    update_call = mock_client.table.return_value.update.call_args
-    assert update_call is not None
+    # events.update was called with the merged payload
+    update_calls = mock_client.table.return_value.update.call_args_list
+    assert update_calls, "events.update should fire"
+    merged = update_calls[0].args[0]["payload"]
+    assert merged["fok_verdict"] == "partial"
+    assert merged["fok_confidence"] == 0.7
+
+
+def test_write_verdict_to_event_dual_writes_to_fok_judgments():
+    """Canonical write: fok_judgments table receives an upsert with the right shape."""
+    mock_client = MagicMock()
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        Mock(
+            data=[
+                {
+                    "payload": {
+                        "query": "what is fok?",
+                        "project": "Osasuwu/jarvis",
+                    }
+                }
+            ]
+        )
+    )
+    event_id = "evt-042"
+    verdict = {
+        "verdict": "insufficient",
+        "confidence": 0.42,
+        "reason": "Memories don't address the query.",
+    }
+
+    fok_batch.write_verdict_to_event(mock_client, event_id, verdict)
+
+    # Find the fok_judgments call specifically (events.update is also called)
+    upsert_calls = [
+        c
+        for c in mock_client.table.return_value.upsert.call_args_list
+        if c.args
+    ]
+    assert upsert_calls, "fok_judgments.upsert should fire"
+
+    # Confirm the table name was fok_judgments at least once
+    table_names = [c.args[0] for c in mock_client.table.call_args_list if c.args]
+    assert "fok_judgments" in table_names
+
+    record = upsert_calls[0].args[0]
+    assert record["recall_event_id"] == event_id
+    assert record["query"] == "what is fok?"
+    assert record["project"] == "Osasuwu/jarvis"
+    assert record["verdict"] == "insufficient"
+    assert record["confidence"] == 0.42
+    assert record["rationale"] == "Memories don't address the query."
+    assert record["judge_version"] == "5.3-β"
+    assert "judged_at" in record
+
+    # on_conflict for idempotent retries
+    assert upsert_calls[0].kwargs.get("on_conflict") == "recall_event_id"
 
 
 def test_write_event_summary():


### PR DESCRIPTION
Closes #443

## What's implemented

1. **Migrations**
   - `supabase/migrations/20260429065042_add_fok_judgments_table.sql` — `fok_judgments` table (DDL per issue spec, idempotent `IF NOT EXISTS`).
   - `supabase/migrations/20260429070204_enable_fok_judgments_rls.sql` — RLS + allow-all policies (matches `known_unknowns` / `task_queue` convention).

2. **Schema-drift guard**: `mcp-memory/schema.sql` mirrors both migrations (table + RLS).

3. **Dual-write in `scripts/fok-batch.py`**
   - `write_verdict_to_event(client, event_id, verdict)` — signature unchanged from upstream. Fetches `events.payload` once, derives `query`/`project` from the freshly-fetched DB payload, shares a single `judged_at` between the legacy mirror and the canonical `fok_judgments.upsert(..., on_conflict="recall_event_id")`.
   - `format_judgment_for_display(event_id, verdict, payload, judged_at)` — pure helper for dry-run output.

4. **Tests** (`tests/test_fok_batch.py`)
   - `test_write_verdict_to_event` updated for the merged-payload assertion.
   - `test_write_verdict_to_event_dual_writes_to_fok_judgments` (new) — asserts the `fok_judgments.upsert` shape, fields, and `on_conflict="recall_event_id"`.
   - Suite: **19/19 pass**.

## Verification

- Both migrations applied to live Supabase (`svwrzttdkxeselkpxfgm`). RLS verified: `relrowsecurity=true`; policies `Allow all for authenticated` + `Allow all for anon` present.
- `python -m pytest tests/test_fok_batch.py` — 19 passed in 0.14s.
- `python scripts/fok-batch.py --dry-run --limit 1` — emits dual-target write plan with shared `judged_at`.

## Review iteration (Copilot, 2026-04-29)

| # | Comment | Resolved |
|---|---|---|
| 1 | RLS missing on `fok_judgments` (migration + schema.sql) | yes — separate RLS migration + schema.sql block |
| 2 | Migration header comment missing | yes — added |
| 3 | `CREATE TABLE` not idempotent | yes — `CREATE TABLE/INDEX IF NOT EXISTS` |
| 4 | `write_verdict_to_event` signature change broke unit tests | yes — reverted to 3-arg signature; canonical write reads payload from existing DB fetch |
| 5 | Two `datetime.now()` calls — payload-source mismatch | yes — single `judged_at`; canonical uses the DB-fetched payload |
| 6 | No tests for dual-write | yes — new test `..._dual_writes_to_fok_judgments` |
| 7 | RLS missing in schema.sql section | yes — added |

## Out of scope (5.3-γ / 5.3-δ)

- Haiku 4.5 migration (#444)
- Hook-level emit in `memory-recall-hook.py` (#444)
- Removing inline `_upsert_known_unknown` (#444)
- Outcome linkage (`outcome_id` population) (#445)
- `fok_calibration_summary` RPC (#445)
- Dropping `events.payload.fok_verdict` mirror (#445)
