### PR TITLE
fix(tests): time-bomb in escalation/dispatcher `_now()` fixtures

### DIFF
--- a/tests/test_agents_dispatcher.py
+++ b/tests/test_agents_dispatcher.py
@@ -156,8 +156,16 @@ class _StubClient:
 # ---------------------------------------------------------------------------
 
 
+# Snapshot real wall-clock UTC at module import. See
+# test_agents_escalation.py for full rationale — TL;DR: dispatcher uses
+# real-now for staleness, so the fixture must follow real-now, but cached
+# once per import so multiple `_now()` calls in one test return the same
+# instant (avoids μs drift between calls).
+_NOW_SNAPSHOT = datetime.now(UTC)
+
+
 def _now() -> datetime:
-    return datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+    return _NOW_SNAPSHOT
 
 
 def _queue_row(**overrides: Any) -> dict[str, Any]:

--- a/tests/test_agents_escalation.py
+++ b/tests/test_agents_escalation.py
@@ -37,8 +37,19 @@ from agents.usage_probe import UsageReading
 # ---------------------------------------------------------------------------
 
 
+# Snapshot real wall-clock UTC once at module import. The escalation checks
+# under test compare `approved_at` against `datetime.now(timezone.utc)`
+# directly, so the fixture must drift WITH real-now (not be hard-coded to a
+# past date that crosses STALE_APPROVAL_MAX_DAYS as the real clock advances).
+# Caching at module-load — instead of returning a fresh `datetime.now()` on
+# each call — keeps `_now()` calls within one test consistent: the
+# "exact-threshold-does-not-escalate" test would otherwise tick a few μs
+# between its two `_now()` calls and trip the strict-greater check.
+_NOW_SNAPSHOT = datetime.now(UTC)
+
+
 def _now() -> datetime:
-    return datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+    return _NOW_SNAPSHOT
 
 
 def _queue_row(**overrides: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

\`_now()\` in \`test_agents_escalation.py\` and \`test_agents_dispatcher.py\` was hard-coded to \`datetime(2026, 4, 22, ...)\`. The production code under test (\`agents/escalation.py\`, \`agents/dispatcher.py\`) compares \`approved_at\` against real \`datetime.now(timezone.utc)\`. On 2026-04-30, exactly 8 days later, \`STALE_APPROVAL_MAX_DAYS = 7\` is exceeded and 8 tests start failing.

This is the kind of bug that's invisible until the day it explodes. PR #489 was the canary.

## Fix

Replace the hard-coded fixture with \`_NOW_SNAPSHOT = datetime.now(UTC)\` at module load. Snapshot once (not on each call) so multiple \`_now()\` calls in a single test return the same instant — \`test_stale_approval_exact_threshold_does_not_escalate\` would otherwise tick a few μs between its two \`_now()\` calls and trip the strict-greater check.

## Verification

\`\`\`
$ python -m pytest
1025 passed, 20 skipped in 9.82s
\`\`\`

Previously 8 failing in escalation + dispatcher; now all green.

## Out of scope (followup, not blocking)

A \`tests/ci/test_no_hardcoded_now.py\` meta-test that scans test files for \`datetime\(2\d{3}, \d+, ...\)\` patterns would catch the next time-bomb at PR open time. Worth tracking as a separate enhancement.

Closes #490

## Test plan

- [x] All 1025 tests pass locally
- [ ] CI green on this PR
- [ ] After merge: PR #489 picks up the fix on rebase, becomes mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)