### PR TITLE
feat(memory): Tier 2 hook blocks record_decision without memories_used (#524)

### DIFF
--- a/.claude-userlevel/settings.json
+++ b/.claude-userlevel/settings.json
@@ -148,6 +148,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python scripts/record-decision-gate.py"
+          },
+          {
+            "type": "command",
             "command": "python scripts/pretooluse-recall-hook.py"
           }
         ]

--- a/mcp-memory/handlers/decision.py
+++ b/mcp-memory/handlers/decision.py
@@ -232,6 +232,8 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
         payload["confidence"] = confidence
     if project:
         payload["project"] = project
+    if bool(args.get("intentionally_empty")):
+        payload["intentionally_empty"] = True
 
     try:
         result = (

--- a/mcp-memory/tools_schema.py
+++ b/mcp-memory/tools_schema.py
@@ -603,6 +603,16 @@ def tool_definitions() -> list[Tool]:
                         "items": {"type": "string"},
                         "description": "Memory IDs that informed this decision (from recall).",
                     },
+                    "intentionally_empty": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": (
+                            "Set true to acknowledge that no memory informed this "
+                            "decision. The Tier 2 PreToolUse hook (#524) blocks "
+                            "calls with empty memories_used unless this is true. "
+                            "Sustained >10% rate is a flag for human review."
+                        ),
+                    },
                     "outcomes_referenced": {
                         "type": "array",
                         "items": {"type": "string"},

--- a/scripts/record-decision-gate.py
+++ b/scripts/record-decision-gate.py
@@ -1,0 +1,103 @@
+"""PreToolUse hook: block ``record_decision`` with empty ``memories_used`` (#524).
+
+Tier 2 mechanical backstop for the Tier 1 prompt rule in
+``~/.claude/CLAUDE.md`` — "Memory & decision protocol", brief-mode → UUID
+map. Per #325 audit, 12 of 33 historical ``decision_made`` episodes stored
+names not UUIDs (broken FK), and a separate audit found a non-trivial
+fraction emitted with no memories at all. The Tier 1 rule alone hasn't
+held the line.
+
+Contract
+--------
+- Fires on ``mcp__memory__record_decision``.
+- Blocks (``permissionDecision=deny``) when ``memories_used`` is missing
+  or empty AND ``intentionally_empty`` is not explicitly true.
+- Structural escape: pass ``intentionally_empty=true`` in the tool args
+  to acknowledge no memory informed the decision. The server emits the
+  flag into the episode payload so ``/learn`` (#526) can track the rate;
+  sustained >10% is a flag for human review.
+- Any other tool name → silent exit 0 (defense-in-depth: this hook is
+  also registered under a narrow matcher).
+- Parse failure / malformed input → silent exit 0. Never block on
+  hook-internal bugs; the rule must not become a footgun.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+TOOL_NAME = "mcp__memory__record_decision"
+
+BLOCK_REASON = (
+    "record_decision blocked: memories_used is empty.\n"
+    "\n"
+    "Per ~/.claude/CLAUDE.md (Memory & decision protocol, rule 2):\n"
+    "  Every record_decision call passes UUIDs in memories_used, not names.\n"
+    "  Empty list valid only when nothing in memory informed the choice.\n"
+    "\n"
+    "Fix one of:\n"
+    "  1. Run memory_recall(brief=true), parse name→uuid, pass UUIDs.\n"
+    "  2. If genuinely no memory informed this decision, pass\n"
+    "     intentionally_empty=true to acknowledge it. The flag is recorded\n"
+    "     on the episode payload for /learn rate tracking (#524, #526)."
+)
+
+
+def _emit_deny(reason: str) -> None:
+    """Output deny JSON and exit 2 (PreToolUse deny convention)."""
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    json.dump(payload, sys.stdout)
+    sys.exit(2)
+
+
+def _silent_exit() -> None:
+    sys.exit(0)
+
+
+def evaluate(tool_name: str, tool_input: dict) -> bool:
+    """Return True iff this call should be blocked.
+
+    Pure function — testable without stdin/stdout plumbing.
+    """
+    if tool_name != TOOL_NAME:
+        return False
+    if not isinstance(tool_input, dict):
+        return False
+    if bool(tool_input.get("intentionally_empty")):
+        return False
+    memories = tool_input.get("memories_used")
+    if isinstance(memories, list) and len(memories) > 0:
+        return False
+    return True
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+    except Exception:
+        _silent_exit()
+    if not raw.strip():
+        _silent_exit()
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        _silent_exit()
+
+    tool_name = data.get("tool_name") or ""
+    tool_input = data.get("tool_input") or {}
+
+    if evaluate(tool_name, tool_input):
+        _emit_deny(BLOCK_REASON)
+    _silent_exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_record_decision.py
+++ b/tests/test_record_decision.py
@@ -218,6 +218,59 @@ class TestRecordDecisionInsert:
         assert "confidence" not in payload
 
     @pytest.mark.asyncio
+    async def test_intentionally_empty_true_emits_into_payload(self, monkeypatch):
+        """#524 — flag is preserved on the episode payload for /learn rate tracking."""
+        client = _make_client_returning()
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "no recall data available",
+                "reversibility": "reversible",
+                "memories_used": [],
+                "intentionally_empty": True,
+            }
+        )
+
+        all_inserts = [
+            c.args[0]
+            for c in client.table.return_value.insert.call_args_list
+            if c.args
+        ]
+        episode_inserts = [
+            p for p in all_inserts if "kind" in p and "trace_id" not in p
+        ]
+        payload = episode_inserts[0]["payload"]
+        assert payload.get("intentionally_empty") is True
+
+    @pytest.mark.asyncio
+    async def test_intentionally_empty_omitted_when_false(self, monkeypatch):
+        """Default path — flag absent from payload (keeps episodes lean)."""
+        client = _make_client_returning()
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+                "memories_used": [_UID_A],
+            }
+        )
+
+        all_inserts = [
+            c.args[0]
+            for c in client.table.return_value.insert.call_args_list
+            if c.args
+        ]
+        episode_inserts = [
+            p for p in all_inserts if "kind" in p and "trace_id" not in p
+        ]
+        payload = episode_inserts[0]["payload"]
+        assert "intentionally_empty" not in payload
+
+    @pytest.mark.asyncio
     async def test_db_failure_returns_error_text(self, monkeypatch):
         client = MagicMock()
         client.table.return_value.insert.return_value.execute.side_effect = RuntimeError("boom")

