### PR TITLE
fix(sandcastle): drop redundant user.email/name hooks (#610 workaround)

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -101,8 +101,12 @@ const result = await run({
   hooks: {
     sandbox: {
       onSandboxReady: [
-        { command: "git config user.email agent@jarvis.local" },
-        { command: "git config user.name 'Jarvis Agent'" },
+        // Sandcastle's own SandboxLifecycle already propagates host git
+        // user.name/user.email via `git config --global` before user hooks
+        // run, so explicit overrides here are redundant. Repo-local
+        // `git config` (without --global) would write to the worktree's
+        // parent .git/config which on Windows bind-mounts races on the
+        // .lock file (#607 v2 / Workshop PC4 repro 2026-05-13).
         // Override the worktree's .mcp.json with the container-scoped version
         // (memory MCP only). The host .mcp.json registers many host-only
         // servers that would fail inside the sterile container. Sandcastle


### PR DESCRIPTION
## Summary

Workshop-PC4 verification of #607/#608 surfaced a third sandcastle bug (#610) — Windows Docker Desktop virtiofs apparently has eventual-consistency on lockfile metadata between sequential \`docker exec\` calls, so our \`onSandboxReady\` hook's \`git config --global user.email\` immediately after sandcastle's own \`--global user.email\` fails with \`File exists\` on \`/home/agent/.gitconfig\`.

These two hooks are **redundant**: sandcastle's \`SandboxLifecycle.js:79-86\` already propagates host git identity via \`git config --global user.name/email\` before user hooks run. Removing ours sidesteps the race entirely.

Side effect: agent commits now attributed to host identity (\`sergazy@gmail.com\` / \"Jarvis Agent\") instead of \`agent@jarvis.local\`. The name is already correct; recovering the email-distinction is tracked in #610.

## Test plan

- [x] Verified on Workshop PC4 (Win 11, Docker Desktop 29.4.3, PS 5.1) — sandcastle now gets past sandbox setup. Surfaces an unrelated next-layer bug (#611, prompt preprocessor) instead.

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)