### PR TITLE
feat(c17): record_decision dual-writes to events_canonical (#477)

### DIFF
--- a/mcp-memory/events_canonical.py
+++ b/mcp-memory/events_canonical.py
@@ -1,0 +1,188 @@
+"""C17 events_canonical writer + transient-failure buffer (#477).
+
+The first writer wired to this substrate is ``record_decision``
+(``handlers/decision.py``). Subsequent writers (memory_write, tool_call,
+error, etc.) follow in the substrate-consumer wave.
+
+Design (``docs/design/c17-events-substrate.md`` §4 — Write semantics):
+
+Happy path:
+    1. Caller invokes :func:`emit_event` with action / actor / payload.
+    2. Writer drains any buffered events first (so chronology is best-
+       effort preserved), each tagged ``degraded=true``.
+    3. Writer inserts the new event row.
+    4. After-insert trigger fires ``pg_notify`` on channel
+       ``events_canonical``.
+    5. Writer returns the inserted row dict.
+
+Degraded path:
+    1. INSERT fails (transient pg outage, RLS misconfig, etc.).
+    2. Writer logs a warning to stderr (visible in MCP server logs).
+    3. Writer pushes the failed payload onto a bounded ring buffer
+       (~100 events). Overflow drops the oldest with a ``signal_dropped``
+       log line.
+    4. Writer returns ``None`` to caller — **the original action does
+       not fail.**
+    5. On the next successful insert, the buffer drains; replayed rows
+       carry ``degraded=true`` so dashboards / cost reconciliation can
+       exclude them.
+
+This keeps ``record_decision`` (and future writers) from coupling to
+substrate availability — a transient outage does not lose the original
+event, nor does it crash the calling skill / hook.
+"""
+
+from __future__ import annotations
+
+import collections
+import logging
+import sys
+from typing import Any, Optional
+
+from trace_context import current_trace, new_trace
+
+_BUFFER_MAX = 100
+_buffer: collections.deque[dict[str, Any]] = collections.deque(maxlen=_BUFFER_MAX)
+
+logger = logging.getLogger(__name__)
+# Default to stderr so MCP server logs surface the warnings — the host
+# may layer additional handlers, those compose on top.
+if not logger.handlers:
+    _h = logging.StreamHandler(sys.stderr)
+    _h.setFormatter(logging.Formatter("[events_canonical] %(levelname)s: %(message)s"))
+    logger.addHandler(_h)
+    logger.setLevel(logging.WARNING)
+
+
+def emit_event(
+    client: Any,
+    *,
+    actor: str,
+    action: str,
+    payload: Optional[dict[str, Any]] = None,
+    outcome: Optional[str] = None,
+    cost_tokens: Optional[int] = None,
+    cost_usd: Optional[float] = None,
+    parent_event_id: Optional[str] = None,
+    trace_id: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Insert an event into ``events_canonical`` (with degraded fallback).
+
+    ``trace_id`` defaults to the current ContextVar value, or a fresh
+    synthesized id when nothing is set. ``parent_event_id`` likewise
+    falls back to the ContextVar — caller-passed values win.
+
+    Returns the inserted row (dict) on success, ``None`` on failure
+    (event was buffered for retry on next call). The caller MUST treat
+    a ``None`` return as "do not fail downstream" — this contract is
+    why ``record_decision`` continues even when substrate is degraded.
+    """
+    ctx_trace, ctx_parent = current_trace()
+    final_trace = trace_id or ctx_trace or new_trace()
+    final_parent = parent_event_id or ctx_parent
+
+    row = {
+        "trace_id": final_trace,
+        "parent_event_id": final_parent,
+        "actor": actor,
+        "action": action,
+        "payload": payload or {},
+    }
+    if outcome is not None:
+        row["outcome"] = outcome
+    if cost_tokens is not None:
+        row["cost_tokens"] = cost_tokens
+    if cost_usd is not None:
+        row["cost_usd"] = cost_usd
+
+    # Always try to drain buffered events FIRST so they land before the
+    # current one (best-effort chronology). Buffered rows carry their
+    # original ``ts`` if the DB supports it; we rely on the DEFAULT now()
+    # for un-stamped rows, which means buffered rows get a "drain time"
+    # ts — acceptable for Sprint 35 substrate POC, refine in 1.x.
+    _drain_buffer(client)
+
+    try:
+        result = client.table("events_canonical").insert(row).execute()
+    except Exception as exc:  # noqa: BLE001 — substrate must not propagate
+        logger.warning(
+            "INSERT failed (action=%s actor=%s): %s — buffering for retry",
+            action,
+            actor,
+            exc,
+        )
+        _enqueue(row)
+        return None
+
+    data = getattr(result, "data", None)
+    if not isinstance(data, list) or not data:
+        # Insert call returned without a row — defensive: also buffer.
+        logger.warning(
+            "INSERT returned empty data (action=%s actor=%s) — buffering", action, actor
+        )
+        _enqueue(row)
+        return None
+
+    return data[0]
+
+
+def _enqueue(row: dict[str, Any]) -> None:
+    """Push a row onto the buffer, logging when overflow drops oldest."""
+    if len(_buffer) == _buffer.maxlen:
+        dropped = _buffer[0]
+        logger.warning(
+            "buffer full (max=%d) — dropping oldest action=%s actor=%s",
+            _BUFFER_MAX,
+            dropped.get("action"),
+            dropped.get("actor"),
+        )
+    _buffer.append(row)
+
+
+def _drain_buffer(client: Any) -> int:
+    """Try to insert every buffered row with ``degraded=true``.
+
+    Returns the number drained. On per-row failure, the row stays in
+    the buffer for a future drain attempt — there is no "give up after
+    N tries" because the caller already returned success and the buffer
+    is the only place this event still exists.
+    """
+    if not _buffer:
+        return 0
+
+    drained = 0
+    # Snapshot length so we don't loop on rows re-enqueued by failure.
+    pending = len(_buffer)
+    for _ in range(pending):
+        row = _buffer.popleft()
+        replay = {**row, "degraded": True}
+        try:
+            client.table("events_canonical").insert(replay).execute()
+            drained += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "drain failed (action=%s actor=%s): %s — re-buffering",
+                replay.get("action"),
+                replay.get("actor"),
+                exc,
+            )
+            # Push back to the right side so order with newer events
+            # is preserved. Note: maxlen behavior may drop us if buffer
+            # is now full of newer entries; that's correct (degraded
+                # signal already lost).
+            _buffer.append(row)
+            return drained
+    return drained
+
+
+# Test-only helpers — exposed for unit tests, NOT part of the runtime
+# contract. Names start with the visible-private convention so any
+# accidental import from production code triggers review attention.
+
+
+def _buffer_len_for_test() -> int:
+    return len(_buffer)
+
+
+def _buffer_clear_for_test() -> None:
+    _buffer.clear()

--- a/mcp-memory/handlers/decision.py
+++ b/mcp-memory/handlers/decision.py
@@ -265,6 +265,78 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
             )
         )
 
+    # Dual-write to events_canonical substrate (C17, #477). Two-mode
+    # coexistence — legacy episodes table stays for the cutover wave;
+    # this is the substrate path. emit_event MUST NOT raise — it buffers
+    # on failure and returns None so the legacy path still surfaces
+    # success to the caller.
+    try:
+        from events_canonical import emit_event
+    except Exception:  # noqa: BLE001 — substrate optional during rollout
+        emit_event = None
+    if emit_event is not None:
+        canonical_payload = dict(payload)
+        canonical_payload["episode_id"] = eid
+        if decision_timestamp:
+            canonical_payload["decision_made_at"] = decision_timestamp
+
+        llm_meta = args.get("llm") or {}
+        cost_tokens: int | None = None
+        cost_usd: float | None = None
+        if isinstance(llm_meta, dict) and llm_meta:
+            # OTel GenAI semantic conventions verbatim — see
+            # docs/design/c17-events-substrate.md §2.
+            if "model" in llm_meta:
+                canonical_payload["gen_ai.request.model"] = llm_meta["model"]
+                canonical_payload["gen_ai.response.model"] = llm_meta.get(
+                    "response_model", llm_meta["model"]
+                )
+            if "input_tokens" in llm_meta:
+                canonical_payload["gen_ai.usage.input_tokens"] = llm_meta[
+                    "input_tokens"
+                ]
+            if "output_tokens" in llm_meta:
+                canonical_payload["gen_ai.usage.output_tokens"] = llm_meta[
+                    "output_tokens"
+                ]
+            if "cost_usd" in llm_meta:
+                canonical_payload["gen_ai.usage.cost_usd"] = llm_meta["cost_usd"]
+                try:
+                    cost_usd = float(llm_meta["cost_usd"])
+                except (TypeError, ValueError):
+                    cost_usd = None
+            if "input_tokens" in llm_meta or "output_tokens" in llm_meta:
+                try:
+                    cost_tokens = int(llm_meta.get("input_tokens", 0)) + int(
+                        llm_meta.get("output_tokens", 0)
+                    )
+                except (TypeError, ValueError):
+                    cost_tokens = None
+            if "provider" in llm_meta:
+                canonical_payload["gen_ai.provider.name"] = llm_meta["provider"]
+            if "operation" in llm_meta:
+                canonical_payload["gen_ai.operation.name"] = llm_meta["operation"]
+
+        try:
+            emit_event(
+                client,
+                actor=actor,
+                action="decision_made",
+                payload=canonical_payload,
+                outcome="success",
+                cost_tokens=cost_tokens,
+                cost_usd=cost_usd,
+            )
+        except Exception as exc:  # noqa: BLE001 — defense in depth
+            # emit_event already buffers on its own exceptions — this
+            # catches anything in the wrapper logic itself.
+            import sys as _sys
+
+            print(
+                f"[decision.py] events_canonical dual-write skipped: {exc}",
+                file=_sys.stderr,
+            )
+
     msg = f"Decision recorded: episode {eid}"
     if unresolved_memories:
         msg += (

--- a/mcp-memory/tools_schema.py
+++ b/mcp-memory/tools_schema.py
@@ -632,6 +632,26 @@ def tool_definitions() -> list[Tool]:
                         "type": ["string", "null"],
                         "description": "Optional project scope for the decision payload.",
                     },
+                    "llm": {
+                        "type": "object",
+                        "description": (
+                            "Optional LLM call metadata. When present, populates "
+                            "OTel GenAI keys in the events_canonical payload "
+                            "(gen_ai.request.model, gen_ai.usage.input_tokens, "
+                            "gen_ai.usage.output_tokens, gen_ai.usage.cost_usd, "
+                            "gen_ai.provider.name, gen_ai.operation.name) and "
+                            "fills cost_tokens / cost_usd columns. C17 substrate, #477."
+                        ),
+                        "properties": {
+                            "model": {"type": "string"},
+                            "response_model": {"type": "string"},
+                            "input_tokens": {"type": "integer", "minimum": 0},
+                            "output_tokens": {"type": "integer", "minimum": 0},
+                            "cost_usd": {"type": "number", "minimum": 0},
+                            "provider": {"type": "string"},
+                            "operation": {"type": "string"},
+                        },
+                    },
                 },
             },
         ),

--- a/mcp-memory/trace_context.py
+++ b/mcp-memory/trace_context.py
@@ -1,0 +1,95 @@
+"""Trace propagation primitives for the C17 events substrate (#477).
+
+Implements OTel-style trace_id + parent_event_id propagation via
+``contextvars.ContextVar`` so writers can pick up the current trace
+without explicit threading through every call site.
+
+Contract (locked in ``docs/design/c17-events-substrate.md`` §3):
+
+1. Owner message → fresh trace_id (skill / hook entry sets it).
+2. Scheduled task fire → fresh trace_id.
+3. Subagent spawn → inherits parent's trace_id; ``parent_event_id``
+   = the spawning event's id.
+4. Hook fire → inherits trace_id of the session/task it fires in.
+
+Caller-omitted context: writers MUST NOT crash. ``current_trace`` returns
+``(None, None)`` and the writer synthesizes a fresh trace_id with no
+parent_event_id. The orphaned-trace pattern (``parent_event_id IS NULL``
+on a non-root actor) is itself a queryable signal that propagation is
+missing upstream.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Optional
+
+# Internal — readers go through ``current_trace()``; writers go through
+# ``with_trace()`` so we control the API surface.
+_trace_id_var: ContextVar[Optional[str]] = ContextVar(
+    "events_canonical_trace_id", default=None
+)
+_parent_event_id_var: ContextVar[Optional[str]] = ContextVar(
+    "events_canonical_parent_event_id", default=None
+)
+
+
+def new_trace() -> str:
+    """Generate a fresh trace_id (canonical UUID hex)."""
+    return uuid.uuid4().hex
+
+
+def current_trace() -> tuple[Optional[str], Optional[str]]:
+    """Return ``(trace_id, parent_event_id)`` from the current context.
+
+    Either or both may be ``None`` when no caller has set them — that's
+    valid; the writer synthesizes per the design 1-pager §3.
+    """
+    return _trace_id_var.get(), _parent_event_id_var.get()
+
+
+@contextmanager
+def with_trace(
+    trace_id: str, parent_event_id: Optional[str] = None
+) -> Iterator[None]:
+    """Run a block with a specific trace_id + optional parent_event_id.
+
+    ContextVars are async-safe (per-task) and reset on exit, so nested
+    use within asyncio.gather, subagent dispatch, etc. preserves the
+    expected scope.
+
+    Example::
+
+        with with_trace(new_trace()):
+            await some_writer(...)
+    """
+    if not _looks_like_uuid_or_hex(trace_id):
+        raise ValueError(
+            f"trace_id must be a UUID hex string (got {trace_id!r})"
+        )
+    if parent_event_id is not None and not _looks_like_uuid_or_hex(
+        parent_event_id
+    ):
+        raise ValueError(
+            f"parent_event_id must be a UUID hex string (got {parent_event_id!r})"
+        )
+    trace_token = _trace_id_var.set(trace_id)
+    parent_token = _parent_event_id_var.set(parent_event_id)
+    try:
+        yield
+    finally:
+        _parent_event_id_var.reset(parent_token)
+        _trace_id_var.reset(trace_token)
+
+
+def _looks_like_uuid_or_hex(s: object) -> bool:
+    """Accept canonical UUIDs (8-4-4-4-12) and bare hex (32 chars)."""
+    if not isinstance(s, str):
+        return False
+    try:
+        uuid.UUID(s)
+        return True
+    except (ValueError, AttributeError):
+        return False

--- a/tests/test_events_canonical_writer.py
+++ b/tests/test_events_canonical_writer.py
@@ -1,0 +1,228 @@
+"""Unit tests for the C17 events_canonical writer + buffer (#477).
+
+Stub-based — no live Supabase. Verifies:
+- Happy path: emit_event inserts a row + returns the response.
+- Failure path: emit_event buffers, returns None, does NOT raise.
+- Drain path: buffered events replay with degraded=true on next success.
+- ContextVar bridge: caller-omitted trace_id is synthesized.
+- Buffer overflow: oldest events drop (logged, not raised).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "mcp-memory"))
+
+from events_canonical import (  # noqa: E402
+    _BUFFER_MAX,
+    _buffer_clear_for_test,
+    _buffer_len_for_test,
+    emit_event,
+)
+from trace_context import new_trace, with_trace  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_buffer() -> None:
+    """Each test starts with an empty buffer."""
+    _buffer_clear_for_test()
+    yield
+    _buffer_clear_for_test()
+
+
+def _stub_client(
+    *,
+    insert_returns: list[dict] | None = None,
+    insert_raises: Exception | None = None,
+) -> MagicMock:
+    """Minimal Supabase-shaped stub.
+
+    Returns a MagicMock whose ``.table(name).insert(row).execute()``
+    chain mirrors the real client. ``insert_returns`` controls the
+    payload of every successful insert; ``insert_raises`` makes
+    ``insert(...)`` raise when set.
+    """
+    client = MagicMock()
+    table = MagicMock()
+    insert = MagicMock()
+    execute = MagicMock()
+
+    if insert_raises is not None:
+        insert.side_effect = insert_raises
+        client.table.return_value.insert = insert
+    else:
+        # Explicit `is None` so passing `insert_returns=[]` produces an
+        # empty data response (used to verify defensive empty-result path).
+        if insert_returns is None:
+            data = [{"event_id": "stub-event-id", "trace_id": "stub-trace-id"}]
+        else:
+            data = insert_returns
+        execute.return_value = MagicMock(data=data)
+        insert.return_value = MagicMock(execute=execute)
+        table.insert = insert
+        client.table.return_value = table
+
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_emit_event_inserts_and_returns_row() -> None:
+    client = _stub_client(
+        insert_returns=[{"event_id": "abc", "trace_id": "xyz"}]
+    )
+    result = emit_event(
+        client,
+        actor="skill:test",
+        action="decision_made",
+        payload={"foo": 1},
+        outcome="success",
+    )
+    assert result == {"event_id": "abc", "trace_id": "xyz"}
+    client.table.assert_called_with("events_canonical")
+
+
+def test_emit_event_uses_context_trace_id() -> None:
+    """When context is set, writer picks it up automatically."""
+    client = _stub_client()
+    tid = new_trace()
+    with with_trace(tid):
+        emit_event(
+            client,
+            actor="skill:test",
+            action="memory_recall",
+        )
+    inserted = client.table.return_value.insert.call_args[0][0]
+    assert inserted["trace_id"] == tid
+
+
+def test_emit_event_synthesizes_trace_when_context_missing() -> None:
+    """No ContextVar set → writer mints a fresh trace_id, doesn't crash."""
+    client = _stub_client()
+    emit_event(client, actor="skill:test", action="orphan_action")
+    inserted = client.table.return_value.insert.call_args[0][0]
+    assert isinstance(inserted["trace_id"], str)
+    assert len(inserted["trace_id"]) == 32  # hex
+
+
+def test_emit_event_includes_optional_cost_fields_when_provided() -> None:
+    client = _stub_client()
+    emit_event(
+        client,
+        actor="skill:test",
+        action="decision_made",
+        cost_tokens=1234,
+        cost_usd=0.0125,
+    )
+    inserted = client.table.return_value.insert.call_args[0][0]
+    assert inserted["cost_tokens"] == 1234
+    assert inserted["cost_usd"] == 0.0125
+
+
+def test_emit_event_omits_cost_fields_when_not_provided() -> None:
+    """Cost fields default to NULL — omit from row dict, don't pass None."""
+    client = _stub_client()
+    emit_event(client, actor="skill:test", action="decision_made")
+    inserted = client.table.return_value.insert.call_args[0][0]
+    assert "cost_tokens" not in inserted
+    assert "cost_usd" not in inserted
+
+
+def test_emit_event_caller_overrides_context() -> None:
+    """Explicit trace_id wins over ContextVar."""
+    client = _stub_client()
+    ctx_id = new_trace()
+    explicit = new_trace()
+    with with_trace(ctx_id):
+        emit_event(
+            client,
+            actor="skill:test",
+            action="x",
+            trace_id=explicit,
+        )
+    inserted = client.table.return_value.insert.call_args[0][0]
+    assert inserted["trace_id"] == explicit
+
+
+# ---------------------------------------------------------------------------
+# Failure path — buffer
+# ---------------------------------------------------------------------------
+
+
+def test_emit_event_does_not_raise_on_insert_exception() -> None:
+    """Caller MUST NOT see substrate failures."""
+    client = _stub_client(insert_raises=RuntimeError("connection dropped"))
+    result = emit_event(client, actor="skill:test", action="x")
+    assert result is None
+
+
+def test_emit_event_buffers_on_failure() -> None:
+    client = _stub_client(insert_raises=RuntimeError("rls flap"))
+    assert _buffer_len_for_test() == 0
+    emit_event(client, actor="skill:test", action="x")
+    assert _buffer_len_for_test() == 1
+
+
+def test_emit_event_returns_none_on_empty_data_response() -> None:
+    """Defensive — Supabase returning empty data is a soft failure."""
+    client = _stub_client(insert_returns=[])
+    result = emit_event(client, actor="skill:test", action="x")
+    assert result is None
+    assert _buffer_len_for_test() == 1
+
+
+# ---------------------------------------------------------------------------
+# Drain path
+# ---------------------------------------------------------------------------
+
+
+def test_buffered_events_drain_on_next_success() -> None:
+    """A failure followed by a success drains the buffer with degraded=true."""
+    # First call: fails, buffers.
+    bad_client = _stub_client(insert_raises=RuntimeError("transient"))
+    emit_event(bad_client, actor="skill:test", action="first")
+    assert _buffer_len_for_test() == 1
+
+    # Second call: succeeds — should drain the buffered row first.
+    good_client = _stub_client()
+    emit_event(good_client, actor="skill:test", action="second")
+
+    inserts = [c.args[0] for c in good_client.table.return_value.insert.call_args_list]
+    # Two inserts on good client: drained replay + the new one.
+    assert len(inserts) == 2
+    drained, new = inserts
+    assert drained["action"] == "first"
+    assert drained["degraded"] is True
+    assert new["action"] == "second"
+    assert "degraded" not in new or new["degraded"] is False
+    assert _buffer_len_for_test() == 0
+
+
+def test_drain_failure_keeps_row_in_buffer() -> None:
+    """If drain replay also fails, the row stays buffered for next attempt."""
+    # Buffer one row.
+    bad1 = _stub_client(insert_raises=RuntimeError("boom"))
+    emit_event(bad1, actor="skill:test", action="first")
+    assert _buffer_len_for_test() == 1
+
+    # Second attempt also fails: drain attempt fails, AND new event buffers.
+    bad2 = _stub_client(insert_raises=RuntimeError("still boom"))
+    emit_event(bad2, actor="skill:test", action="second")
+    # Buffer now holds both: failed drain re-buffers + new failure adds.
+    assert _buffer_len_for_test() == 2
+
+
+def test_buffer_overflow_drops_oldest() -> None:
+    """When the buffer fills, oldest events drop (FIFO)."""
+    bad = _stub_client(insert_raises=RuntimeError("down"))
+    for i in range(_BUFFER_MAX + 5):
+        emit_event(bad, actor="skill:test", action=f"event-{i}")
+    assert _buffer_len_for_test() == _BUFFER_MAX

--- a/tests/test_record_decision.py
+++ b/tests/test_record_decision.py
@@ -150,9 +150,24 @@ class TestRecordDecisionInsert:
         # Returned message contains episode id
         assert "ep-42" in result[0].text
 
-        # Correct table + row shape
-        client.table.assert_called_with("episodes")
-        insert_arg = client.table.return_value.insert.call_args.args[0]
+        # Both legacy episodes and canonical substrate get a write
+        # post-#477 (dual-write during cutover wave).
+        client.table.assert_any_call("episodes")
+        client.table.assert_any_call("events_canonical")
+        # Find the episodes-shaped insert (has 'kind', no 'trace_id').
+        all_inserts = [
+            c.args[0]
+            for c in client.table.return_value.insert.call_args_list
+            if c.args
+        ]
+        episode_inserts = [
+            p for p in all_inserts if "kind" in p and "trace_id" not in p
+        ]
+        assert len(episode_inserts) == 1, (
+            "expected exactly one episodes insert, got "
+            f"{len(episode_inserts)}: {all_inserts!r}"
+        )
+        insert_arg = episode_inserts[0]
         assert insert_arg["actor"] == "skill:delegate"
         assert insert_arg["kind"] == "decision_made"
 

--- a/tests/test_record_decision_canonical_dualwrite.py
+++ b/tests/test_record_decision_canonical_dualwrite.py
@@ -1,0 +1,227 @@
+"""Integration tests for record_decision dual-write (#477).
+
+The handler now writes to BOTH the legacy ``episodes`` table AND the
+canonical ``events_canonical`` substrate. These tests verify:
+
+1. Both tables receive an insert on a successful call.
+2. OTel-shaped keys appear in the events_canonical payload only when
+   ``llm`` metadata is supplied.
+3. A failure in the events_canonical write does NOT propagate — the
+   episodes write is still surfaced as success.
+4. Without ``llm`` metadata, the events_canonical row has no cost
+   columns (substrate uses NULL — design 1-pager §1).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from server import _handle_record_decision
+import events_canonical as events_canonical_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate_buffer() -> None:
+    events_canonical_mod._buffer_clear_for_test()
+    yield
+    events_canonical_mod._buffer_clear_for_test()
+
+
+def _dual_write_client(
+    *,
+    canonical_raises: Exception | None = None,
+    inserted_episode_id: str = "ep-123",
+) -> MagicMock:
+    """Stub that distinguishes inserts by table name.
+
+    Caches one Table mock per name on first request — re-requests
+    return the same mock, so .insert.call_args_list captures every
+    payload sent to that table.
+    """
+    client = MagicMock()
+    tables: dict[str, MagicMock] = {}
+
+    def _table_factory(name: str) -> MagicMock:
+        if name in tables:
+            return tables[name]
+        table = MagicMock()
+        if name == "episodes":
+            table.insert.return_value.execute.return_value = MagicMock(
+                data=[{"id": inserted_episode_id, "created_at": "2026-04-29T15:00:00Z"}]
+            )
+        elif name == "events_canonical":
+            insert = MagicMock()
+            if canonical_raises is not None:
+                insert.side_effect = canonical_raises
+            else:
+                insert.return_value.execute.return_value = MagicMock(
+                    data=[{"event_id": "ev-456", "trace_id": "deadbeef" * 4}]
+                )
+            table.insert = insert
+        elif name == "memories":
+            chain = MagicMock()
+            leaf = MagicMock()
+            leaf.data = []
+            chain.eq.return_value.is_.return_value.order.return_value.limit.return_value.execute.return_value = leaf
+            chain.eq.return_value.is_.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = leaf
+            chain.eq.return_value.eq.return_value.is_.return_value.order.return_value.limit.return_value.execute.return_value = leaf
+            table.select.return_value = chain
+        else:
+            table.insert.return_value.execute.return_value = MagicMock(data=[])
+            table.select.return_value.eq.return_value.execute.return_value = MagicMock(
+                data=[]
+            )
+        tables[name] = table
+        # Stash the cache on client so tests can introspect.
+        client._tables = tables  # type: ignore[attr-defined]
+        return table
+
+    client.table.side_effect = _table_factory
+    client._tables = tables  # type: ignore[attr-defined]
+    return client
+
+
+def _calls_to_table(client: MagicMock, name: str) -> list:
+    """Return the list of insert payloads executed against ``name``."""
+    tables = getattr(client, "_tables", {})
+    table = tables.get(name)
+    if table is None:
+        return []
+    return [c.args[0] for c in table.insert.call_args_list if c.args]
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestDualWriteHappyPath:
+    @pytest.mark.asyncio
+    async def test_writes_to_both_tables(self, monkeypatch):
+        client = _dual_write_client()
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": "Pick X",
+                "rationale": "Because of Y",
+                "reversibility": "reversible",
+            }
+        )
+        assert "Decision recorded" in result[0].text
+
+        episode_inserts = _calls_to_table(client, "episodes")
+        canonical_inserts = _calls_to_table(client, "events_canonical")
+        assert len(episode_inserts) == 1, f"expected 1 episodes insert, got {len(episode_inserts)}"
+        assert len(canonical_inserts) == 1, f"expected 1 events_canonical insert, got {len(canonical_inserts)}"
+
+        # Episodes path preserved (legacy contract).
+        ep = episode_inserts[0]
+        assert ep["kind"] == "decision_made"
+        assert ep["payload"]["decision"] == "Pick X"
+
+        # Canonical row carries action + actor + trace_id.
+        ec = canonical_inserts[0]
+        assert ec["action"] == "decision_made"
+        assert ec["actor"]  # default 'skill:unknown' or whatever passed
+        assert "trace_id" in ec and isinstance(ec["trace_id"], str)
+        assert ec["outcome"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_canonical_payload_includes_episode_id_link(self, monkeypatch):
+        client = _dual_write_client(inserted_episode_id="ep-link-test")
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+            }
+        )
+        canonical = _calls_to_table(client, "events_canonical")[0]
+        assert canonical["payload"]["episode_id"] == "ep-link-test"
+
+
+class TestOTelKeysFromLLMMetadata:
+    @pytest.mark.asyncio
+    async def test_otel_keys_present_when_llm_provided(self, monkeypatch):
+        client = _dual_write_client()
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+                "llm": {
+                    "model": "claude-haiku-4-5-20251001",
+                    "input_tokens": 1234,
+                    "output_tokens": 567,
+                    "cost_usd": 0.0125,
+                    "provider": "anthropic",
+                    "operation": "chat",
+                },
+            }
+        )
+        canonical = _calls_to_table(client, "events_canonical")[0]
+        p = canonical["payload"]
+        assert p["gen_ai.request.model"] == "claude-haiku-4-5-20251001"
+        assert p["gen_ai.usage.input_tokens"] == 1234
+        assert p["gen_ai.usage.output_tokens"] == 567
+        assert p["gen_ai.usage.cost_usd"] == 0.0125
+        assert p["gen_ai.provider.name"] == "anthropic"
+        assert p["gen_ai.operation.name"] == "chat"
+        # cost columns populated
+        assert canonical["cost_tokens"] == 1234 + 567
+        assert canonical["cost_usd"] == 0.0125
+
+    @pytest.mark.asyncio
+    async def test_otel_keys_absent_when_no_llm_metadata(self, monkeypatch):
+        client = _dual_write_client()
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+            }
+        )
+        canonical = _calls_to_table(client, "events_canonical")[0]
+        p = canonical["payload"]
+        for key in (
+            "gen_ai.request.model",
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.output_tokens",
+            "gen_ai.usage.cost_usd",
+            "gen_ai.provider.name",
+            "gen_ai.operation.name",
+        ):
+            assert key not in p, f"OTel key {key!r} unexpectedly set"
+        assert "cost_tokens" not in canonical
+        assert "cost_usd" not in canonical
+
+
+class TestCanonicalFailureDoesNotBreakEpisodeWrite:
+    @pytest.mark.asyncio
+    async def test_substrate_failure_returns_success(self, monkeypatch):
+        client = _dual_write_client(
+            canonical_raises=RuntimeError("connection dropped")
+        )
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+            }
+        )
+        # Episode write succeeded — caller sees success.
+        assert "Decision recorded" in result[0].text
+
+        # Episode insert happened. Canonical insert was attempted.
+        assert _calls_to_table(client, "episodes")
+        # Buffer absorbed the failed canonical event.
+        assert events_canonical_mod._buffer_len_for_test() == 1

--- a/tests/test_trace_context.py
+++ b/tests/test_trace_context.py
@@ -1,0 +1,106 @@
+"""Unit tests for the C17 trace propagation primitives (#477)."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+# Add mcp-memory to sys.path so flat-module imports work like in production.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "mcp-memory"))
+
+from trace_context import (  # noqa: E402
+    current_trace,
+    new_trace,
+    with_trace,
+)
+
+
+def test_new_trace_is_canonical_uuid_hex() -> None:
+    tid = new_trace()
+    # 32 hex chars, parseable by uuid.UUID.
+    assert len(tid) == 32
+    assert uuid.UUID(tid)
+
+
+def test_new_trace_returns_unique_ids() -> None:
+    seen = {new_trace() for _ in range(100)}
+    assert len(seen) == 100
+
+
+def test_default_context_is_none_pair() -> None:
+    """Outside any with_trace block, both vars are None."""
+    assert current_trace() == (None, None)
+
+
+def test_with_trace_sets_and_resets() -> None:
+    tid = new_trace()
+    pid = new_trace()
+    assert current_trace() == (None, None)
+    with with_trace(tid, parent_event_id=pid):
+        assert current_trace() == (tid, pid)
+    assert current_trace() == (None, None)
+
+
+def test_with_trace_no_parent_event_id() -> None:
+    tid = new_trace()
+    with with_trace(tid):
+        got_trace, got_parent = current_trace()
+        assert got_trace == tid
+        assert got_parent is None
+
+
+def test_with_trace_nests() -> None:
+    outer = new_trace()
+    inner = new_trace()
+    with with_trace(outer):
+        assert current_trace() == (outer, None)
+        with with_trace(inner, parent_event_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"):
+            assert current_trace() == (
+                inner,
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            )
+        # Exiting inner restores outer (with the original None parent).
+        assert current_trace() == (outer, None)
+
+
+def test_with_trace_rejects_non_uuid_trace_id() -> None:
+    with pytest.raises(ValueError):
+        with with_trace("not-a-uuid"):
+            pass  # pragma: no cover
+
+
+def test_with_trace_rejects_non_uuid_parent_event_id() -> None:
+    with pytest.raises(ValueError):
+        with with_trace(new_trace(), parent_event_id="bogus"):
+            pass  # pragma: no cover
+
+
+def test_with_trace_accepts_canonical_uuid_string() -> None:
+    """uuid.UUID() canonical form (8-4-4-4-12) also accepted."""
+    canonical = str(uuid.uuid4())
+    with with_trace(canonical):
+        got_trace, _ = current_trace()
+        assert got_trace == canonical
+
+
+@pytest.mark.asyncio
+async def test_async_tasks_have_isolated_context() -> None:
+    """Per-task ContextVar isolation — concurrent tasks see their own
+    trace_id, not each other's."""
+    seen: list[tuple[str, str]] = []
+
+    async def worker(label: str, tid: str) -> None:
+        with with_trace(tid):
+            await asyncio.sleep(0)  # yield to other tasks
+            got, _ = current_trace()
+            seen.append((label, got))
+
+    a = new_trace()
+    b = new_trace()
+    await asyncio.gather(worker("A", a), worker("B", b))
+
+    assert sorted(seen) == sorted([("A", a), ("B", b)])


### PR DESCRIPTION
## Summary

Sprint #35 final substrate-consumer issue. `record_decision` is now the first writer wired to the C17 canonical events substrate (#476), with the degraded-fallback contract from design 1-pager §4 fully in place.

Two new modules + a non-breaking handler change + 27 new tests + 1 existing test updated for the dual-write shape.

## Why

The substrate (#476) needed a real consumer to prove the trace propagation, OTel column mapping, and degraded-fallback contracts work end-to-end. `record_decision` is the right first writer because (a) high-signal events feeding `/reflect` and outcome attribution, (b) the existing legacy-episodes path stays untouched so behavior under failure is testable, (c) future C5/C13 sprints will read these events from day one.

Closes #477. Sprint #35 substrate complete.

## Decisions & Alternatives

- **Two new modules** (`trace_context.py`, `events_canonical.py`) **at `mcp-memory/` root**, not under `handlers/`. Both are shared infrastructure that future writers (memory_write, tool_call, error, etc.) will reuse — handlers/ is reserved for MCP tool dispatch.
- **`emit_event` NEVER raises** — the contract is "substrate-availability bug → caller still completes its primary action." The defense-in-depth wrapper in `decision.py` catches even hypothetical bugs in `emit_event` itself.
- **Buffer drains on next successful insert**, not on a background thread. Synchronous drain is testable, debuggable, and avoids asyncio complexity for the substrate POC. Re-evaluate in 1.x once volume justifies it.
- **Per-error-class transient/non-transient classification deferred** — design 1-pager §4 distinguishes by Postgres error code class, but PostgREST (Supabase SDK) wraps SQL errors generically. Surfacing repeated drain failures via warning logs is acceptable for substrate POC; refine when we have real failure data.
- **Tool-schema extension `llm` field is optional** — existing callers preserved unchanged. When supplied, populates OTel-shaped payload keys + cost columns.
- **`with_trace` validates UUID format** — orphaned-trace-id queries (`WHERE parent_event_id IS NULL AND actor NOT IN ...`) need clean UUIDs, not free-form strings. Fail-fast at the with_trace boundary.
- **Module-level `_buffer` deque (singleton)** — bounded at 100 events with FIFO overflow. The buffer is in-process state; restarts lose buffered events (acceptable for transient outages).

## Risk Assessment

- **MEDIUM** — touches the production decision-recording hot path, but the dual-write is fully fenced from breaking the legacy contract: (1) `emit_event` never raises; (2) handler-level try/except catches anything in the wiring; (3) episodes insert happens BEFORE the canonical write, so a substrate bug cannot silently lose decision history. Live smoke confirmed shape; full test suite (1129 passing) confirms no regressions.

## Testing

```
$ python -m pytest tests/test_trace_context.py tests/test_events_canonical_writer.py tests/test_record_decision_canonical_dualwrite.py tests/test_record_decision.py tests/test_events_canonical_substrate.py -q
99 passed in 1.26s

$ python -m pytest tests/ -q --ignore=tests/memory-eval
1129 passed, 5 skipped, 11 warnings in 30.28s
```

Live smoke (Supabase project `svwrzttdkxeselkpxfgm`):
- ✅ INSERT with the OTel-shaped payload my code produces succeeded.
- ✅ All required fields populated: `trace_id`, `actor=skill:implement`, `action=decision_made`, `outcome=success`, `cost_tokens=1801`, `cost_usd=0.0125`, `degraded=false`.
- ✅ OTel keys queryable from payload: `gen_ai.request.model`, `gen_ai.usage.input_tokens`, etc.
- ✅ `episode_id` link from legacy episodes table preserved in canonical payload.
- ✅ Materialized view refresh aggregated correctly.
- ✅ Cleanup left 0 rows; `events_canonical` ready for production traffic.

## Files Changed

- `mcp-memory/trace_context.py` — new (90 lines). ContextVar trace propagation primitives.
- `mcp-memory/events_canonical.py` — new (170 lines). `emit_event` + bounded buffer + drain.
- `mcp-memory/handlers/decision.py` — dual-write call after episodes insert succeeds (~70 lines added).
- `mcp-memory/tools_schema.py` — optional `llm` field on `record_decision` MCP tool.
- `tests/test_trace_context.py` — new (10 tests).
- `tests/test_events_canonical_writer.py` — new (12 tests).
- `tests/test_record_decision_canonical_dualwrite.py` — new (5 integration tests).
- `tests/test_record_decision.py` — updated `assert_called_with` to `assert_any_call` for dual-write shape.

## Out of scope (substrate-consumer wave, post-Sprint 35)

- Hook-side trace_id seeding (skill / hook entry points calling `with_trace()`).
- Subagent trace inheritance via mailbox payload.
- Other writers (`memory_write`, `tool_call`, `error`) — design lines 537+.
- `traceloop-sdk` OTel exporter — deferred until volume justifies.
- LISTEN client subscriber for real-time consumers.