### PR TITLE
fix(setup-device): resolve claude.cmd via shutil.which on Windows

### DIFF
--- a/scripts/setup-device.py
+++ b/scripts/setup-device.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 IS_WINDOWS = platform.system() == "Windows"
+CLAUDE_BIN = "claude"  # resolved to absolute path in check_prerequisites()
 
 # ── Formatting helpers ──────────────────────────────────────────────────────
 
@@ -97,8 +98,12 @@ def check_prerequisites():
             print(f"    {DIM}Install: https://cli.github.com{RESET}")
 
     # Claude Code CLI
-    claude_ok = shutil.which("claude") is not None
-    if claude_ok:
+    # On Windows the executable is `claude.cmd` (npm shim); subprocess.run
+    # with a list does NOT expand PATHEXT, so we resolve the absolute path
+    # once via shutil.which (which DOES) and reuse it everywhere below.
+    global CLAUDE_BIN
+    CLAUDE_BIN = shutil.which("claude")
+    if CLAUDE_BIN:
         ok("Claude Code CLI")
     else:
         fail("Claude Code CLI not found -- this is required")
@@ -482,7 +487,7 @@ def install_claude_plugins():
         # ("already on disk"). Absolute path required so claude doesn't
         # mis-treat it as a Git source.
         add_result = subprocess.run(
-            ["claude", "plugins", "marketplace", "add", str(mp_path.resolve())],
+            [CLAUDE_BIN, "plugins", "marketplace", "add", str(mp_path.resolve())],
             capture_output=True, text=True,
         )
         if add_result.returncode != 0:
@@ -495,7 +500,7 @@ def install_claude_plugins():
         # to an already-registered marketplace would be invisible until the
         # user manually ran `claude plugins marketplace update`.
         update_result = subprocess.run(
-            ["claude", "plugins", "marketplace", "update", mp_name],
+            [CLAUDE_BIN, "plugins", "marketplace", "update", mp_name],
             capture_output=True, text=True,
         )
         if update_result.returncode != 0:
@@ -507,7 +512,7 @@ def install_claude_plugins():
         for entry in entries:
             install_result = subprocess.run(
                 [
-                    "claude", "plugins", "install",
+                    CLAUDE_BIN, "plugins", "install",
                     f"{entry['plugin']}@{mp_name}",
                     "--scope", "user",
                 ],


### PR DESCRIPTION
## Summary

- `subprocess.run(["claude", ...])` on Windows does not expand `PATHEXT`, so the npm-installed `claude.cmd` shim is unfindable — Step [7] of `setup-device.py` died with `WinError 2` on a fresh Windows account even though Step [1]'s `shutil.which("claude")` check reported OK.
- Resolve `claude` once in Step [1] (which already runs `shutil.which`) into a module-level `CLAUDE_BIN`, and reuse that absolute path in all `subprocess.run` calls for marketplace add/update and plugin install.
- `scripts/install/installer.py` already handled this via `_resolve_claude_cli()`; this brings `setup-device.py` in line.

Closes #520

## Test plan

- [x] Reproduced on fresh Windows 11 device — Step [7] failed before fix.
- [ ] Re-run `python scripts/setup-device.py` after fix; Step [7] should complete without `WinError 2`.
- [ ] Re-run on a device that already has plugins installed — should be idempotent (marketplace `add` is no-op when already on disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)