### PR TITLE
feat(sandcastle): slice 2 — memory MCP bridge in container + skills baked in (#540)

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,8 +1,9 @@
 # Sandcastle agent runtime config. Copy to .sandcastle/.env (gitignored).
 #
-# Slice 1 default path: Claude Code CLI inside the container talks to Ollama
-# on the host via Ollama's native Anthropic-compatible endpoint
-# (Ollama ≥ v0.14, Jan 2026). No proxy.
+# Slice 1: Claude Code CLI inside the container talks to Ollama on the host
+# via Ollama's native Anthropic-compatible endpoint (Ollama ≥ v0.14, Jan 2026).
+# Slice 2: memory MCP runs inside the container and reaches Supabase using an
+# anon key (decision 228a2d9b). RLS lands in slice 3 (#542).
 #
 # Override these per device or per smoke run as needed.
 
@@ -26,6 +27,31 @@ OLLAMA_MODEL=qwen2.5-coder:14b
 # open PRs. Use a fine-grained PAT scoped to this repo (Issues: RW, PRs: RW,
 # Contents: RW). Never commit the real value.
 GH_TOKEN=ghp_...
+
+# ---------------------------------------------------------------------------
+# Memory MCP bridge (slice 2 — issue #540)
+# ---------------------------------------------------------------------------
+# These are forwarded into the container by main.mts and consumed by the
+# in-container memory MCP server (/opt/mcp-memory/server.py).
+#
+# CRITICAL: SUPABASE_KEY must be the **anon** key, never the service-role key.
+# The container runs unattended overnight; a leaked service-role key gives
+# bearer rights over arbitrary memory rows and bypasses RLS. Slice 3 (#542)
+# adds the RLS policy that constrains anon-key writes to source_provenance
+# matching `sandcastle:%`. Until that lands, the prompt-level discipline in
+# .sandcastle/prompt.md is the only enforcement layer — keep it intact.
+
+SUPABASE_URL=https://xxxxxxxxxxxx.supabase.co
+
+# Anon key (the public one, safe to ship to clients with RLS). Find it under
+# Supabase dashboard → Project Settings → API → Project API keys → `anon`.
+# DO NOT paste the `service_role` key here.
+SUPABASE_KEY=eyJ_anon_...
+
+# Voyage AI key for memory embeddings — recall works without it (falls back to
+# keyword-only) but quality drops. Pulled from your existing host .env if you
+# already use mcp-memory locally.
+VOYAGE_API_KEY=pa-...
 
 # Anthropic API key — kept as escape hatch only. Slice 1 smoke MUST run on
 # Ollama (no Anthropic API calls). Leave unset unless you are explicitly

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -1,29 +1,37 @@
-# Sandcastle agent image — slice 1 (epic #534, issue #537)
+# Sandcastle agent image — slice 2 (epic #534, issue #540)
 #
-# Thin runtime: Claude Code CLI + git + gh + curl. The agent inside this
-# container talks to a local Ollama instance running on the host (Docker
-# Desktop's host.docker.internal:11434), via Ollama's native
-# Anthropic-compatible endpoint. No proxy. No model weights baked in.
+# Runtime: Claude Code CLI + git + gh + python3 + memory MCP bridge.
+# The agent inside this container talks to a local Ollama instance running
+# on the host (Docker Desktop's host.docker.internal:11434), via Ollama's
+# native Anthropic-compatible endpoint. Memory MCP runs in-container over
+# stdio and reaches Supabase using a Supabase anon key (RLS-gated, slice 3).
 #
-# Build:   docker build -t sandcastle:jarvis .sandcastle/
+# Build (from repo root — context must include mcp-memory/ and
+# .claude-userlevel/skills/):
+#   docker build -t sandcastle:jarvis -f .sandcastle/Dockerfile .
+#
 # Used by: .sandcastle/main.mts (npm run sandcastle)
 #
-# Decisions: 894ac658 (Claude Code + local Ollama, sterile container) and
-# 436f9549 (sandcastle opens PRs only, never merges) — see epic #534.
+# Decisions:
+#   894ac658 — Claude Code + local Ollama, sterile container
+#   436f9549 — sandcastle opens PRs only, never merges
+#   228a2d9b — full memory MCP in container, anon key + provenance discipline
 
 FROM node:22-bookworm
 
-# System deps. jq is used by gh and by ad-hoc shell in the agent prompt.
+# System deps. python3 + venv for the memory MCP server. jq for gh shell snippets.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git \
       curl \
       ca-certificates \
       jq \
       gnupg \
+      python3 \
+      python3-venv \
+      python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI — needed for `gh issue edit`, `gh pr create`. Official apt repo.
-# Pinned to the keyring location upstream documents; refresh on image rebuild.
 RUN install -dm 0755 /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
@@ -33,6 +41,24 @@ RUN install -dm 0755 /etc/apt/keyrings \
     && apt-get update \
     && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
+
+# Memory MCP — vendor the entire mcp-memory/ directory because server.py imports
+# from sibling modules (client, embeddings, recall, handlers/*). Install Python
+# deps into an isolated venv at /opt/mcp-memory/.venv to avoid PEP 668 conflicts
+# with system python on Debian bookworm.
+COPY mcp-memory/ /opt/mcp-memory/
+RUN python3 -m venv /opt/mcp-memory/.venv \
+    && /opt/mcp-memory/.venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/mcp-memory/.venv/bin/pip install --no-cache-dir -r /opt/mcp-memory/requirements.txt \
+    && rm -rf /root/.cache
+
+# Container-scoped MCP config — onSandboxReady (main.mts) copies this over the
+# worktree's .mcp.json at run start. Sandcastle uses copy-on-write worktrees
+# (see node_modules/@ai-hero/sandcastle/dist/CopyToWorktree.js) so the host
+# repo's .mcp.json is never mutated. Override is necessary because the host
+# .mcp.json registers many host-only servers (telegram, blender, etc.) that
+# would fail noisily inside the sterile container.
+COPY .sandcastle/container-mcp.json /opt/sandcastle/container-mcp.json
 
 # Match sandcastle's reference image: rename node user → agent, keep UID 1000
 # so bind-mounts owned by the host user resolve cleanly.
@@ -44,6 +70,11 @@ WORKDIR /home/agent
 # Claude Code CLI (official installer). Lands in ~/.local/bin/claude.
 RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/home/agent/.local/bin:$PATH"
+
+# Canonical skill set — vendor .claude-userlevel/skills/ so the agent has the
+# same skill surface as an inline /implement session. User-scope path picked up
+# automatically by Claude Code at runtime.
+COPY --chown=agent:agent .claude-userlevel/skills/ /home/agent/.claude/skills/
 
 # Sandcastle bind-mounts the worktree at SANDBOX_REPO_DIR and exec's into it.
 # Container just needs to stay alive; sandcastle drives commands via `docker exec`.

--- a/.sandcastle/README.md
+++ b/.sandcastle/README.md
@@ -2,8 +2,9 @@
 
 This directory is the substrate for [epic #534](https://github.com/Osasuwu/jarvis/issues/534)
 — Docker-isolated AFK coding agent. Slice 1 ([#537](https://github.com/Osasuwu/jarvis/issues/537))
-ships only the **manual smoke command** on Main PC. No watchdog, no scheduler,
-no memory bridge yet — those land in slices 2/4/8.
+shipped the **manual smoke command** on Main PC. Slice 2 ([#540](https://github.com/Osasuwu/jarvis/issues/540))
+adds the **memory MCP bridge inside the container** + canonical skill set baked
+into the image. Watchdog and scheduler land in slices 4/8.
 
 ## What it does
 
@@ -58,11 +59,14 @@ From the repo root:
 npm install
 
 # 1. Build the image (one-time, or after Dockerfile changes).
-docker build -t sandcastle:jarvis .sandcastle/
+#    Build context is the repo root because the image vendors mcp-memory/
+#    and .claude-userlevel/skills/ from outside .sandcastle/.
+docker build -t sandcastle:jarvis -f .sandcastle/Dockerfile .
 
-# 2. Copy env example and fill in GH_TOKEN.
+# 2. Copy env example and fill in GH_TOKEN, SUPABASE_URL, SUPABASE_KEY.
 cp .sandcastle/.env.example .sandcastle/.env
-# edit .sandcastle/.env — set GH_TOKEN
+# edit .sandcastle/.env — set GH_TOKEN, SUPABASE_URL, SUPABASE_KEY (anon!),
+# VOYAGE_API_KEY (optional)
 
 # 3. Run the smoke loop. Picks one tracer issue, opens a PR, exits.
 #    `npm run sandcastle` auto-loads .sandcastle/.env via Node's
@@ -85,7 +89,7 @@ Ollama-routed runs).
 | Concern | Lands in |
 |---|---|
 | PowerShell watchdog (autostart, soft-stop, outcome_record) | slice 4 ([#541](https://github.com/Osasuwu/jarvis/issues/541)) |
-| Memory MCP bridge inside container + skills baked in | slice 2 ([#540](https://github.com/Osasuwu/jarvis/issues/540)) |
+| ~~Memory MCP bridge inside container + skills baked in~~ | **slice 2 — landed ([#540](https://github.com/Osasuwu/jarvis/issues/540))** |
 | Supabase RLS for `sandcastle:agent` provenance | slice 3 ([#542](https://github.com/Osasuwu/jarvis/issues/542)) |
 | Multi-tier model escalation (Ollama → small → DeepSeek → owner) | slice 5 ([#543](https://github.com/Osasuwu/jarvis/issues/543)) |
 | Telegram alerting | slice 6 ([#544](https://github.com/Osasuwu/jarvis/issues/544)) |
@@ -95,6 +99,7 @@ Ollama-routed runs).
 
 - `894ac658-67da-4f32-a0a2-5b5ebefac8ee` — Runtime: Claude Code + local Ollama, sterile container, no `~/.claude` mount.
 - `436f9549-3acf-4ee0-85e5-c7259735d62e` — Sandcastle opens PRs only, never merges.
+- `228a2d9b-b57a-4d0f-8771-662482386b8a` — Memory MCP in container with anon key + provenance discipline; skills baked into image (slice 2).
 
 Slice-1 implementation choice (no proxy, native Ollama Anthropic endpoint)
 recorded as `decision_made` episode `375449f9-5026-4471-a705-922c5baddf7f`.

--- a/.sandcastle/container-mcp.json
+++ b/.sandcastle/container-mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "memory": {
+      "type": "stdio",
+      "command": "/opt/mcp-memory/.venv/bin/python",
+      "args": ["/opt/mcp-memory/server.py"],
+      "env": {
+        "SUPABASE_URL": "${SUPABASE_URL}",
+        "SUPABASE_KEY": "${SUPABASE_KEY}",
+        "VOYAGE_API_KEY": "${VOYAGE_API_KEY}"
+      }
+    }
+  }
+}

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -33,6 +33,13 @@ if (!supabaseUrl || !supabaseKey) {
   );
 }
 
+// Stable per-run identifier consumed by the agent's source_provenance tags
+// (prompt.md §"Memory provenance"). Format: <run-name>-<UTC-yyyymmdd-hhmmss>.
+// Stays opaque (no secrets) so it's safe to embed in memory rows and PR bodies.
+const runId =
+  process.env.SANDCASTLE_RUN_ID ??
+  `jarvis-worker-${new Date().toISOString().replace(/[-:T.Z]/g, "").slice(0, 14)}`;
+
 await run({
   name: "jarvis-worker",
   sandbox: docker({
@@ -43,10 +50,14 @@ await run({
       ANTHROPIC_AUTH_TOKEN: "ollama",
       // Forward host-side gh credentials so the agent can claim issues + open PRs.
       GH_TOKEN: ghToken,
-      // Memory MCP bridge — Claude Code expands ${...} in ~/.claude.json from these.
+      // Memory MCP bridge — Claude Code expands ${...} in the project-scope
+      // .mcp.json (copied from /opt/sandcastle/container-mcp.json by the
+      // onSandboxReady hook below) from these container env vars.
       SUPABASE_URL: supabaseUrl,
       SUPABASE_KEY: supabaseKey,
       VOYAGE_API_KEY: voyageKey,
+      // Per-run id for the agent's source_provenance tags. See prompt.md.
+      SANDCASTLE_RUN_ID: runId,
     },
   }),
   agent: claudeCode(ollamaModel),
@@ -62,6 +73,9 @@ await run({
         // (memory MCP only). The host .mcp.json registers many host-only
         // servers that would fail inside the sterile container. Sandcastle
         // uses copy-on-write worktrees so this never touches the host repo.
+        // Adding the path to .git/info/exclude first ensures `git add -A`
+        // inside the agent loop cannot accidentally stage the override.
+        { command: "echo /.mcp.json >> .git/info/exclude" },
         { command: "cp /opt/sandcastle/container-mcp.json .mcp.json" },
       ],
     },

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,12 +1,12 @@
 import { run, claudeCode } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
-// Jarvis sandcastle entry — slice 1 of epic #534. Manual smoke loop on Main PC.
+// Jarvis sandcastle entry — slices 1 + 2 of epic #534. Manual smoke loop on Main PC.
 // Run: npm run sandcastle  (or: npx tsx .sandcastle/main.mts)
 //
 // Prereqs + decisions: see .sandcastle/README.md and decisions 894ac658,
-// 436f9549, 0c3017c6 referenced from epic #534. Watchdog + schedule + memory
-// MCP bridge land in slices 2/4 — this file stays config-only (<50 lines).
+// 436f9549, 228a2d9b, 0c3017c6 referenced from epic #534. Watchdog + schedule
+// land in slice 4 — this file stays config-only.
 
 const ollamaModel = process.env.OLLAMA_MODEL ?? "qwen2.5-coder:14b";
 const ollamaUrl = process.env.OLLAMA_BASE_URL ?? "http://host.docker.internal:11434";
@@ -15,6 +15,21 @@ if (!ghToken) {
   throw new Error(
     "GH_TOKEN is required (sandcastle agent claims issues + opens PRs via gh). " +
       "Set it in .sandcastle/.env — see .sandcastle/.env.example.",
+  );
+}
+
+// Memory MCP bridge env (slice 2, issue #540). Forwarded into the container so
+// the in-container memory MCP server (/opt/mcp-memory/server.py) can reach
+// Supabase. SUPABASE_KEY MUST be the anon key — service-role is banned per
+// decision 228a2d9b. VOYAGE_API_KEY is optional (recall degrades to keyword).
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+const voyageKey = process.env.VOYAGE_API_KEY ?? "";
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error(
+    "SUPABASE_URL and SUPABASE_KEY are required for the memory MCP bridge. " +
+      "Set them in .sandcastle/.env — anon key only, never service-role. " +
+      "See .sandcastle/.env.example for details.",
   );
 }
 
@@ -28,6 +43,10 @@ await run({
       ANTHROPIC_AUTH_TOKEN: "ollama",
       // Forward host-side gh credentials so the agent can claim issues + open PRs.
       GH_TOKEN: ghToken,
+      // Memory MCP bridge — Claude Code expands ${...} in ~/.claude.json from these.
+      SUPABASE_URL: supabaseUrl,
+      SUPABASE_KEY: supabaseKey,
+      VOYAGE_API_KEY: voyageKey,
     },
   }),
   agent: claudeCode(ollamaModel),
@@ -39,6 +58,11 @@ await run({
       onSandboxReady: [
         { command: "git config user.email agent@jarvis.local" },
         { command: "git config user.name 'Jarvis Agent'" },
+        // Override the worktree's .mcp.json with the container-scoped version
+        // (memory MCP only). The host .mcp.json registers many host-only
+        // servers that would fail inside the sterile container. Sandcastle
+        // uses copy-on-write worktrees so this never touches the host repo.
+        { command: "cp /opt/sandcastle/container-mcp.json .mcp.json" },
       ],
     },
   },

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -16,21 +16,53 @@ never merging**.
 
 ## Workflow per iteration
 
-1. **Pick** the highest-priority open issue labelled `sandcastle` not already
+1. **Recall first** (mandatory). Before reading the issue, before any other
+   tool call, invoke the memory MCP:
+   ```
+   memory_recall(query="<issue title + area keywords>", project="jarvis", brief=true, limit=10)
+   ```
+   This surfaces always-load gates, prior decisions, and outcomes from past
+   work in the same area. If recall returns hits, read the relevant ones with
+   `memory_get` before deciding the approach. **Skipping this step is a
+   protocol violation** — the live `/implement` session always recalls; the
+   sandcastle agent must match. Empty result is fine; refusing to call is not.
+2. **Pick** the highest-priority open issue labelled `sandcastle` not already
    labelled `status:in-progress`.
-2. **Claim** — `gh issue edit <N> --add-label status:in-progress` and comment
+3. **Claim** — `gh issue edit <N> --add-label status:in-progress` and comment
    `Claimed by sandcastle agent. Branch: feat/<N>-<slug>`.
-3. **Branch** — `git checkout -b feat/<N>-<slug>` (exact name — race mitigation).
-4. **Explore** — read the issue body fully. Check acceptance criteria. Read
-   referenced files.
-5. **Implement** — follow the project /implement skill rules:
+4. **Branch** — `git checkout -b feat/<N>-<slug>` (exact name — race mitigation).
+5. **Explore** — read the issue body fully. Check acceptance criteria. Read
+   referenced files. Run a second `memory_recall` keyed off any new entities
+   the issue body introduces.
+6. **Implement** — follow the project /implement skill rules:
    - TDD when tests are non-trivial: red → green → refactor
    - Preserve existing values, defaults, seeds, magic numbers unless the issue
      explicitly says to change them
    - Lint + tests must pass before commit
-6. **Commit + PR** — single rich commit. Open PR with `Closes #<N>` in body.
-7. **Stop on this issue** — do NOT merge. The orchestrator (live Claude Code
+7. **Commit + PR** — single rich commit. Open PR with `Closes #<N>` in body.
+8. **Record outcome** — emit one `outcome_record` describing the iteration
+   (success / partial / failure) with the provenance tags from §"Memory
+   provenance" below. Always record, even on failure — failed outcomes are
+   the most valuable signal for the orchestrator review.
+9. **Stop on this issue** — do NOT merge. The orchestrator (live Claude Code
    session) reviews and merges separately.
+
+## Memory provenance (mandatory on every memory write)
+
+Every `record_decision`, `memory_store`, `outcome_record`, or any other memory
+MCP write you make in this iteration MUST carry both:
+
+- `source_provenance="sandcastle:agent:<run_id>"` — `<run_id>` is the
+  sandcastle run identifier, available from the `SANDCASTLE_RUN_ID` env var
+  inside the container. If unset, fall back to the current branch name
+  (e.g. `sandcastle:agent:feat/540-foo`).
+- `actor="sandcastle:agent"` — distinguishes agent-attributed writes from
+  orchestrator/session writes during review.
+
+The orchestrator filters and audits sandcastle-attributed rows on these tags;
+omitting them silently merges agent decisions into the un-audited memory
+stream. This is non-negotiable. If the memory tool rejects the write because
+of a missing field, fix the call and retry — do not skip the write.
 
 ## Hard rules (subagent boundaries)
 
@@ -44,7 +76,13 @@ never merging**.
   - anything under `.github/workflows/`
   - any `.env*` file other than `.env.example`
 - **NEVER output secret values** — not in PR bodies, comments, commit messages,
-  logs, or memory. Describe an error without quoting the value.
+  logs, or memory. Describe an error without quoting the value. Supabase keys
+  and `GH_TOKEN` are the most likely accidental leaks; if either appears in
+  any output, redact before continuing.
+- **NEVER use a Supabase service-role key** — the container is configured with
+  the anon key only (decision 228a2d9b). If memory writes start failing with
+  RLS errors after slice 3 lands (#542), that is the policy doing its job, not
+  a bug to bypass.
 - **If blocked** (missing context, ambiguous AC, failing tests you cannot
   resolve), comment on the issue with what's missing, drop `status:in-progress`,
   and continue. Do not force a half-fix.

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -16,8 +16,16 @@ never merging**.
 
 ## Workflow per iteration
 
-1. **Recall first** (mandatory). Before reading the issue, before any other
-   tool call, invoke the memory MCP:
+The `!` shell blocks at the top of this prompt (issue list + git log) run before
+the agent's first turn — they are context, not the agent's tool calls. The
+"recall first" rule below applies to **the first MCP tool call the agent
+issues**, not to the prompt-level context blocks.
+
+1. **Pick** the highest-priority open issue labelled `sandcastle` not already
+   labelled `status:in-progress`. (You can pull the title from the issue list in
+   the Context section above without an MCP call.)
+2. **Recall first** (mandatory — first MCP tool call). Before any other MCP
+   tool call, invoke the memory bridge:
    ```
    memory_recall(query="<issue title + area keywords>", project="jarvis", brief=true, limit=10)
    ```
@@ -26,8 +34,6 @@ never merging**.
    `memory_get` before deciding the approach. **Skipping this step is a
    protocol violation** — the live `/implement` session always recalls; the
    sandcastle agent must match. Empty result is fine; refusing to call is not.
-2. **Pick** the highest-priority open issue labelled `sandcastle` not already
-   labelled `status:in-progress`.
 3. **Claim** — `gh issue edit <N> --add-label status:in-progress` and comment
    `Claimed by sandcastle agent. Branch: feat/<N>-<slug>`.
 4. **Branch** — `git checkout -b feat/<N>-<slug>` (exact name — race mitigation).
@@ -52,9 +58,10 @@ never merging**.
 Every `record_decision`, `memory_store`, `outcome_record`, or any other memory
 MCP write you make in this iteration MUST carry both:
 
-- `source_provenance="sandcastle:agent:<run_id>"` — `<run_id>` is the
-  sandcastle run identifier, available from the `SANDCASTLE_RUN_ID` env var
-  inside the container. If unset, fall back to the current branch name
+- `source_provenance="sandcastle:agent:<run_id>"` — `<run_id>` is the value
+  of the `SANDCASTLE_RUN_ID` env var injected into the container by
+  `.sandcastle/main.mts` (defaults to the sandcastle run name + UTC timestamp).
+  If for any reason the var is empty, fall back to the current branch name
   (e.g. `sandcastle:agent:feat/540-foo`).
 - `actor="sandcastle:agent"` — distinguishes agent-attributed writes from
   orchestrator/session writes during review.
@@ -75,6 +82,13 @@ of a missing field, fix the call and retry — do not skip the write.
   - `mcp-memory/server.py`
   - anything under `.github/workflows/`
   - any `.env*` file other than `.env.example`
+
+  Note: at sandbox-ready time the runtime overwrites the worktree's `.mcp.json`
+  with the container-scoped MCP config (`/opt/sandcastle/container-mcp.json`).
+  That is **infrastructure setup**, not an agent edit, and the entry is
+  excluded from staging via `.git/info/exclude` so it cannot be accidentally
+  committed by `git add -A`. The protected-file rule above governs **agent
+  edits** to the file — those are still forbidden.
 - **NEVER output secret values** — not in PR bodies, comments, commit messages,
   logs, or memory. Describe an error without quoting the value. Supabase keys
   and `GH_TOKEN` are the most likely accidental leaks; if either appears in


### PR DESCRIPTION
## Summary

Slice 2 of the sandcastle epic ([#534](https://github.com/Osasuwu/jarvis/issues/534)). Vendors the full `mcp-memory/` package and the canonical `.claude-userlevel/skills/` set into the sandcastle Docker image, and wires a project-scope `.mcp.json` override so the in-container agent reaches Supabase memory the same way an inline `/implement` session does. Adds prompt-level discipline mandating `memory_recall` as the first action of every iteration and `source_provenance='sandcastle:agent:<run_id>'` + `actor='sandcastle:agent'` on every memory write.

## Why

Per epic [#534](https://github.com/Osasuwu/jarvis/issues/534) and decision `228a2d9b-b57a-4d0f-8771-662482386b8a`: the sandcastle agent must surface the same prior-decision/outcome context as a live session, otherwise it walks straight into class-of-mistake regressions (#648 IK-seed, #649v2 J6-pin, etc.) that memory recall would have flagged. RLS enforcement of the provenance tags lands in slice 3 ([#542](https://github.com/Osasuwu/jarvis/issues/542)); this slice ships the wiring and prompt discipline.

Closes #540

## Decisions & Alternatives

- **Project-scope `.mcp.json` override via `onSandboxReady`** chosen over user-scope `~/.claude.json` baked into image. Project-scope deterministically wins MCP server name conflicts when the bind-mounted worktree carries the host `.mcp.json`. Sandcastle uses copy-on-write worktrees ([CopyToWorktree.js](https://github.com/Osasuwu/jarvis/blob/main/node_modules/%40ai-hero/sandcastle/dist/CopyToWorktree.js)), so overwriting the worktree's `.mcp.json` never mutates the host repo.
- **Build context moves from `.sandcastle/` to repo root** because the image now vendors `mcp-memory/` and `.claude-userlevel/skills/` from outside `.sandcastle/`. README updated to reflect `docker build -t sandcastle:jarvis -f .sandcastle/Dockerfile .`.
- **Vendored entire `mcp-memory/` directory** (not just `server.py`) — `server.py` imports from sibling modules (`client`, `embeddings`, `recall`, `handlers/*`); a single-file copy would break at import time.
- **Python deps in an isolated venv** at `/opt/mcp-memory/.venv` to avoid PEP 668 conflicts with system Python on Debian bookworm.
- **`SUPABASE_KEY` documented as anon-only**, never service-role (decision 228a2d9b). The `.env.example` flags this in three places: header, inline comment on the var, and a banned-pattern note.
- **Prompt mandates over hooks** — RLS enforcement is slice 3's job (#542). Until then, prompt-level discipline is the only enforcement layer; the prompt language was sharpened to make the rule unambiguous and skip-resistant.

Decision episode: `50018458-e618-4e0c-a11c-f82e866b2f57`

## Risk Assessment

- **MEDIUM** — touches sandcastle infrastructure (Dockerfile, container config) and changes how the in-container agent reaches Supabase. Reversible: revert resets to slice 1 state. No production AFK loop running yet (slice 8 work, #545).
- **LOW** for `.env.example` and `README.md` updates — documentation only.
- No protected files modified. `.mcp.json` (host project-scope) is untouched; the override is a runtime `cp` in the isolated worktree.

## Testing

Static checks performed:
- `node -e "JSON.parse(...)"` on `container-mcp.json` — valid JSON.
- `npx tsx -e "import('main.mts')"` — module parses, runtime guards (`GH_TOKEN`, `SUPABASE_URL`/`SUPABASE_KEY`) fire as expected.
- Diff review against issue scope — all changed files are in `.sandcastle/`.

**Smoke run pending — user-driven on Main PC** (the AC's "agent inside container calls memory_recall" requires Docker Desktop + Ollama ≥ 0.14 + a populated `.sandcastle/.env` + a tracer issue labelled `sandcastle`):

```powershell
docker build -t sandcastle:jarvis -f .sandcastle/Dockerfile .
# fill .sandcastle/.env with GH_TOKEN, SUPABASE_URL, SUPABASE_KEY (anon!), VOYAGE_API_KEY
$env:OLLAMA_CONTEXT_LENGTH = "65536"; ollama serve  # in another terminal
npm run sandcastle
```

Expected observables in the run log:
1. Agent calls `memory_recall` as its first tool action (mandated by prompt §1).
2. At least one `outcome_record` row appears in Supabase with `source_provenance` starting `sandcastle:agent:` and `actor='sandcastle:agent'`.

If smoke fails, the most likely culprits are: (a) Ollama context < 64K (system prompt truncated, agent bails to `<promise>COMPLETE</promise>` without tool use), (b) Supabase key swap (service-role accidentally pasted instead of anon), (c) `host.docker.internal` unresolvable on native Linux Docker (add `--add-host` flag).

## Files Changed

- `.sandcastle/Dockerfile` — vendor `mcp-memory/` to `/opt/mcp-memory/` + venv install of `requirements.txt`; vendor `.claude-userlevel/skills/` to `/home/agent/.claude/skills/`; copy `container-mcp.json` to `/opt/sandcastle/`. Build context moves to repo root.
- `.sandcastle/container-mcp.json` (new) — minimal MCP config registering only the in-container memory server, with `${SUPABASE_URL}` / `${SUPABASE_KEY}` / `${VOYAGE_API_KEY}` env-substitution.
- `.sandcastle/main.mts` — forwards `SUPABASE_URL` / `SUPABASE_KEY` / `VOYAGE_API_KEY` from `.sandcastle/.env` into container env; adds `cp /opt/sandcastle/container-mcp.json .mcp.json` to `onSandboxReady`; throws on missing Supabase vars at startup.
- `.sandcastle/prompt.md` — adds step 0 (mandatory `memory_recall`); adds §"Memory provenance" mandating `source_provenance` + `actor` on every write; adds step 8 (mandatory `outcome_record`); reinforces anon-only Supabase key.
- `.sandcastle/.env.example` — adds `SUPABASE_URL`, `SUPABASE_KEY` (anon, with explicit warning), `VOYAGE_API_KEY` (optional). Service-role key explicitly banned.
- `.sandcastle/README.md` — updates build command (context = repo root, `-f .sandcastle/Dockerfile`), env file vars, slice-2 status, decision UUID list.