### PR TITLE
feat(claude-md): centralise memory + record_decision protocol in user-level CLAUDE.md (#523)

### DIFF
--- a/.claude-userlevel/CLAUDE.md
+++ b/.claude-userlevel/CLAUDE.md
@@ -1,0 +1,79 @@
+# User-level CLAUDE.md
+
+Process and protocol rules that apply across every project. Loaded into every Claude Code session as user-level memory.
+
+**Source of truth:** `<jarvis-repo>/.claude-userlevel/CLAUDE.md`. The live file at `~/.claude/CLAUDE.md` is a mirror — `install.ps1 -Apply` propagates from source. Never edit the mirror; edits drift on next install.
+
+Project-specific rules live in `<repo>/CLAUDE.md`. SOUL.md (`~/.claude/SOUL.md`) holds identity/personality; this file holds process.
+
+## Memory & decision protocol
+
+Skills consume this section instead of restating it. Three load-bearing rules: **recall before deciding**, **brief-mode UUIDs**, and the **`record_decision` contract**.
+
+This is the **Tier 1** layer (soft prompt rule). Backstops:
+
+- **Tier 2 — hooks.** Mechanical enforcement that can't be skipped (e.g. `PreToolUse` on `record_decision` blocks calls with empty `memories_used`).
+- **Tier 3 — skill-specific gates.** Things that genuinely belong to one skill (e.g. `/grill-me`'s completeness gate, `/implement`'s already-done audit). Stay in the skill file.
+
+If the empty-`memories_used` rate rises after centralising here, the relevant rule escalates Tier 1 → Tier 2 (issue #532 tracks this).
+
+### 1. Recall before deciding
+
+Before any non-trivial decision, save, or skill invocation, consult memory. Three passes — run in parallel where possible:
+
+- **Always-load gates** — `memory_list(project=<project>, type=feedback, always_load=true)`. Surface unconditionally; these are session-wide rules that bind every skill.
+- **Topic recall with skill name** — `memory_recall(query="<skill-name> <topic + entities>", type=decision/feedback, brief=true, limit=10–15)`. **The literal skill name MUST appear in the query** so skill-specific contract memories (e.g. `grill_me_record_decision_gate`) surface every invocation. Skill contracts are not always_load — they ride on this recall.
+- **Outcomes for the area** — `outcome_list(scope=<area>, severity≥medium, since=90d)` when the work touches a known-failure region. 2+ failures cluster → surface in the first turn before acting.
+
+For mid-task branch shifts (entering a new sub-area of a design tree), re-run topic recall with sub-area-specific entities. Goal: keep `memories_used` populated with sub-area UUIDs at decision time, not generic top-level recall.
+
+If args are short or meta (≤5 words, or entity names dominate), a second pass with entities expanded — don't lean on a narrow query.
+
+### 2. Brief-mode → UUID map
+
+`memory_recall(brief=true, ...)` returns `name=<slug>` AND `id=<uuid>` per hit. Parse both into a local `name → uuid` map at recall time.
+
+**Every later `record_decision` call passes UUIDs in `memories_used`, not names.** The schema demands UUIDs; slugs drift. Per #325 audit: of 33 historical `decision_made` episodes, 12 stored names not UUIDs — every one was a broken FK in the outcome→memory join.
+
+### 3. record_decision contract
+
+When a resolution is architectural / cadence-defining / between named alternatives / has consequences past this session — emit `mcp__memory__record_decision` **immediately on resolution** (not batched at end).
+
+Pass:
+
+- `decision` — one line, the resolved answer (not the question).
+- `rationale` — one paragraph, the *why* the user gave (not just what was chosen).
+- `alternatives_considered` — every option discussed, each with one-clause rejection reason. Empty list is rare; "none discussed" is itself a flag.
+- `reversibility` — `reversible | hard | irreversible`. Be honest; this gates downstream caution.
+- `confidence` — `0.0–1.0`. If <0.6, flag the uncertainty in-line, don't bury it.
+- `memories_used` — UUIDs (not names) from the recall map. Empty list valid only when nothing in memory informed the choice (rare; the rationale should note it).
+- `actor` — `session:<short-slug>` so the trail is recoverable.
+- `project` — scope to the project being designed for.
+
+Capture the returned episode UUID. Maintain a running `decision_uuids[]` per session for handoff to downstream skills.
+
+#### Trigger list — emit when ANY of these hold
+
+1. **Issue implementation** — always, even if reversible. Outcome attribution needs the basis.
+2. **`reversibility ∈ {hard, irreversible}`** — destructive DB ops, force-pushed history, published API changes.
+3. **`confidence < 0.7`** — uncertain calls deserve recorded rationale so `/reflect` can classify failures as reasoning vs execution.
+4. **Policy / schema / tag / config change** — `always_load` tags, protected-file edits, skill add/remove, hook config, schema migrations, installer manifest. Reversible but affects future sessions.
+5. **Architectural direction picked** — resolved "chose X over Y" after discussion, even if reversible. The rationale matters more than the bit set.
+
+Rule of thumb: "I just made a call that will outlive this session" → emit. "I just clarified my own thinking" → skip. When unsure, emit — one tool call vs. a `/reflect` blind spot.
+
+#### Post-hoc marker
+
+If a decision is recorded after-the-fact (catching up on a missed call, e.g. during `/end` reconciliation), encode `:post-hoc` into the `actor` field — `actor="session:<id>:post-hoc"`. `/self-improve` greps actor for regression patterns; real-time capture is the goal, post-hoc saves are a regression. (#517 tracks adding a structured `post_hoc` field.)
+
+### Memory staleness
+
+Memory records can be wrong:
+
+- **Dead references** — file/skill/issue that no longer exists: ignore + note in skill output for `/reflect`. Don't ask the user about every dead reference.
+- **Show-and-continue** — when a turn leans on memory, list inline as `(leaning on: <one-line> — <uuid>, <age>d)`. Catches staleness in real time without a question per memory. Keep terse: 1–3 records per turn max.
+- **Old reversibles** — `reversibility=reversible` decisions older than ~60 days: surface but don't treat as a constraint.
+
+### Decisions belong in memory, not in issue/PR bodies
+
+Architectural resolutions go to `record_decision`. Issue bodies, PR bodies, PRD prose all decay; the queryable decision log doesn't. Skills that produce issues (`/to-prd`, `/to-issues`) reference `decision_uuids[]` rather than restating the *why* — see each skill for the section template.

--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -52,12 +52,9 @@ For **each** issue in the batch — apply the SOUL.md `### Grill-me trigger chec
 
 **Subagents do NOT run grill-me on their own.** They consume already-grilled AC via the issue body. Their dispatch prompt must include the literal AC list, and their first action is to confirm the AC is verifiable from the issue body alone — if not, they post a comment and stop, escalating back to main session.
 
-### 0b. Load context from memory (parallel)
+### 0b. Load context from memory
 
-Same as /implement §0b:
-- `memory_recall(query="delegation", limit=3)` — past delegation rules and feedback
-- `memory_recall(query=<batch topic>, limit=3)` — decisions about this area
-- `memory_recall(type="feedback", project="global", limit=3)` — behavioral rules
+Apply the memory recall protocol from user-level CLAUDE.md `### 1. Recall before deciding`, with `<skill-name>=delegate` and `<topic>=<batch-topic + per-issue entities>`. Brief-mode hits feed the `name → uuid` map used in §3 below.
 
 ### 1. Classify each issue: delegatable or inline
 
@@ -88,13 +85,13 @@ done
 
 ### 3. Record decision
 
-Emit one `record_decision` covering the batch — which went to subagents, which stayed inline, why.
+Apply the `record_decision` contract from user-level CLAUDE.md `### 3. record_decision contract`. One call covers the batch — which went to subagents, which stayed inline, why. Skeleton:
 
 ```
 mcp__memory__record_decision(
   decision="delegate batch #<N1> #<N2> ... (split <inline>/<delegated>)",
   rationale="<why this split — subagent fitness, session-context dependency, safety zones>",
-  memories_used=[<ids>],
+  memories_used=[<UUIDs from §0b recall>],
   confidence=<0.0-1.0>,
   alternatives_considered=["all inline", "all delegated", "sequential"],
   reversibility="reversible"

--- a/.claude-userlevel/skills/grill-me/SKILL.md
+++ b/.claude-userlevel/skills/grill-me/SKILL.md
@@ -9,63 +9,23 @@ Ask questions one at a time. If a question can be answered by exploring the code
 
 Resolve **WHY before HOW** — establish the problem the design solves before debating mechanism. If the user flags a "wrong question", you almost certainly skipped to mechanism.
 
-## Memory protocol (load-bearing)
+## Memory protocol
 
-Pocock's original /grill-me had no memory layer. Ours does. The grill must consult memory on input and surface what it leaned on, not just record what it decided.
+The recall protocol (always_load gates, skill-name-in-query, brief-mode UUID map, mid-task refresh) and the staleness rules live in user-level CLAUDE.md `## Memory & decision protocol`. Apply them with `<skill-name>=grill-me`.
 
-### Pre-grill load (one-shot at start)
+Per-grill specifics on top of that protocol:
 
-Before the first Q:
+- **Pre-grill outcomes pass.** `outcome_list(scope=<area or topic>, severity≥medium, since=90d)`. If 2+ failures cluster → surface them in the very first Q before the user starts answering: "before we start, X failed twice in this area due to Y, proceed or rethink?"
+- **Repo context files.** Read `CONTEXT.md` (full — it's short by design). Glob `docs/adr/*.md` filenames; full-Read only when the grill walks into a topic the filename signals.
+- **Per-branch refresh.** When the grill crosses into a new sub-area of the design tree (branch-shifts only, not every Q), re-run topic recall with sub-area entities. Goal: keep `memories_used` populated with sub-area-specific UUIDs at the moment of `record_decision`.
 
-1. **Hybrid recall — three passes:**
-   - `memory_list(project=<project>, type=feedback, always_load=true)` — session-wide gates, surface unconditionally.
-   - `memory_recall(query="grill-me <args> <extracted entities>", type=decision/feedback, brief=true, limit=15)`. **Always include the literal skill name (`grill-me`) in the query** so this skill's own contract memory (`grill_me_record_decision_gate` and any successor) surfaces every invocation. Skill-specific contracts are not always_load — they ride on the skill's own recall, per `always_loaded_context_budget_principle`.
-   - If args are short or meta (≤5 words, or entity names like skill names dominate), second-pass recall with the entities expanded — don't lean on a narrow query.
-   - Capture `id=<uuid>` from each brief hit into a local `name → uuid` map. **memories_used in record_decision takes UUIDs, not names** — the brief output already carries them.
-2. **Outcomes for the area.** `outcome_list(scope=<area or topic>, severity≥medium, since=90d)`. If 2+ failures cluster → surface them in the very first Q before the user starts answering: "before we start, X failed twice in this area due to Y, proceed or rethink?"
-3. **Repo context files.** Read `CONTEXT.md` (full — it's short by design). Glob `docs/adr/*.md` filenames; do not full-Read ADRs at start. Full-Read an ADR only when the grill walks into a topic its filename signals.
+## Decision-recording contract — completeness gate (skill-specific)
 
-### Per-branch refresh (mid-grill)
+The general `record_decision` contract (when to emit, what to pass, post-hoc marker) lives in user-level CLAUDE.md `### record_decision contract`. The grill adds a **completeness gate** on top — Tier 3, can't be lifted to global because only the grill knows what counts as a "resolved Q".
 
-When the grill crosses into a new sub-area of the design tree (not every Q — only branch-shifts), re-run `memory_recall(query=<sub-area>, type=decision/feedback, brief=true, limit=10)`. Point of the refresh: keep `memories_used` populated with sub-area-specific UUIDs at the moment of `record_decision`, not generic top-level recall.
+This gate exists because of a recurrent failure mode: grill resolves N sub-decisions, downstream `/to-issues` files them as issue bodies, the queryable decision log misses N entries, future sessions reconstruct from issue bodies (lossy) or working-state (frozen). See memory `decisions_belong_in_memory_not_gh_issue_bodies`.
 
-### Memory use & staleness
-
-Memory records can be stale. Use them, but:
-
-- **Auto-flag obvious red signals (don't ask, ignore + note).** If a recalled memory references a file/skill/issue that no longer exists, or names a path that's been moved, treat it as untrustworthy. Don't ask the user about every dead reference; note them in the grill output for `/reflect` to consume.
-- **Show-and-continue ritual (every Q-block).** When a Q-block leans on memory records, list them inline as `(leaning on: <one-line summary> — <uuid>, <age>d)`. Lets the user catch staleness in real time without an explicit question per memory. Keep it terse: 1-3 records per Q max, not the whole recall dump.
-- For `reversibility=reversible` decisions older than ~60 days, downgrade their weight: still surface, but don't treat as constraint.
-
-## Decision-recording contract (load-bearing)
-
-Decisions made during a grill are queryable knowledge. Issue bodies are *not*. Every architectural resolution that survives the session **must** land in `record_decision` in real time, not at the end.
-
-This contract exists because of a recurrent failure mode: grill resolves N sub-decisions, downstream `/to-issues` files them as issue bodies, the queryable decision log misses N entries, future sessions have to reconstruct from issue bodies (lossy) or working-state (frozen). See memory `decisions_belong_in_memory_not_gh_issue_bodies` and `record_decision_during_refactors`.
-
-### When to record (per-Q rule)
-
-Record a decision **immediately on resolution** — the same turn the user agrees — when the resolution is any of:
-
-- Architectural: shape of a system, module boundary, data flow, lifecycle.
-- Cadence / trigger / scheduling rule that will be encoded somewhere.
-- Choice between named alternatives where rejecting the loser has consequences.
-- Anything you'd want to recover the *why* of, six weeks from now.
-
-Skip the call only for purely mechanical resolutions (naming, ordering, labels, copy-edits).
-
-### What to pass to `record_decision`
-
-- `decision`: one-line statement (the resolved answer, not the question).
-- `rationale`: one paragraph — the *why* the user gave, not just what was chosen.
-- `alternatives_considered`: every option discussed, with one-clause reason for rejection.
-- `reversibility`: reversible / hard / irreversible — be honest, this gates downstream caution.
-- `confidence`: 0.0–1.0; if you're below 0.6, flag the uncertainty in the grill, don't bury it.
-- `memories_used`: UUIDs of memories that informed the choice (not names — UUIDs, per `record_decision_always_pass_memories_used`).
-- `actor`: `session:<short-slug>` so the trail is recoverable.
-- `project`: scope to the project being designed for.
-
-Capture the returned episode UUID. Maintain a running list `decision_uuids[]` for the grill.
+For each architectural Q resolved during the grill, capture the returned episode UUID into a running `decision_uuids[]` list.
 
 ### Final completeness gate (refuse to finish without it)
 

--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -39,14 +39,11 @@ After grill-me, re-enter `/implement` — the AC will now drive the rest of the 
 
 **0 yes:** continue to step 0b. Most "fix typo / bump dep / move file" issues land here.
 
-### 0b. Load context from memory (parallel)
+### 0b. Load context from memory
 
-Before anything else, recall relevant memories:
-- `memory_recall(query="delegation", limit=3)` — past delegation rules and feedback
-- `memory_recall(query=<issue topic>, limit=3)` — decisions about this area
-- `memory_recall(type="feedback", project="global", limit=3)` — behavioral rules
+Apply the memory recall protocol from user-level CLAUDE.md `### 1. Recall before deciding`, with `<skill-name>=implement` and `<topic>=<issue-area + acceptance-criteria entities>`. The brief-mode hits feed the `name → uuid` map used in §3.5 below.
 
-Apply recalled context to all subsequent steps. Skip if memories are empty.
+Skip subsequent steps gracefully when memories are empty.
 
 ### 1. Pre-flight checks (parallel work protocol)
 
@@ -84,34 +81,21 @@ git checkout -b feat/<N>-<slug>
 
 ### 3.5. Record decision (reasoning trace, #252, #334)
 
-After claim, before implementation — emit a `decision_made` episode so `/reflect` can later attribute outcomes to reasoning (missing memory / wrong memory / wrong reasoning):
+After claim, before implementation — emit a `decision_made` episode so `/reflect` can later attribute outcomes to reasoning (missing memory / wrong memory / wrong reasoning).
+
+Apply the `record_decision` contract from user-level CLAUDE.md `### 3. record_decision contract`. Issue implementation always satisfies trigger #1, so the call is non-optional. Skeleton:
 
 ```
 mcp__memory__record_decision(
   decision="implement <issue title> (#<N>)",
   rationale="<one paragraph: why this issue matters now, what approach is planned, what non-obvious choices were made at claim time>",
-  memories_used=[<ids from step 0 recall>],
+  memories_used=[<UUIDs from §0b recall>],
   outcomes_referenced=[],
   confidence=<0.0-1.0>,
   alternatives_considered=["<rejected options — e.g. 'defer to next sprint', 'delegate to subagent'>"],
   reversibility="reversible"
 )
 ```
-
-**Trigger list — emit `record_decision` when ANY of the following hold** (canonical rule; mirrored in global `record_decision_when_what` feedback memory):
-
-1. **Issue implementation** — always, even if reversible. Outcome attribution needs the basis.
-2. **`reversibility ∈ {hard, irreversible}`** — e.g. destructive DB ops, force-pushed history, published API changes.
-3. **`confidence < 0.7`** — uncertain calls deserve a recorded rationale so `/reflect` can classify the outcome as reasoning-failure vs execution-failure.
-4. **Policy / schema / tag / config change** — tagging memories `always_load`, editing protected files, adding/removing skills, changing hook config, schema migrations, installer manifest edits. These are *reversible* but affect the system's behavior across future sessions.
-5. **Architectural direction picked** — a resolved "chose X over Y" after discussion, even if reversible. The rationale matters more than the bit that's set; `/reflect` can only learn if the picked direction is captured at pick time.
-
-Rules of thumb:
-- "I just made a call that will outlive this session" → emit.
-- "I just clarified my own thinking on an approach" → don't emit (no persisted effect).
-- When unsure, emit. The cost is one tool call; the cost of missing a decision is a blind spot for `/reflect`.
-
-Pass `memories_used = [<uuids from step 0 recall>]` whenever recall surfaced something. Empty list is valid only when nothing in memory informed the decision — which itself is rare and should be noted in the rationale.
 
 ### 4. Implement
 

--- a/.claude-userlevel/skills/to-issues/SKILL.md
+++ b/.claude-userlevel/skills/to-issues/SKILL.md
@@ -13,13 +13,13 @@ Issue tracker conventions and triage label vocabulary should be defined in the p
 
 ### 0. Memory & context load
 
-Run before anything else, even before fetching a passed-in issue reference:
+Run before anything else, even before fetching a passed-in issue reference.
 
-1. **Always-load gates.** `memory_list(project=<project>, type=feedback, always_load=true)`. These rules constrain how the breakdown is shaped (e.g. label vocabulary, PR-scope rules, naming conventions).
-2. **Topic recall — include the skill name in the query.** `memory_recall(query="to-issues <source-material topic>", type=decision/feedback, brief=true, limit=10)`. The literal skill name `to-issues` ensures this skill's own contract memory (e.g. `grill_me_record_decision_gate`, which tags `to-issues`) surfaces every invocation. Skill-specific contracts are not always_load — they ride on the skill's own recall. Capture `id=<uuid>` from the brief output into a local `name → uuid` map — these UUIDs feed the `## Decisions` section in each issue body.
-3. **Repo context files.** Read `CONTEXT.md`. Glob `docs/adr/*.md` filenames; full-Read only ADRs whose filename matches the area being broken down. Issue titles + descriptions must use this vocabulary.
+Apply the recall protocol from user-level CLAUDE.md `### 1. Recall before deciding` with `<skill-name>=to-issues` and `<topic>=<source-material topic + entities>`. The brief-mode UUIDs feed the `## Decisions` section in each issue body produced below.
 
-If a recalled memory references a file/skill/issue that no longer exists, ignore it and note in output for `/reflect` — don't ask the user about every dead reference. For load-bearing memory hits surface them inline as `(leaning on: <one-line> — <uuid>)` so the user can interject if stale.
+Read `CONTEXT.md` (full). Glob `docs/adr/*.md` filenames; full-Read only ADRs whose filename matches the area being broken down. Issue titles + descriptions must use this vocabulary.
+
+Apply the staleness rules from user-level CLAUDE.md `### Memory staleness` (auto-flag dead refs, show-and-continue inline `(leaning on: ...)`).
 
 ### 1. Gather context
 

--- a/.claude-userlevel/skills/to-prd/SKILL.md
+++ b/.claude-userlevel/skills/to-prd/SKILL.md
@@ -12,10 +12,9 @@ Issue tracker conventions and triage label vocabulary should be defined in the p
 ## Process
 
 0. **Memory & context load.** Before drafting:
-   - `memory_list(project=<project>, type=feedback, always_load=true)` — session-wide gates.
-   - `memory_recall(query="to-prd <topic> <entities>", type=decision/feedback, brief=true, limit=10)`. **Include the literal skill name `to-prd` in the query** so skill-specific contract memory (e.g. `grill_me_record_decision_gate`, tagged `to-prd`) surfaces every invocation — these are not always_load. Parse `id=<uuid>` from brief output into a local `name → uuid` map; these UUIDs feed the `## Decisions` section.
+   - Apply the recall protocol from user-level CLAUDE.md `### 1. Recall before deciding` with `<skill-name>=to-prd` and `<topic>=<PRD topic + entities>`. The brief-mode UUIDs feed the `## Decisions` section below.
    - Read `CONTEXT.md` (full). Glob `docs/adr/*.md` filenames; full-Read only ADRs matching the topic area. PRD vocabulary must align with these.
-   - Auto-flag stale memory hits (dead file/skill/issue refs) — ignore + note for `/reflect`, don't ask. Surface load-bearing hits inline `(leaning on: <one-line> — <uuid>)` so the user can interject if stale.
+   - Apply the staleness rules from user-level CLAUDE.md `### Memory staleness` (auto-flag dead refs, show-and-continue inline `(leaning on: ...)`).
 
 1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD, and respect any ADRs in the area you're touching.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,20 @@ Terms used across the codebase. Definitions are domain-meaningful, not implement
 - **Deletion test** — diagnostic for module depth: imagine deleting it. If complexity vanishes, it was a pass-through (shallow). If complexity reappears across N callers, it earned its keep (deep).
 - **Implicit assumption** — domain rule that's "obvious" to the human but not in writing. Source of scope shrinkage. Surfaced via `/grill-me`, fixed by adding to this file or to AC.
 
+### Skill trigger model (ADR-0001)
+
+- **Type 1 trigger** — event/cron-driven skill invocation (Stop hook, SessionStart, scheduled cron, GitHub webhook). The skill fires in a fresh session, deterministically, without the model deciding. Examples: `/cycle`, `/learn`, `/end`.
+- **Type 2 trigger** — user or orchestrator supplies an intent-shaped prompt at session start; the model matches the skill description and invokes. Both human-typed and headless-orchestrator-issued prompts are Type 2. Examples: `/grill`, `/implement`, `/diagnose`.
+- **Type 3 trigger** — mid-task self-trigger by the model. **Not designed for.** Skill invocation mid-task eats smart-zone budget for the current task and empirically fires unreliably. Let the current task finish; the orchestrator triggers the next skill in a fresh session.
+
+### Protocol layers (ADR-0002)
+
+Where load-bearing rules live, in order of preference:
+
+- **Tier 1 — durable prompt rules** in user-level CLAUDE.md (mirrored from `.claude-userlevel/CLAUDE.md`). Loaded every session via SessionStart context. Memory recall protocol, `record_decision` contract, skill-name-in-query rule live here. Default home for cross-skill rules.
+- **Tier 2 — mechanical hooks** (`PreToolUse`, `PostToolUse`). Backstop for binary checks Tier 1 might miss — e.g. blocking `record_decision` when `memories_used` is empty. Hooks are not for nuanced judgement; they are deterministic fences.
+- **Tier 3 — skill-specific gates** that genuinely belong to one skill (`/grill`'s completeness gate, `/implement`'s already-done audit). Stay inside the skill file. Never duplicate Tier 1 content here.
+
 ### Devices & paths
 
 - **3 devices** — owner runs Jarvis on Lenovo laptop, desktop, MacBook. Different usernames, different paths. Anything device-pinned is a bug.

--- a/docs/adr/0001-skill-trigger-model.md
+++ b/docs/adr/0001-skill-trigger-model.md
@@ -1,0 +1,15 @@
+# Skill trigger model
+
+Every Jarvis skill is classified by its **primary trigger**:
+
+- **Type 1 — event/cron.** Hook (`Stop`, `SessionStart`, `PreToolUse`) or cron fires the skill in a fresh session. Examples: `/cycle`, `/learn`, `/end`.
+- **Type 2 — user or orchestrator intent.** A human at the keyboard, or a sandcastle orchestrator sending a task-prompt, supplies the intent at session start; the model matches the skill's description and invokes. Examples: `/implement`, `/grill`, `/diagnose`.
+
+**Mid-task self-trigger ("Type 3") is explicitly not designed for.** When the model is mid-task, invoking a skill eats the smart-zone budget (~100K tokens) for the current task and rarely fires anyway — the model is biased toward task continuation, not meta-step-out. We accept this and let the current task complete; the orchestrator (or the user) triggers the next skill in a fresh session.
+
+This means **headless mode under sandcastle is Type 2**: the orchestrator sends an intent-shaped prompt at session start, and the skill description must be specific enough to be matched against that intent. Skill descriptions are written for two readers — humans and orchestrators — both supplying the intent at session start, never mid-task.
+
+## Considered options
+
+- **Type 3 retained.** Rejected — empirically the agent does not invoke skills from its own mid-task reasoning, and engineering for it inflates description complexity.
+- **Single trigger model (everything goes through skills, no hooks).** Rejected — event-driven things (session end, weekly review) become reliable when fired by hooks/cron, not by hoping the model self-triggers.

--- a/docs/adr/0002-shared-protocol-in-global-claude-md.md
+++ b/docs/adr/0002-shared-protocol-in-global-claude-md.md
@@ -1,0 +1,26 @@
+# Shared protocol lives in global CLAUDE.md, not duplicated across skills
+
+The memory recall protocol (`always_load` gates, skill-name-in-query, brief-mode UUIDs) and the `record_decision` contract (memories_used as UUIDs, alternatives_considered, post-hoc marker, etc.) live in user-level CLAUDE.md, loaded into every session. Skills do not restate them.
+
+**Source of truth is in this repo at `.claude-userlevel/CLAUDE.md`**; the live file `~/.claude/CLAUDE.md` is a mirror, propagated by `install.ps1 -Apply` per the existing `install-manifest.yaml` pattern (same as SOUL.md, settings.json, skills). Never edit the mirror directly — edits drift on next install. Add a new `claude_md` group to the manifest as part of the migration.
+
+This is the **Tier 1** layer. Two backstops exist:
+
+- **Tier 2 — hooks.** Mechanical enforcement that can't be skipped. Example: `PreToolUse` on `record_decision` blocks calls with empty `memories_used`.
+- **Tier 3 — skill-specific gates.** Things that genuinely belong to one skill — e.g. `/grill`'s completeness gate, `/implement`'s already-done audit. These stay in the skill file.
+
+**Why this matters.** The previous arrangement smeared the protocol across 5+ skills with light variations, which was the dominant source of (a) drift between skills, (b) cognitive load when reading any one skill, and (c) the "all skills look the same" feeling that triggered this redesign. Centralising the protocol lets each skill be thin and distinct.
+
+**Tracking.** Existing recall-audit aggregates (`empty_memories_used_pct`, `decision_text_no_recall`, `store_no_recall`) already roll across the last ~20 sessions. After migration, watch these. If the empty-`memories_used` rate rises, the Tier 1 prompt-rule isn't being honoured and we escalate the relevant rule into a Tier 2 hook.
+
+## Considered options
+
+- **Keep protocol in each skill.** Rejected — current state, source of the rewrite pressure.
+- **Tier 2 only (hooks for everything).** Rejected — too brittle for soft rules; hooks are best for binary checks, not nuanced "recall before deciding" judgement.
+- **Move to SOUL.md instead of CLAUDE.md.** Rejected — SOUL.md is identity/personality; CLAUDE.md is rules/process. Memory protocol is a process.
+
+## Consequences
+
+- Skills shrink. `/implement`, `/delegate`, `/grill`, `/to-prd`, `/to-issues` lose their memory/decision sections.
+- Global CLAUDE.md grows. The canonical file lives at `.claude-userlevel/CLAUDE.md` in this repo (PR-reviewed, git-versioned). Cross-device sync uses the existing installer flow — no new mechanism.
+- New skills inherit the protocol for free. Authoring a skill no longer requires copy-pasting the recall preamble.

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -41,6 +41,21 @@ groups:
         dest: "SOUL.md"
         template: false
 
+  - id: claude_md
+    description: "User-level CLAUDE.md — process rules incl. memory & decision protocol (#523)"
+    enabled: true
+    files:
+      # Canonical source at .claude-userlevel/CLAUDE.md (git-versioned,
+      # PR-reviewed). Installer copies to ~/.claude/CLAUDE.md, which
+      # Claude Code auto-loads as user-level memory in every session.
+      # Edit flow: edit .claude-userlevel/CLAUDE.md -> PR -> merge ->
+      # `git pull && install.ps1 -Apply` on each device propagates.
+      # Per ADR-0002: skills reference this file rather than restate
+      # the memory/decision protocol locally.
+      - source: ".claude-userlevel/CLAUDE.md"
+        dest: "CLAUDE.md"
+        template: false
+
   - id: hooks_settings
     description: "settings.json — hooks pointing at JARVIS_HOME scripts (M3 #338)"
     enabled: true


### PR DESCRIPTION
## Summary
- Adds `.claude-userlevel/CLAUDE.md` as source of truth for user-level process rules — the **Memory & decision protocol** section consolidates `always_load` gates, skill-name-in-query, brief-mode → UUID map, the `record_decision` contract (with trigger list + post-hoc marker), and staleness rules.
- Adds `claude_md` group to `install-manifest.yaml`; `install.ps1 -Apply` now mirrors the file into `~/.claude/CLAUDE.md`.
- Strips the protocol from 5 skills (`grill-me`, `implement`, `delegate`, `to-prd`, `to-issues`) and replaces with cross-references. Skill-specific Tier 3 gates (e.g. grill-me's completeness gate, implement's already-done audit) stay in-skill.

## Why
Per [ADR-0002](docs/adr/0002-shared-protocol-in-global-claude-md.md): the protocol was smeared across 5+ skills with light variations — primary source of drift, cognitive load, and the "all skills look the same" feeling that triggered the redesign. Centralising lets each skill be thin and distinct.

Closes #523

## Decisions & Alternatives
- **Source at `.claude-userlevel/CLAUDE.md`, mirror via installer** — same pattern as SOUL.md, settings.json, skills. Rejected: editing `~/.claude/CLAUDE.md` directly (no PR review, no git history, drifts on next install).
- **Tier 3 stays in-skill** — completeness gate and already-done audit are skill-specific and don't generalise. Trade-off: each skill still has *some* memory-protocol prose, but it's now strictly the parts that only that skill knows about.
- **Issue references in prose are pointers to GH (source of truth), not state copies** — consistent with existing skill files that cite `#NNN` for context. Memory `no_state_in_static_storage` interpreted as "don't store mutable state", not "no GH citations".

## Risk Assessment
- **MEDIUM** — affects every session via auto-loaded `~/.claude/CLAUDE.md`. Behavioural surface change: skill files now lean on global content. If global content fails to load in a fresh session, skills lose protocol references.
- Mitigation: ADR-0002 + issue #532 (recall-audit baseline captured 2026-05-06; post-migration measurement after ≥20 fresh sessions catches the regression case).

## Testing
- `python scripts/install/installer.py` — dry-run shows `copy_file [claude_md] .claude-userlevel/CLAUDE.md -> ~/.claude/CLAUDE.md` action.
- `install.ps1 -Apply` — file written; `diff ~/.claude/CLAUDE.md .claude-userlevel/CLAUDE.md` matches.
- **SessionStart loading note**: `~/.claude/CLAUDE.md` is auto-loaded by Claude Code's user-memory mechanism (the same way project `CLAUDE.md` reaches the system prompt's `claudeMd` block), not by `scripts/session-context.py`. Acceptance criterion phrasing "loaded by SessionStart hook" is technically loaded by the harness, not by our hook — but the visible outcome (content surfaces in fresh-session system prompt) is the same. Verifiable by starting a fresh session post-merge.

## Files Changed
- `.claude-userlevel/CLAUDE.md` — NEW; global protocol source
- `install-manifest.yaml` — new `claude_md` group
- `.claude-userlevel/skills/grill-me/SKILL.md` — strip Memory protocol + Decision-recording contract sections; keep Tier 3 completeness gate
- `.claude-userlevel/skills/implement/SKILL.md` — strip §0b recall + §3.5 trigger list; keep skeleton call shape
- `.claude-userlevel/skills/delegate/SKILL.md` — strip §0b + §3 trigger list; keep skeleton
- `.claude-userlevel/skills/to-prd/SKILL.md` — strip §0 always_load + brief-UUID rules; reference global section
- `.claude-userlevel/skills/to-issues/SKILL.md` — strip §0 always_load + brief-UUID rules; reference global section

🤖 Generated with [Claude Code](https://claude.com/claude-code)