### PR TITLE
ci(535): bypass paperwork checks for dependabot/renovate PRs

### DIFF
--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -19,6 +19,13 @@ jobs:
             const body = pr.body || '';
             const labels = (pr.labels || []).map(l => l.name);
 
+            // Bot bypass: dependabot/renovate cannot author linked issues. Paperwork-only — pytest, gitleaks, meta-tests still gate.
+            const author = (pr.user && pr.user.login) || '';
+            if (author === 'dependabot[bot]' || author === 'renovate[bot]') {
+              console.log(`bot author (${author}) — skipping linked-issue requirement.`);
+              return;
+            }
+
             // Hotfix escape: priority:critical label bypasses the linked-issue requirement.
             // Aligns with issue-checks.yml which treats priority:critical as hotfix.
             if (labels.includes('priority:critical')) {

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -179,7 +179,8 @@ jobs:
           fi
 
       - name: Set PR status to In Progress
-        if: ${{ github.event_name == 'pull_request' }}
+        # Bot PRs (dependabot/renovate) run with restricted secrets and aren't on the planning board.
+        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
         env:
           ITEM_URL: ${{ github.event.pull_request.html_url }}
           CONTENT_NODE_ID: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
## Summary

- `pr-body-check.yml`: early-exit success when author is `dependabot[bot]` / `renovate[bot]`
- `project-sync.yml`: skip the PR status step for the same actors (planning board doesn't track bot PRs; bot context lacks the required secret scope anyway)

## Why

Open dependabot PRs (#446–#452) are otherwise green (pytest / gitleaks / meta-tests pass) but blocked by two paperwork checks bots can't satisfy. Real defenses stay required.

## Test plan

- [ ] Owner PR (this one) — `require-linked-issue` still runs; passes via `Refs #535` (the rule allows bypass via `priority:critical` or bot author, **not** "Refs"; if it fails, I'll reword to `Closes #535`)
- [ ] Existing dependabot PR (e.g. #446) — re-run checks → both turn green
- [ ] Owner-authored PR with no linked issue → still red (regression guard, manual)

Closes #535