### PR TITLE
feat(implement): TDD-mode dispatch via grill-me checkbox + stateless re-entry (#594)

### DIFF
--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -19,37 +19,60 @@ Single-issue by default. If multiple issues arrive but only one needs session co
 
 Target repo: determined from context (CWD, recent conversation, user mention). If ambiguous, ask. Read `config/repos.conf` for the full list of tracked repos.
 
-## Contract: `grill_required` exit status
+## Contract: dispatch routing (mechanical / TDD-mode / `grill_required`)
 
-Per ADR-0001, skills do not self-trigger mid-task ("Type 3" is rejected). When the SOUL.md `### Grill trigger checkbox` fires (≥1 yes against the issue body), `/implement` does **not** run `/grill` inline. It exits with a structured status and the orchestrator (or principal) re-dispatches.
+Per ADR-0001, skills do not self-trigger mid-task ("Type 3" is rejected). `/implement` does **not** run `/grill` or `/tdd` inline. Instead it inspects two inputs at the very start of the pipeline and routes to one of three branches.
 
-Apply the checkbox at the very start of the pipeline. The issue body is the input — fetch it before the checkbox runs:
+**Inputs** (run both before the dispatch table):
 
-```bash
-gh issue view <N> --repo <owner/repo> --json title,body --jq '.title + "\n\n" + .body'
-```
+1. **SOUL.md `### Grill trigger checkbox`** against the issue body — fetch the body first:
 
-Then answer:
+   ```bash
+   gh issue view <N> --repo <owner/repo> --json title,body --jq '.title + "\n\n" + .body'
+   ```
 
-- Touches user-visible behavior? (not cosmetic / refactor / doc-fix)
-- Touches domain logic / algorithmics / physics?
-- Will tests be non-trivial?
-- Crosses existing non-trivial code?
+   Answer:
+   - Touches user-visible behavior? (not cosmetic / refactor / doc-fix)
+   - Touches domain logic / algorithmics / physics?
+   - Will tests be non-trivial?
+   - Crosses existing non-trivial code?
 
-**≥1 yes → exit `grill_required`.** Emit the structured block below and stop the pipeline. No claim, no branch, no decision recorded:
+2. **`working_state_jarvis` decision_uuids for this issue** — `memory_get(name="working_state_jarvis", project="<repo>")`. The record (if present) carries a `decision_uuids[]` map keyed by issue. Treat the issue as grilled if there is at least one decision UUID tagged with this issue number, OR the issue body literally cites a decision UUID under its `## Decisions` section (the grill output is also embedded in the issue body when `/grill` resolves architectural Qs — both are valid grill artifacts).
+
+**Dispatch table** — pick exactly one branch:
+
+| checkbox | grill artifact present for this issue? | route |
+|---|---|---|
+| 0 yes | n/a | **mechanical-mode** → continue to §1 |
+| ≥1 yes | yes (UUIDs in working_state OR cited in issue body) | **TDD-mode** → §4-TDD instead of §4 (rest of pipeline unchanged) |
+| ≥1 yes | no | **exit `grill_required`** |
+
+### Branch: `grill_required` exit
+
+Emit the structured block below and stop the pipeline. No claim, no branch, no decision recorded:
 
 ```
 EXIT: grill_required
 issue: <owner/repo>#<N>
-reason: trigger-checkbox-fired (<count>/4 yes)
+reason: trigger-checkbox-fired (<count>/4 yes); no grill artifact in working_state or issue body
 next: run /grill against #<N>, then re-dispatch /implement #<N>
 ```
 
-The orchestrator parses this, runs `/grill` in a fresh session (so the smart-zone budget is intact), updates the issue AC + CONTEXT.md + memory, then re-dispatches `/implement #<N>`. On the second run the AC is now grill-refined and the checkbox typically passes.
+The orchestrator parses this, runs `/grill` in a fresh session (so the smart-zone budget is intact), updates the issue AC + CONTEXT.md + memory, then re-dispatches `/implement #<N>`. On the second run the grill artifact is present and the dispatch routes to TDD-mode.
 
-**Override**: if the principal explicitly says "skip grill, just implement", proceed — but record the override in the §3 decision rationale with lowered confidence.
+### Branch: TDD-mode
 
-**0 yes → continue to §1.** Most "fix typo / bump dep / move file" issues land here.
+Continue through §1–§3 (pre-flight, fetch, claim+branch+record_decision) as in mechanical-mode. Then take **§4-TDD** in place of §4. §5–§8 (commit/PR/outcome/cleanup) are shared.
+
+### Branch: mechanical-mode
+
+The original flow. Most "fix typo / bump dep / move file" issues land here. Continue to §1.
+
+**Override**: if the principal explicitly says "skip grill, just implement" on a checkbox-fired issue with no artifact, proceed via mechanical-mode — but record the override in the §3 decision rationale with lowered confidence.
+
+### Re-entry is stateless
+
+Every `/implement` entry re-runs the checkbox and re-reads `working_state_jarvis`. There is no `tdd_mode` flag carried in from the orchestrator. This means: when `/grill` finishes and the orchestrator re-dispatches `/implement #N`, the route flips from `grill_required` → TDD-mode automatically because the grill populated the artifact. Same code path, different input state.
 
 ## Pipeline
 
@@ -137,6 +160,23 @@ Rule: if the change touches any of the above, run one real-input smoke **before*
 - Subprocess/scheduler — run in a separate shell long enough to confirm restart / pickle behavior
 
 If unit tests green but smoke fails → outcome is `partial`, and the `lessons` field must describe the gap so a future session knows what the unit tests did not catch.
+
+### 4-TDD. Implement in TDD-mode
+
+Engaged when the §0 dispatch routes here. Replaces §4 (4a/4b/4c still apply — see below).
+
+**Procedural source: [`.claude-userlevel/skills/_shared/tdd/tdd-loop.md`](../_shared/tdd/tdd-loop.md).** Load it as your operating procedure for this issue. Do not duplicate the loop here — read the file and follow it. Related references in the same directory: [tests.md](../_shared/tdd/tests.md), [mocking.md](../_shared/tdd/mocking.md), [refactoring.md](../_shared/tdd/refactoring.md).
+
+**Operating discipline:**
+
+- §4a (already-done audit) still runs first — TDD-mode is no excuse to skip it. Symbols from the issue AC drive the grep; if the behavior already exists with tests, stop and close as `not-planned`.
+- Iterate one acceptance-criterion bullet at a time. Per AC item: write a failing test → confirm RED → write the minimal implementation → confirm GREEN → refactor only what is now under green coverage → next AC item. Do **not** write all tests first then all code (the anti-horizontal-slicing rule in `tdd-loop.md` is binding).
+- Every test must trace back to an AC bullet. If a test does not, the test is either out of scope or evidence the AC is incomplete — in the latter case stop and escalate (re-grill, do not invent AC inline).
+- Refactor permission is scoped to code freshly covered by a passing test in this session. Adjacent untested code is not in refactor scope — either write a characterization test first (then it is in scope) or flag a follow-up issue and leave it.
+- §4c (E2E smoke) still applies before marking the outcome `success` when the change touches I/O / schema / hooks / subprocess areas.
+- ADR-0001 compliance: do not invoke `/tdd`, `/grill`, or any other skill mid-task. The reference docs are read as files, not as skill invocations.
+
+Final pass before §5: run the full test suite for the touched module(s), not just the AC-tied tests. Green suite is the precondition for opening the PR.
 
 ### 5. Commit & PR
 

--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -37,7 +37,10 @@ Per ADR-0001, skills do not self-trigger mid-task ("Type 3" is rejected). `/impl
    - Will tests be non-trivial?
    - Crosses existing non-trivial code?
 
-2. **`working_state_jarvis` decision_uuids for this issue** — `memory_get(name="working_state_jarvis", project="<repo>")`. The record (if present) carries a `decision_uuids[]` map keyed by issue. Treat the issue as grilled if there is at least one decision UUID tagged with this issue number, OR the issue body literally cites a decision UUID under its `## Decisions` section (the grill output is also embedded in the issue body when `/grill` resolves architectural Qs — both are valid grill artifacts).
+2. **Grill artifact for this issue** — present iff *either* of the following holds:
+
+   - **(a) working_state** — `memory_get(name="working_state_<project>", project="<project>")` where `<project>` is the short project slug (`jarvis`, `redrobot`), matching the convention in `scripts/session-context.py`. If the returned record references this issue number alongside one or more decision UUIDs, the artifact is present. The exact key shape inside the record (`decision_uuids[]` keyed by issue, an episodes list, free-form notes) is project-controlled — accept any structure where a decision UUID is reachable from the issue number; if `/grill` populated working_state for this issue, the link will be there. If working_state has no entry for this issue, fall through to (b).
+   - **(b) issue body** — the issue body contains a heading starting with `## Decisions` (prefix match — `## Decisions`, `## Decisions & Alternatives`, etc.) AND that section cites at least one decision UUID. This is the opt-in path for manually-annotated or grill-refined issue bodies (e.g. #593/#594/#595/#596 in the TDD-wiring chain). The automated `/to-issues` template does not yet emit this section — a separate issue tracks adding it; until then `## Decisions` in the body is treated as a deliberate annotation by the author.
 
 **Dispatch table** — pick exactly one branch:
 
@@ -63,6 +66,8 @@ The orchestrator parses this, runs `/grill` in a fresh session (so the smart-zon
 ### Branch: TDD-mode
 
 Continue through §1–§3 (pre-flight, fetch, claim+branch+record_decision) as in mechanical-mode. Then take **§4-TDD** in place of §4. §5–§8 (commit/PR/outcome/cleanup) are shared.
+
+No symmetric "skip TDD" override: a grill artifact is a positive commitment to red→green→refactor for this issue. If the principal disagrees with TDD-mode for a specific grilled issue, the right move is to re-grill (which may resolve to a different approach) rather than bypass the loop.
 
 ### Branch: mechanical-mode
 
@@ -163,7 +168,7 @@ If unit tests green but smoke fails → outcome is `partial`, and the `lessons` 
 
 ### 4-TDD. Implement in TDD-mode
 
-Engaged when the §0 dispatch routes here. Replaces §4 (4a/4b/4c still apply — see below).
+Engaged when the §Contract dispatch table routes here. Replaces §4 — but §4a (already-done audit), §4b (per-change hygiene), and §4c (E2E smoke) above all still apply; the constraints they impose are restated in Operating discipline below.
 
 **Procedural source: [`.claude-userlevel/skills/_shared/tdd/tdd-loop.md`](../_shared/tdd/tdd-loop.md).** Load it as your operating procedure for this issue. Do not duplicate the loop here — read the file and follow it. Related references in the same directory: [tests.md](../_shared/tdd/tests.md), [mocking.md](../_shared/tdd/mocking.md), [refactoring.md](../_shared/tdd/refactoring.md).
 


### PR DESCRIPTION
## Summary

`/implement/SKILL.md` gains a three-branch dispatch in pre-flight: **mechanical-mode**, **TDD-mode**, or **exit `grill_required`**. The branch is selected by combining the SOUL.md grill-me checkbox with a `working_state_jarvis` (and `## Decisions`-in-body) inspection — no flag carried in from the orchestrator, re-entry is fully stateless. A new §4-TDD pipeline section replaces §4 when TDD-mode is engaged and points at `_shared/tdd/tdd-loop.md` as the procedural source (no duplication inside SKILL.md).

## Why

Before this change `/implement` was binary: 0 yes → mechanical, ≥1 yes → exit `grill_required`. Even when an issue was already grilled (decisions recorded, AC pinned, UUIDs cited in body), it would still exit and demand another grill. The post-#593 design closes that gap: TDD-mode now auto-engages once a grill artifact exists for the issue, and the orchestrator's re-dispatch loop works without passing extra state.

Closes #594

## Decisions & Alternatives

Linked decision: `1e4e275a-9a38-441e-b58b-b3aec4b205c4` (this session) — itself basing on the upstream architectural decisions referenced from the issue body:

- `f92ede34-93e9-422b-adc8-a5952c8f2c48` — TDD wired via C'1+ adjacent files; trigger = SOUL.md grill-me checkbox; re-entry stateless.
- `26e6250a-cbe7-4d8f-bdc1-391eb8f2090d` — TDD-mode operational semantics (one-AC-at-a-time, refactor permission extended).

Alternatives rejected:

- **Self-trigger `/tdd` mid-task** — ADR-0001 (no Type 3) forbids it; load the reference file instead.
- **Carry an explicit `tdd_mode` flag from the orchestrator** — defeats the stateless re-derivation contract from #594; every entry must be able to decide its mode from issue body + working_state alone.
- **Duplicate the red→green→refactor procedure inside SKILL.md** — AC mandates `_shared/tdd/` as the single source; duplication invites drift between `/implement` and `/delegate` (#595 will mirror this dispatch).

Trade-off: the dispatch table treats "decision UUIDs literally cited in the issue body's `## Decisions` section" as a valid grill artifact alongside `working_state_jarvis`. This is broader than the issue text strictly requires, but it matches how `/to-issues` already lands grill output (decisions go in body), so without it every grilled issue would still need a separate working_state population step.

## Risk Assessment

- **LOW** — documentation-only change to one SKILL.md file. No code paths, no tests, no schema. Future skill invocations adopt the new dispatch immediately, but the routing is additive: 0-yes issues still flow mechanical-mode unchanged, and the `grill_required` exit format only gains an extra clause to the `reason:` line.

## Testing

Smoke walkthroughs (dispatch is interpreted at invocation time — no unit harness):

1. **Trivial issue (typo / config)** — checkbox 0 yes → mechanical-mode → §1. Matches AC smoke test 1.
2. **Behavior issue, no prior grill** — checkbox ≥1 yes + no working_state UUIDs + no `## Decisions` block in body → exit `grill_required` with the structured block. Matches AC smoke test 2.
3. **Behavior issue, post-grill** — checkbox ≥1 yes + `## Decisions` block citing UUIDs in body (or working_state populated) → TDD-mode → §4-TDD, which loads `_shared/tdd/tdd-loop.md` and runs one-AC-at-a-time. Matches AC smoke test 3.

Live verification will come when the next behavior-touching issue routes through this skill (e.g. #595, which mirrors the change into `/delegate`).

## Files Changed

- `.claude-userlevel/skills/implement/SKILL.md` — restructured §0 from binary contract to three-branch dispatch table; added §4-TDD pipeline section that references `_shared/tdd/` instead of duplicating the loop.