### PR TITLE
fix(mcp-memory): prefer SUPABASE_SERVICE_KEY on host before #542 RLS lands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,15 @@ ANTHROPIC_API_KEY=
 
 # ── Required: Supabase memory (cross-device persistent memory) ────────────────
 # Get from: Supabase project → Settings → API
+#
+# Key precedence on the host: SUPABASE_SERVICE_KEY → SUPABASE_KEY (anon).
+# After the #542 RLS migration is applied, anon-key INSERTs are gated to
+# source_provenance LIKE 'sandcastle:%' — host writes (skill:/hook:/session:/...)
+# require service-role to bypass RLS. Set SUPABASE_SERVICE_KEY on every host
+# device. Sandcastle containers receive only the anon SUPABASE_KEY by design
+# (decision 228a2d9b) — never put service-role inside .sandcastle/.env.
 SUPABASE_URL=https://your-project-id.supabase.co
+SUPABASE_SERVICE_KEY=your-service-role-key-here
 SUPABASE_KEY=your-anon-key-here
 
 # ── Optional: Voyage AI (semantic memory search) ─────────────────────────────

--- a/mcp-memory/client.py
+++ b/mcp-memory/client.py
@@ -26,7 +26,9 @@ def _get_client():
     key = os.environ.get("SUPABASE_SERVICE_KEY")
     if not key:
         key = os.environ.get("SUPABASE_KEY")
