### PR TITLE
feat(end): add "Suggested next skills" hint to working state

### DIFF
--- a/.claude-userlevel/skills/end/SKILL.md
+++ b/.claude-userlevel/skills/end/SKILL.md
@@ -117,6 +117,7 @@ Save `working_state_jarvis` (type=project) to Supabase. Always. Content:
 - What was done this session
 - Open items: unfinished work, things to fix, deferred tasks
 - Key context for next session (blockers, decisions pending review)
+- **Suggested next skills** — explicit chain hint for the next session, e.g. `/status → /implement #532 → /verify`. One line, ordered. Omit only if truly nothing pending (rare; usually at least `/status`). Lets the next session skip the "what should I run first" decision; mirrors the one useful idea from Pocock's `/handoff` skill without forking durable storage out of Supabase.
 
 This is the handoff to the next session. If open items exist in Step 8 output, they MUST be in this memory too — output is ephemeral, memory persists.
 


### PR DESCRIPTION
## Summary

- Add a "Suggested next skills" line to `working_state_jarvis` content schema in `/end` Step 5.
- One ordered chain (e.g. `/status → /implement #532 → /verify`) saved per session-close.
- Lets the next session — manual resume or future autonomous chain — skip the "what should I run first" decision.

## Why not Pocock's `/handoff` skill

Looked at `mattpocock/skills/productivity/handoff` against our `/end` + working state. Conclusion: don't adopt.

| Criterion | Pocock `/handoff` | Our stack |
|---|---|---|
| Path discovery | `mktemp -t handoff-XXXXXX.md` random | `memory_get("working_state_jarvis")` known name |
| Durability | `/tmp` device-local | Supabase persistent + replicated |
| Cross-device | no | yes (3 machines) |
| Queryable | grep | `memory_recall` |
| Compaction-safe | no | yes (PreCompact hook → `session_snapshot_<id>`) |
| Discipline | "write summary" | reconciliation + outcome enrichment + goal log |

For autonomous chaining (cron → session A → session B), random tempfile path is a non-starter — would need a manifest pointer, defeating the simplicity. We already have three durable layers (real-time `record_decision` + `session_snapshot_<id>` + `working_state_jarvis`).

Only useful idea from `/handoff` was the explicit "suggest next skills" line. This PR steals just that, into the canonical location autonomous-loop and manual resume both already read.

## Test plan

- [ ] Run `/end` on a session with open work — verify "Suggested next skills" appears in saved `working_state_jarvis`.
- [ ] Start fresh session, `memory_get("working_state_jarvis")` — confirm chain hint readable.
- [ ] `/end` on truly empty session — verify line is omitted (not forced to `/status` only).
- [ ] `install.ps1 -Apply` propagates to `~/.claude/skills/end/SKILL.md` mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #603
