### PR TITLE
feat(installer): orphan-skill cleanup — quarantine dirs absent from include whitelist (#576)

### DIFF
--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -40,7 +40,7 @@ DEFAULT_MANIFEST = "install-manifest.yaml"
 class Action:
     """One planned filesystem action."""
 
-    kind: str  # "copy_file" | "copy_dir" | "merge_json" | "quarantine_file" | "register_mcp_user" | "write_version" | "set_env"
+    kind: str  # "copy_file" | "copy_dir" | "merge_json" | "quarantine_file" | "prune_orphan" | "register_mcp_user" | "write_version" | "set_env"
     source: str | None
     dest: str
     template: bool = False
@@ -97,9 +97,7 @@ def load_manifest(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"manifest {path} did not parse to a mapping")
     if data.get("version") != 1:
-        raise ValueError(
-            f"unsupported manifest version {data.get('version')!r}; expected 1"
-        )
+        raise ValueError(f"unsupported manifest version {data.get('version')!r}; expected 1")
     return data
 
 
@@ -141,9 +139,7 @@ def _transform_json_paths(node: Any, repo_root_posix: str) -> Any:
     absolute paths inside the jarvis repo. JSON-aware walk preserves
     structure while only touching string leaves."""
     if isinstance(node, str):
-        return _POSIX_PATH_PATTERN.sub(
-            lambda m: f"{repo_root_posix}/{m.group(1)}/", node
-        )
+        return _POSIX_PATH_PATTERN.sub(lambda m: f"{repo_root_posix}/{m.group(1)}/", node)
     if isinstance(node, list):
         return [_transform_json_paths(x, repo_root_posix) for x in node]
     if isinstance(node, dict):
@@ -189,13 +185,18 @@ def find_legacy_parent_mcp(repo_root: Path, max_depth: int = 4) -> list[Path]:
     return found
 
 
-def _quarantine_dest(path: Path) -> Path:
-    """Compute non-clobbering `.bak.pre-jarvis-migration` destination for `path`."""
-    base = path.with_name(path.name + ".bak.pre-jarvis-migration")
+def _backup_dest(path: Path, label: str) -> Path:
+    """Compute non-clobbering `.bak.<label>` destination for `path`."""
+    base = path.with_name(path.name + f".bak.{label}")
     if not base.exists():
         return base
     stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
-    return path.with_name(f"{path.name}.bak.pre-jarvis-migration-{stamp}")
+    return path.with_name(f"{path.name}.bak.{label}-{stamp}")
+
+
+def _quarantine_dest(path: Path) -> Path:
+    """Legacy-MCP quarantine path. See `_backup_dest` for the generic form."""
+    return _backup_dest(path, "pre-jarvis-migration")
 
 
 def _plan_mcp_user_registrations(
@@ -314,9 +315,8 @@ def _register_mcp_user(name: str, spec: dict[str, Any]) -> None:
 
 
 def _substitute_placeholders(text: str, repo_root: Path, claude_home: Path) -> str:
-    return (
-        text.replace("{{JARVIS_HOME}}", repo_root.as_posix())
-        .replace("{{CLAUDE_USER_HOME}}", claude_home.as_posix())
+    return text.replace("{{JARVIS_HOME}}", repo_root.as_posix()).replace(
+        "{{CLAUDE_USER_HOME}}", claude_home.as_posix()
     )
 
 
@@ -336,9 +336,7 @@ def template_content(source: Path, repo_root: Path, claude_home: Path) -> bytes:
             return raw
         transformed = _transform_json_paths(data, repo_root.as_posix())
         rendered = json.dumps(transformed, indent=2, ensure_ascii=False) + "\n"
-        return _substitute_placeholders(rendered, repo_root, claude_home).encode(
-            "utf-8"
-        )
+        return _substitute_placeholders(rendered, repo_root, claude_home).encode("utf-8")
     try:
         text = raw.decode("utf-8")
     except UnicodeDecodeError:
@@ -354,9 +352,7 @@ def build_plan(
     repo_root: Path,
     target_root_override: str | None = None,
 ) -> Plan:
-    target_root = _expand(
-        target_root_override or manifest.get("target_root", "~/.claude")
-    )
+    target_root = _expand(target_root_override or manifest.get("target_root", "~/.claude"))
     current_sha = current_git_sha(repo_root)
     state, previous_sha = detect_state(target_root, current_sha)
 
@@ -381,14 +377,10 @@ def build_plan(
             src = repo_root / entry["source"]
             install_as = entry.get("install_as")
             if install_as == "user_mcp_registrations":
-                actions.extend(
-                    _plan_mcp_user_registrations(src, repo_root, target_root)
-                )
+                actions.extend(_plan_mcp_user_registrations(src, repo_root, target_root))
                 continue
             if install_as is not None:
-                raise ValueError(
-                    f"manifest group {gid!r}: unknown install_as {install_as!r}"
-                )
+                raise ValueError(f"manifest group {gid!r}: unknown install_as {install_as!r}")
             dest = target_root / entry["dest"]
             # `merge: true` → deep-merge JSON instead of plain overwrite.
             # Preserves user keys not owned by jarvis (M3 #338).
@@ -416,6 +408,24 @@ def build_plan(
                     note=f"include={include}" if include else "",
                 )
             )
+            # Orphan cleanup (#576): if the entry pins an `include` whitelist
+            # and the destination already exists, anything under dest not in
+            # the whitelist is a leftover from a previous install whose
+            # source/manifest no longer lists it. Quarantine each leftover.
+            if include and dest.exists() and dest.is_dir():
+                allowed = set(include)
+                for child in sorted(dest.iterdir()):
+                    if child.name in allowed:
+                        continue
+                    actions.append(
+                        Action(
+                            kind="prune_orphan",
+                            source=str(child),
+                            dest=str(_backup_dest(child, "orphan")),
+                            group=gid,
+                            note=f"absent from {entry['dest']} include whitelist",
+                        )
+                    )
 
     for legacy in find_legacy_parent_mcp(repo_root):
         actions.append(
@@ -449,9 +459,7 @@ def build_plan(
         )
 
     # Backup only when target_root already exists AND we have destructive actions.
-    has_writes = any(
-        a.kind in {"copy_file", "copy_dir", "merge_json"} for a in actions
-    )
+    has_writes = any(a.kind in {"copy_file", "copy_dir", "merge_json"} for a in actions)
     backup_path: Path | None = None
     if target_root.exists() and has_writes:
         stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -486,9 +494,7 @@ def _copy_dir(
         if allowed is not None and child.name not in allowed:
             continue
         if child.is_dir():
-            _copy_dir(
-                child, dest / child.name, None, template, repo_root, claude_home
-            )
+            _copy_dir(child, dest / child.name, None, template, repo_root, claude_home)
         else:
             _copy_file(child, dest / child.name, template, repo_root, claude_home)
 
@@ -594,11 +600,8 @@ def _set_env(name: str, value: str, platform: str) -> None:
     if platform == "windows":
         result = subprocess.run(["setx", name, value], check=False, capture_output=True)
         if result.returncode != 0:
-            stderr_msg = result.stderr.decode(errors='replace').strip()
-            print(
-                f"setx {name} failed (rc={result.returncode}): {stderr_msg}",
-                file=sys.stderr
-            )
+            stderr_msg = result.stderr.decode(errors="replace").strip()
+            print(f"setx {name} failed (rc={result.returncode}): {stderr_msg}", file=sys.stderr)
     else:
         rc_files = [Path.home() / ".bashrc", Path.home() / ".zshrc"]
         line = f'export {name}="{value}"\n'
@@ -608,8 +611,7 @@ def _set_env(name: str, value: str, platform: str) -> None:
             existing = rc.read_text(encoding="utf-8")
             if f"export {name}=" in existing:
                 continue
-            rc.write_text(existing + "\n# added by jarvis installer\n" + line,
-                          encoding="utf-8")
+            rc.write_text(existing + "\n# added by jarvis installer\n" + line, encoding="utf-8")
 
 
 def _platform() -> str:
@@ -700,6 +702,16 @@ def apply_plan(
             if src.exists():
                 src.rename(dst)
                 print(f"quarantined legacy {src} -> {dst}", file=sys.stderr)
+        elif action.kind == "prune_orphan":
+            src = Path(action.source)
+            dst = Path(action.dest)
+            # `dst` was computed at plan time; recompute if a sibling backup
+            # has appeared since (rare race during long installs).
+            if dst.exists():
+                dst = _backup_dest(src, "orphan")
+            if src.exists():
+                src.rename(dst)
+                print(f"quarantined orphan {src} -> {dst}", file=sys.stderr)
         elif action.kind == "register_mcp_user":
             if register_mcp is not None:
                 payload = json.loads(action.note)
@@ -778,9 +790,7 @@ def _rollback_failed_apply(plan: Plan) -> None:
         rollback(plan.target_root, plan.backup_path)
         return
     if plan.state == "fresh" and plan.target_root.exists():
-        print(
-            f"fresh install failed — removing {plan.target_root}", file=sys.stderr
-        )
+        print(f"fresh install failed — removing {plan.target_root}", file=sys.stderr)
         shutil.rmtree(plan.target_root, ignore_errors=True)
 
 
@@ -812,9 +822,7 @@ def run_health_check(manifest: dict[str, Any], repo_root: Path) -> tuple[bool, l
             logs.append(f"FAIL {cmd}: {exc}")
             return False, logs
         if result.returncode != 0:
-            logs.append(
-                f"FAIL {cmd} exit={result.returncode} stderr={result.stderr[:200]}"
-            )
+            logs.append(f"FAIL {cmd} exit={result.returncode} stderr={result.stderr[:200]}")
             return False, logs
         logs.append(f"OK   {cmd}")
     return True, logs
@@ -848,18 +856,19 @@ def format_plan(plan: Plan) -> str:
                 )
             elif a.kind == "copy_dir":
                 extra = f"  {a.note}" if a.note else ""
-                lines.append(
-                    f"  copy_dir   [{a.group:>14}] {a.source} -> {a.dest}{extra}"
-                )
+                lines.append(f"  copy_dir   [{a.group:>14}] {a.source} -> {a.dest}{extra}")
             elif a.kind == "quarantine_file":
                 lines.append(
                     f"  quarantine [{a.group:>14}] {a.source} -> {a.dest}"
                     + (f"  ({a.note})" if a.note else "")
                 )
-            elif a.kind == "register_mcp_user":
+            elif a.kind == "prune_orphan":
                 lines.append(
-                    f"  mcp_user   [{a.group:>14}] claude mcp add -s user {a.dest}"
+                    f"  prune_orph [{a.group:>14}] {a.source} -> {a.dest}"
+                    + (f"  ({a.note})" if a.note else "")
                 )
+            elif a.kind == "register_mcp_user":
+                lines.append(f"  mcp_user   [{a.group:>14}] claude mcp add -s user {a.dest}")
             elif a.kind == "write_version":
                 lines.append(f"  write_ver  -> {a.dest}  sha={a.note[:12]}")
             elif a.kind == "set_env":

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -112,9 +112,7 @@ def manifest(tmp_path: Path, fake_repo: Path) -> Path:
             {
                 "id": "mcp_config",
                 "enabled": True,
-                "files": [
-                    {"source": ".mcp.json", "dest": ".mcp.json", "template": True}
-                ],
+                "files": [{"source": ".mcp.json", "dest": ".mcp.json", "template": True}],
             },
             {
                 "id": "skills",
@@ -129,7 +127,9 @@ def manifest(tmp_path: Path, fake_repo: Path) -> Path:
                 ],
             },
         ],
-        "env_vars": [{"name": "JARVIS_HOME", "value": "{repo_root}", "platforms": ["windows", "posix"]}],
+        "env_vars": [
+            {"name": "JARVIS_HOME", "value": "{repo_root}", "platforms": ["windows", "posix"]}
+        ],
         "health_check": {"enabled": False},
         "backup": {"prefix": ".claude.backup-", "retain": 3},
     }
@@ -203,9 +203,7 @@ def test_build_plan_state_fresh_has_writes_no_backup(manifest: Path, fake_repo: 
     assert kinds.count("set_env") == 1
 
 
-def test_apply_plan_creates_files_and_version_marker(
-    manifest: Path, fake_repo: Path
-) -> None:
+def test_apply_plan_creates_files_and_version_marker(manifest: Path, fake_repo: Path) -> None:
     m = installer.load_manifest(manifest)
     plan = installer.build_plan(m, fake_repo)
     installer.apply_plan(plan, m, run_env=None)
@@ -255,6 +253,7 @@ def test_rollback_restores_target(manifest: Path, fake_repo: Path) -> None:
 
     backup = plan.target_root.parent / ".claude.backup-manual"
     import shutil
+
     shutil.copytree(plan.target_root, backup)
 
     # Corrupt the target.
@@ -266,8 +265,12 @@ def test_rollback_restores_target(manifest: Path, fake_repo: Path) -> None:
 def test_prune_backups_keeps_latest_n(fake_repo: Path, tmp_path: Path) -> None:
     target_root = tmp_path / "claude_home"
     parent = target_root.parent
-    for name in [".claude.backup-20260401-000000", ".claude.backup-20260402-000000",
-                 ".claude.backup-20260403-000000", ".claude.backup-20260404-000000"]:
+    for name in [
+        ".claude.backup-20260401-000000",
+        ".claude.backup-20260402-000000",
+        ".claude.backup-20260403-000000",
+        ".claude.backup-20260404-000000",
+    ]:
         (parent / name).mkdir()
     dropped = installer.prune_backups(target_root, ".claude.backup-", retain=2)
     assert len(dropped) == 2
@@ -292,7 +295,7 @@ def test_health_check_failed_command_reports_failure(fake_repo: Path) -> None:
     _sys.platform != "win32",
     reason=(
         "Regression #352 is specific to non-UTF-8 Windows consoles (cp1251/"
-        "cp866). The inline `python -c \"...\"` quoting also relies on cmd.exe "
+        'cp866). The inline `python -c "..."` quoting also relies on cmd.exe '
         "parsing — bash terminates the outer string on the first inner quote."
     ),
 )
@@ -312,6 +315,111 @@ def test_health_check_handles_utf8_output(fake_repo: Path) -> None:
     ok, logs = installer.run_health_check(m, fake_repo)
     assert ok is True, logs
     assert any("OK" in line for line in logs)
+
+
+# ---------- orphan-skill cleanup (#576) ----------
+
+
+def test_build_plan_emits_prune_orphan_for_stale_skill_dir(
+    manifest: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    """Stale skill dir absent from `include` whitelist produces a prune_orphan action."""
+    m = installer.load_manifest(manifest)
+    # First apply: target gets `implement` skill from whitelist.
+    installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
+    target = tmp_path / "claude_home"
+    # Simulate a deprecated skill left behind from a prior install.
+    (target / "skills" / "deprecated-skill").mkdir()
+    (target / "skills" / "deprecated-skill" / "SKILL.md").write_text("# stale\n", encoding="utf-8")
+    # Bump SHA so state goes outdated and actions are re-emitted.
+    (target / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+
+    plan = installer.build_plan(m, fake_repo)
+    orphans = [a for a in plan.actions if a.kind == "prune_orphan"]
+    assert len(orphans) == 1
+    assert Path(orphans[0].source).name == "deprecated-skill"
+    assert ".bak.orphan" in orphans[0].dest
+
+
+def test_apply_plan_quarantines_orphan_skill(
+    manifest: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    """apply_plan moves orphan dir to a quarantine sibling, doesn't delete."""
+    m = installer.load_manifest(manifest)
+    installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
+    target = tmp_path / "claude_home"
+    orphan_dir = target / "skills" / "deprecated-skill"
+    orphan_dir.mkdir()
+    (orphan_dir / "SKILL.md").write_text("# stale\n", encoding="utf-8")
+    (target / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+
+    plan = installer.build_plan(m, fake_repo)
+    installer.apply_plan(plan, m, run_env=None)
+
+    assert not orphan_dir.exists(), "orphan should have been moved out of skills/"
+    quarantined = list((target / "skills").glob("deprecated-skill.bak.orphan*"))
+    assert len(quarantined) == 1
+    assert (quarantined[0] / "SKILL.md").read_text(encoding="utf-8") == "# stale\n"
+    # Whitelisted skill still present.
+    assert (target / "skills" / "implement" / "SKILL.md").exists()
+
+
+def test_dry_run_does_not_remove_orphan(manifest: Path, fake_repo: Path, tmp_path: Path) -> None:
+    """Building the plan must not touch orphans — only apply does."""
+    m = installer.load_manifest(manifest)
+    installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
+    target = tmp_path / "claude_home"
+    orphan_dir = target / "skills" / "deprecated-skill"
+    orphan_dir.mkdir()
+    (target / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+
+    plan = installer.build_plan(m, fake_repo)  # plan-only, no apply
+    assert any(a.kind == "prune_orphan" for a in plan.actions)
+    assert orphan_dir.exists(), "dry-run must not move the orphan"
+
+
+def test_no_orphan_actions_when_all_in_whitelist(
+    manifest: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    """When every dest child is in the whitelist, no prune actions are planned."""
+    m = installer.load_manifest(manifest)
+    installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
+    target = tmp_path / "claude_home"
+    (target / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+
+    plan = installer.build_plan(m, fake_repo)
+    assert not any(a.kind == "prune_orphan" for a in plan.actions)
+
+
+def test_fresh_install_emits_no_orphan_actions(manifest: Path, fake_repo: Path) -> None:
+    """Fresh state (target absent) cannot have orphans by definition."""
+    m = installer.load_manifest(manifest)
+    plan = installer.build_plan(m, fake_repo)
+    assert plan.state == "fresh"
+    assert not any(a.kind == "prune_orphan" for a in plan.actions)
+
+
+def test_directory_without_include_skips_orphan_check(
+    manifest: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    """An entry without `include` copies everything → orphan-detection must skip it."""
+    data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    for g in data["groups"]:
+        if g["id"] == "skills":
+            for d in g["directories"]:
+                d.pop("include", None)
+    manifest.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    m = installer.load_manifest(manifest)
+    installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
+    target = tmp_path / "claude_home"
+    # Without include, the source dir is copied wholesale (both implement +
+    # niche). A child not in source/manifest is just a user file — leave it.
+    (target / "skills" / "user-extra").mkdir()
+    (target / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+
+    plan = installer.build_plan(m, fake_repo)
+    assert not any(a.kind == "prune_orphan" for a in plan.actions)
 
 
 def test_disabled_group_is_skipped(manifest: Path, fake_repo: Path) -> None:
@@ -373,9 +481,7 @@ def test_userlevel_settings_points_soul_at_user_level(fake_repo: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     settings_src = repo_root / ".claude-userlevel" / "settings.json"
     claude_home = Path("/opt/fakehome/.claude")
-    rendered = installer.template_content(
-        settings_src, repo_root, claude_home
-    ).decode("utf-8")
+    rendered = installer.template_content(settings_src, repo_root, claude_home).decode("utf-8")
     data = json.loads(rendered)
     # Every SessionStart cat must reference the user-level SOUL, not
     # <JARVIS_HOME>/config/SOUL.md.
@@ -467,9 +573,7 @@ def test_fresh_install_rollback_on_apply_failure(
 
     # Now invoke the rollback helper directly (what main() does in the except).
     installer._rollback_failed_apply(plan)
-    assert not plan.target_root.exists(), (
-        "fresh install failure must remove target_root entirely"
-    )
+    assert not plan.target_root.exists(), "fresh install failure must remove target_root entirely"
 
 
 def test_health_check_uses_shlex_for_argv_parsing(
@@ -516,19 +620,39 @@ def test_deep_merge_preserves_user_hook_events(tmp_path: Path) -> None:
     """User events jarvis doesn't own (e.g. Stop) must survive merge."""
     existing = {
         "hooks": {
-            "SessionStart": [{"matcher": "startup", "hooks": [
-                {"type": "command", "command": "user-custom-session.sh"}
-            ]}],
+            "SessionStart": [
+                {
+                    "matcher": "startup",
+                    "hooks": [{"type": "command", "command": "user-custom-session.sh"}],
+                }
+            ],
             "Stop": [{"hooks": [{"type": "command", "command": "user-cleanup.sh"}]}],
         },
         "theme": "dark",  # top-level user key
     }
     source = {
         "hooks": {
-            "SessionStart": [{"matcher": "startup", "hooks": [
-                {"type": "command", "command": "python /abs/jarvis/scripts/session-context.py"}
-            ]}],
-            "PreCompact": [{"hooks": [{"type": "command", "command": "python /abs/jarvis/scripts/pre-compact-backup.py"}]}],
+            "SessionStart": [
+                {
+                    "matcher": "startup",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "python /abs/jarvis/scripts/session-context.py",
+                        }
+                    ],
+                }
+            ],
+            "PreCompact": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "python /abs/jarvis/scripts/pre-compact-backup.py",
+                        }
+                    ]
+                }
+            ],
         }
     }
     merged = installer._deep_merge_jarvis_json(existing, source)
@@ -576,11 +700,9 @@ def test_deep_merge_preserves_user_mcp_servers(tmp_path: Path) -> None:
 def test_merge_json_file_fresh_write_when_dest_missing(tmp_path: Path) -> None:
     """No existing target → write source as-is (still templated)."""
     src = tmp_path / "src.json"
-    src.write_text(json.dumps({"hooks": {"SessionStart": [{"command": "x"}]}}),
-                   encoding="utf-8")
+    src.write_text(json.dumps({"hooks": {"SessionStart": [{"command": "x"}]}}), encoding="utf-8")
     dest = tmp_path / "out" / "settings.json"
-    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path,
-                               claude_home=tmp_path)
+    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path, claude_home=tmp_path)
     assert dest.exists()
     loaded = json.loads(dest.read_text(encoding="utf-8"))
     assert loaded["hooks"]["SessionStart"][0]["command"] == "x"
@@ -589,14 +711,13 @@ def test_merge_json_file_fresh_write_when_dest_missing(tmp_path: Path) -> None:
 def test_merge_json_file_merges_onto_existing(tmp_path: Path) -> None:
     """Existing dest → deep-merge (user keys preserved)."""
     dest = tmp_path / "settings.json"
-    dest.write_text(json.dumps({"hooks": {"Stop": [{"c": "user"}]}, "theme": "dark"}),
-                    encoding="utf-8")
+    dest.write_text(
+        json.dumps({"hooks": {"Stop": [{"c": "user"}]}, "theme": "dark"}), encoding="utf-8"
+    )
     src = tmp_path / "src.json"
-    src.write_text(json.dumps({"hooks": {"SessionStart": [{"c": "jarvis"}]}}),
-                   encoding="utf-8")
+    src.write_text(json.dumps({"hooks": {"SessionStart": [{"c": "jarvis"}]}}), encoding="utf-8")
 
-    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path,
-                               claude_home=tmp_path)
+    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path, claude_home=tmp_path)
     merged = json.loads(dest.read_text(encoding="utf-8"))
     assert merged["hooks"]["Stop"][0]["c"] == "user"  # survived
     assert merged["hooks"]["SessionStart"][0]["c"] == "jarvis"  # added
