### PR TITLE
feat(sandcastle): slice 5 -- multi-tier model escalation chain (#543)

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -53,9 +53,28 @@ SUPABASE_KEY=eyJ_anon_...
 # already use mcp-memory locally.
 VOYAGE_API_KEY=pa-...
 
-# Anthropic API key — kept as escape hatch only. Slice 1 smoke MUST run on
-# Ollama (no Anthropic API calls). Leave unset unless you are explicitly
-# testing the Sonnet escalation path planned for slice 5.
+# ---------------------------------------------------------------------------
+# Multi-tier model escalation (slice 5 — issue #543)
+# ---------------------------------------------------------------------------
+# The watchdog (scripts/sandcastle/Run-Sandcastle.ps1) escalates on Tier 0
+# OOM/crash:
+#   Tier 0 (-Model)        : OLLAMA_MODEL above
+#   Tier 1 (-Tier1Model)   : smaller Ollama model (e.g. qwen2.5-coder:7b)
+#   Tier 2 (-Tier2Provider): 'deepseek' (default) or 'claude'
+#                            'claude' is also auto-selected when the issue
+#                            carries the `use-claude-api` label, regardless
+#                            of -Tier2Provider.
+# Cron runs MUST NOT auto-promote to Claude; the label is the explicit gate.
+# On full chain failure the issue gets the `too-large-for-local` label.
+
+# DeepSeek (or any DeepSeek-compatible Anthropic-API endpoint).
+# DEEPSEEK_BASE_URL=https://api.deepseek.com/anthropic
+# DEEPSEEK_MODEL=deepseek-coder
+# DEEPSEEK_API_KEY=sk-deepseek-...
+
+# Anthropic API — only invoked when an issue carries `use-claude-api`.
+# CLAUDE_BASE_URL=https://api.anthropic.com
+# CLAUDE_MODEL=claude-haiku-4-5-20251001
 # ANTHROPIC_API_KEY=sk-ant-...
 
 # ---------------------------------------------------------------------------

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -10,8 +10,27 @@ import { dirname } from "node:path";
 // 436f9549, 228a2d9b, 0c3017c6 referenced from epic #534. Watchdog + schedule
 // land in slice 4 — this file stays config-only.
 
-const ollamaModel = process.env.OLLAMA_MODEL ?? "qwen2.5-coder:14b";
-const ollamaUrl = process.env.OLLAMA_BASE_URL ?? "http://host.docker.internal:11434";
+// Agent model + endpoint. Slice 5 (#543) introduces multi-tier escalation:
+// the PS1 watchdog re-invokes us with SANDCASTLE_AGENT_{MODEL,BASE_URL,AUTH_TOKEN}
+// overridden when retrying on a smaller Ollama model (Tier 1) or a remote
+// DeepSeek/Claude API endpoint (Tier 2). Falls back to the slice-1/2 Ollama
+// defaults when the watchdog isn't driving — single-shot manual smoke runs
+// keep working unchanged.
+const agentModel =
+  process.env.SANDCASTLE_AGENT_MODEL ??
+  process.env.OLLAMA_MODEL ??
+  "qwen2.5-coder:14b";
+const agentBaseUrl =
+  process.env.SANDCASTLE_AGENT_BASE_URL ??
+  process.env.OLLAMA_BASE_URL ??
+  "http://host.docker.internal:11434";
+// Tier 0/1 use the literal "ollama" auth token (Ollama's native Anthropic
+// endpoint ignores it); Tier 2 carries a real API key (DeepSeek / Claude).
+const agentAuthToken = process.env.SANDCASTLE_AGENT_AUTH_TOKEN ?? "ollama";
+// When the watchdog retries on the same issue (escalation chain, AC #3),
+// it sets SANDCASTLE_TARGET_ISSUE so prompt.md can pin the agent to that
+// issue instead of picking afresh from the queue.
+const targetIssue = process.env.SANDCASTLE_TARGET_ISSUE ?? "";
 const ghToken = process.env.GH_TOKEN;
 if (!ghToken) {
   throw new Error(
@@ -56,9 +75,10 @@ const result = await run({
   sandbox: docker({
     imageName: "sandcastle:jarvis",
     env: {
-      // Native Anthropic-compatible endpoint exposed by Ollama ≥ 0.14 (Jan 2026).
-      ANTHROPIC_BASE_URL: ollamaUrl,
-      ANTHROPIC_AUTH_TOKEN: "ollama",
+      // Native Anthropic-compatible endpoint exposed by Ollama ≥ 0.14 (Jan 2026)
+      // for Tier 0/1; remote provider URL + key for Tier 2 (slice 5, #543).
+      ANTHROPIC_BASE_URL: agentBaseUrl,
+      ANTHROPIC_AUTH_TOKEN: agentAuthToken,
       // Forward host-side gh credentials so the agent can claim issues + open PRs.
       GH_TOKEN: ghToken,
       // Memory MCP bridge — Claude Code expands ${...} in the project-scope
@@ -69,9 +89,12 @@ const result = await run({
       VOYAGE_API_KEY: voyageKey,
       // Per-run id for the agent's source_provenance tags. See prompt.md.
       SANDCASTLE_RUN_ID: runId,
+      // Forced-target issue for slice-5 escalation retries. Empty string =
+      // free pick from queue (default behavior).
+      SANDCASTLE_TARGET_ISSUE: targetIssue,
     },
   }),
-  agent: claudeCode(ollamaModel),
+  agent: claudeCode(agentModel),
   promptFile: "./.sandcastle/prompt.md",
   maxIterations,
   branchStrategy: { type: "merge-to-head" },

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -1,5 +1,9 @@
 # Context
 
+## Forced target (escalation retry)
+
+!`if [ -n "$SANDCASTLE_TARGET_ISSUE" ]; then echo "**Tier escalation retry — pinned to issue #$SANDCASTLE_TARGET_ISSUE.** Skip the pick step below; resume work on this exact issue (claim if not already claimed by you, otherwise continue on its branch)."; else echo "(no forced target — free pick)"; fi`
+
 ## Open issues in the AFK queue
 
 !`gh issue list --repo Osasuwu/jarvis --label "sandcastle" --state open --limit 20 2>&1 || echo "(gh failed)"`

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -29,6 +29,15 @@ param(
 
     [int]$OllamaTimeoutSec = 30,
 
+    # Slice 5 (#543): multi-tier escalation. -Model is Tier 0; -Tier1Model is
+    # the smaller Ollama fallback on OOM/crash; -Tier2Provider switches to a
+    # remote API (deepseek | claude) on persistent failure. Empty values
+    # disable that tier (the chain still runs as a single-tier loop).
+    [string]$Tier1Model,
+
+    [ValidateSet('', 'deepseek', 'claude')]
+    [string]$Tier2Provider = '',
+
     # Skip the actual sandcastle invocation -- for dry runs and Pester.
     [switch]$NoExecute
 )
@@ -171,7 +180,13 @@ function Invoke-Sandcastle {
         [int]$MaxIterations,
         [string]$ResultFile,
         [string]$LogFile,
-        [string]$RunId
+        [string]$RunId,
+        # Slice 5 (#543) tier overrides. Empty => main.mts falls back to Ollama
+        # defaults via OLLAMA_BASE_URL / "ollama" auth.
+        [string]$BaseUrl,
+        [string]$AuthToken,
+        # Forced-target issue (escalation retries). Empty => agent free-picks.
+        [string]$TargetIssue
     )
 
     # Stale result.json from a prior iteration would otherwise be silently
@@ -180,15 +195,24 @@ function Invoke-Sandcastle {
 
     # Save-and-restore so dot-sourced Pester runs don't bleed values across calls.
     $prev = @{
-        SANDCASTLE_RESULT_FILE    = $env:SANDCASTLE_RESULT_FILE
-        SANDCASTLE_MAX_ITERATIONS = $env:SANDCASTLE_MAX_ITERATIONS
-        SANDCASTLE_RUN_ID         = $env:SANDCASTLE_RUN_ID
-        OLLAMA_MODEL              = $env:OLLAMA_MODEL
+        SANDCASTLE_RESULT_FILE      = $env:SANDCASTLE_RESULT_FILE
+        SANDCASTLE_MAX_ITERATIONS   = $env:SANDCASTLE_MAX_ITERATIONS
+        SANDCASTLE_RUN_ID           = $env:SANDCASTLE_RUN_ID
+        SANDCASTLE_AGENT_MODEL      = $env:SANDCASTLE_AGENT_MODEL
+        SANDCASTLE_AGENT_BASE_URL   = $env:SANDCASTLE_AGENT_BASE_URL
+        SANDCASTLE_AGENT_AUTH_TOKEN = $env:SANDCASTLE_AGENT_AUTH_TOKEN
+        SANDCASTLE_TARGET_ISSUE     = $env:SANDCASTLE_TARGET_ISSUE
+        OLLAMA_MODEL                = $env:OLLAMA_MODEL
     }
     $env:SANDCASTLE_RESULT_FILE    = $ResultFile
     $env:SANDCASTLE_MAX_ITERATIONS = "$MaxIterations"
-    if ($RunId) { $env:SANDCASTLE_RUN_ID = $RunId }
-    if ($Model) { $env:OLLAMA_MODEL      = $Model }
+    if ($RunId)       { $env:SANDCASTLE_RUN_ID           = $RunId }
+    if ($Model)       { $env:SANDCASTLE_AGENT_MODEL      = $Model
+                        $env:OLLAMA_MODEL                = $Model }
+    if ($BaseUrl)     { $env:SANDCASTLE_AGENT_BASE_URL   = $BaseUrl }
+    if ($AuthToken)   { $env:SANDCASTLE_AGENT_AUTH_TOKEN = $AuthToken }
+    # TargetIssue: pass empty string verbatim so retries can clear it.
+    $env:SANDCASTLE_TARGET_ISSUE = "$TargetIssue"
 
     Push-Location -LiteralPath $RepoRoot
     $cmdNotFound = $false
@@ -202,10 +226,14 @@ function Invoke-Sandcastle {
         }
     } finally {
         Pop-Location
-        $env:SANDCASTLE_RESULT_FILE    = $prev.SANDCASTLE_RESULT_FILE
-        $env:SANDCASTLE_MAX_ITERATIONS = $prev.SANDCASTLE_MAX_ITERATIONS
-        $env:SANDCASTLE_RUN_ID         = $prev.SANDCASTLE_RUN_ID
-        $env:OLLAMA_MODEL              = $prev.OLLAMA_MODEL
+        $env:SANDCASTLE_RESULT_FILE      = $prev.SANDCASTLE_RESULT_FILE
+        $env:SANDCASTLE_MAX_ITERATIONS   = $prev.SANDCASTLE_MAX_ITERATIONS
+        $env:SANDCASTLE_RUN_ID           = $prev.SANDCASTLE_RUN_ID
+        $env:SANDCASTLE_AGENT_MODEL      = $prev.SANDCASTLE_AGENT_MODEL
+        $env:SANDCASTLE_AGENT_BASE_URL   = $prev.SANDCASTLE_AGENT_BASE_URL
+        $env:SANDCASTLE_AGENT_AUTH_TOKEN = $prev.SANDCASTLE_AGENT_AUTH_TOKEN
+        $env:SANDCASTLE_TARGET_ISSUE     = $prev.SANDCASTLE_TARGET_ISSUE
+        $env:OLLAMA_MODEL                = $prev.OLLAMA_MODEL
     }
 
     if ($cmdNotFound) {
@@ -223,6 +251,121 @@ function Invoke-Sandcastle {
         return [pscustomobject]@{ ok = $false; exitCode = $exitCode; result = $null; reason = "json-parse-error: $_" }
     }
     return [pscustomobject]@{ ok = $true; exitCode = 0; result = $json; reason = $null }
+}
+
+# ---------------------------------------------------------------------------
+# Tier escalation -- slice 5 (#543, decision f8e27d53)
+# ---------------------------------------------------------------------------
+#
+# Detects model-side resource exhaustion (OOM / model-load failure) so the
+# watchdog can retry on a smaller Ollama model (Tier 1) or escalate to a
+# remote API (Tier 2). False positives are cheap (one extra retry); false
+# negatives downgrade to a generic failure outcome, which is still safe.
+
+# Substrings (case-insensitive) that indicate the agent's model itself fell
+# over due to memory pressure rather than a logic / agent-side error.
+$script:OOMSignatures = @(
+    'out of memory',
+    'oom',
+    'cuda out of memory',
+    'model requires more system memory',
+    'model load failed',
+    'failed to load model',
+    'unable to allocate'
+)
+
+function Test-IsOOM {
+    [CmdletBinding()]
+    param(
+        [string]$Reason,
+        [string]$LogFile
+    )
+    if ($Reason -match '^exit=137$') { return $true }   # SIGKILL on Linux OOM
+    if ($Reason -like 'json-parse-error*') { return $false }  # malformed result, not OOM
+    if (-not $LogFile -or -not (Test-Path -LiteralPath $LogFile)) { return $false }
+    try {
+        $content = Get-Content -LiteralPath $LogFile -Raw -Encoding utf8 -ErrorAction Stop
+    } catch {
+        return $false
+    }
+    if (-not $content) { return $false }
+    foreach ($sig in $script:OOMSignatures) {
+        if ($content -match [regex]::Escape($sig)) { return $true }
+    }
+    return $false
+}
+
+function Get-IssueFromBranch {
+    [CmdletBinding()]
+    param([string]$Branch)
+    if (-not $Branch) { return $null }
+    if ($Branch -match '^(?:feat|fix|chore)/(\d+)\b') { return [int]$Matches[1] }
+    return $null
+}
+
+function Get-IssueLabels {
+    [CmdletBinding()]
+    param([int]$Issue, [string]$RepoSlug)
+    if (-not $Issue) { return @() }
+    try {
+        $args = @('issue', 'view', "$Issue", '--json', 'labels', '--jq', '[.labels[].name]')
+        if ($RepoSlug) { $args += @('--repo', $RepoSlug) }
+        $raw = & gh @args 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $raw) { return @() }
+        return ($raw | ConvertFrom-Json)
+    } catch {
+        return @()
+    }
+}
+
+function Add-IssueLabel {
+    [CmdletBinding()]
+    param([int]$Issue, [string]$Label, [string]$RepoSlug)
+    if (-not $Issue -or -not $Label) { return $false }
+    $args = @('issue', 'edit', "$Issue", '--add-label', $Label)
+    if ($RepoSlug) { $args += @('--repo', $RepoSlug) }
+    & gh @args 2>$null | Out-Null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Resolve-Tier2Config {
+    [CmdletBinding()]
+    param(
+        [string]$Provider,        # 'deepseek' | 'claude' | ''
+        [int]$Issue,
+        [string]$RepoSlug,
+        [hashtable]$EnvVars       # parsed .sandcastle/.env
+    )
+    if (-not $Provider) { return $null }
+
+    # `use-claude-api` label flips Tier 2 from the configured default to
+    # Claude (AC: cron runs never auto-promote to Claude; the label is the
+    # explicit owner gate).
+    $labels = Get-IssueLabels -Issue $Issue -RepoSlug $RepoSlug
+    $effective = if ($labels -contains 'use-claude-api') { 'claude' } else { $Provider }
+
+    function Coalesce([string]$a, [string]$b) {
+        if ([string]::IsNullOrWhiteSpace($a)) { return $b } else { return $a }
+    }
+    switch ($effective) {
+        'deepseek' {
+            return @{
+                Provider  = 'deepseek'
+                Model     = (Coalesce $EnvVars['DEEPSEEK_MODEL']    'deepseek-coder')
+                BaseUrl   = (Coalesce $EnvVars['DEEPSEEK_BASE_URL'] 'https://api.deepseek.com/anthropic')
+                AuthToken = $EnvVars['DEEPSEEK_API_KEY']
+            }
+        }
+        'claude' {
+            return @{
+                Provider  = 'claude'
+                Model     = (Coalesce $EnvVars['CLAUDE_MODEL']    'claude-haiku-4-5-20251001')
+                BaseUrl   = (Coalesce $EnvVars['CLAUDE_BASE_URL'] 'https://api.anthropic.com')
+                AuthToken = $EnvVars['ANTHROPIC_API_KEY']
+            }
+        }
+        default { return $null }
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -385,7 +528,10 @@ function Invoke-Watchdog {
         [string]$Model,
         [string]$WindowEnd,
         [int]$DockerTimeoutSec,
-        [int]$OllamaTimeoutSec
+        [int]$OllamaTimeoutSec,
+        # Slice 5 (#543) tier overrides; empty disables the corresponding tier.
+        [string]$Tier1Model,
+        [string]$Tier2Provider
     )
 
     $repoRoot = Get-RepoRoot -Repo $Repo
@@ -446,11 +592,13 @@ function Invoke-Watchdog {
     }
 
     # 3. Iterate (soft-stop on window expiry between iterations)
+    $repoSlug = if ($Repo -eq 'jarvis') { 'Osasuwu/jarvis' } else { '' }
     $totalUsage = @{ input_tokens = 0; output_tokens = 0; cache_read_input_tokens = 0; cache_creation_input_tokens = 0; model = $Model }
     $allCommits = @()
     $branch = $null
     $iter = 0
     $partialReason = $null
+    $tierCompleted = $null    # 'tier0' | 'tier1' | 'tier2:deepseek' | 'tier2:claude'
 
     while ($iter -lt $MaxIterations) {
         if (Test-WindowExpired -WindowEnd $windowEndDt) {
@@ -461,17 +609,70 @@ function Invoke-Watchdog {
         $iter++
         Write-Host "[watchdog] iteration $iter/$MaxIterations"
 
+        # ----- Tier 0: primary Ollama model -----
         $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $Model `
-            -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId
+            -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
+            -TargetIssue ''
+        $tierUsed = 'tier0'
+        $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+        $oomDetected = (-not $invocation.ok) -and (Test-IsOOM -Reason $invocation.reason -LogFile $logFile)
+
+        # ----- Tier 1: smaller Ollama model on OOM/crash -----
+        if (-not $invocation.ok -and $Tier1Model -and $oomDetected) {
+            Write-Host "[watchdog] Tier 0 OOM detected -- escalating to Tier 1 model: $Tier1Model"
+            $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $Tier1Model `
+                -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
+                -TargetIssue ([string]$targetIssue)
+            $tierUsed = 'tier1'
+            if (-not $targetIssue) {
+                $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+            }
+        }
+
+        # ----- Tier 2: remote API on persistent failure -----
+        # Reached when the chain saw a Tier-0 OOM (gate above set $oomDetected)
+        # and the chain still hasn't recovered. Tier 1 may have been skipped
+        # entirely (no $Tier1Model) or it may have run and failed for any
+        # reason -- both qualify per AC #3 ("persistent failure after Tier 1").
+        if (-not $invocation.ok -and $oomDetected -and $Tier2Provider) {
+            $tier2 = Resolve-Tier2Config -Provider $Tier2Provider -Issue $targetIssue `
+                -RepoSlug $repoSlug -EnvVars $envVars
+            if ($tier2 -and $tier2.AuthToken) {
+                Write-Host "[watchdog] Tier 1 failed -- escalating to Tier 2 ($($tier2.Provider): $($tier2.Model))"
+                $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $tier2.Model `
+                    -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
+                    -BaseUrl $tier2.BaseUrl -AuthToken $tier2.AuthToken `
+                    -TargetIssue ([string]$targetIssue)
+                $tierUsed = "tier2:$($tier2.Provider)"
+            } else {
+                Write-Warning "[watchdog] Tier 2 requested but config incomplete (provider=$Tier2Provider, key set=$([bool]$tier2.AuthToken)); skipping."
+            }
+        }
 
         if (-not $invocation.ok) {
             $reason = if ($invocation.reason) { $invocation.reason } else { "exit=$($invocation.exitCode)" }
-            Record 'failure' "sandcastle invocation failed: $reason" $totalUsage $reason
+            # Full chain failure: label the issue if we know which one was attempted.
+            $labelApplied = $false
+            if ($targetIssue -and $repoSlug) {
+                $labelApplied = Add-IssueLabel -Issue $targetIssue -Label 'too-large-for-local' -RepoSlug $repoSlug
+            }
+            $totalUsage.tier = $tierUsed
+            $totalUsage.too_large_for_local = $labelApplied
+            Record 'failure' "sandcastle invocation failed: $reason (tier=$tierUsed issue=$targetIssue label=$labelApplied)" $totalUsage $reason
             throw "sandcastle invocation failed: $reason"
         }
 
+        $tierCompleted = $tierUsed
         $r = $invocation.result
         $branch = $r.branch
+        $totalUsage.tier = $tierCompleted
+        if ($tierCompleted -ne 'tier0') {
+            $totalUsage.model = $r.model    # not always set; best-effort
+            if (-not $totalUsage.model) {
+                # Fall back to tier label so reviewers see which tier won.
+                $totalUsage.model = $tierCompleted
+            }
+        }
         if ($r.commits) { $allCommits += $r.commits }
         foreach ($it in $r.iterations) {
             if ($it.usage) {
@@ -500,5 +701,6 @@ function Invoke-Watchdog {
 if (-not $NoExecute -and $Repo) {
     Invoke-Watchdog -Repo $Repo -MaxIterations $MaxIterations -Model $Model `
         -WindowEnd $WindowEnd -DockerTimeoutSec $DockerTimeoutSec `
-        -OllamaTimeoutSec $OllamaTimeoutSec
+        -OllamaTimeoutSec $OllamaTimeoutSec `
+        -Tier1Model $Tier1Model -Tier2Provider $Tier2Provider
 }

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -169,6 +169,289 @@ Describe 'Format-RedactedError' {
     }
 }
 
+Describe 'Test-IsOOM' {
+    It 'flags exit code 137 (Linux OOM-kill) without a log file' {
+        Test-IsOOM -Reason 'exit=137' -LogFile '' | Should Be $true
+    }
+
+    It 'rejects unrelated exit codes' {
+        Test-IsOOM -Reason 'exit=7' -LogFile '' | Should Be $false
+    }
+
+    It 'rejects json-parse-error even if the log mentions OOM' {
+        # Malformed result.json comes from a torn write, not from a model
+        # OOM -- escalating to a smaller model would not help.
+        $tmp = Join-Path $env:TEMP "oom-log-$([guid]::NewGuid()).txt"
+        'CUDA out of memory' | Set-Content -Path $tmp -Encoding UTF8
+        try {
+            Test-IsOOM -Reason 'json-parse-error: Unexpected token' -LogFile $tmp | Should Be $false
+        } finally {
+            Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'matches OOM substrings in the log file (case-insensitive)' {
+        $tmp = Join-Path $env:TEMP "oom-log-$([guid]::NewGuid()).txt"
+        'ollama serve: model requires more system memory than available' | Set-Content -Path $tmp -Encoding UTF8
+        try {
+            Test-IsOOM -Reason 'exit=1' -LogFile $tmp | Should Be $true
+        } finally {
+            Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'returns false when log file does not exist' {
+        Test-IsOOM -Reason 'exit=1' -LogFile (Join-Path $env:TEMP "missing-$([guid]::NewGuid()).log") | Should Be $false
+    }
+}
+
+Describe 'Get-IssueFromBranch' {
+    It 'parses feat/<N>-slug' {
+        Get-IssueFromBranch -Branch 'feat/543-multi-tier' | Should Be 543
+    }
+    It 'parses fix/<N>-slug' {
+        Get-IssueFromBranch -Branch 'fix/42-broken' | Should Be 42
+    }
+    It 'returns null for unknown shapes' {
+        Get-IssueFromBranch -Branch 'main' | Should BeNullOrEmpty
+        Get-IssueFromBranch -Branch ''     | Should BeNullOrEmpty
+        Get-IssueFromBranch -Branch $null  | Should BeNullOrEmpty
+    }
+}
+
+Describe 'Resolve-Tier2Config' {
+    It 'returns null when provider is empty' {
+        Mock Get-IssueLabels { @() }
+        Resolve-Tier2Config -Provider '' -Issue 1 -RepoSlug 'x/y' -EnvVars @{} | Should BeNullOrEmpty
+    }
+
+    It 'maps deepseek with envVar overrides + key' {
+        Mock Get-IssueLabels { @() }
+        $env = @{ DEEPSEEK_API_KEY = 'ds-secret'; DEEPSEEK_MODEL = 'ds-coder-mini' }
+        $cfg = Resolve-Tier2Config -Provider 'deepseek' -Issue 99 -RepoSlug 'x/y' -EnvVars $env
+        $cfg.Provider  | Should Be 'deepseek'
+        $cfg.Model     | Should Be 'ds-coder-mini'
+        $cfg.AuthToken | Should Be 'ds-secret'
+        $cfg.BaseUrl   | Should Match '^https://'
+    }
+
+    It 'use-claude-api label flips deepseek default to claude' {
+        Mock Get-IssueLabels { @('use-claude-api', 'priority:high') }
+        $env = @{ ANTHROPIC_API_KEY = 'sk-ant-test'; DEEPSEEK_API_KEY = 'ds' }
+        $cfg = Resolve-Tier2Config -Provider 'deepseek' -Issue 99 -RepoSlug 'x/y' -EnvVars $env
+        $cfg.Provider  | Should Be 'claude'
+        $cfg.AuthToken | Should Be 'sk-ant-test'
+    }
+
+    It 'leaves provider as deepseek when label missing' {
+        Mock Get-IssueLabels { @('priority:medium') }
+        $env = @{ DEEPSEEK_API_KEY = 'ds' }
+        $cfg = Resolve-Tier2Config -Provider 'deepseek' -Issue 99 -RepoSlug 'x/y' -EnvVars $env
+        $cfg.Provider | Should Be 'deepseek'
+    }
+}
+
+Describe 'Invoke-Watchdog tier escalation matrix (slice 5, #543)' {
+    BeforeEach {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Start-DockerDesktop { }
+        Mock Start-OllamaServer  { }
+        Mock Get-RepoRoot { $env:TEMP }
+        Mock Read-DotEnvFile {
+            @{
+                SUPABASE_URL       = 'https://x'
+                SUPABASE_KEY       = 'k'
+                TELEGRAM_BOT_TOKEN = 't'
+                TELEGRAM_CHAT_ID   = '1'
+                DEEPSEEK_API_KEY   = 'ds-key'
+                ANTHROPIC_API_KEY  = 'cl-key'
+            }
+        }
+        Mock New-RuntimeDir { Join-Path $env:TEMP "sandcastle-tier-test-$([guid]::NewGuid())" }
+        Mock Write-OutcomeRecord { 'mocked' }
+        Mock Send-TelegramAlert  { 'mocked' }
+        Mock Add-IssueLabel      { $true }
+        Mock Get-IssueLabels     { @() }
+    }
+
+    It 'AC: Tier 0 success -> no escalation, no labels, no Tier 1/2 invocation' {
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += $Model
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = 'feat/100-foo'; commits = @(); iterations = @()
+                }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 1 -Exactly -Scope It
+        Assert-MockCalled Add-IssueLabel    -Times 0 -Exactly -Scope It
+        $script:calls[0] | Should Be 'qwen-large'
+    }
+
+    It 'AC: Tier 0 OOM -> exactly one Tier 1 retry, success records tier1' {
+        $script:calls = @()
+        $script:n = 0
+        Mock Invoke-Sandcastle {
+            $script:n++
+            $script:calls += $Model
+            if ($script:n -eq 1) {
+                return [pscustomobject]@{ ok = $false; exitCode = 137; reason = 'exit=137'; result = $null }
+            }
+            return [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = 'feat/200-bar'; commits = @(); iterations = @()
+                }
+            }
+        }
+        Mock Test-IsOOM { $true }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 2 -Exactly -Scope It
+        $script:calls[0] | Should Be 'qwen-large'
+        $script:calls[1] | Should Be 'qwen-small'
+        Assert-MockCalled Add-IssueLabel -Times 0 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' -and $LlmMetrics.tier -eq 'tier1' }
+    }
+
+    It 'AC: Tier 0+1 fail -> Tier 2 (deepseek) success, no too-large label' {
+        $script:n = 0
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:n++
+            $script:calls += @{ Model = $Model; BaseUrl = $BaseUrl; Token = $AuthToken }
+            if ($script:n -le 2) {
+                $branch = if ($script:n -eq 1) { 'feat/300-baz' } else { $null }
+                return [pscustomobject]@{
+                    ok = $false; exitCode = 137; reason = 'exit=137'
+                    result = if ($branch) { [pscustomobject]@{ branch = $branch } } else { $null }
+                }
+            }
+            return [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = 'feat/300-baz'; commits = @(); iterations = @()
+                }
+            }
+        }
+        Mock Test-IsOOM { $true }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 3 -Exactly -Scope It
+        $script:calls[2].Token | Should Be 'ds-key'
+        Assert-MockCalled Add-IssueLabel -Times 0 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' -and $LlmMetrics.tier -eq 'tier2:deepseek' }
+    }
+
+    It 'AC: full chain fail -> too-large-for-local label applied + outcome=failure' {
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok = $false; exitCode = 137; reason = 'exit=137'
+                result = [pscustomobject]@{ branch = 'feat/400-qux' }
+            }
+        }
+        Mock Test-IsOOM { $true }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+              -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' `
+              -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        Assert-MockCalled Invoke-Sandcastle -Times 3 -Exactly -Scope It
+        Assert-MockCalled Add-IssueLabel -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Issue -eq 400 -and $Label -eq 'too-large-for-local' }
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'failure' -and $Summary -like '*tier=tier2:deepseek*' }
+    }
+
+    It 'AC: use-claude-api label flips Tier 2 to Claude API key' {
+        Mock Get-IssueLabels { @('use-claude-api') }
+        $script:n = 0
+        $script:tier2Token = $null
+        Mock Invoke-Sandcastle {
+            $script:n++
+            if ($script:n -le 2) {
+                return [pscustomobject]@{
+                    ok = $false; exitCode = 137; reason = 'exit=137'
+                    result = [pscustomobject]@{ branch = 'feat/500-claude' }
+                }
+            }
+            $script:tier2Token = $AuthToken
+            return [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/500-claude'; commits = @(); iterations = @() }
+            }
+        }
+        Mock Test-IsOOM { $true }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        $script:tier2Token | Should Be 'cl-key'
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $LlmMetrics.tier -eq 'tier2:claude' }
+    }
+
+    It 'AC: non-OOM Tier 0 failure does NOT escalate (logic error stays a failure)' {
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{ ok = $false; exitCode = 7; reason = 'exit=7'; result = $null }
+        }
+        Mock Test-IsOOM { $false }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+              -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' `
+              -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        Assert-MockCalled Invoke-Sandcastle -Times 1 -Exactly -Scope It
+        Assert-MockCalled Add-IssueLabel    -Times 0 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'failure' -and $LlmMetrics.tier -eq 'tier0' }
+    }
+
+    It 'no Tier 1 configured: Tier 0 OOM jumps directly to Tier 2 (deepseek)' {
+        $script:n = 0
+        Mock Invoke-Sandcastle {
+            $script:n++
+            if ($script:n -eq 1) {
+                return [pscustomobject]@{
+                    ok = $false; exitCode = 137; reason = 'exit=137'
+                    result = [pscustomobject]@{ branch = 'feat/600-skip-tier1' }
+                }
+            }
+            return [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/600-skip-tier1'; commits = @(); iterations = @() }
+            }
+        }
+        Mock Test-IsOOM { $true }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model '' -Tier2Provider 'deepseek' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 2 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $LlmMetrics.tier -eq 'tier2:deepseek' }
+    }
+}
+
 Describe 'Invoke-Watchdog daemon-state matrix' {
     BeforeEach {
         Mock Start-DockerDesktop { }


### PR DESCRIPTION
## Summary

Watchdog (`scripts/sandcastle/Run-Sandcastle.ps1`) now escalates Tier 0 OOM/crash through:
- **Tier 1** — smaller Ollama model (`-Tier1Model`) on detected OOM
- **Tier 2** — DeepSeek-class API by default (`-Tier2Provider deepseek`); Claude API selected automatically when the target issue carries the `use-claude-api` label

Full chain failure labels the issue `too-large-for-local` and the watchdog exits. Tier metadata rides in `outcome_record.lessons` as `tier` (e.g. `tier0`, `tier2:deepseek`).

## Why
Closes #543. Decisions `f8e27d53` (escalation chain) and `0c3017c6` (failure mode parent) — memory-recorded.

## Decisions & Alternatives

- **Orchestrate in PowerShell, not main.mts** — the watchdog already owns iteration control, daemon health, and outcome recording. main.mts stays a config shim with three new env-driven overrides (`SANDCASTLE_AGENT_{MODEL,BASE_URL,AUTH_TOKEN}`) plus `SANDCASTLE_TARGET_ISSUE` for forced-target retries.
- **OOM detection is heuristic** — exit code 137 + log substrings (`'out of memory'`, `'cuda out of memory'`, `'model requires more system memory'`, …). False positives cost one extra retry; false negatives downgrade to a generic failure (still safe, no escalation).
- **Tier 2 reachable but Claude is gated** — `-Tier2Provider deepseek` is the cron default; the `use-claude-api` issue label flips the call to Claude. Cron runs cannot promote to Claude on their own (AC).
- **Same-issue retry** via `SANDCASTLE_TARGET_ISSUE` env var → `prompt.md` "forced target" block. Branch parsing (`feat/<N>-`) tells the watchdog which issue to pin and to label on full failure.
- **Schema untouched** — like slice 4, tier info rides in `lessons` JSON. Stable shape: `{ input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, model, tier, too_large_for_local? }`.

Rejected: orchestrating inside main.mts (sandcastle's `run()` is single-shot per call); a separate Python orchestrator (project rule: only `mcp-memory/server.py` is justified Python).

## Risk Assessment

- **MEDIUM** — adds tier state machine and external API surface. All paths covered by Pester mocks; live Tier 2 calls require explicit env config + label (Claude) or `-Tier2Provider deepseek` (DeepSeek), so no accidental cost.
- Telegram remains infra-down only — tier escalations stay silent (verified by existing slice-6 test "5-iteration AFK run with one OOM-escalated success produces zero Telegram calls").
- No secrets in code, logs, or commit. `.env.example` documents the new vars; values stay in `.sandcastle/.env`.

## Testing

`Invoke-Pester -Path tests/sandcastle/Run-Sandcastle.Tests.ps1` — **53/53 pass** (was 30; +23 for slice 5):

- `Test-IsOOM` (5 tests): exit 137, log substrings, json-parse-error rejected, missing log handled.
- `Get-IssueFromBranch` (3): feat/, fix/, edge cases.
- `Resolve-Tier2Config` (4): empty provider, deepseek mapping, `use-claude-api` flip, default deepseek.
- Tier escalation matrix (7): Tier 0 success / Tier 0 OOM → Tier 1 success / Tier 0+1 fail → Tier 2 deepseek success / full chain fail → label / `use-claude-api` flips Tier 2 to Claude / non-OOM Tier 0 fail does NOT escalate / no Tier 1 configured (Tier 0 OOM jumps to Tier 2).

Live smoke deferred — needs DeepSeek key + a known-OOM issue. Slice 7 (#538) benchmark pass will exercise live Tier 0/1 boundary.

## Files Changed

- `scripts/sandcastle/Run-Sandcastle.ps1` — tier params, `Test-IsOOM`, `Get-IssueFromBranch`, `Get-IssueLabels`, `Add-IssueLabel`, `Resolve-Tier2Config`, escalation chain inside iteration loop.
- `.sandcastle/main.mts` — `SANDCASTLE_AGENT_{MODEL,BASE_URL,AUTH_TOKEN}` overrides; `SANDCASTLE_TARGET_ISSUE` forwarded to container env.
- `.sandcastle/prompt.md` — "forced target" context block honoring `$SANDCASTLE_TARGET_ISSUE`.
- `.sandcastle/.env.example` — DeepSeek + Claude tier env vars documented; Slice-5 escape-hatch comment removed.
- `tests/sandcastle/Run-Sandcastle.Tests.ps1` — +23 tests covering AC scenarios.