-        if key:
+        # Suppress in sandcastle containers — they intentionally ship anon-only
+        # (decision 228a2d9b) and the warning would mis-instruct the operator.
+        if key and not os.environ.get("SANDCASTLE_RUN_ID"):
             print(
                 "WARNING: mcp-memory using SUPABASE_KEY (anon). After the #542 RLS "
                 "migration is applied, host writes with non-sandcastle provenance "

--- a/mcp-memory/client.py
+++ b/mcp-memory/client.py
@@ -7,6 +7,7 @@ fire-and-forget — never raises into the caller.
 from __future__ import annotations
 
 import os
+import sys
 
 _supabase = None
 
@@ -17,10 +18,25 @@ def _get_client():
         return _supabase
 
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_KEY")
+    # Prefer service-role key on the host: after #542 RLS lands in live DB,
+    # anon-key INSERTs are gated to source_provenance LIKE 'sandcastle:%'.
+    # Host writes (skill:/hook:/session:/...) bypass RLS via service-role.
+    # Sandcastle containers continue to ship only SUPABASE_KEY (anon) per
+    # decision 228a2d9b — never set SUPABASE_SERVICE_KEY in .sandcastle/.env.
+    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    if not key:
+        key = os.environ.get("SUPABASE_KEY")
+        if key:
+            print(
+                "WARNING: mcp-memory using SUPABASE_KEY (anon). After the #542 RLS "
+                "migration is applied, host writes with non-sandcastle provenance "
+                "(skill:/hook:/session:/...) will be rejected. Set SUPABASE_SERVICE_KEY "
+                "in .env — see .env.example.",
+                file=sys.stderr,
+            )
     if not url or not key:
         raise RuntimeError(
-            "SUPABASE_URL and SUPABASE_KEY must be set. "
+            "SUPABASE_URL and one of SUPABASE_SERVICE_KEY / SUPABASE_KEY must be set. "
             "Get them from your Supabase project settings."
         )
 

--- a/scripts/consolidation-report.py
+++ b/scripts/consolidation-report.py
@@ -278,9 +278,11 @@ def main() -> int:
     args = p.parse_args()
 
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_KEY")
+    # Prefer service-role: writes memories with skill:consolidation provenance,
+    # which the #542 RLS gate rejects for anon. See mcp-memory/client.py.
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_KEY")
     if not url or not key:
-        print("SUPABASE_URL / SUPABASE_KEY missing from env", file=sys.stderr)
+        print("SUPABASE_URL / SUPABASE_KEY (or SUPABASE_SERVICE_KEY) missing from env", file=sys.stderr)
         return 2
 
     client = create_client(url, key)

--- a/scripts/evolve-neighbors.py
+++ b/scripts/evolve-neighbors.py
@@ -869,9 +869,11 @@ def main() -> int:
     args = p.parse_args()
 
     sb_url = os.environ.get("SUPABASE_URL")
-    sb_key = os.environ.get("SUPABASE_KEY")
+    # Prefer service-role: writes memories with skill:evolution:* provenance,
+    # which the #542 RLS gate rejects for anon. See mcp-memory/client.py.
+    sb_key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_KEY")
     if not sb_url or not sb_key:
-        print("SUPABASE_URL / SUPABASE_KEY missing from env", file=sys.stderr)
+        print("SUPABASE_URL / SUPABASE_KEY (or SUPABASE_SERVICE_KEY) missing from env", file=sys.stderr)
         return 2
     # ANTHROPIC_API_KEY is NOT a hard requirement: call_haiku() falls back to
     # a KEEP-only plan when the key is absent, matching the documented fallback


### PR DESCRIPTION
## Summary

Host MCP and two standalone scripts now resolve `SUPABASE_SERVICE_KEY` first and fall back to `SUPABASE_KEY` (anon) with a stderr warning. `.env.example` documents the precedence + the hard rule that sandcastle containers never carry the service-role key.

## Why

Closes #564.

PR #542 / migration `20260508120000_sandcastle_anon_rls_provenance_gate.sql` (already merged but not yet applied to live Supabase) gates anon-key INSERTs on the four sandcastle-writable tables to `source_provenance LIKE 'sandcastle:%'` (or `actor LIKE 'sandcastle:%'` for `episodes` / `events_canonical`). On the host the MCP writes provenance like `skill:implement`, `hook:user-prompt-submit`, `session:<id>`, `skill:consolidation`, `skill:evolution:*` — all of those would be rejected the moment the migration applies. Service-role bypasses RLS, so host writes work and the sandcastle gate stays intact.

## Decisions & Alternatives

- **Chose option 1** from the issue (key precedence in `client.py`). Option 2 (multi-prefix anon allow policies) defeats the threat model — any compromised anon path can spoof `skill:` prefixes. Option 3 (mandatory provenance plumbing at every callsite) is brittle and high-effort.
- **Symmetric fix to `consolidation-report.py` + `evolve-neighbors.py`** — these are standalone host scripts called out in the issue break-list; they don't share `client.py` so the precedence had to be replicated. Per `feedback_symmetric_fixes`. Pattern matches `backfill-outcome-memories.py` which has used this precedence since #288.
- **Warning when only anon key is set** — the host can still boot on devices that haven't rotated yet, but the operator sees a stderr line on first MCP call so the gap is visible before live RLS application. No silent degradation.
- Decision 228a2d9b stays intact: `.env.example` reiterates that `.sandcastle/.env` never holds service-role.

## Risk Assessment

- **MEDIUM**: changes the credential precedence on the host MCP startup path. Existing devices that only have `SUPABASE_KEY` set continue to work (anon fallback) — they'll see the warning until they add `SUPABASE_SERVICE_KEY`. No breaking change for sandcastle (`.sandcastle/.env.example` unchanged, still ships only anon).

## Testing

- `ruff check` clean on `mcp-memory/client.py`.
- Inline precedence smoke (Python): SERVICE only → uses service; both set → prefers service; SERVICE absent → falls back to anon. All three cases pass.
- **Live Supabase smoke (AC #3) + `apply_migration` (AC #4) deferred to principal** — these are the manual gates that close out the slice once the host devices have `SUPABASE_SERVICE_KEY` set in `.env`. Workflow: rotate `.env` on each device → restart MCP → confirm warning is gone → `record_decision` / `emit_event` / `outcome_record` smoke against live Supabase → `apply_migration` for `20260508120000_sandcastle_anon_rls_provenance_gate.sql`.

## Files Changed

- \`mcp-memory/client.py\` — service-role precedence + stderr warning + updated error message.
- \`.env.example\` — document precedence; reiterate sandcastle never holds service-role.
- \`scripts/consolidation-report.py\` — symmetric precedence (writes \`skill:consolidation\` memories).
- \`scripts/evolve-neighbors.py\` — symmetric precedence (writes \`skill:evolution:*\` memories).