### PR TITLE
fix(sandcastle): worktree .git/info path + PS 5.1 stderr crash (#607, #608)

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -107,9 +107,15 @@ const result = await run({
         // (memory MCP only). The host .mcp.json registers many host-only
         // servers that would fail inside the sterile container. Sandcastle
         // uses copy-on-write worktrees so this never touches the host repo.
-        // Adding the path to .git/info/exclude first ensures `git add -A`
-        // inside the agent loop cannot accidentally stage the override.
-        { command: "echo /.mcp.json >> .git/info/exclude" },
+        // Adding the path to info/exclude first ensures `git add -A` inside
+        // the agent loop cannot accidentally stage the override.
+        //
+        // `.git` in a worktree is a *file* (gitdir pointer), not a directory,
+        // so `>> .git/info/exclude` opens via the shell and fails with ENOTDIR.
+        // `git rev-parse --git-path info/exclude` resolves the actual shared
+        // info/exclude path inside the parent .git directory (#607).
+        { command: "mkdir -p $(git rev-parse --git-path info)" },
+        { command: "echo /.mcp.json >> $(git rev-parse --git-path info/exclude)" },
         { command: "cp /opt/sandcastle/container-mcp.json .mcp.json" },
       ],
     },

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -217,12 +217,17 @@ function Invoke-Sandcastle {
     Push-Location -LiteralPath $RepoRoot
     $cmdNotFound = $false
     try {
-        try {
-            $combined = & npm run --silent sandcastle 2>&1
+        if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+            $cmdNotFound = $true
+        } else {
+            # PS 5.1 wraps every native-command stderr line as a NativeCommandError
+            # under EAP=Stop, killing the watchdog on npm's first stderr line
+            # (any warning). Delegate the 2>&1 merge to cmd.exe so PS only sees
+            # a single stdout stream — no wrapping, no terminating exception.
+            # See issue #608.
+            $combined = & cmd.exe /c 'npm run --silent sandcastle 2>&1'
             $exitCode = $LASTEXITCODE
             $combined | Out-File -FilePath $LogFile -Encoding utf8 -Append
-        } catch [System.Management.Automation.CommandNotFoundException] {
-            $cmdNotFound = $true
         }
     } finally {
         Pop-Location


### PR DESCRIPTION
## Summary

Two co-discovered Workshop-deploy bugs, both blocking #545.

### #607 — worktree `.git/info/exclude` ENOTDIR

The host-side `onSandboxReady` hook in `.sandcastle/main.mts` did:
```sh
echo /.mcp.json >> .git/info/exclude
```
In a sandcastle worktree, `.git` is a regular file (gitdir pointer), not a directory. Shell-level `>>` opens the literal path, hits ENOTDIR, sandcastle aborts in ~5s before reaching Ollama. Sandcastle's Windows-mount patcher (ADR-0006) was correct; the issue was the hook command itself, which would also fail on Linux for the same reason — worktrees never have a literal `.git/info/` subdir, since `info/` lives in the shared parent `.git`.

**Fix:** resolve the shared-info path with `git rev-parse --git-path info/exclude` (works for both worktrees and plain repos) and `mkdir -p` its parent first.

### #608 — Run-Sandcastle.ps1 crash on PS 5.1

Watchdog used `& npm ... 2>&1` under `$ErrorActionPreference = 'Stop'`. PowerShell 5.1 wraps every native-cmd stderr line as `NativeCommandError`; under `EAP=Stop` the first npm warning becomes a terminating exception that bypasses the inner `catch [CommandNotFoundException]`. PS 7+ doesn't wrap stderr, so the script worked there — but Task Scheduler on Workshop PC launches PS 5.1 by default and pwsh 7 isn't installed.

**Fix:** delegate the `2>&1` merge to `cmd.exe /c`, so PS only sees a single stdout stream — no wrapping. Add a `Get-Command npm` pre-check to keep the `npm-not-found` signal flowing (replaces the now-unreachable `CommandNotFoundException` catch).

## Test plan

- [x] Pester suite green on PS 5.1 (53/53)
- [x] Manual `Invoke-Sandcastle` smoke on PS 5.1.26100.8115 returns structured `{ok=$false, reason='exit=1'}` instead of throwing
- [ ] Full `npm run sandcastle` on Workshop PC4 after PR merge to confirm #607 fix unblocks Ollama loop (needs Workshop access)

Closes #607
Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)