@@ -608,18 +729,14 @@ def test_merge_json_file_corrupt_existing_falls_back_to_source(tmp_path: Path) -
     dest = tmp_path / "settings.json"
     dest.write_text("{not valid json", encoding="utf-8")
     src = tmp_path / "src.json"
-    src.write_text(json.dumps({"hooks": {"SessionStart": [{"c": "new"}]}}),
-                   encoding="utf-8")
+    src.write_text(json.dumps({"hooks": {"SessionStart": [{"c": "new"}]}}), encoding="utf-8")
 
-    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path,
-                               claude_home=tmp_path)
+    installer._merge_json_file(src, dest, template=False, repo_root=tmp_path, claude_home=tmp_path)
     merged = json.loads(dest.read_text(encoding="utf-8"))
     assert merged["hooks"]["SessionStart"][0]["c"] == "new"
 
 
-def test_merge_json_preserves_user_mcp_on_reapply(
-    manifest: Path, fake_repo: Path
-) -> None:
+def test_merge_json_preserves_user_mcp_on_reapply(manifest: Path, fake_repo: Path) -> None:
     """Full flow: apply once, user adds a custom mcpServer, re-apply,
     jarvis-owned server updates while custom server survives.
     Idempotency for jarvis keys: re-apply doesn't duplicate."""
