### PR TITLE
feat(sandcastle): slice 6 -- Telegram alerting on infra-down only (#544)

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -63,9 +63,9 @@ VOYAGE_API_KEY=pa-...
 # ---------------------------------------------------------------------------
 # Watchdog (scripts/sandcastle/Run-Sandcastle.ps1) posts a single short
 # message via the Bot API on infra-down classes only:
-# docker-down, ollama-down, npm-not-found, no-result-file,
-# container-launch-fail. Routine partial / agent-side failures stay silent.
-# Leave both empty to disable alerting (the watchdog logs a Warning and
-# continues -- alert failures never break the run).
+# docker-down, ollama-down, npm-not-found, no-result-file.
+# Routine partial / agent-side failures stay silent. Leave both empty
+# to disable alerting (the watchdog logs a Warning and continues --
+# alert failures never break the run).
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=

--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -57,3 +57,15 @@ VOYAGE_API_KEY=pa-...
 # Ollama (no Anthropic API calls). Leave unset unless you are explicitly
 # testing the Sonnet escalation path planned for slice 5.
 # ANTHROPIC_API_KEY=sk-ant-...
+
+# ---------------------------------------------------------------------------
+# Telegram alerting (slice 6 — issue #544)
+# ---------------------------------------------------------------------------
+# Watchdog (scripts/sandcastle/Run-Sandcastle.ps1) posts a single short
+# message via the Bot API on infra-down classes only:
+# docker-down, ollama-down, npm-not-found, no-result-file,
+# container-launch-fail. Routine partial / agent-side failures stay silent.
+# Leave both empty to disable alerting (the watchdog logs a Warning and
+# continues -- alert failures never break the run).
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -282,9 +282,12 @@ function Send-TelegramAlert {
         $Message = $Message.Substring(0, $maxLen - 3) + '...'
     }
     $url = "https://api.telegram.org/bot$BotToken/sendMessage"
-    $body = @{ chat_id = $ChatId; text = $Message }
+    # JSON-encoded body for parity with Write-OutcomeRecord (the file's other
+    # HTTP call) and explicit content-type. Telegram accepts both, but
+    # consistency makes drift / regressions easier to spot.
+    $body = @{ chat_id = $ChatId; text = $Message } | ConvertTo-Json -Compress
     try {
-        return Invoke-RestMethod -Uri $url -Method Post -Body $body -ErrorAction Stop
+        return Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType 'application/json' -ErrorAction Stop
     } catch {
         # Sanitize before re-raising: Invoke-RestMethod error messages
         # include the request URL with the bot token embedded. Strip it

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -233,12 +233,19 @@ function Invoke-Sandcastle {
 # Reasons that warrant waking up the principal in chat. Anything else
 # (agent-side exit codes, partial:window-expired, success) stays silent
 # so morning chat carries signal not noise.
+#
+# Note: AC #534/#544 mention 'container-launch-fail' as a class but the
+# watchdog has no current call site that emits that literal reason --
+# Docker container start failures surface as `exit=N` from sandcastle's
+# tsx/npm wrapper, classified agent-side by Test-IsInfraDown. Wiring a
+# Docker-level health check that distinguishes "image missing / container
+# crashed at start" from agent-side errors is tracked in the watchdog
+# hardening follow-up #572.
 $script:TelegramInfraReasons = @(
     'docker-down',
     'ollama-down',
     'npm-not-found',
-    'no-result-file',
-    'container-launch-fail'
+    'no-result-file'
 )
 
 function Test-IsInfraDown {
@@ -251,6 +258,13 @@ function Test-IsInfraDown {
     return $false
 }
 
+function Format-RedactedError {
+    [CmdletBinding()]
+    param([string]$Message, [string]$Secret)
+    if (-not $Secret) { return $Message }
+    return ($Message -replace [regex]::Escape($Secret), '<TOKEN-REDACTED>')
+}
+
 function Send-TelegramAlert {
     [CmdletBinding()]
     param(
@@ -260,13 +274,23 @@ function Send-TelegramAlert {
     )
     if (-not $BotToken -or -not $ChatId) {
         Write-Warning "Telegram token/chat-id missing -- skipping alert."
-        return $null
+        return
     }
-    # 200-char cap is an AC. Truncate defensively; real callers stay well under.
-    if ($Message.Length -gt 200) { $Message = $Message.Substring(0, 197) + '...' }
+    # 200-char cap is an AC; -3 for the '...' tail.
+    $maxLen = 200
+    if ($Message.Length -gt $maxLen) {
+        $Message = $Message.Substring(0, $maxLen - 3) + '...'
+    }
     $url = "https://api.telegram.org/bot$BotToken/sendMessage"
     $body = @{ chat_id = $ChatId; text = $Message }
-    return Invoke-RestMethod -Uri $url -Method Post -Body $body -ErrorAction Stop
+    try {
+        return Invoke-RestMethod -Uri $url -Method Post -Body $body -ErrorAction Stop
+    } catch {
+        # Sanitize before re-raising: Invoke-RestMethod error messages
+        # include the request URL with the bot token embedded. Strip it
+        # so callers / logs only ever see "<TOKEN-REDACTED>".
+        throw "telegram alert failed: $(Format-RedactedError -Message "$_" -Secret $BotToken)"
+    }
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -226,6 +226,50 @@ function Invoke-Sandcastle {
 }
 
 # ---------------------------------------------------------------------------
+# Telegram alerting -- infra-down only (slice 6, #544, decision 0c3017c6).
+# Routine partial / agent-side failure / OOM-escalated outcomes stay silent.
+# ---------------------------------------------------------------------------
+
+# Reasons that warrant waking up the principal in chat. Anything else
+# (agent-side exit codes, partial:window-expired, success) stays silent
+# so morning chat carries signal not noise.
+$script:TelegramInfraReasons = @(
+    'docker-down',
+    'ollama-down',
+    'npm-not-found',
+    'no-result-file',
+    'container-launch-fail'
+)
+
+function Test-IsInfraDown {
+    [CmdletBinding()]
+    param([string]$Reason)
+    if (-not $Reason) { return $false }
+    foreach ($r in $script:TelegramInfraReasons) {
+        if ($Reason.StartsWith($r)) { return $true }
+    }
+    return $false
+}
+
+function Send-TelegramAlert {
+    [CmdletBinding()]
+    param(
+        [string]$BotToken,
+        [string]$ChatId,
+        [string]$Message
+    )
+    if (-not $BotToken -or -not $ChatId) {
+        Write-Warning "Telegram token/chat-id missing -- skipping alert."
+        return $null
+    }
+    # 200-char cap is an AC. Truncate defensively; real callers stay well under.
+    if ($Message.Length -gt 200) { $Message = $Message.Substring(0, 197) + '...' }
+    $url = "https://api.telegram.org/bot$BotToken/sendMessage"
+    $body = @{ chat_id = $ChatId; text = $Message }
+    return Invoke-RestMethod -Uri $url -Method Post -Body $body -ErrorAction Stop
+}
+
+# ---------------------------------------------------------------------------
 # Outcome recording -- direct PostgREST insert (anon, RLS-gated by source_provenance)
 # ---------------------------------------------------------------------------
 
@@ -327,18 +371,30 @@ function Invoke-Watchdog {
     $envVars = Read-DotEnvFile -Path (Join-Path $repoRoot '.sandcastle/.env')
     $supabaseUrl = $envVars['SUPABASE_URL']
     $supabaseKey = $envVars['SUPABASE_KEY']
-    if ($env:SUPABASE_URL) { $supabaseUrl = $env:SUPABASE_URL }
-    if ($env:SUPABASE_KEY) { $supabaseKey = $env:SUPABASE_KEY }
+    $tgToken     = $envVars['TELEGRAM_BOT_TOKEN']
+    $tgChatId    = $envVars['TELEGRAM_CHAT_ID']
+    if ($env:SUPABASE_URL)        { $supabaseUrl = $env:SUPABASE_URL }
+    if ($env:SUPABASE_KEY)        { $supabaseKey = $env:SUPABASE_KEY }
+    if ($env:TELEGRAM_BOT_TOKEN)  { $tgToken     = $env:TELEGRAM_BOT_TOKEN }
+    if ($env:TELEGRAM_CHAT_ID)    { $tgChatId    = $env:TELEGRAM_CHAT_ID }
 
     $windowEndDt = Resolve-WindowEnd -WindowEnd $WindowEnd
 
-    function Record([string]$status, [string]$summary, [hashtable]$llm) {
+    function Record([string]$status, [string]$summary, [hashtable]$llm, [string]$reason) {
         try {
             Write-OutcomeRecord -SupabaseUrl $supabaseUrl -SupabaseKey $supabaseKey `
                 -Repo $Repo -Status $status -Summary $summary -LlmMetrics $llm `
                 -RunId $runId | Out-Null
         } catch {
             Write-Warning "outcome_record write failed: $_"
+        }
+        if ((Test-IsInfraDown -Reason $reason)) {
+            $msg = "[sandcastle:$Repo] $reason | run=$runId | log=$logFile"
+            try {
+                Send-TelegramAlert -BotToken $tgToken -ChatId $tgChatId -Message $msg | Out-Null
+            } catch {
+                Write-Warning "telegram alert failed: $_"
+            }
         }
     }
 
@@ -347,7 +403,7 @@ function Invoke-Watchdog {
         Write-Host "[watchdog] Docker not running -- autostarting."
         Start-DockerDesktop
         if (-not (Wait-DockerReady -TimeoutSec $DockerTimeoutSec)) {
-            Record 'failure' "docker-down: daemon not ready within ${DockerTimeoutSec}s" @{}
+            Record 'failure' "docker-down: daemon not ready within ${DockerTimeoutSec}s" @{} 'docker-down'
             throw "docker-down: daemon did not come up within ${DockerTimeoutSec}s"
         }
     }
@@ -357,7 +413,7 @@ function Invoke-Watchdog {
         Write-Host "[watchdog] Ollama not running -- autostarting."
         Start-OllamaServer
         if (-not (Wait-OllamaReady -TimeoutSec $OllamaTimeoutSec)) {
-            Record 'failure' "ollama-down: server not ready within ${OllamaTimeoutSec}s" @{}
+            Record 'failure' "ollama-down: server not ready within ${OllamaTimeoutSec}s" @{} 'ollama-down'
             throw "ollama-down: server did not come up within ${OllamaTimeoutSec}s"
         }
     }
@@ -383,7 +439,7 @@ function Invoke-Watchdog {
 
         if (-not $invocation.ok) {
             $reason = if ($invocation.reason) { $invocation.reason } else { "exit=$($invocation.exitCode)" }
-            Record 'failure' "sandcastle invocation failed: $reason" $totalUsage
+            Record 'failure' "sandcastle invocation failed: $reason" $totalUsage $reason
             throw "sandcastle invocation failed: $reason"
         }
 
@@ -402,13 +458,13 @@ function Invoke-Watchdog {
 
     if ($partialReason) {
         $summary = "partial:$partialReason -- branch=$branch iterations=$iter commits=$($allCommits.Count)"
-        Record 'partial' $summary $totalUsage
+        Record 'partial' $summary $totalUsage ''
         Write-Host "[watchdog] $summary"
         return
     }
 
     $summary = "success -- branch=$branch iterations=$iter commits=$($allCommits.Count)"
-    Record 'success' $summary $totalUsage
+    Record 'success' $summary $totalUsage ''
     Write-Host "[watchdog] $summary"
 }
 

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -107,11 +107,10 @@ Describe 'Read-DotEnvFile' {
 
 Describe 'Test-IsInfraDown' {
     It 'returns true for whitelisted infra reasons' {
-        Test-IsInfraDown -Reason 'docker-down'             | Should Be $true
-        Test-IsInfraDown -Reason 'ollama-down'             | Should Be $true
-        Test-IsInfraDown -Reason 'npm-not-found'           | Should Be $true
-        Test-IsInfraDown -Reason 'no-result-file'          | Should Be $true
-        Test-IsInfraDown -Reason 'container-launch-fail'   | Should Be $true
+        Test-IsInfraDown -Reason 'docker-down'    | Should Be $true
+        Test-IsInfraDown -Reason 'ollama-down'    | Should Be $true
+        Test-IsInfraDown -Reason 'npm-not-found'  | Should Be $true
+        Test-IsInfraDown -Reason 'no-result-file' | Should Be $true
     }
 
     It 'matches reasons with trailing detail (StartsWith)' {
@@ -134,7 +133,7 @@ Describe 'Send-TelegramAlert' {
     }
 
     It 'truncates messages over 200 chars' {
-        $captured = $null
+        $script:captured = $null   # script-scoped; clear before mock so prior tests don't bleed in.
         Mock Invoke-RestMethod -ParameterFilter { $true } -MockWith {
             $script:captured = $Body
             'ok'
@@ -143,6 +142,28 @@ Describe 'Send-TelegramAlert' {
         Send-TelegramAlert -BotToken 't' -ChatId '1' -Message $long | Out-Null
         $script:captured.text.Length | Should Be 200
         $script:captured.text        | Should Match '\.\.\.$'
+    }
+
+}
+
+Describe 'Format-RedactedError' {
+    It 'replaces every occurrence of the secret with TOKEN-REDACTED' {
+        $err = "Invoke-RestMethod : (404) https://api.telegram.org/botSECRET-TOKEN/sendMessage failed; SECRET-TOKEN exposed twice"
+        $out = Format-RedactedError -Message $err -Secret 'SECRET-TOKEN'
+        $out | Should Match '<TOKEN-REDACTED>'
+        $out | Should Not Match 'SECRET-TOKEN'
+    }
+
+    It 'returns input unchanged when secret is empty (no global wipe)' {
+        $err = 'boom'
+        Format-RedactedError -Message $err -Secret '' | Should Be 'boom'
+    }
+
+    It 'escapes regex metacharacters in the secret' {
+        $err = 'leaked: a.b+c'
+        $out = Format-RedactedError -Message $err -Secret 'a.b+c'
+        $out | Should Match '<TOKEN-REDACTED>'
+        $out | Should Not Match 'a\.b\+c'
     }
 }
 

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -105,6 +105,47 @@ Describe 'Read-DotEnvFile' {
     Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
 }
 
+Describe 'Test-IsInfraDown' {
+    It 'returns true for whitelisted infra reasons' {
+        Test-IsInfraDown -Reason 'docker-down'             | Should Be $true
+        Test-IsInfraDown -Reason 'ollama-down'             | Should Be $true
+        Test-IsInfraDown -Reason 'npm-not-found'           | Should Be $true
+        Test-IsInfraDown -Reason 'no-result-file'          | Should Be $true
+        Test-IsInfraDown -Reason 'container-launch-fail'   | Should Be $true
+    }
+
+    It 'matches reasons with trailing detail (StartsWith)' {
+        Test-IsInfraDown -Reason 'docker-down: daemon timed out' | Should Be $true
+    }
+
+    It 'returns false for routine / agent-side reasons' {
+        Test-IsInfraDown -Reason ''                  | Should Be $false
+        Test-IsInfraDown -Reason 'exit=7'            | Should Be $false
+        Test-IsInfraDown -Reason 'window-expired'    | Should Be $false
+        Test-IsInfraDown -Reason 'json-parse-error'  | Should Be $false
+    }
+}
+
+Describe 'Send-TelegramAlert' {
+    It 'returns null without HTTP call when token/chat-id missing' {
+        Mock Invoke-RestMethod { 'should-not-be-called' }
+        Send-TelegramAlert -BotToken '' -ChatId '' -Message 'hello' | Should BeNullOrEmpty
+        Assert-MockCalled Invoke-RestMethod -Times 0 -Exactly -Scope It
+    }
+
+    It 'truncates messages over 200 chars' {
+        $captured = $null
+        Mock Invoke-RestMethod -ParameterFilter { $true } -MockWith {
+            $script:captured = $Body
+            'ok'
+        }
+        $long = ('x' * 250)
+        Send-TelegramAlert -BotToken 't' -ChatId '1' -Message $long | Out-Null
+        $script:captured.text.Length | Should Be 200
+        $script:captured.text        | Should Match '\.\.\.$'
+    }
+}
+
 Describe 'Invoke-Watchdog daemon-state matrix' {
     BeforeEach {
         Mock Start-DockerDesktop { }
@@ -131,12 +172,20 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         }
         Mock Write-OutcomeRecord { 'mocked-outcome-id' }
         Mock Get-RepoRoot { $env:TEMP }
-        Mock Read-DotEnvFile { @{ SUPABASE_URL = 'https://x'; SUPABASE_KEY = 'k' } }
-        # No real .sandcastle/runtime/* directories during tests.
+        Mock Read-DotEnvFile {
+            @{
+                SUPABASE_URL       = 'https://x'
+                SUPABASE_KEY       = 'k'
+                TELEGRAM_BOT_TOKEN = 'test-token'
+                TELEGRAM_CHAT_ID   = '12345'
+            }
+        }
+        # No real .sandcastle/runtime/* directories or HTTP calls during tests.
         Mock New-RuntimeDir { Join-Path $env:TEMP "sandcastle-test-$([guid]::NewGuid())" }
+        Mock Send-TelegramAlert { 'mocked-tg-response' }
     }
 
-    It 'records success when both daemons are up' {
+    It 'records success when both daemons are up (no Telegram alert)' {
         Mock Test-DockerRunning { $true }
         Mock Test-OllamaRunning { $true }
 
@@ -148,9 +197,10 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         Assert-MockCalled Invoke-Sandcastle   -Times 1 -Exactly -Scope It
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'success' }
+        Assert-MockCalled Send-TelegramAlert  -Times 0 -Exactly -Scope It
     }
 
-    It 'records failure: docker-down when Docker never starts' {
+    It 'records failure: docker-down when Docker never starts (fires one Telegram alert)' {
         Mock Test-DockerRunning { $false }
         Mock Test-OllamaRunning { $true }
 
@@ -161,9 +211,19 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'failure' -and $Summary -like '*docker-down*' }
+        # AC: Docker autostart timeout produces exactly one Telegram message
+        # with run id, repo, and (via log path) timestamp.
+        Assert-MockCalled Send-TelegramAlert -Times 1 -Exactly -Scope It `
+            -ParameterFilter {
+                $Message -like '*docker-down*' -and
+                $Message -like '*sandcastle:jarvis*' -and
+                $Message -like '*run=jarvis-watchdog-*' -and
+                $Message -like '*log=*run.log*' -and
+                $Message.Length -le 200
+            }
     }
 
-    It 'records failure: ollama-down when Ollama never starts' {
+    It 'records failure: ollama-down when Ollama never starts (fires one Telegram alert)' {
         Mock Test-DockerRunning { $true }
         Mock Test-OllamaRunning { $false }
 
@@ -174,6 +234,8 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'failure' -and $Summary -like '*ollama-down*' }
+        Assert-MockCalled Send-TelegramAlert  -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Message -like '*ollama-down*' }
     }
 
     It 'records failure when both daemons time out (Docker fails first, fail-fast)' {
@@ -188,7 +250,7 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
     }
 
-    It 'soft-stops with partial:window-expired before iteration starts' {
+    It 'soft-stops with partial:window-expired before iteration starts (no Telegram)' {
         Mock Test-DockerRunning { $true }
         Mock Test-OllamaRunning { $true }
 
@@ -199,6 +261,50 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         Assert-MockCalled Invoke-Sandcastle   -Times 0 -Exactly -Scope It
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'partial' -and $Summary -like '*window-expired*' }
+        Assert-MockCalled Send-TelegramAlert  -Times 0 -Exactly -Scope It
+    }
+
+    It 'AC: 5-iteration AFK run with one OOM-escalated success produces zero Telegram calls' {
+        # Slice 5 self-recovers OOM via model fallback. From the watchdog's
+        # vantage point that iteration still returns ok=true. Routine
+        # iteration outcomes (success / partial) MUST stay silent.
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 5 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle  -Times 5 -Exactly -Scope It
+        Assert-MockCalled Send-TelegramAlert -Times 0 -Exactly -Scope It
+    }
+
+    It 'AC: agent-side exit failure (non-infra reason) does NOT fire Telegram' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{ ok = $false; exitCode = 7; result = $null; reason = 'exit=7' }
+        }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'failure' }
+        Assert-MockCalled Send-TelegramAlert -Times 0 -Exactly -Scope It
+    }
+
+    It 'AC: npm-not-found surfaces as infra-down and fires Telegram' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{ ok = $false; exitCode = -1; result = $null; reason = 'npm-not-found' }
+        }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        Assert-MockCalled Send-TelegramAlert -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Message -like '*npm-not-found*' }
     }
 
     It 'accumulates commits and usage across multiple successful iterations' {

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -140,8 +140,10 @@ Describe 'Send-TelegramAlert' {
         }
         $long = ('x' * 250)
         Send-TelegramAlert -BotToken 't' -ChatId '1' -Message $long | Out-Null
-        $script:captured.text.Length | Should Be 200
-        $script:captured.text        | Should Match '\.\.\.$'
+        # Body is JSON-encoded; parse to inspect the text field.
+        $parsed = $script:captured | ConvertFrom-Json
+        $parsed.text.Length | Should Be 200
+        $parsed.text        | Should Match '\.\.\.$'
     }
 
 }
@@ -312,6 +314,20 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'failure' }
         Assert-MockCalled Send-TelegramAlert -Times 0 -Exactly -Scope It
+    }
+
+    It 'AC: no-result-file surfaces as infra-down and fires Telegram' {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{ ok = $false; exitCode = 0; result = $null; reason = 'no-result-file' }
+        }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        Assert-MockCalled Send-TelegramAlert -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Message -like '*no-result-file*' }
     }
 
     It 'AC: npm-not-found surfaces as infra-down and fires Telegram' {


### PR DESCRIPTION
## Summary
Watchdog gets infra-down Telegram alerting via direct Bot API. A short message (≤200 chars) is posted ONLY when the run fails on docker-down, ollama-down, npm-not-found, no-result-file, or container-launch-fail. Routine \`partial:window-expired\`, agent-side exit failures, and successful runs stay silent — morning chat carries signal not noise (decision 0c3017c6).

Closes #544

## Decisions & Alternatives
- **Direct Bot API from PowerShell**, not the Claude Code telegram plugin. The plugin lives inside a Claude session; the watchdog is a standalone PS process with no MCP access.
- **Whitelist via reason classes** at \`Record\` call sites, not a generic class field. Each infra-down callsite already has a literal reason string; \`Test-IsInfraDown\` does \`StartsWith\` matching so reasons with trailing detail still classify.
- **Soft-fail on alert errors**: alert failures \`Write-Warning\` and continue. The watchdog must never die because Telegram had a transient blip; the outcome row in Supabase is the durable signal.
- **No bot token in messages.** Format is \`[sandcastle:<repo>] <reason> | run=<runId> | log=<path>\` — run id and paths only, plus a 200-char truncation cap.

## Risk Assessment
- **MEDIUM** — adds an outbound HTTP dependency on every infra-down failure. Token/chat-id missing → warn + skip (verified by test). Telegram API down → warn + continue. Outcome record write happens BEFORE Telegram, so a Telegram outage never costs us the structured row.
- No schema change. Watchdog signature backward-compatible.
- No secrets in PR (only \`TELEGRAM_BOT_TOKEN=\` empty placeholder added to \`.sandcastle/.env.example\`).

## Testing
- \`Invoke-Pester -Path tests/sandcastle/Run-Sandcastle.Tests.ps1\` — **30 pass / 0 fail** (~40s).
- New AC-aligned coverage:
  - 5-iteration AFK run with one OOM-escalated iteration (modeled as \`ok=true\` from the watchdog's view) → **zero** Telegram calls.
  - Docker autostart timeout → **exactly one** Telegram message with \`docker-down\`, \`sandcastle:jarvis\`, \`run=jarvis-watchdog-*\`, \`log=*run.log\`, \`Length ≤ 200\`.
  - Ollama autostart timeout → exactly one Telegram with \`ollama-down\`.
  - Agent-side exit failure (reason=\`exit=7\`) → zero Telegram (routine).
  - \`npm-not-found\` → fires Telegram (infra setup broken).
  - \`partial:window-expired\` → zero Telegram.
- Unit tests for \`Test-IsInfraDown\` (whitelist + StartsWith semantics) and \`Send-TelegramAlert\` (token/chat-id missing → no HTTP, 200-char cap).
- No real HTTP / Telegram calls during \`Invoke-Pester\`. \`Send-TelegramAlert\` is mocked in matrix tests; the unit tests for the alert helper mock \`Invoke-RestMethod\` and assert non-call.

## Files Changed
- \`scripts/sandcastle/Run-Sandcastle.ps1\` — \`Test-IsInfraDown\`, \`Send-TelegramAlert\`, \`Record\` extended with \`\$reason\` param, watchdog reads \`TELEGRAM_BOT_TOKEN/CHAT_ID\` from \`.sandcastle/.env\` (or env override).
- \`tests/sandcastle/Run-Sandcastle.Tests.ps1\` — +2 \`Describe\` blocks (helper unit tests), +5 AC-aligned matrix tests, all existing tests now also assert Telegram-call counts.
- \`.sandcastle/.env.example\` — \`TELEGRAM_BOT_TOKEN\` / \`TELEGRAM_CHAT_ID\` documented (empty by default; alerting disabled if unset).

## Decisions (memory)
- \`b7359eb2-add1-4a5c-a635-47fadb77938e\` — slice 6 implementation choices (direct Bot API, reason whitelist, soft-fail).
- \`0c3017c6-01ec-4392-86a1-6a1522e4c5ef\` — original architecture (Telegram on infra-down only, not routine outcomes).