### PR TITLE
fix(tests): unhardcode _now() in dispatcher tests (#479)

### DIFF
--- a/tests/test_agents_dispatcher.py
+++ b/tests/test_agents_dispatcher.py
@@ -156,8 +156,15 @@ class _StubClient:
 # ---------------------------------------------------------------------------
 
 
+# Module-load snapshot — gives every test in this file a single,
+# stable "current time" while still tracking real wall-clock so the
+# production code's datetime.now(UTC) (called without explicit now=
+# injection) sees a fresh approved_at relative to fixture rows.
+_NOW = datetime.now(UTC)
+
+
 def _now() -> datetime:
-    return datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+    return _NOW
 
 
 def _queue_row(**overrides: Any) -> dict[str, Any]:

--- a/tests/test_agents_escalation.py
+++ b/tests/test_agents_escalation.py
@@ -37,8 +37,15 @@ from agents.usage_probe import UsageReading
 # ---------------------------------------------------------------------------
 
 
+# Module-load snapshot — gives every test in this file a single,
+# stable "current time" while still tracking real wall-clock so the
+# production code's datetime.now(UTC) (called in check_all paths
+# without explicit now= injection) sees a fresh approved_at.
+_NOW = datetime.now(UTC)
+
+
 def _now() -> datetime:
-    return datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+    return _NOW
 
 
 def _queue_row(**overrides: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

`tests/test_agents_dispatcher.py:159` and `tests/test_agents_escalation.py:40` both returned a hardcoded `datetime(2026, 4, 22, 12, 0, 0)` from their `_now()` helpers. Production `agents/escalation.py:check_stale_approval` uses real `datetime.now(UTC)` with `STALE_APPROVAL_MAX_DAYS = 7`. As of 2026-04-29 12:00 UTC, every fixture row's `approved_at` is exactly 7 days stale — `stale_approval` triggers before the test's expected outcome, breaking 8 dispatcher tests + 2 escalation `check_all` tests.

Replace with a **module-load snapshot**: `_NOW = datetime.now(UTC)` captured once, `_now()` returns it. This gives:
- A single stable "current time" within a test run (so threshold tests like `test_stale_approval_exact_threshold_does_not_escalate` that pass `now=_now()` to both row builder and production function see the same value on both sides).
- Wall-clock-fresh values relative to real time (so `check_all` paths that use `datetime.now(UTC)` internally see fresh `approved_at`, microseconds-stale rather than 7-days-stale).

Closes #479.

## Why critical

Blocks ALL PR merges right now. In particular blocks #478 (#475 Sprint #35 design doc) and follow-on #476/#477. `priority:critical` label is the PR Body Check escape (since #459 still blocks `[no-issue]`).

## Decisions & Alternatives

- **Module-load snapshot** chosen over `datetime.now(UTC)` per call. Per-call `now()` introduces microsecond drift between row-builder and production-function-call sides, breaking `test_stale_approval_exact_threshold_does_not_escalate` (which expects `now - approved_at == exactly 7d`).
- **Snapshot, not frozen prod clock**: monkeypatching `escalation._now_utc` to the snapshot would be more deterministic but expands fixture surface; current tests are happy with snapshot-vs-real-clock divergence under second-scale.
- **Symmetric-fixes audit**: `tests/test_agents_perception_github.py` also has hardcoded dates (2026-04-25), but those are passed explicitly to `_build_row(issue, repo, now)` — production function is clock-injected, no real-clock drift, no fix needed.

## Risk Assessment

- **LOW** — test fixture change in two files. All affected tests pass locally.

## Testing

```
$ python -m pytest tests/test_agents_dispatcher.py tests/test_agents_escalation.py tests/test_agents_perception_github.py -q
86 passed, 11 warnings in 8.20s
```

## Files Changed

- `tests/test_agents_dispatcher.py` — `_NOW` module snapshot + `_now()` returns it.
- `tests/test_agents_escalation.py` — same pattern (was failing `check_all` tests where prod `datetime.now(UTC)` was called without `now=` injection).