@@ -682,9 +799,9 @@ def test_real_userlevel_templates_rewrite_scripts_paths(fake_repo: Path) -> None
     settings_rendered = installer.template_content(
         settings_src, repo_root, Path("/opt/fake/.claude")
     ).decode("utf-8")
-    mcp_rendered = installer.template_content(
-        mcp_src, repo_root, Path("/opt/fake/.claude")
-    ).decode("utf-8")
+    mcp_rendered = installer.template_content(mcp_src, repo_root, Path("/opt/fake/.claude")).decode(
+        "utf-8"
+    )
 
     repo_posix = repo_root.as_posix()
     # Every `scripts/` reference in the rendered output is absolute-rooted.
@@ -702,9 +819,7 @@ def test_userlevel_skills_dir_exists_and_has_whitelisted_skills() -> None:
 
     m = installer.load_manifest(repo_root / "install-manifest.yaml")
     include = next(
-        d["include"]
-        for g in m["groups"] if g["id"] == "skills"
-        for d in g["directories"]
+        d["include"] for g in m["groups"] if g["id"] == "skills" for d in g["directories"]
     )
     for name in include:
         skill_md = src / name / "SKILL.md"
@@ -755,9 +870,7 @@ def test_backup_tolerates_vanished_file(
     assert "unreadable" in stderr and "latest" in stderr
 
 
-def test_backup_tolerates_locked_file(
-    manifest: Path, fake_repo: Path, monkeypatch, capsys
-) -> None:
+def test_backup_tolerates_locked_file(manifest: Path, fake_repo: Path, monkeypatch, capsys) -> None:
     """Windows log rotation can hold a PermissionError on the file being appended to.
     Same tolerance applies (#350 review nit)."""
     m = installer.load_manifest(manifest)
@@ -829,9 +942,7 @@ def test_find_legacy_parent_mcp_ignores_unrelated_mcp_configs(tmp_path: Path) ->
     assert installer.find_legacy_parent_mcp(repo) == []
 
 
-def test_apply_plan_quarantines_legacy_parent_mcp(
-    manifest: Path, fake_repo: Path
-) -> None:
+def test_apply_plan_quarantines_legacy_parent_mcp(manifest: Path, fake_repo: Path) -> None:
     legacy = fake_repo.parent / ".mcp.json"
     legacy.write_text(_legacy_mcp_payload(), encoding="utf-8")
 
@@ -922,9 +1033,7 @@ def test_plan_user_mcp_registrations_quarantines_stale_target_file(
     assert any(Path(a.source).resolve() == stale.resolve() for a in quarantine)
 
 
-def test_apply_register_mcp_user_calls_injected_runner(
-    fake_repo: Path, tmp_path: Path
-) -> None:
+def test_apply_register_mcp_user_calls_injected_runner(fake_repo: Path, tmp_path: Path) -> None:
     target = tmp_path / "claude_home"
     manifest_path = _user_mcp_manifest(fake_repo, target)
     m = installer.load_manifest(manifest_path)
@@ -946,10 +1055,12 @@ def test_register_mcp_user_stdio_command_shape(monkeypatch) -> None:
 
     def fake_run(cmd, **kwargs):
         captured.append(list(cmd))
+
         class R:
             returncode = 0
             stdout = ""
             stderr = ""
+
         return R()
 
     monkeypatch.setattr(installer.subprocess, "run", fake_run)
@@ -981,10 +1092,12 @@ def test_register_mcp_user_stdio_command_shape_no_env(monkeypatch) -> None:
 
     def fake_run(cmd, **kwargs):
         captured.append(list(cmd))
+
         class R:
             returncode = 0
             stdout = ""
             stderr = ""
+
         return R()
 
     monkeypatch.setattr(installer.subprocess, "run", fake_run)
@@ -1005,10 +1118,12 @@ def test_register_mcp_user_http_command_shape(monkeypatch) -> None:
 
     def fake_run(cmd, **kwargs):
         captured.append(list(cmd))
+
         class R:
             returncode = 0
             stdout = ""
             stderr = ""
+
         return R()
 
     monkeypatch.setattr(installer.subprocess, "run", fake_run)
@@ -1039,10 +1154,12 @@ def test_register_mcp_user_http_no_headers(monkeypatch) -> None:
 
     def fake_run(cmd, **kwargs):
         captured.append(list(cmd))
+
         class R:
             returncode = 0
             stdout = ""
             stderr = ""
+
         return R()
 
     monkeypatch.setattr(installer.subprocess, "run", fake_run)
@@ -1065,6 +1182,7 @@ def test_register_mcp_user_raises_on_add_failure(monkeypatch) -> None:
             returncode = next(seq)
             stdout = ""
             stderr = "boom"
+
         return R()
 
     monkeypatch.setattr(installer.subprocess, "run", fake_run)
@@ -1080,7 +1198,9 @@ def test_resolve_claude_cli_uses_pathext_when_available(monkeypatch, tmp_path) -
     """
     fake = tmp_path / "claude.CMD"
     fake.write_text("@echo off\n")
-    monkeypatch.setattr(installer.shutil, "which", lambda name: str(fake) if name == "claude" else None)
+    monkeypatch.setattr(
+        installer.shutil, "which", lambda name: str(fake) if name == "claude" else None
+    )
     assert installer._resolve_claude_cli() == str(fake)
 
 
@@ -1099,9 +1219,7 @@ def test_unknown_install_as_raises(fake_repo: Path, tmp_path: Path) -> None:
             {
                 "id": "mcp_config",
                 "enabled": True,
-                "files": [
-                    {"source": ".mcp.json", "install_as": "bogus", "template": True}
-                ],
+                "files": [{"source": ".mcp.json", "install_as": "bogus", "template": True}],
             }
         ],
     }


### PR DESCRIPTION
## Summary
Installer now detects skill directories (and any whitelisted directory) that exist in the target tree but are absent from the manifest's `include` list, and quarantines them to a `.bak.orphan[-stamp]` sibling instead of leaving them stale forever.

## Why
After a skill is removed from source + manifest, the corresponding `~/.claude/skills/<name>/` persists on every device until manually `rm -rf`'d. Concrete trigger: #527 left `~/.claude/skills/end-quick/` behind on every device. Without this, the upcoming #531 cleanup would leak ~10 stale skill dirs across all 3 devices, and stale routings (e.g. `/reflect`, `/self-improve`) would remain invokable indefinitely.

Closes #576. Lands before #531 so the deprecated-skills purge produces clean device state.

Decision episode: `f5121b71-18f8-4700-acc8-2a7745cabfb5` (architecture from `0aa17584-…`).

## Decisions & Alternatives
- **Generalised to any directories entry with `include`**, not skill-specific. Future whitelisted dirs benefit without duplicate logic. Trade-off: `.claude-userlevel/skills` is currently the only such entry, so the abstraction is paid forward.
- **Quarantine via rename**, not delete. Issue requires recoverability; rename is atomic and reversible. The `.bak.orphan` sibling lives next to the dest dir, not inside the timestamped `.claude.backup-*` snapshot.
- **Refactored `_quarantine_dest` → `_backup_dest(path, label)`**; legacy helper is now a thin shim. Keeps the existing `pre-jarvis-migration` label intact for backwards compatibility while letting the orphan path use a clean label.
- Rejected: skill-only special-case (would need duplicate logic for any future include-pinned group); irreversible delete (issue requires backup); deferring to #531 (must land first to avoid mass leak).

## Risk Assessment
- **MEDIUM**: installer touches `~/.claude/` on every device. Plan stays dry-run by default; only `--apply` actually moves anything. Quarantine is reversible via filesystem rename. Existing test fixture (`niche` skill in source, whitelist=`["implement"]`) and 5 new tests cover happy path, no-op, dry-run, no-include skip, and fresh-state cases.

## Testing
- `python -m pytest tests/test_installer.py tests/install/ -x -q` → 90 passed
- `python -m ruff check scripts/install/installer.py tests/test_installer.py` → clean
- `python -m ruff format` applied

New test cases (5):
- `test_build_plan_emits_prune_orphan_for_stale_skill_dir`
- `test_apply_plan_quarantines_orphan_skill`
- `test_dry_run_does_not_remove_orphan`
- `test_no_orphan_actions_when_all_in_whitelist`
- `test_fresh_install_emits_no_orphan_actions`
- `test_directory_without_include_skips_orphan_check`

## Files Changed
- `scripts/install/installer.py` — `_backup_dest` generic helper; `prune_orphan` action kind + plan emission + apply handler + dry-run formatter line.
- `tests/test_installer.py` — 6 new tests for orphan cleanup path.