--- a/tests/test_record_decision_gate.py
+++ b/tests/test_record_decision_gate.py
@@ -1,0 +1,177 @@
+"""Tests for scripts/record-decision-gate.py — Tier 2 hook (#524)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+gate = importlib.import_module("record-decision-gate")
+
+_HOOK = Path(__file__).resolve().parent.parent / "scripts" / "record-decision-gate.py"
+
+
+# ── Pure evaluator ───────────────────────────────────────────────────
+
+
+def test_blocks_when_memories_used_missing():
+    assert gate.evaluate("mcp__memory__record_decision", {}) is True
+
+
+def test_blocks_when_memories_used_empty_list():
+    assert (
+        gate.evaluate("mcp__memory__record_decision", {"memories_used": []}) is True
+    )
+
+
+def test_blocks_when_memories_used_none():
+    assert (
+        gate.evaluate("mcp__memory__record_decision", {"memories_used": None}) is True
+    )
+
+
+def test_passes_when_memories_used_has_uuids():
+    uuids = ["11111111-1111-1111-1111-111111111111"]
+    assert (
+        gate.evaluate("mcp__memory__record_decision", {"memories_used": uuids})
+        is False
+    )
+
+
+def test_passes_when_intentionally_empty_true_and_empty_list():
+    assert (
+        gate.evaluate(
+            "mcp__memory__record_decision",
+            {"memories_used": [], "intentionally_empty": True},
+        )
+        is False
+    )
+
+
+def test_passes_when_intentionally_empty_true_and_missing():
+    assert (
+        gate.evaluate(
+            "mcp__memory__record_decision",
+            {"intentionally_empty": True},
+        )
+        is False
+    )
+
+
+def test_intentionally_empty_false_does_not_bypass():
+    assert (
+        gate.evaluate(
+            "mcp__memory__record_decision",
+            {"memories_used": [], "intentionally_empty": False},
+        )
+        is True
+    )
+
+
+def test_other_tool_never_blocks():
+    assert gate.evaluate("Bash", {"command": "ls"}) is False
+    assert gate.evaluate("mcp__memory__memory_store", {}) is False
+
+
+def test_intentionally_empty_overrides_even_with_full_list():
+    # Flag is checked first; non-empty list also passes — both routes work.
+    uuids = ["11111111-1111-1111-1111-111111111111"]
+    assert (
+        gate.evaluate(
+            "mcp__memory__record_decision",
+            {"memories_used": uuids, "intentionally_empty": True},
+        )
+        is False
+    )
+
+
+# ── End-to-end: subprocess with stdin JSON ───────────────────────────
+
+
+def _run_hook(input_obj: dict) -> tuple[int, str]:
+    proc = subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input=json.dumps(input_obj),
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout
+
+
+def test_subprocess_blocks_empty_with_deny_json():
+    rc, out = _run_hook(
+        {
+            "tool_name": "mcp__memory__record_decision",
+            "tool_input": {"memories_used": []},
+        }
+    )
+    assert rc == 2
+    payload = json.loads(out)
+    inner = payload["hookSpecificOutput"]
+    assert inner["hookEventName"] == "PreToolUse"
+    assert inner["permissionDecision"] == "deny"
+    assert "memories_used" in inner["permissionDecisionReason"]
+    assert "CLAUDE.md" in inner["permissionDecisionReason"]
+    assert "intentionally_empty" in inner["permissionDecisionReason"]
+
+
+def test_subprocess_passes_with_uuids():
+    rc, out = _run_hook(
+        {
+            "tool_name": "mcp__memory__record_decision",
+            "tool_input": {
+                "memories_used": ["11111111-1111-1111-1111-111111111111"]
+            },
+        }
+    )
+    assert rc == 0
+    assert out == ""
+
+
+def test_subprocess_passes_with_intentionally_empty():
+    rc, out = _run_hook(
+        {
+            "tool_name": "mcp__memory__record_decision",
+            "tool_input": {"memories_used": [], "intentionally_empty": True},
+        }
+    )
+    assert rc == 0
+    assert out == ""
+
+
+def test_subprocess_silent_on_other_tool():
+    rc, out = _run_hook(
+        {"tool_name": "Bash", "tool_input": {"command": "ls"}}
+    )
+    assert rc == 0
+    assert out == ""
+
+
+def test_subprocess_silent_on_malformed_stdin():
+    proc = subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input="not json at all",
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+
+
+def test_subprocess_silent_on_empty_stdin():
+    proc = subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input="",
+        text=True,
+        capture_output=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary

Tier 2 mechanical backstop for the Tier 1 prompt rule in `~/.claude/CLAUDE.md` (Memory & decision protocol). PreToolUse hook on `mcp__memory__record_decision` denies calls with empty `memories_used` unless the new structural escape `intentionally_empty=true` is set explicitly.

Per #325 audit: 12 of 33 historical `decision_made` episodes stored names not UUIDs (broken FKs). Tier 1 alone doesn't hold the line.

## Changes

- `mcp-memory/tools_schema.py` — add `intentionally_empty: bool = false` field
- `mcp-memory/handlers/decision.py` — emit flag into episode payload (audit trail; /learn #526 will track rate)
- `scripts/record-decision-gate.py` — new hook, pure evaluator + stdin/stdout shim, fail-soft on parse errors
- `.claude-userlevel/settings.json` — register gate hook ahead of recall hook on the same matcher
- Tests: 9 pure-evaluator + 6 subprocess (gate) + 2 handler (payload field) — 17 new tests

## Acceptance criteria

- [x] `record_decision` schema gains optional `intentionally_empty: bool = false`
- [x] Server emits the field into the decision episode payload
- [x] Hook script registered in `.claude-userlevel/settings.json` (mirrors to `~/.claude/settings.json` via `install.ps1`)
- [x] Test: empty `memories_used`, `intentionally_empty` unset → blocked
- [x] Test: empty `memories_used`, `intentionally_empty=true` → passes
- [x] Test: non-empty `memories_used` → passes (regardless of flag)
- [x] Block message references the CLAUDE.md rule
- [ ] `/learn` (#526) tracks `intentionally_empty=true` rate — deferred to #526

## Test plan

- [x] `pytest tests/test_record_decision_gate.py` — 15/15 pass
- [x] `pytest tests/test_record_decision.py` — 30/30 pass (incl. 2 new for the payload field)
- [x] Broader hook/schema sweep: 150 passed, 1 skipped

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)