### PR TITLE
feat(delegate): TDD-mode dispatch + AC-completeness gate in subagent prompt (#595)

### DIFF
--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -32,9 +32,11 @@ Memory recall and the `record_decision` contract come from user-level CLAUDE.md 
 
 **Jarvis judgment overrides the principal's "параллельно":** The principal has explicitly delegated this call to Jarvis (memory: this decision). If a task looks deceptively complex or a subagent will struggle (needs memory context, cross-file reasoning, recent-decisions awareness), keep it inline even if asked to delegate. Don't silently downgrade — tell the principal "keeping #X inline because <reason>".
 
-## Contract: `grill_required` exit status (per issue)
+## Contract: dispatch routing (per issue: mechanical / TDD-mode / `grill_required`)
 
-Per ADR-0001, no Type 3 self-trigger. For **each** issue in the batch, fetch the issue body and apply the SOUL.md `### Grill trigger checkbox`:
+Per ADR-0001, skills do not self-trigger mid-task ("Type 3" is rejected). `/delegate` does **not** run `/grill` or `/tdd` inline. For **each** issue in the batch it inspects two inputs and routes to one of three branches. Routing is per-issue: a single batch can mix mechanical-mode and TDD-mode dispatches (and exclude grill-failing issues).
+
+**Inputs** (per issue — fetch the body first):
 
 ```bash
 for N in <N1> <N2> ...; do
@@ -42,40 +44,71 @@ for N in <N1> <N2> ...; do
 done
 ```
 
-Then answer per issue:
+1. **SOUL.md `### Grill trigger checkbox`** — answer per issue:
 
-- Touches user-visible behavior?
-- Touches domain logic / algorithmics / physics?
-- Tests will be non-trivial?
-- Crosses existing non-trivial code?
+   - Touches user-visible behavior? (not cosmetic / refactor / doc-fix)
+   - Touches domain logic / algorithmics / physics?
+   - Will tests be non-trivial?
+   - Crosses existing non-trivial code?
 
-**Per-issue ≥1 yes → that issue is NOT delegate-ready.** Do not run `/grill` inline. Emit the structured `grill_required` block below per affected issue and exclude them from the dispatch (they are also not claimed in §2 — claim happens after this exclusion):
+2. **Grill artifact for this issue** — present iff *either* of the following holds:
+
+   - **(a) working_state** — `memory_get(name="working_state_<project>", project="<project>")` where `<project>` is the short project slug (`jarvis`, `redrobot`), matching the convention in `scripts/session-context.py`. If the returned record references this issue number alongside one or more decision UUIDs, the artifact is present. The exact key shape inside the record is project-controlled — accept any structure where a decision UUID is reachable from the issue number. If working_state has no entry for this issue, fall through to (b).
+   - **(b) issue body** — the issue body contains a heading starting with `## Decisions` (prefix match — `## Decisions`, `## Decisions & Alternatives`, etc.) AND that section cites at least one decision UUID. This is the opt-in path for manually-annotated or grill-refined issue bodies. The automated `/to-issues` template does not yet emit this section — a separate issue tracks adding it; until then `## Decisions` in the body is treated as a deliberate annotation by the author.
+
+**Dispatch table** — per issue, pick exactly one branch:
+
+| checkbox | grill artifact present for this issue? | route |
+|---|---|---|
+| 0 yes | n/a | **mechanical-mode** dispatch (current flow, no AC-completeness clause) |
+| ≥1 yes | yes (UUIDs in working_state OR cited in issue body) | **TDD-mode** dispatch (subagent prompt gains AC-completeness clause; see §4) |
+| ≥1 yes | no | **exit `grill_required`** (issue excluded from batch) |
+
+### Branch: `grill_required` exit (per issue)
+
+Emit the structured block below per affected issue and exclude them from dispatch. They are NOT claimed in §2 — claim happens after this exclusion:
 
 ```
 EXIT: grill_required
 issue: <owner/repo>#<N>
-reason: trigger-checkbox-fired (<count>/4 yes)
+reason: trigger-checkbox-fired (<count>/4 yes); no grill artifact in working_state or issue body
 next: run /grill against #<N>, then re-dispatch /delegate (or /implement) #<N>
 ```
 
-Continue dispatching the rest of the batch in the same call — partial dispatch is fine. Report to the principal: "issues #X, #Y exited `grill_required`; #A, #B, #C dispatched". The orchestrator handles re-dispatch in fresh sessions after `/grill`.
+Continue dispatching the rest of the batch in the same call — partial dispatch is fine. Report to the principal: "issues #X, #Y exited `grill_required`; #A dispatched mechanical, #B dispatched TDD-mode". The orchestrator handles re-dispatch in fresh sessions after `/grill`.
 
-**Subagents never run `/grill` themselves.** Their dispatch prompt carries the grill-refined AC verbatim. First subagent action is to confirm the AC is verifiable from the issue body alone — if not, post a comment and stop, escalating back to the main session.
+### Branch: mechanical-mode
 
-**0 yes → delegatable as-is.** Continue.
+Most "fix typo / bump dep / move file" issues land here. Subagent prompt template (§4) is the canonical form **without** the AC-completeness clause.
 
-**No "skip grill" override at the batch level.** Unlike `/implement` (where the principal can say "skip grill, just implement" for a single issue), `/delegate` does not offer a one-shot override. Per-issue grilling is the gate that keeps subagents from drifting on under-specified AC, and silently overriding it for an entire batch is exactly the failure mode this contract prevents. If the principal wants a triggered issue dispatched anyway, route it through `/implement` with the explicit single-issue override.
+### Branch: TDD-mode
+
+Subagent prompt template (§4) gains an additional AC-completeness clause directing the subagent to follow `_shared/tdd/tdd-loop.md`, cover every AC bullet with at least one test, and escalate (not silently drop) any AC that does not fit.
+
+The TDD-mode clause is **/delegate-specific** — it is not present in `/implement`'s TDD-mode (which relies on Operating discipline in the skill body) because the failure mode it targets (subagent AC-dodging via "out of scope" relabeling, per memories `subagent_acceptance_criteria_dodged_as_out_of_scope` and `subagent_test_coverage_overclaim`) only manifests in subagent dispatch.
+
+### Subagents never run `/grill` or `/tdd` themselves
+
+Their dispatch prompt carries the grill-refined AC verbatim and (in TDD-mode) the TDD operating clause inline. First subagent action is to confirm the AC is verifiable from the issue body alone — if not, post a comment and stop, escalating back to the main session.
+
+### Re-entry is stateless
+
+Every `/delegate` entry re-runs the checkbox and re-reads `working_state_<project>` per issue. There is no `tdd_mode` flag carried in from the orchestrator. When `/grill` finishes and the orchestrator re-dispatches `/delegate <N>`, the route flips from `grill_required` → TDD-mode automatically because the grill populated the artifact. Same code path, different input state.
+
+### No "skip grill" override at the batch level
+
+Unlike `/implement` (where the principal can say "skip grill, just implement" for a single issue), `/delegate` does not offer a one-shot override. Per-issue grilling is the gate that keeps subagents from drifting on under-specified AC, and silently overriding it for an entire batch is exactly the failure mode this contract prevents. If the principal wants a triggered issue dispatched anyway, route it through `/implement` with the explicit single-issue override.
 
 ## Pipeline
 
 ### 1. Classify each issue: delegatable or inline
 
-For each delegatable issue (passed the checkbox above):
+For each issue routed to **mechanical-mode** or **TDD-mode** by the §Contract dispatch table (issues that exited `grill_required` are already excluded):
 
 1. Run pre-flight (5 checks — same as /implement §1).
 2. Classify:
-   - **Delegatable** → fresh subagent can handle it from the issue body alone
-   - **Inline** → needs session context / safety review / cross-cutting peripheral vision
+   - **Delegatable** → fresh subagent can handle it from the issue body alone (subagent prompt = template + TDD-mode block if route == TDD-mode)
+   - **Inline** → needs session context / safety review / cross-cutting peripheral vision (route through /implement, which re-runs its own dispatch)
 
 Produce a short split plan for the principal before acting. Example:
 
@@ -113,7 +146,10 @@ Agent(
 )
 ```
 
-**Subagent prompt template** (self-contained — subagent does NOT share main-session memory):
+**Subagent prompt template** (self-contained — subagent does NOT share main-session memory). The `<TDD-mode block>` placeholder below is filled differently depending on the per-issue dispatch routing (§Contract):
+
+- **mechanical-mode** → omit the block entirely (no AC-completeness clause; trivial issues stay terse).
+- **TDD-mode** → insert the AC-completeness clause verbatim, exactly as specified in [issue #595](https://github.com/Osasuwu/jarvis/issues/595).
 
 ```
 Implement GitHub issue #<N> in repo <owner/repo>.
@@ -125,6 +161,8 @@ Files likely to change: <list>
 
 Branch name: feat/<N>-<slug>   (MUST use exactly this — branch-name race mitigation)
 Target repo CWD: <absolute path to worktree>
+
+<TDD-mode block — present iff per-issue route == TDD-mode, see §Contract>
 
 Follow the /implement skill pipeline (loaded in your session). Specifically:
 - §4 Implement — read existing code first, check if already done, lint, test
@@ -141,6 +179,23 @@ HARD RULES for you (subagent):
 
 Report back: PR URL + 2-line summary of what you did.
 ```
+
+**TDD-mode block (insert verbatim when the per-issue route is TDD-mode):**
+
+```
+TDD-mode active for this issue.
+
+Operating discipline:
+- Follow .claude-userlevel/skills/_shared/tdd/tdd-loop.md: pick one AC, write failing
+  test, confirm red, write minimal impl, confirm green, refactor if useful, next AC.
+- Every item in the issue's acceptance criteria MUST have at least one corresponding
+  test. Marking an AC item as "out of scope" is a delivery defect, not a scope
+  decision — escalate to the orchestrator instead of dropping the item.
+- Refactor permission extends to code freshly covered by a passing test in this
+  session. Code without test coverage is NOT in your refactor scope.
+```
+
+ADR-0001 compliance: the TDD-mode block is **inline operating discipline**, not a `/tdd` skill invocation. The subagent does not call `/tdd`, `/grill`, or any other skill mid-task — the reference doc `_shared/tdd/tdd-loop.md` is read as a file.
 
 **Principal env propagation note (#426)**: The Agent tool inherits parent env, so `JARVIS_PRINCIPAL` set in the parent session carries to the subagent. Auto-injection of `JARVIS_PRINCIPAL=subagent` is deferred — the parent is `live` (principal-driven dispatch), and subagents are already constrained by the worktree isolation and skill-level rules above. If a future code path runs `/delegate` autonomously (e.g. dispatcher hands work to a subagent), revisit and inject `JARVIS_PRINCIPAL=subagent` explicitly via the spawn wrapper.
 


### PR DESCRIPTION
## Summary

Mirrors `/implement`'s three-branch dispatch contract (mechanical / TDD-mode / `grill_required`) into `/delegate`, on a **per-issue** basis. Adds a `/delegate`-specific AC-completeness clause to the subagent prompt template — inserted only when the per-issue route resolves to TDD-mode, omitted in mechanical-mode.

## Why

Subagents are the dominant AC-overclaim vector (memories `subagent_acceptance_criteria_dodged_as_out_of_scope`, `subagent_test_coverage_overclaim`). TDD alone fixes test ordering but not AC coverage — subagents relabel inconvenient AC items as "out of scope" and ship anyway. The explicit AC-completeness clause makes that move a delivery defect, not a scope decision.

Closes #595

## Decisions

Per memory + decision protocol — basis lives in queryable decisions, not in this PR body:

- [\`f92ede34-93e9-422b-adc8-a5952c8f2c48\`](https://github.com/Osasuwu/jarvis/issues/595) — TDD wired via C'1+; trigger = grill-me checkbox; re-entry is stateless re-derivation.
- [\`26e6250a-cbe7-4d8f-bdc1-391eb8f2090d\`](https://github.com/Osasuwu/jarvis/issues/595) — operational semantics; \`/delegate\` AC-completeness gate is /delegate-specific (subagent dispatch only, not shared with /implement).
- [\`56ff5817-9f45-4d15-820a-f94a6511838d\`](https://github.com/Osasuwu/jarvis/issues/595) — this implementation decision (mirror /implement three-branch, per-issue, TDD-mode-only AC clause).

Alternatives rejected: (a) AC clause in mechanical-mode → noise on trivial issues; (b) batch-level TDD flag → conflicts with /delegate's existing per-issue grill_required model; (c) shared AC clause in \`_shared/tdd/\` → 26e6250a explicitly marks it /delegate-specific because the failure mode is subagent-context-only.

## Risk Assessment

- **LOW** — markdown-only change to a skill definition. No code paths, no schema, no protected files. Reversible via revert. The subagent prompt template change is additive: mechanical-mode prompts are byte-identical to pre-PR (the new \`<TDD-mode block>\` placeholder is omitted in that route).

## Testing

Smoke tests for this issue are AC items 5–7 — they verify prompt assembly. They are analytical (markdown-only PR, no runtime dispatcher to invoke):

- **Smoke 1 (mechanical batch)** — Contract §dispatch table row "0 yes / n/a" routes to mechanical-mode. §4 mechanical-mode bullet: "omit the block entirely". → No AC clause in dispatched prompt. ✓
- **Smoke 2 (mixed batch)** — Per-issue routing: #X (behavior+grilled) → TDD-mode → \`<TDD-mode block>\` substituted with the AC-completeness clause; #Y (trivial) → mechanical-mode → block omitted. ✓
- **Smoke 3 (prompt assembly verification)** — The template makes the variable section explicit (\`<TDD-mode block — present iff per-issue route == TDD-mode, see §Contract>\`). Reviewers can verify by reading the dispatched-prompt log or by inspecting the orchestrator's template substitution against the dispatch table, not by trusting the dispatcher's self-report.

ADR-0001 compliance (AC #4): the TDD-mode block is **inline operating discipline** — the subagent does not call \`/tdd\`, \`/grill\`, or any other skill mid-task. The reference doc \`_shared/tdd/tdd-loop.md\` is read as a file. Stated explicitly in the new §4 paragraph.

## Files Changed

- \`.claude-userlevel/skills/delegate/SKILL.md\` — replaces \`Contract: grill_required exit status (per issue)\` with \`Contract: dispatch routing (per issue: mechanical / TDD-mode / grill_required)\` mirroring /implement's three-branch structure; adds \`<TDD-mode block>\` placeholder + verbatim AC-completeness clause to §4; updates §1 phrasing to align with new dispatch terminology.

## Follow-ups

- #596 — drop \`/tdd/\` directory + update CLAUDE.md routing table (blocked by this PR).
- \`/to-issues\` template should emit \`## Decisions\` section from \`decision_uuids[]\` so the body-detection path is populated in the automated chain (drive-by from #598 review, not yet filed).