### PR TITLE
chore(sandcastle): post-merge polish — gitignore drafts + test comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ yarn-error.log*
 .env.*.local
 .sandcastle/.env
 .sandcastle/runtime/
+.sandcastle/worktrees/
+docs/research/
 
 # Logs
 *.log

--- a/tests/ci/test_sandcastle_rls.py
+++ b/tests/ci/test_sandcastle_rls.py
@@ -167,7 +167,7 @@ class TestPolicyLogic:
             "skill:implement",
             "user:explicit",
             "Sandcastle:agent",  # case-sensitive — LIKE in PG is case-sensitive
-            "sandcastles:agent",  # close but no colon
+            "sandcastles:agent",  # extra 's' — prefix is 'sandcastles:', not 'sandcastle:'
             "",
             "sandcastle",  # no colon
         ]:


### PR DESCRIPTION
## Summary

Two minor follow-ups from the slice-3 review (#542 / closed PR #563, which landed on main via #562's stacked squash):

- `.gitignore`: ignore `.sandcastle/worktrees/` (ephemeral container worktree state) and `docs/research/` (per memory: unfinished drafts, never auto-commit). A `git add -A` accidentally swept these into a commit during #563 work; this prevents recurrence.
- `tests/ci/test_sandcastle_rls.py`: rejection-reason comment for `'sandcastles:agent'` claimed "no colon" — actual reason is the extra 's' (prefix is `'sandcastles:'`, not `'sandcastle:'`). Caught by Claude code-review on #563.

Schema/migration LIKE case-sensitivity comments + rollback notes from the same review will fold into #564 (host MCP service-role switch), which adds a new migration anyway and avoids a ceremonial no-op migration just to satisfy the schema-drift guard.

Closes #567

## Risk

LOW — `.gitignore` additions don't change tracked files; test comment is non-functional.

## Test plan

- [x] Existing tests still pass (`pytest tests/ci/test_sandcastle_rls.py` → 32 passed)
- [x] No schema.sql change — drift guard not triggered