### PR TITLE
feat(sandcastle): slice 4 -- PowerShell watchdog wrapper (#541)

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -47,7 +47,9 @@ const runId =
 // (commits, branch, iterations, usage). Direct stdout capture is too noisy
 // — sandcastle interleaves agent output with orchestrator logs.
 const resultFile = process.env.SANDCASTLE_RESULT_FILE;
-const maxIterations = Number(process.env.SANDCASTLE_MAX_ITERATIONS ?? "1");
+// `??` does not coalesce empty string -- guard against blank env vars
+// silently producing maxIterations=0 (zero-iteration silent run).
+const maxIterations = Math.max(1, Number(process.env.SANDCASTLE_MAX_ITERATIONS) || 1);
 
 const result = await run({
   name: "jarvis-worker",

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -103,10 +103,11 @@ if (resultFile) {
         completionSignal: result.completionSignal,
         logFilePath: result.logFilePath,
         preservedWorktreePath: result.preservedWorktreePath,
-        iterations: result.iterations.map((it) => ({
-          sessionId: it.sessionId,
-          usage: it.usage,
-        })),
+        iterations:
+          result.iterations?.map((it) => ({
+            sessionId: it.sessionId,
+            usage: it.usage,
+          })) ?? [],
       },
       null,
       2,

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,5 +1,7 @@
 import { run, claudeCode } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
 
 // Jarvis sandcastle entry — slices 1 + 2 of epic #534. Manual smoke loop on Main PC.
 // Run: npm run sandcastle  (or: npx tsx .sandcastle/main.mts)
@@ -40,7 +42,14 @@ const runId =
   process.env.SANDCASTLE_RUN_ID ??
   `jarvis-worker-${new Date().toISOString().replace(/[-:T.Z]/g, "").slice(0, 14)}`;
 
-await run({
+// Slice 4 (#541): when the PowerShell watchdog invokes us, it sets
+// SANDCASTLE_RESULT_FILE so we dump the RunResult JSON for it to parse
+// (commits, branch, iterations, usage). Direct stdout capture is too noisy
+// — sandcastle interleaves agent output with orchestrator logs.
+const resultFile = process.env.SANDCASTLE_RESULT_FILE;
+const maxIterations = Number(process.env.SANDCASTLE_MAX_ITERATIONS ?? "1");
+
+const result = await run({
   name: "jarvis-worker",
   sandbox: docker({
     imageName: "sandcastle:jarvis",
@@ -62,7 +71,7 @@ await run({
   }),
   agent: claudeCode(ollamaModel),
   promptFile: "./.sandcastle/prompt.md",
-  maxIterations: 1,
+  maxIterations,
   branchStrategy: { type: "merge-to-head" },
   hooks: {
     sandbox: {
@@ -81,3 +90,27 @@ await run({
     },
   },
 });
+
+if (resultFile) {
+  await mkdir(dirname(resultFile), { recursive: true });
+  await writeFile(
+    resultFile,
+    JSON.stringify(
+      {
+        runId,
+        branch: result.branch,
+        commits: result.commits,
+        completionSignal: result.completionSignal,
+        logFilePath: result.logFilePath,
+        preservedWorktreePath: result.preservedWorktreePath,
+        iterations: result.iterations.map((it) => ({
+          sessionId: it.sessionId,
+          usage: it.usage,
+        })),
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -162,31 +162,51 @@ function Invoke-Sandcastle {
         [string]$Model,
         [int]$MaxIterations,
         [string]$ResultFile,
-        [string]$LogFile
+        [string]$LogFile,
+        [string]$RunId
     )
 
-    $env:SANDCASTLE_RESULT_FILE = $ResultFile
+    # Stale result.json from a prior iteration would otherwise be silently
+    # re-read on a partial-write crash. Always start clean.
+    Remove-Item -LiteralPath $ResultFile -ErrorAction SilentlyContinue
+
+    # Save-and-restore so dot-sourced Pester runs don't bleed values across calls.
+    $prev = @{
+        SANDCASTLE_RESULT_FILE    = $env:SANDCASTLE_RESULT_FILE
+        SANDCASTLE_MAX_ITERATIONS = $env:SANDCASTLE_MAX_ITERATIONS
+        SANDCASTLE_RUN_ID         = $env:SANDCASTLE_RUN_ID
+        OLLAMA_MODEL              = $env:OLLAMA_MODEL
+    }
+    $env:SANDCASTLE_RESULT_FILE    = $ResultFile
     $env:SANDCASTLE_MAX_ITERATIONS = "$MaxIterations"
-    if ($Model) { $env:OLLAMA_MODEL = $Model }
+    if ($RunId) { $env:SANDCASTLE_RUN_ID = $RunId }
+    if ($Model) { $env:OLLAMA_MODEL      = $Model }
 
     Push-Location -LiteralPath $RepoRoot
     try {
-        # Capture stderr to the same log file (per fire_and_forget_subprocess_capture_stderr).
-        $stdout = & npm run --silent sandcastle 2>&1
+        $combined = & npm run --silent sandcastle 2>&1
         $exitCode = $LASTEXITCODE
-        $stdout | Out-File -FilePath $LogFile -Encoding utf8 -Append
+        $combined | Out-File -FilePath $LogFile -Encoding utf8 -Append
     } finally {
         Pop-Location
+        $env:SANDCASTLE_RESULT_FILE    = $prev.SANDCASTLE_RESULT_FILE
+        $env:SANDCASTLE_MAX_ITERATIONS = $prev.SANDCASTLE_MAX_ITERATIONS
+        $env:SANDCASTLE_RUN_ID         = $prev.SANDCASTLE_RUN_ID
+        $env:OLLAMA_MODEL              = $prev.OLLAMA_MODEL
     }
 
     if ($exitCode -ne 0) {
-        return [pscustomobject]@{ ok = $false; exitCode = $exitCode; result = $null }
+        return [pscustomobject]@{ ok = $false; exitCode = $exitCode; result = $null; reason = "exit=$exitCode" }
     }
     if (-not (Test-Path -LiteralPath $ResultFile)) {
         return [pscustomobject]@{ ok = $false; exitCode = $exitCode; result = $null; reason = 'no-result-file' }
     }
-    $json = Get-Content -LiteralPath $ResultFile -Raw -Encoding utf8 | ConvertFrom-Json
-    return [pscustomobject]@{ ok = $true; exitCode = 0; result = $json }
+    try {
+        $json = Get-Content -LiteralPath $ResultFile -Raw -Encoding utf8 | ConvertFrom-Json
+    } catch {
+        return [pscustomobject]@{ ok = $false; exitCode = $exitCode; result = $null; reason = "json-parse-error: $_" }
+    }
+    return [pscustomobject]@{ ok = $true; exitCode = 0; result = $json; reason = $null }
 }
 
 # ---------------------------------------------------------------------------
@@ -204,7 +224,15 @@ function Read-DotEnvFile {
         $eq = $trimmed.IndexOf('=')
         if ($eq -lt 1) { continue }
         $key = $trimmed.Substring(0, $eq).Trim()
-        $val = $trimmed.Substring($eq + 1).Trim().Trim('"').Trim("'")
+        $val = $trimmed.Substring($eq + 1).Trim()
+        # Strip only matched outer quote pairs so values like "it's" or
+        # base64 padding ending in '=' survive verbatim.
+        if ($val.Length -ge 2) {
+            $first = $val[0]; $last = $val[$val.Length - 1]
+            if (($first -eq '"' -and $last -eq '"') -or ($first -eq "'" -and $last -eq "'")) {
+                $val = $val.Substring(1, $val.Length - 2)
+            }
+        }
         $vars[$key] = $val
     }
     return $vars
@@ -220,9 +248,7 @@ function Write-OutcomeRecord {
         [string]$Summary,
         [hashtable]$LlmMetrics, # @{ input_tokens; output_tokens; cache_read; cache_creation; model }
         [string[]]$ExtraTags = @(),
-        [string]$RunId,
-        [string]$IssueUrl,
-        [string]$PrUrl
+        [string]$RunId
     )
 
     if (-not $SupabaseUrl -or -not $SupabaseKey) {
@@ -244,9 +270,6 @@ function Write-OutcomeRecord {
         lessons           = ($LlmMetrics | ConvertTo-Json -Compress)
         source_provenance = "sandcastle:watchdog:$RunId"
     }
-    if ($IssueUrl) { $body.issue_url = $IssueUrl }
-    if ($PrUrl)    { $body.pr_url    = $PrUrl }
-
     $headers = @{
         apikey          = $SupabaseKey
         Authorization   = "Bearer $SupabaseKey"
@@ -337,11 +360,12 @@ function Invoke-Watchdog {
         Write-Host "[watchdog] iteration $iter/$MaxIterations"
 
         $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $Model `
-            -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile
+            -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId
 
         if (-not $invocation.ok) {
-            Record 'failure' "sandcastle invocation failed (exit=$($invocation.exitCode))" $totalUsage
-            throw "sandcastle invocation failed: exit=$($invocation.exitCode)"
+            $reason = if ($invocation.reason) { $invocation.reason } else { "exit=$($invocation.exitCode)" }
+            Record 'failure' "sandcastle invocation failed: $reason" $totalUsage
+            throw "sandcastle invocation failed: $reason"
         }
 
         $r = $invocation.result

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -155,6 +155,14 @@ function Get-RepoRoot {
     }
 }
 
+function New-RuntimeDir {
+    [CmdletBinding()]
+    param([string]$RepoRoot, [string]$Stamp)
+    $dir = Join-Path $RepoRoot ".sandcastle/runtime/$Stamp"
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    return $dir
+}
+
 function Invoke-Sandcastle {
     [CmdletBinding()]
     param(
@@ -183,10 +191,15 @@ function Invoke-Sandcastle {
     if ($Model) { $env:OLLAMA_MODEL      = $Model }
 
     Push-Location -LiteralPath $RepoRoot
+    $cmdNotFound = $false
     try {
-        $combined = & npm run --silent sandcastle 2>&1
-        $exitCode = $LASTEXITCODE
-        $combined | Out-File -FilePath $LogFile -Encoding utf8 -Append
+        try {
+            $combined = & npm run --silent sandcastle 2>&1
+            $exitCode = $LASTEXITCODE
+            $combined | Out-File -FilePath $LogFile -Encoding utf8 -Append
+        } catch [System.Management.Automation.CommandNotFoundException] {
+            $cmdNotFound = $true
+        }
     } finally {
         Pop-Location
         $env:SANDCASTLE_RESULT_FILE    = $prev.SANDCASTLE_RESULT_FILE
@@ -195,6 +208,9 @@ function Invoke-Sandcastle {
         $env:OLLAMA_MODEL              = $prev.OLLAMA_MODEL
     }
 
+    if ($cmdNotFound) {
+        return [pscustomobject]@{ ok = $false; exitCode = -1; result = $null; reason = 'npm-not-found' }
+    }
     if ($exitCode -ne 0) {
         return [pscustomobject]@{ ok = $false; exitCode = $exitCode; result = $null; reason = "exit=$exitCode" }
     }
@@ -267,6 +283,10 @@ function Write-OutcomeRecord {
         pattern_tags      = $tags
         # Token metrics ride in lessons until task_outcomes gains a dedicated
         # llm jsonb column -- slice 4 keeps the schema untouched on purpose.
+        # `lessons` carries token metrics as JSON until task_outcomes gains a
+        # dedicated llm jsonb column. Stable shape consumers can rely on:
+        #   { input_tokens, output_tokens, cache_read_input_tokens,
+        #     cache_creation_input_tokens, model }
         lessons           = ($LlmMetrics | ConvertTo-Json -Compress)
         source_provenance = "sandcastle:watchdog:$RunId"
     }
@@ -299,8 +319,7 @@ function Invoke-Watchdog {
 
     $repoRoot = Get-RepoRoot -Repo $Repo
     $stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
-    $runtimeDir = Join-Path $repoRoot ".sandcastle/runtime/$stamp"
-    New-Item -ItemType Directory -Path $runtimeDir -Force | Out-Null
+    $runtimeDir = New-RuntimeDir -RepoRoot $repoRoot -Stamp $stamp
     $logFile = Join-Path $runtimeDir 'run.log'
     $resultFile = Join-Path $runtimeDir 'result.json'
     $runId = "$Repo-watchdog-$stamp"

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -1,0 +1,378 @@
+﻿# Run-Sandcastle.ps1 -- slice 4 watchdog wrapper for the AFK sandcastle loop.
+# Single entry point production code paths use instead of `tsx main.mts`.
+# Decision: 0c3017c6 (fail-fast + autostart + soft-stop window).
+#
+# Responsibilities:
+#  1. Ensure Docker daemon is up (autostart + poll, fail fast on timeout).
+#  2. Ensure Ollama is up (autostart + poll, fail fast on timeout).
+#  3. Run sandcastle one or more iterations via tsx/npm.
+#  4. Parse the result JSON dumped by main.mts.
+#  5. Write outcome_record to Supabase via PostgREST anon insert.
+#  6. Honor a safe-hours window -- soft-stop between iterations only.
+#
+# Telegram (slice 6) and multi-tier escalation (slice 5) are layered later.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('jarvis', 'redrobot')]
+    [string]$Repo,
+
+    [int]$MaxIterations = 1,
+
+    [string]$Model,
+
+    # Either ISO-8601 datetime ("2026-05-09T03:00:00") or "HH:mm" interpreted
+    # as the next occurrence today. Empty string disables the window.
+    [string]$WindowEnd,
+
+    [int]$DockerTimeoutSec = 120,
+
+    [int]$OllamaTimeoutSec = 30,
+
+    # Skip the actual sandcastle invocation -- for dry runs and Pester.
+    [switch]$NoExecute
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Daemon health probes
+# ---------------------------------------------------------------------------
+
+function Test-DockerRunning {
+    [CmdletBinding()]
+    param()
+    try {
+        & docker info --format '{{.ServerVersion}}' 2>$null | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+function Start-DockerDesktop {
+    [CmdletBinding()]
+    param()
+    $exe = "$env:ProgramFiles\Docker\Docker\Docker Desktop.exe"
+    if (-not (Test-Path -LiteralPath $exe)) {
+        throw "Docker Desktop not installed at expected path: $exe"
+    }
+    Start-Process -FilePath $exe -WindowStyle Hidden | Out-Null
+}
+
+function Wait-DockerReady {
+    [CmdletBinding()]
+    param([int]$TimeoutSec)
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-DockerRunning) { return $true }
+        Start-Sleep -Seconds 2
+    }
+    return $false
+}
+
+function Test-OllamaRunning {
+    [CmdletBinding()]
+    param([string]$BaseUrl = 'http://localhost:11434')
+    try {
+        $resp = Invoke-WebRequest -Uri "$BaseUrl/api/tags" -UseBasicParsing -TimeoutSec 3 -ErrorAction Stop
+        return ($resp.StatusCode -eq 200)
+    } catch {
+        return $false
+    }
+}
+
+function Start-OllamaServer {
+    [CmdletBinding()]
+    param()
+    $cmd = Get-Command ollama -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        throw "ollama executable not on PATH; cannot autostart."
+    }
+    Start-Process -FilePath $cmd.Source -ArgumentList 'serve' -WindowStyle Hidden | Out-Null
+}
+
+function Wait-OllamaReady {
+    [CmdletBinding()]
+    param([int]$TimeoutSec, [string]$BaseUrl = 'http://localhost:11434')
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-OllamaRunning -BaseUrl $BaseUrl) { return $true }
+        Start-Sleep -Seconds 1
+    }
+    return $false
+}
+
+# ---------------------------------------------------------------------------
+# Safe-hours window
+# ---------------------------------------------------------------------------
+
+function Resolve-WindowEnd {
+    [CmdletBinding()]
+    param([string]$WindowEnd)
+    if ([string]::IsNullOrWhiteSpace($WindowEnd)) { return $null }
+    if ($WindowEnd -match '^\d{2}:\d{2}$') {
+        $today = (Get-Date).Date
+        $end = $today.Add([TimeSpan]::Parse($WindowEnd + ':00'))
+        # If the wall clock has already passed HH:mm today, the window is
+        # already closed -- we treat it as "now" so the watchdog records
+        # window-expired before doing any work.
+        return $end
+    }
+    return [datetime]::Parse($WindowEnd)
+}
+
+function Test-WindowExpired {
+    [CmdletBinding()]
+    param([Nullable[datetime]]$WindowEnd)
+    if (-not $WindowEnd) { return $false }
+    return ((Get-Date) -ge $WindowEnd)
+}
+
+# ---------------------------------------------------------------------------
+# Sandcastle invocation
+# ---------------------------------------------------------------------------
+
+function Get-RepoRoot {
+    [CmdletBinding()]
+    param([string]$Repo)
+    switch ($Repo) {
+        'jarvis' {
+            # scripts/sandcastle/Run-Sandcastle.ps1 → repo root is two levels up.
+            return (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+        }
+        'redrobot' {
+            $root = $env:REDROBOT_REPO_ROOT
+            if ([string]::IsNullOrWhiteSpace($root)) {
+                throw "Set REDROBOT_REPO_ROOT to the redrobot checkout (slice 9 will deploy this on Workshop)."
+            }
+            if (-not (Test-Path -LiteralPath $root)) {
+                throw "REDROBOT_REPO_ROOT does not exist: $root"
+            }
+            return (Resolve-Path -LiteralPath $root).Path
+        }
+        default { throw "Unknown repo: $Repo" }
+    }
+}
+
+function Invoke-Sandcastle {
+    [CmdletBinding()]
+    param(
+        [string]$RepoRoot,
+        [string]$Model,
+        [int]$MaxIterations,
+        [string]$ResultFile,
+        [string]$LogFile
+    )
+
+    $env:SANDCASTLE_RESULT_FILE = $ResultFile
+    $env:SANDCASTLE_MAX_ITERATIONS = "$MaxIterations"
+    if ($Model) { $env:OLLAMA_MODEL = $Model }
+
+    Push-Location -LiteralPath $RepoRoot
+    try {
+        # Capture stderr to the same log file (per fire_and_forget_subprocess_capture_stderr).
+        $stdout = & npm run --silent sandcastle 2>&1
+        $exitCode = $LASTEXITCODE
+        $stdout | Out-File -FilePath $LogFile -Encoding utf8 -Append
+    } finally {
+        Pop-Location
+    }
+
+    if ($exitCode -ne 0) {
+        return [pscustomobject]@{ ok = $false; exitCode = $exitCode; result = $null }
+    }
+    if (-not (Test-Path -LiteralPath $ResultFile)) {
+        return [pscustomobject]@{ ok = $false; exitCode = $exitCode; result = $null; reason = 'no-result-file' }
+    }
+    $json = Get-Content -LiteralPath $ResultFile -Raw -Encoding utf8 | ConvertFrom-Json
+    return [pscustomobject]@{ ok = $true; exitCode = 0; result = $json }
+}
+
+# ---------------------------------------------------------------------------
+# Outcome recording -- direct PostgREST insert (anon, RLS-gated by source_provenance)
+# ---------------------------------------------------------------------------
+
+function Read-DotEnvFile {
+    [CmdletBinding()]
+    param([string]$Path)
+    $vars = @{}
+    if (-not (Test-Path -LiteralPath $Path)) { return $vars }
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed -or $trimmed.StartsWith('#')) { continue }
+        $eq = $trimmed.IndexOf('=')
+        if ($eq -lt 1) { continue }
+        $key = $trimmed.Substring(0, $eq).Trim()
+        $val = $trimmed.Substring($eq + 1).Trim().Trim('"').Trim("'")
+        $vars[$key] = $val
+    }
+    return $vars
+}
+
+function Write-OutcomeRecord {
+    [CmdletBinding()]
+    param(
+        [string]$SupabaseUrl,
+        [string]$SupabaseKey,
+        [string]$Repo,
+        [string]$Status,        # success | partial | failure
+        [string]$Summary,
+        [hashtable]$LlmMetrics, # @{ input_tokens; output_tokens; cache_read; cache_creation; model }
+        [string[]]$ExtraTags = @(),
+        [string]$RunId,
+        [string]$IssueUrl,
+        [string]$PrUrl
+    )
+
+    if (-not $SupabaseUrl -or -not $SupabaseKey) {
+        Write-Warning "SUPABASE_URL/SUPABASE_KEY missing -- skipping outcome_record write."
+        return $null
+    }
+
+    $tags = @('sandcastle', 'afk') + $ExtraTags
+
+    $body = @{
+        task_type         = 'autonomous'
+        task_description  = "sandcastle:$Repo watchdog run $RunId"
+        outcome_status    = $Status
+        outcome_summary   = $Summary
+        project           = $Repo
+        pattern_tags      = $tags
+        # Token metrics ride in lessons until task_outcomes gains a dedicated
+        # llm jsonb column -- slice 4 keeps the schema untouched on purpose.
+        lessons           = ($LlmMetrics | ConvertTo-Json -Compress)
+        source_provenance = "sandcastle:watchdog:$RunId"
+    }
+    if ($IssueUrl) { $body.issue_url = $IssueUrl }
+    if ($PrUrl)    { $body.pr_url    = $PrUrl }
+
+    $headers = @{
+        apikey          = $SupabaseKey
+        Authorization   = "Bearer $SupabaseKey"
+        'Content-Type'  = 'application/json'
+        Prefer          = 'return=representation'
+    }
+
+    $url = "$($SupabaseUrl.TrimEnd('/'))/rest/v1/task_outcomes"
+    $resp = Invoke-RestMethod -Uri $url -Method Post -Headers $headers -Body ($body | ConvertTo-Json -Depth 6) -ErrorAction Stop
+    return $resp
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+function Invoke-Watchdog {
+    [CmdletBinding()]
+    param(
+        [string]$Repo,
+        [int]$MaxIterations,
+        [string]$Model,
+        [string]$WindowEnd,
+        [int]$DockerTimeoutSec,
+        [int]$OllamaTimeoutSec
+    )
+
+    $repoRoot = Get-RepoRoot -Repo $Repo
+    $stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+    $runtimeDir = Join-Path $repoRoot ".sandcastle/runtime/$stamp"
+    New-Item -ItemType Directory -Path $runtimeDir -Force | Out-Null
+    $logFile = Join-Path $runtimeDir 'run.log'
+    $resultFile = Join-Path $runtimeDir 'result.json'
+    $runId = "$Repo-watchdog-$stamp"
+
+    $envVars = Read-DotEnvFile -Path (Join-Path $repoRoot '.sandcastle/.env')
+    $supabaseUrl = $envVars['SUPABASE_URL']
+    $supabaseKey = $envVars['SUPABASE_KEY']
+    if ($env:SUPABASE_URL) { $supabaseUrl = $env:SUPABASE_URL }
+    if ($env:SUPABASE_KEY) { $supabaseKey = $env:SUPABASE_KEY }
+
+    $windowEndDt = Resolve-WindowEnd -WindowEnd $WindowEnd
+
+    function Record([string]$status, [string]$summary, [hashtable]$llm) {
+        try {
+            Write-OutcomeRecord -SupabaseUrl $supabaseUrl -SupabaseKey $supabaseKey `
+                -Repo $Repo -Status $status -Summary $summary -LlmMetrics $llm `
+                -RunId $runId | Out-Null
+        } catch {
+            Write-Warning "outcome_record write failed: $_"
+        }
+    }
+
+    # 1. Docker
+    if (-not (Test-DockerRunning)) {
+        Write-Host "[watchdog] Docker not running -- autostarting."
+        Start-DockerDesktop
+        if (-not (Wait-DockerReady -TimeoutSec $DockerTimeoutSec)) {
+            Record 'failure' "docker-down: daemon not ready within ${DockerTimeoutSec}s" @{}
+            throw "docker-down: daemon did not come up within ${DockerTimeoutSec}s"
+        }
+    }
+
+    # 2. Ollama
+    if (-not (Test-OllamaRunning)) {
+        Write-Host "[watchdog] Ollama not running -- autostarting."
+        Start-OllamaServer
+        if (-not (Wait-OllamaReady -TimeoutSec $OllamaTimeoutSec)) {
+            Record 'failure' "ollama-down: server not ready within ${OllamaTimeoutSec}s" @{}
+            throw "ollama-down: server did not come up within ${OllamaTimeoutSec}s"
+        }
+    }
+
+    # 3. Iterate (soft-stop on window expiry between iterations)
+    $totalUsage = @{ input_tokens = 0; output_tokens = 0; cache_read_input_tokens = 0; cache_creation_input_tokens = 0; model = $Model }
+    $allCommits = @()
+    $branch = $null
+    $iter = 0
+    $partialReason = $null
+
+    while ($iter -lt $MaxIterations) {
+        if (Test-WindowExpired -WindowEnd $windowEndDt) {
+            $partialReason = 'window-expired'
+            break
+        }
+
+        $iter++
+        Write-Host "[watchdog] iteration $iter/$MaxIterations"
+
+        $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $Model `
+            -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile
+
+        if (-not $invocation.ok) {
+            Record 'failure' "sandcastle invocation failed (exit=$($invocation.exitCode))" $totalUsage
+            throw "sandcastle invocation failed: exit=$($invocation.exitCode)"
+        }
+
+        $r = $invocation.result
+        $branch = $r.branch
+        if ($r.commits) { $allCommits += $r.commits }
+        foreach ($it in $r.iterations) {
+            if ($it.usage) {
+                $totalUsage.input_tokens               += [int]$it.usage.inputTokens
+                $totalUsage.output_tokens              += [int]$it.usage.outputTokens
+                $totalUsage.cache_read_input_tokens    += [int]$it.usage.cacheReadInputTokens
+                $totalUsage.cache_creation_input_tokens+= [int]$it.usage.cacheCreationInputTokens
+            }
+        }
+    }
+
+    if ($partialReason) {
+        $summary = "partial:$partialReason -- branch=$branch iterations=$iter commits=$($allCommits.Count)"
+        Record 'partial' $summary $totalUsage
+        Write-Host "[watchdog] $summary"
+        return
+    }
+
+    $summary = "success -- branch=$branch iterations=$iter commits=$($allCommits.Count)"
+    Record 'success' $summary $totalUsage
+    Write-Host "[watchdog] $summary"
+}
+
+# Entry guard: only run when invoked as a script with a -Repo argument.
+# Dot-sourcing without arguments (Pester) loads functions but does not execute.
+if (-not $NoExecute -and $Repo) {
+    Invoke-Watchdog -Repo $Repo -MaxIterations $MaxIterations -Model $Model `
+        -WindowEnd $WindowEnd -DockerTimeoutSec $DockerTimeoutSec `
+        -OllamaTimeoutSec $OllamaTimeoutSec
+}

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -75,6 +75,10 @@ Describe 'Read-DotEnvFile' {
         'SUPABASE_URL=https://example.supabase.co',
         'SUPABASE_KEY="anon-key-here"',
         "QUOTED='single'",
+        # Unbalanced quotes must survive verbatim (regression: naive Trim
+        # corrupted base64 padding `key=` and apostrophes in values).
+        'BASE64_KEY=abcd1234==',
+        "APOS_VAL=it's",
         '',
         'INVALID_LINE_NO_EQUALS'
     ) | Set-Content -Path $tmp -Encoding UTF8
@@ -85,6 +89,12 @@ Describe 'Read-DotEnvFile' {
         $vars['SUPABASE_KEY']                          | Should Be 'anon-key-here'
         $vars['QUOTED']                                | Should Be 'single'
         $vars.ContainsKey('INVALID_LINE_NO_EQUALS')    | Should Be $false
+    }
+
+    It 'preserves base64 padding and apostrophes' {
+        $vars = Read-DotEnvFile -Path $tmp
+        $vars['BASE64_KEY'] | Should Be 'abcd1234=='
+        $vars['APOS_VAL']   | Should Be "it's"
     }
 
     It 'returns empty hashtable for missing file' {
@@ -187,5 +197,65 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'partial' -and $Summary -like '*window-expired*' }
+    }
+
+    It 'accumulates commits and usage across multiple successful iterations' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 3 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        # 3 iterations × the BeforeEach mock (1k input, 200 output, 1 commit each)
+        Assert-MockCalled Invoke-Sandcastle -Times 3 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter {
+                $Status -eq 'success' -and
+                $Summary -like '*iterations=3*' -and
+                $Summary -like '*commits=3*' -and
+                $LlmMetrics.input_tokens -eq 3000 -and
+                $LlmMetrics.output_tokens -eq 600
+            }
+    }
+
+    It 'records failure and stops loop when sandcastle invocation returns ok=false' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{ ok = $false; exitCode = 0; result = $null; reason = 'no-result-file' }
+        }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 3 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } |
+            Should Throw 'no-result-file'
+
+        Assert-MockCalled Invoke-Sandcastle   -Times 1 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'failure' -and $Summary -like '*no-result-file*' }
+    }
+
+    It 'soft-stops mid-run when window expires after iteration N succeeds' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+
+        # Window expires partway through. First call → not expired; subsequent
+        # calls → expired. With MaxIterations=3 the watchdog should run
+        # exactly one iteration then bail with partial:window-expired.
+        $script:windowChecks = 0
+        Mock Test-WindowExpired {
+            $script:windowChecks++
+            return ($script:windowChecks -gt 1)
+        }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 3 -Model 'm' `
+            -WindowEnd '23:59' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle   -Times 1 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter {
+                $Status -eq 'partial' -and
+                $Summary -like '*window-expired*' -and
+                $Summary -like '*iterations=1*'
+            }
     }
 }

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -1,0 +1,191 @@
+﻿# Pester tests for scripts/sandcastle/Run-Sandcastle.ps1 (issue #541).
+# Exercises the daemon-state matrix and soft-stop window logic with mocked
+# health probes -- no real Docker/Ollama/Supabase calls.
+#
+# Compatible with Pester 3.4 (built-in on Windows PowerShell 5.1) -- uses
+# `Should Be` and `Assert-MockCalled` rather than the Pester 5 dash-syntax.
+#
+# Run:
+#   Invoke-Pester -Path tests/sandcastle/Run-Sandcastle.Tests.ps1
+
+$script:WatchdogPath = Join-Path $PSScriptRoot '..\..\scripts\sandcastle\Run-Sandcastle.ps1'
+. $script:WatchdogPath -NoExecute
+
+Describe 'Resolve-WindowEnd' {
+    It 'returns null for empty input' {
+        Resolve-WindowEnd -WindowEnd '' | Should BeNullOrEmpty
+    }
+
+    It 'parses HH:mm as today' {
+        $end = Resolve-WindowEnd -WindowEnd '23:30'
+        $end.Hour   | Should Be 23
+        $end.Minute | Should Be 30
+        $end.Date   | Should Be (Get-Date).Date
+    }
+
+    It 'parses ISO datetime' {
+        $end = Resolve-WindowEnd -WindowEnd '2026-05-09T03:00:00'
+        $end.Year | Should Be 2026
+        $end.Hour | Should Be 3
+    }
+}
+
+Describe 'Test-WindowExpired' {
+    It 'returns false when window is null' {
+        Test-WindowExpired -WindowEnd $null | Should Be $false
+    }
+
+    It 'returns true when window is in the past' {
+        Test-WindowExpired -WindowEnd ((Get-Date).AddMinutes(-5)) | Should Be $true
+    }
+
+    It 'returns false when window is in the future' {
+        Test-WindowExpired -WindowEnd ((Get-Date).AddMinutes(5)) | Should Be $false
+    }
+}
+
+Describe 'Wait-DockerReady' {
+    It 'returns true when Docker becomes ready before timeout' {
+        Mock Test-DockerRunning { $true }
+        Wait-DockerReady -TimeoutSec 2 | Should Be $true
+    }
+
+    It 'returns false when Docker never comes up within timeout' {
+        Mock Test-DockerRunning { $false }
+        Wait-DockerReady -TimeoutSec 1 | Should Be $false
+    }
+}
+
+Describe 'Wait-OllamaReady' {
+    It 'returns true when Ollama is up' {
+        Mock Test-OllamaRunning { $true }
+        Wait-OllamaReady -TimeoutSec 1 | Should Be $true
+    }
+
+    It 'returns false when Ollama times out' {
+        Mock Test-OllamaRunning { $false }
+        Wait-OllamaReady -TimeoutSec 1 | Should Be $false
+    }
+}
+
+Describe 'Read-DotEnvFile' {
+    $tmp = Join-Path $env:TEMP "sandcastle-watchdog-env-$([guid]::NewGuid()).env"
+    @(
+        '# comment',
+        'SUPABASE_URL=https://example.supabase.co',
+        'SUPABASE_KEY="anon-key-here"',
+        "QUOTED='single'",
+        '',
+        'INVALID_LINE_NO_EQUALS'
+    ) | Set-Content -Path $tmp -Encoding UTF8
+
+    It 'parses key=value, ignores comments and blanks' {
+        $vars = Read-DotEnvFile -Path $tmp
+        $vars['SUPABASE_URL']                          | Should Be 'https://example.supabase.co'
+        $vars['SUPABASE_KEY']                          | Should Be 'anon-key-here'
+        $vars['QUOTED']                                | Should Be 'single'
+        $vars.ContainsKey('INVALID_LINE_NO_EQUALS')    | Should Be $false
+    }
+
+    It 'returns empty hashtable for missing file' {
+        $vars = Read-DotEnvFile -Path "$env:TEMP\does-not-exist-$([guid]::NewGuid()).env"
+        $vars.Count | Should Be 0
+    }
+
+    Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-Watchdog daemon-state matrix' {
+    BeforeEach {
+        Mock Start-DockerDesktop { }
+        Mock Start-OllamaServer  { }
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok       = $true
+                exitCode = 0
+                result   = [pscustomobject]@{
+                    branch     = 'feat/test'
+                    commits    = @(@{ sha = 'abc123' })
+                    iterations = @(
+                        [pscustomobject]@{
+                            usage = [pscustomobject]@{
+                                inputTokens               = 1000
+                                outputTokens              = 200
+                                cacheReadInputTokens      = 50
+                                cacheCreationInputTokens  = 10
+                            }
+                        }
+                    )
+                }
+            }
+        }
+        Mock Write-OutcomeRecord { 'mocked-outcome-id' }
+        Mock Get-RepoRoot { $env:TEMP }
+        Mock Read-DotEnvFile { @{ SUPABASE_URL = 'https://x'; SUPABASE_KEY = 'k' } }
+    }
+
+    It 'records success when both daemons are up' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen2.5-coder:14b' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Start-DockerDesktop -Times 0 -Exactly -Scope It
+        Assert-MockCalled Start-OllamaServer  -Times 0 -Exactly -Scope It
+        Assert-MockCalled Invoke-Sandcastle   -Times 1 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' }
+    }
+
+    It 'records failure: docker-down when Docker never starts' {
+        Mock Test-DockerRunning { $false }
+        Mock Test-OllamaRunning { $true }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 1 -OllamaTimeoutSec 1 } | Should Throw 'docker-down'
+
+        Assert-MockCalled Start-DockerDesktop -Times 1 -Exactly -Scope It
+        Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'failure' -and $Summary -like '*docker-down*' }
+    }
+
+    It 'records failure: ollama-down when Ollama never starts' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $false }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 1 -OllamaTimeoutSec 1 } | Should Throw 'ollama-down'
+
+        Assert-MockCalled Start-OllamaServer  -Times 1 -Exactly -Scope It
+        Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'failure' -and $Summary -like '*ollama-down*' }
+    }
+
+    It 'records failure when both daemons time out (Docker fails first, fail-fast)' {
+        Mock Test-DockerRunning { $false }
+        Mock Test-OllamaRunning { $false }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 1 -OllamaTimeoutSec 1 } | Should Throw
+
+        Assert-MockCalled Start-DockerDesktop -Times 1 -Exactly -Scope It
+        Assert-MockCalled Start-OllamaServer  -Times 0 -Exactly -Scope It
+        Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
+    }
+
+    It 'soft-stops with partial:window-expired before iteration starts' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 3 -Model 'm' `
+            -WindowEnd ((Get-Date).AddMinutes(-1).ToString('s')) `
+            -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'partial' -and $Summary -like '*window-expired*' }
+    }
+}

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -132,6 +132,8 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         Mock Write-OutcomeRecord { 'mocked-outcome-id' }
         Mock Get-RepoRoot { $env:TEMP }
         Mock Read-DotEnvFile { @{ SUPABASE_URL = 'https://x'; SUPABASE_KEY = 'k' } }
+        # No real .sandcastle/runtime/* directories during tests.
+        Mock New-RuntimeDir { Join-Path $env:TEMP "sandcastle-test-$([guid]::NewGuid())" }
     }
 
     It 'records success when both daemons are up' {
@@ -216,6 +218,21 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
                 $LlmMetrics.input_tokens -eq 3000 -and
                 $LlmMetrics.output_tokens -eq 600
             }
+    }
+
+    It 'records failure when npm is not on PATH (npm-not-found surfaces through Record)' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{ ok = $false; exitCode = -1; result = $null; reason = 'npm-not-found' }
+        }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } |
+            Should Throw 'npm-not-found'
+
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'failure' -and $Summary -like '*npm-not-found*' }
     }
 
     It 'records failure and stops loop when sandcastle invocation returns ok=false' {


### PR DESCRIPTION
## Summary
Single PowerShell entry point `scripts/sandcastle/Run-Sandcastle.ps1` that production code paths invoke instead of `tsx main.mts` directly. Handles Docker + Ollama autostart/health-poll, runs the sandcastle iteration(s), parses the result JSON, writes an `outcome_record` row to Supabase (RLS-gated by `source_provenance='sandcastle:watchdog:<run_id>'` per #565), and honors a safe-hours window with soft-stop **between** iterations (never mid-iteration).

## Why
Slice 4 of epic #534 — production needs a wrapper that survives a Docker/Ollama outage on Workshop PC during AFK runs and emits the cost/outcome telemetry the orchestrator session reviews afterward. Decision `0c3017c6` (fail-fast + watchdog autostart + soft-stop window) drove the shape.

Closes #541

## Decisions & Alternatives
- **Result-file handoff over stdout parsing.** `.sandcastle/main.mts` dumps `RunResult` JSON (commits, branch, iterations, usage) to `$SANDCASTLE_RESULT_FILE` when set; PowerShell parses it. Sandcastle's stdout is interleaved agent + orchestrator chatter — too noisy.
- **Token metrics in `lessons` (JSON), not a new schema column.** `task_outcomes` has no `llm` jsonb column. Adding one would force a migration + schema-drift meta-test for one slice. Accepted the small denormalization to keep the slice tight; structured `llm` column can land as a follow-up if recall queries need it.
- **PostgREST anon insert from PowerShell**, not delegated to a Node post-hook in `main.mts`. Single owner of cost-tracking; same `source_provenance` shape as the agent already uses (#542 / #565).
- **Pester 3.4-compatible tests** (built-in on Win 5.1). Pester 5 install was denied for this slice; tests use `Should Be` + `Assert-MockCalled` instead of dash-syntax. 17 tests pass locally.

## Risk Assessment
- **MEDIUM** — new production-facing wrapper with side effects (starts Docker Desktop, starts `ollama serve`, writes Supabase rows). All side effects mocked in tests; no real daemons started during `Invoke-Pester`. Idempotent: skips autostart when daemons are already up.
- Schema untouched, so RLS / migration paths are unaffected.
- `redrobot` repo path requires `$env:REDROBOT_REPO_ROOT` — slice 9 will set this on Workshop. The `-Repo redrobot` path throws a clear error if unset; jarvis path resolves automatically from `$PSScriptRoot`.

## Testing
- `Invoke-Pester -Path tests/sandcastle/Run-Sandcastle.Tests.ps1` — **17 pass / 0 fail** (~14 s).
  - Covers Resolve-WindowEnd, Test-WindowExpired, Wait-DockerReady, Wait-OllamaReady, Read-DotEnvFile.
  - Daemon-state matrix: both up → success outcome; docker-down → failure outcome with `docker-down` summary; ollama-down → same shape; both timeout → fail-fast on Docker first; window-expired before iteration → partial outcome.
- No real Docker / Ollama / Supabase calls in tests. `Invoke-Sandcastle`, `Write-OutcomeRecord`, `Get-RepoRoot`, `Read-DotEnvFile`, `Start-DockerDesktop`, `Start-OllamaServer` are all mocked.
- E2E smoke (real run on Main PC) deferred — needs `GH_TOKEN` + a tracer issue + image build; will be exercised by slice 8 (Workshop schedule) where this wrapper becomes the production entry.

## Files Changed
- `scripts/sandcastle/Run-Sandcastle.ps1` — new watchdog wrapper.
- `tests/sandcastle/Run-Sandcastle.Tests.ps1` — Pester suite (Pester 3.4 syntax).
- `.sandcastle/main.mts` — opt-in result-file dump via `SANDCASTLE_RESULT_FILE` env; `maxIterations` reads `SANDCASTLE_MAX_ITERATIONS`. Existing `npm run sandcastle` behavior unchanged when env vars are absent.

## Decisions (memory)
- `7b303003-67cf-4be0-a2ac-1448662c1a10` — implementation choices for slice 4 (result-file handoff, lessons-as-JSON for tokens, PostgREST insert, Pester 3.4).
- `0c3017c6-01ec-4392-86a1-6a1522e4c5ef` — original architecture choice (fail-fast + autostart + soft-stop).