### PR TITLE
fix(tests): supabase stub works when package is installed-but-empty

### DIFF
--- a/tests/test_memory_recall_hook.py
+++ b/tests/test_memory_recall_hook.py
@@ -26,9 +26,11 @@ for _stub in ("httpx", "dotenv", "supabase"):
             mod = types.ModuleType(_stub)
             if _stub == "dotenv":
                 mod.load_dotenv = lambda *a, **k: None
-            if _stub == "supabase":
-                mod.create_client = lambda *a, **k: None
             sys.modules[_stub] = mod
+    if _stub == "dotenv" and not hasattr(sys.modules[_stub], "load_dotenv"):
+        sys.modules[_stub].load_dotenv = lambda *a, **k: None
+    if _stub == "supabase" and not hasattr(sys.modules[_stub], "create_client"):
+        sys.modules[_stub].create_client = lambda *a, **k: None
 
 
 _HOOK_PATH = Path(__file__).resolve().parent.parent / "scripts" / "memory-recall-hook.py"


### PR DESCRIPTION
## Summary

- `test_memory_recall_hook.py` collection failed in CI when `supabase` was importable but empty (no `create_client`). The existing stub only set `create_client` on a freshly-created module; if `supabase` was already in `sys.modules`, the guard was skipped and the hook's top-level `from supabase import create_client` raised `ImportError`.
- Fix: add unconditional `hasattr` guards after the loop so the stub attributes are applied regardless of how the module entered `sys.modules`.

## Test plan

- [ ] `pytest tests/test_memory_recall_hook.py` — 97 passed (was collection error before fix)
- [ ] `pytest tests/test_memory_server.py` — 41 failed / 59 passed (unchanged; pre-existing failures unrelated to this PR)

## Notes

Pre-existing root cause: discovered while investigating the `pytest` CI failure on #501. The 41 `test_memory_server.py` failures are also pre-existing (tracked separately — they require Supabase mocking rework).

https://claude.ai/code/session_01JRMc6U2SY4RpdBmW3M5u6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRMc6U2SY4RpdBmW3M5u6f)_