### PR TITLE
feat(rls): gate anon UPDATE+DELETE with sandcastle provenance predicate (#565)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,7 @@ These are the "obvious" assumptions that previously bit because they weren't wri
 
 - **Memory is cross-device source of truth.** Anything important goes through Supabase. File-based memory (`~/.claude/projects/.../memory/`) is device-local and does NOT sync.
 - **Every `memory_store` carries `source_provenance`.** No exceptions. Server rejects unattributed writes (JTMS attribution requirement).
+- **Sandcastle provenance gate is table-level + op-level, not agent-level.** RLS on `memories` / `task_outcomes` / `episodes` / `events_canonical` requires `source_provenance` (or `actor`, on episodes/events) `LIKE 'sandcastle:%'` for **every** anon INSERT/UPDATE/DELETE — not just INSERT. Slice 3 (#542) gated INSERT; slice 3.5 (#565) extended to UPDATE+DELETE so anon can neither wipe rows nor forge/erase the provenance column. Service-role bypasses RLS — host MCP must use `SUPABASE_SERVICE_KEY` (#564, #569) to write any non-sandcastle provenance.
 - **State is never in static files or memory.** Status %, dates, PR markers, "current sprint" — all of these live in GitHub. Static storage is for stable knowledge, not state.
 - **`record_decision` always passes `memories_used=[<UUIDs>]`.** Names, not UUIDs, break attribution.
 

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -72,15 +72,20 @@ alter table memories enable row level security;
 create policy "Allow all for authenticated" on memories
   for all using (true) with check (true);
 
--- Anon access (sandcastle agent path) — INSERT is gated by source_provenance
--- prefix per slice 3 of sandcastle epic (#534, #542, decision 228a2d9b).
+-- Anon access (sandcastle agent path) — INSERT/UPDATE/DELETE all gated by
+-- source_provenance prefix. Slice 3 (#542) gated INSERT; slice 3.5 (#565)
+-- extended the gate to UPDATE+DELETE so anon cannot wipe rows or forge the
+-- provenance column. Decisions 228a2d9b (slice 3), f3b85eeb (slice 3.5).
 -- Service-role bypasses RLS automatically; host orchestrator unaffected.
 create policy "Anon select" on memories
   for select to anon using (true);
-create policy "Anon update" on memories
-  for update to anon using (true) with check (true);
-create policy "Anon delete" on memories
-  for delete to anon using (true);
+create policy "Anon sandcastle update" on memories
+  for update to anon
+  using (source_provenance like 'sandcastle:%')
+  with check (source_provenance like 'sandcastle:%');
+create policy "Anon sandcastle delete" on memories
+  for delete to anon
+  using (source_provenance like 'sandcastle:%');
 create policy "Anon sandcastle insert" on memories
   for insert to anon
   with check (source_provenance like 'sandcastle:%');
@@ -391,13 +396,17 @@ alter table task_outcomes enable row level security;
 create policy "Allow all for authenticated" on task_outcomes
   for all using (true) with check (true);
 
--- Anon access — INSERT gated by source_provenance prefix (slice 3, #542).
+-- Anon access — INSERT/UPDATE/DELETE gated by source_provenance prefix
+-- (slices 3 + 3.5, #542 + #565).
 create policy "Anon select" on task_outcomes
   for select to anon using (true);
-create policy "Anon update" on task_outcomes
-  for update to anon using (true) with check (true);
-create policy "Anon delete" on task_outcomes
-  for delete to anon using (true);
+create policy "Anon sandcastle update" on task_outcomes
+  for update to anon
+  using (source_provenance like 'sandcastle:%')
+  with check (source_provenance like 'sandcastle:%');
+create policy "Anon sandcastle delete" on task_outcomes
+  for delete to anon
+  using (source_provenance like 'sandcastle:%');
 create policy "Anon sandcastle insert" on task_outcomes
   for insert to anon
   with check (source_provenance like 'sandcastle:%');
@@ -913,14 +922,18 @@ alter table episodes enable row level security;
 create policy "Allow all for authenticated" on episodes
   for all using (true) with check (true);
 
--- Anon access — INSERT gated on `actor` (the column already used as the
--- provenance field per the convention comment above). Slice 3, #542.
+-- Anon access — INSERT/UPDATE/DELETE gated on `actor` (the column already
+-- used as the provenance field per the convention comment above).
+-- Slices 3 + 3.5, #542 + #565.
 create policy "Anon select" on episodes
   for select to anon using (true);
-create policy "Anon update" on episodes
-  for update to anon using (true) with check (true);
-create policy "Anon delete" on episodes
-  for delete to anon using (true);
+create policy "Anon sandcastle update" on episodes
+  for update to anon
+  using (actor like 'sandcastle:%')
+  with check (actor like 'sandcastle:%');
+create policy "Anon sandcastle delete" on episodes
+  for delete to anon
+  using (actor like 'sandcastle:%');
 create policy "Anon sandcastle insert" on episodes
   for insert to anon
   with check (actor like 'sandcastle:%');
@@ -2574,13 +2587,17 @@ ALTER TABLE events_canonical ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY "Allow all for authenticated" ON events_canonical
   FOR ALL USING (true) WITH CHECK (true);
--- Anon access — INSERT gated on `actor` (provenance field). Slice 3, #542.
+-- Anon access — INSERT/UPDATE/DELETE gated on `actor` (provenance field).
+-- Slices 3 + 3.5, #542 + #565.
 CREATE POLICY "Anon select" ON events_canonical
   FOR SELECT TO anon USING (true);
-CREATE POLICY "Anon update" ON events_canonical
-  FOR UPDATE TO anon USING (true) WITH CHECK (true);
-CREATE POLICY "Anon delete" ON events_canonical
-  FOR DELETE TO anon USING (true);
+CREATE POLICY "Anon sandcastle update" ON events_canonical
+  FOR UPDATE TO anon
+  USING (actor LIKE 'sandcastle:%')
+  WITH CHECK (actor LIKE 'sandcastle:%');
+CREATE POLICY "Anon sandcastle delete" ON events_canonical
+  FOR DELETE TO anon
+  USING (actor LIKE 'sandcastle:%');
 CREATE POLICY "Anon sandcastle insert" ON events_canonical
   FOR INSERT TO anon
   WITH CHECK (actor LIKE 'sandcastle:%');

--- a/supabase/migrations/20260508130000_sandcastle_anon_rls_update_delete_gate.sql
+++ b/supabase/migrations/20260508130000_sandcastle_anon_rls_update_delete_gate.sql
@@ -1,0 +1,81 @@
+-- Slice 3.5 of sandcastle epic (#534, issue #565)
+-- Decision: f3b85eeb-b883-4891-b349-f64c8c9dc28c (extends 228a2d9b-b57a-4d0f-8771-662482386b8a)
+--
+-- Slice 3 (migration 20260508120000) gated anon INSERT with
+--   provenance LIKE 'sandcastle:%' on memories / task_outcomes / episodes /
+--   events_canonical, but UPDATE + DELETE remained wide-open for anon.
+-- That left two holes:
+--   (a) anon DELETE could wipe arbitrary rows (host data evaporates)
+--   (b) anon UPDATE could rewrite source_provenance / actor — forging or
+--       erasing audit, which defeats the slice 3 INSERT gate
+-- This slice replaces the unconditional anon UPDATE/DELETE policies with
+-- ones gated by the same provenance predicate as INSERT. Service-role
+-- bypasses RLS and is unaffected.
+--
+-- Sequencing: requires #564 (host MCP on SUPABASE_SERVICE_KEY) — already
+-- live as of 20260508120000 + host rotation. Otherwise host's own UPDATE
+-- on legacy non-sandcastle rows would also break.
+--
+-- Anon SELECT preserved as-is (slice 3 left it open; this slice does not
+-- touch read access).
+-- Paired with mcp-memory/schema.sql per #326 schema-drift CI gate.
+
+-- =========================================================================
+-- 1. memories: replace open UPDATE/DELETE with sandcastle-gated.
+-- =========================================================================
+DROP POLICY IF EXISTS "Anon update" ON memories;
+DROP POLICY IF EXISTS "Anon delete" ON memories;
+
+CREATE POLICY "Anon sandcastle update" ON memories
+  FOR UPDATE TO anon
+  USING (source_provenance LIKE 'sandcastle:%')
+  WITH CHECK (source_provenance LIKE 'sandcastle:%');
+
+CREATE POLICY "Anon sandcastle delete" ON memories
+  FOR DELETE TO anon
+  USING (source_provenance LIKE 'sandcastle:%');
+
+-- =========================================================================
+-- 2. task_outcomes: same shape.
+-- =========================================================================
+DROP POLICY IF EXISTS "Anon update" ON task_outcomes;
+DROP POLICY IF EXISTS "Anon delete" ON task_outcomes;
+
+CREATE POLICY "Anon sandcastle update" ON task_outcomes
+  FOR UPDATE TO anon
+  USING (source_provenance LIKE 'sandcastle:%')
+  WITH CHECK (source_provenance LIKE 'sandcastle:%');
+
+CREATE POLICY "Anon sandcastle delete" ON task_outcomes
+  FOR DELETE TO anon
+  USING (source_provenance LIKE 'sandcastle:%');
+
+-- =========================================================================
+-- 3. episodes: gated on `actor` (the column already used as provenance).
+-- =========================================================================
+DROP POLICY IF EXISTS "Anon update" ON episodes;
+DROP POLICY IF EXISTS "Anon delete" ON episodes;
+
+CREATE POLICY "Anon sandcastle update" ON episodes
+  FOR UPDATE TO anon
+  USING (actor LIKE 'sandcastle:%')
+  WITH CHECK (actor LIKE 'sandcastle:%');
+
+CREATE POLICY "Anon sandcastle delete" ON episodes
+  FOR DELETE TO anon
+  USING (actor LIKE 'sandcastle:%');
+
+-- =========================================================================
+-- 4. events_canonical: same — gated on `actor`.
+-- =========================================================================
+DROP POLICY IF EXISTS "Anon update" ON events_canonical;
+DROP POLICY IF EXISTS "Anon delete" ON events_canonical;
+
+CREATE POLICY "Anon sandcastle update" ON events_canonical
+  FOR UPDATE TO anon
+  USING (actor LIKE 'sandcastle:%')
+  WITH CHECK (actor LIKE 'sandcastle:%');
+
+CREATE POLICY "Anon sandcastle delete" ON events_canonical
+  FOR DELETE TO anon
+  USING (actor LIKE 'sandcastle:%');

--- a/tests/ci/test_sandcastle_rls.py
+++ b/tests/ci/test_sandcastle_rls.py
@@ -33,6 +33,12 @@ MIGRATION_PATH = (
     / "migrations"
     / "20260508120000_sandcastle_anon_rls_provenance_gate.sql"
 )
+UPDATE_DELETE_MIGRATION_PATH = (
+    REPO_ROOT
+    / "supabase"
+    / "migrations"
+    / "20260508130000_sandcastle_anon_rls_update_delete_gate.sql"
+)
 SCHEMA_PATH = REPO_ROOT / "mcp-memory" / "schema.sql"
 
 # Per-table provenance column. memories + task_outcomes use source_provenance;
@@ -52,6 +58,13 @@ PROVENANCE_COLUMN = {
 def _migration_sql() -> str:
     assert MIGRATION_PATH.exists(), f"Missing migration: {MIGRATION_PATH}"
     return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _update_delete_migration_sql() -> str:
+    assert UPDATE_DELETE_MIGRATION_PATH.exists(), (
+        f"Missing migration: {UPDATE_DELETE_MIGRATION_PATH}"
+    )
+    return UPDATE_DELETE_MIGRATION_PATH.read_text(encoding="utf-8")
 
 
 def _schema_sql() -> str:
@@ -193,3 +206,219 @@ class TestPolicyLogic:
             "Migration should not reference service_role — it bypasses RLS. "
             "If you intentionally added a service_role policy, update this test."
         )
+
+
+# -- Slice 3.5 (#565): UPDATE + DELETE gated on provenance --------------------
+
+
+class TestUpdateDeleteMigrationShape:
+    """Slice 3.5 migration drops the open anon UPDATE/DELETE policies and
+    replaces them with provenance-gated ones (USING + WITH CHECK on the
+    per-table provenance column)."""
+
+    def test_migration_file_exists(self):
+        assert UPDATE_DELETE_MIGRATION_PATH.exists()
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_drops_open_update_policy(self, table: str):
+        sql = _update_delete_migration_sql()
+        pattern = rf'DROP\s+POLICY\s+IF\s+EXISTS\s+"Anon update"\s+ON\s+{table}\b'
+        assert re.search(pattern, sql, re.IGNORECASE), (
+            f"Migration must drop legacy open 'Anon update' policy on {table}"
+        )
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_drops_open_delete_policy(self, table: str):
+        sql = _update_delete_migration_sql()
+        pattern = rf'DROP\s+POLICY\s+IF\s+EXISTS\s+"Anon delete"\s+ON\s+{table}\b'
+        assert re.search(pattern, sql, re.IGNORECASE), (
+            f"Migration must drop legacy open 'Anon delete' policy on {table}"
+        )
+
+    @pytest.mark.parametrize("table,column", list(PROVENANCE_COLUMN.items()))
+    def test_installs_sandcastle_update_policy(self, table: str, column: str):
+        sql = _update_delete_migration_sql()
+        # CREATE POLICY ... ON <t> FOR UPDATE TO anon USING (<col> LIKE 'sandcastle:%') WITH CHECK (<col> LIKE 'sandcastle:%')
+        pattern = (
+            rf"CREATE\s+POLICY\s+\"[^\"]+\"\s+ON\s+{table}\s+"
+            rf"FOR\s+UPDATE\s+TO\s+anon\s+"
+            rf"USING\s*\(\s*{column}\s+LIKE\s+'sandcastle:%'\s*\)\s+"
+            rf"WITH\s+CHECK\s*\(\s*{column}\s+LIKE\s+'sandcastle:%'\s*\)"
+        )
+        assert re.search(pattern, sql, re.IGNORECASE), (
+            f"Missing or malformed sandcastle UPDATE policy on {table} "
+            f"(expected USING + WITH CHECK ({column} LIKE 'sandcastle:%'))"
+        )
+
+    @pytest.mark.parametrize("table,column", list(PROVENANCE_COLUMN.items()))
+    def test_installs_sandcastle_delete_policy(self, table: str, column: str):
+        sql = _update_delete_migration_sql()
+        pattern = (
+            rf"CREATE\s+POLICY\s+\"[^\"]+\"\s+ON\s+{table}\s+"
+            rf"FOR\s+DELETE\s+TO\s+anon\s+"
+            rf"USING\s*\(\s*{column}\s+LIKE\s+'sandcastle:%'\s*\)"
+        )
+        assert re.search(pattern, sql, re.IGNORECASE), (
+            f"Missing or malformed sandcastle DELETE policy on {table} "
+            f"(expected USING ({column} LIKE 'sandcastle:%'))"
+        )
+
+    def test_no_service_role_reference(self):
+        sql = _update_delete_migration_sql()
+        assert "service_role" not in sql.lower(), (
+            "Slice 3.5 migration should not reference service_role — it bypasses RLS."
+        )
+
+
+class TestUpdateDeleteSchemaMirror:
+    """schema.sql must mirror the slice-3.5 UPDATE/DELETE policies and must
+    not retain the legacy open 'Anon update' / 'Anon delete' policies on the
+    four sandcastle-touched tables (#326 schema-drift gate)."""
+
+    @pytest.mark.parametrize("table,column", list(PROVENANCE_COLUMN.items()))
+    def test_schema_has_sandcastle_update_policy(self, table: str, column: str):
+        sql = _schema_sql()
+        pattern = (
+            rf"CREATE\s+POLICY\s+\"[^\"]+\"\s+ON\s+{table}\s+"
+            rf"FOR\s+UPDATE\s+TO\s+anon\s+"
+            rf"USING\s*\(\s*{column}\s+LIKE\s+'sandcastle:%'\s*\)\s+"
+            rf"WITH\s+CHECK\s*\(\s*{column}\s+LIKE\s+'sandcastle:%'\s*\)"
+        )
+        assert re.search(pattern, sql, re.IGNORECASE), (
+            f"schema.sql missing sandcastle UPDATE policy for {table} — drift from migration"
+        )
+
+    @pytest.mark.parametrize("table,column", list(PROVENANCE_COLUMN.items()))
+    def test_schema_has_sandcastle_delete_policy(self, table: str, column: str):
+        sql = _schema_sql()
+        pattern = (
+            rf"CREATE\s+POLICY\s+\"[^\"]+\"\s+ON\s+{table}\s+"
+            rf"FOR\s+DELETE\s+TO\s+anon\s+"
+            rf"USING\s*\(\s*{column}\s+LIKE\s+'sandcastle:%'\s*\)"
+        )
+        assert re.search(pattern, sql, re.IGNORECASE), (
+            f"schema.sql missing sandcastle DELETE policy for {table} — drift from migration"
+        )
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_schema_has_no_open_update_policy(self, table: str):
+        """An unconditional 'Anon update' (USING (true) WITH CHECK (true)) on
+        any of the four tables means slice 3.5 was not mirrored into
+        schema.sql."""
+        sql = _schema_sql()
+        # Match the legacy shape specifically: USING (true) WITH CHECK (true)
+        pattern = (
+            rf'"Anon update"\s+ON\s+{table}\s+'
+            rf"FOR\s+UPDATE\s+TO\s+anon\s+USING\s*\(\s*true\s*\)"
+        )
+        assert not re.search(pattern, sql, re.IGNORECASE), (
+            f"Legacy open 'Anon update' policy still in schema.sql for {table}"
+        )
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_schema_has_no_open_delete_policy(self, table: str):
+        sql = _schema_sql()
+        pattern = (
+            rf'"Anon delete"\s+ON\s+{table}\s+'
+            rf"FOR\s+DELETE\s+TO\s+anon\s+USING\s*\(\s*true\s*\)"
+        )
+        assert not re.search(pattern, sql, re.IGNORECASE), (
+            f"Legacy open 'Anon delete' policy still in schema.sql for {table}"
+        )
+
+
+# -- Slice 3.5 policy logic --------------------------------------------------
+
+
+def _anon_update_allowed(table: str, existing_row: dict, new_row: dict) -> bool:
+    """Pure-Python reimplementation of the anon UPDATE policy.
+
+    Both USING (existing row) and WITH CHECK (new row) must satisfy the
+    sandcastle prefix predicate. This blocks two classes of forgery:
+      - touching a non-sandcastle row at all (USING fails)
+      - rewriting provenance from sandcastle → non-sandcastle (WITH CHECK fails)
+    """
+    column = PROVENANCE_COLUMN[table]
+    existing = existing_row.get(column)
+    new = new_row.get(column, existing)  # unchanged if not in update payload
+    if existing is None or new is None:
+        return False
+    return existing.startswith("sandcastle:") and new.startswith("sandcastle:")
+
+
+def _anon_delete_allowed(table: str, row: dict) -> bool:
+    """Pure-Python reimplementation of the anon DELETE policy."""
+    column = PROVENANCE_COLUMN[table]
+    value = row.get(column)
+    if value is None:
+        return False
+    return value.startswith("sandcastle:")
+
+
+class TestUpdateDeletePolicyLogic:
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_update_sandcastle_to_sandcastle_accepted(self, table: str):
+        col = PROVENANCE_COLUMN[table]
+        assert _anon_update_allowed(
+            table,
+            existing_row={col: "sandcastle:agent:run-1", "data": "old"},
+            new_row={col: "sandcastle:agent:run-1", "data": "new"},
+        )
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_update_non_sandcastle_row_rejected(self, table: str):
+        """Touching a host-owned row (provenance not sandcastle) must fail USING."""
+        col = PROVENANCE_COLUMN[table]
+        for hostlike in ["session:abc", "skill:implement", "user:explicit", "hook:foo"]:
+            assert not _anon_update_allowed(
+                table,
+                existing_row={col: hostlike},
+                new_row={col: hostlike, "data": "rewrite"},
+            ), f"{table}: anon UPDATE should reject host-owned row {hostlike!r}"
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_update_provenance_forge_rejected(self, table: str):
+        """Anon must not be able to rewrite provenance away from sandcastle:
+        (audit erase) or rewrite into sandcastle: from non-sandcastle (forge)."""
+        col = PROVENANCE_COLUMN[table]
+        # Audit-erase: sandcastle row → host-owned provenance (WITH CHECK fails)
+        assert not _anon_update_allowed(
+            table,
+            existing_row={col: "sandcastle:agent"},
+            new_row={col: "user:explicit"},
+        ), f"{table}: anon UPDATE should reject sandcastle → user:explicit (audit erase)"
+        # Forge: host row → sandcastle (USING fails — covered by test_update_non_sandcastle_row_rejected,
+        # but include the symmetric direction here for clarity)
+        assert not _anon_update_allowed(
+            table,
+            existing_row={col: "skill:implement"},
+            new_row={col: "sandcastle:agent"},
+        ), f"{table}: anon UPDATE should reject skill:* → sandcastle (forge)"
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_delete_sandcastle_accepted(self, table: str):
+        col = PROVENANCE_COLUMN[table]
+        assert _anon_delete_allowed(table, {col: "sandcastle:agent:run-7"})
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_delete_non_sandcastle_rejected(self, table: str):
+        col = PROVENANCE_COLUMN[table]
+        for bad in [
+            "session:abc",
+            "skill:implement",
+            "user:explicit",
+            "hook:user-prompt-submit",
+            "Sandcastle:agent",  # case-sensitive
+            "sandcastles:agent",  # extra 's'
+            "",
+            None,
+        ]:
+            assert not _anon_delete_allowed(table, {col: bad}), (
+                f"{table}: anon DELETE should reject row with provenance {bad!r}"
+            )
+
+    @pytest.mark.parametrize("table", list(PROVENANCE_COLUMN.keys()))
+    def test_delete_null_provenance_rejected(self, table: str):
+        col = PROVENANCE_COLUMN[table]
+        assert not _anon_delete_allowed(table, {col: None})
+        assert not _anon_delete_allowed(table, {})


### PR DESCRIPTION
## Summary

Slice 3.5 of the sandcastle epic. Replaces the unconditional anon UPDATE/DELETE policies on `memories` / `task_outcomes` / `episodes` / `events_canonical` with provenance-gated ones — same `LIKE 'sandcastle:%'` predicate as the slice 3 INSERT gate (#542), now extended to all three write ops.

## Why

PR #563 / slice 3 closed the anon INSERT hole but left two:
- **DELETE unrestricted** — any anon-key client (compromised sandcastle agent included) could `DELETE FROM memories;` and evaporate host data.
- **UPDATE allowed provenance rewriting** — anon could change `source_provenance` from `user:explicit` to `sandcastle:agent` (forge) or vice-versa (audit erase). The slice 3 INSERT gate was meaningless once forging was possible.

Closes #565.

## Decisions & Alternatives

- **Same predicate as slice 3, not a different shape.** `provenance LIKE 'sandcastle:%'` is the established gate — adding a second axis (e.g. role-based) would diverge from the threat model. Reviewers can read one rule for all four ops.
- **`USING` + `WITH CHECK` on UPDATE** — `USING` blocks touching non-sandcastle rows at all; `WITH CHECK` blocks rewriting provenance away from sandcastle. Both are needed; either alone is bypassable.
- **DELETE only needs `USING`** — Postgres has no `WITH CHECK` for DELETE; row visibility check is sufficient.
- **No service-role policy added.** Service-role bypasses RLS at the engine level — adding policies for it would be no-ops and dilute the meta-test.
- **Skipped /grill-me** — issue body had final SQL pre-grilled by Claude reviewer on PR #563; no design ambiguity. Logged decision `f3b85eeb-b883-4891-b349-f64c8c9dc28c` with `confidence=0.85`.

## Risk Assessment

- **MEDIUM**: tightens RLS on four tables. Service-role host (post-#569) is unaffected. Sandcastle agents lose the ability to touch non-sandcastle rows — that is the goal. Reversible — drop the new policies and restore the open ones if production behavior surprises us.

**Live-DB application is NOT in this PR.** Migration is committed but not yet `apply_migration`'d. Per safety rule (HIGH-risk schema change against live shared Supabase), waiting for principal explicit approval before applying. Slice 3 (`20260508120000`) is already live as of earlier this session.

## Testing

- `python -m pytest tests/ci/test_sandcastle_rls.py -x -q` — **90 passed**
- The meta-test now covers, per AC #565:
  - Migration shape: drops legacy `Anon update`/`Anon delete`, installs `FOR UPDATE TO anon USING+WITH CHECK` and `FOR DELETE TO anon USING` with `<col> LIKE 'sandcastle:%'`.
  - Schema mirror: schema.sql contains the gated UPDATE/DELETE policies and no longer has the open `USING (true)` shapes for the four tables.
  - Policy logic (Python reimpl):
    - UPDATE accepts sandcastle→sandcastle, rejects host-owned rows (USING), rejects audit-erase (sandcastle→host) and forge (host→sandcastle) via WITH CHECK.
    - DELETE accepts only `sandcastle:%`, rejects host prefixes, case variants, NULL, and missing column.
- No live-DB smoke yet — see Risk note.

## Files Changed

- `supabase/migrations/20260508130000_sandcastle_anon_rls_update_delete_gate.sql` — new migration; drops 8 open policies, creates 8 gated ones across 4 tables.
- `mcp-memory/schema.sql` — mirrored policy shape per #326 schema-drift CI gate.
- `tests/ci/test_sandcastle_rls.py` — added `TestUpdateDeleteMigrationShape`, `TestUpdateDeleteSchemaMirror`, `TestUpdateDeletePolicyLogic` (UPDATE USING+CHECK + DELETE USING reimpl with attack-vector cases).
- `CONTEXT.md` — note: provenance gate is now table-level + op-level (INSERT/UPDATE/DELETE), not agent-level.

## Refs

- Closes #565
- Decision: `f3b85eeb-b883-4891-b349-f64c8c9dc28c`
- Builds on: PR #563, decision `228a2d9b-b57a-4d0f-8771-662482386b8a`
- Sequencing: #564 + #569 (host SERVICE_KEY) — already live

🤖 Generated with [Claude Code](https://claude.com/claude-code)