### PR TITLE
feat(sandcastle): jarvis Task Scheduler entry + setup runbook (#545)

### DIFF
--- a/.claude-userlevel/skills/setup-tasks/SKILL.md
+++ b/.claude-userlevel/skills/setup-tasks/SKILL.md
@@ -43,3 +43,27 @@ This skill idempotently registers all scheduled tasks. If a task already exists,
 - Times are in local timezone (not UTC)
 - Cron dedup via Supabase memory: scheduled tasks check `*_last_run` markers to prevent duplicate runs across devices
 - Prompts reference skill files so updates to skills automatically update scheduled task behavior
+
+## Workshop-only: Sandcastle AFK loops (Windows Task Scheduler)
+
+Sandcastle is a **local** Docker-based AFK loop, not a remote scheduled agent — it runs `Run-Sandcastle.ps1` inside Windows Task Scheduler against an Ollama-backed Claude Code container. Different infra from the six tasks above (those use `create_scheduled_task` MCP; sandcastle uses `Register-ScheduledTask`).
+
+When invoked on the Workshop PC (`config/device.json` name = `VividFormsPC4Workshop`), `/setup-tasks` also registers:
+
+| Task name | Schedule | Window end | Slice |
+|---|---|---|---|
+| `Sandcastle-Jarvis` | Daily 22:00 | 02:00 | [#545](https://github.com/Osasuwu/jarvis/issues/545) |
+| `Sandcastle-Redrobot` | Daily 02:00 | 08:00 | [#546](https://github.com/Osasuwu/jarvis/issues/546) |
+
+Non-overlapping by design — prevents two Ollama jobs contending for VRAM.
+
+Implementation: invoke the registration script directly (idempotent, replaces existing entry):
+
+```powershell
+.\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo jarvis
+.\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo redrobot -RepoRoot D:\Github\redrobot\redrobot
+```
+
+On non-Workshop devices the script refuses unless `-Force` (dev rehearsal). Full setup + troubleshooting: [`docs/agents/sandcastle-setup.md`](../../../docs/agents/sandcastle-setup.md).
+
+Decisions: `4890aa35` (Workshop = prod), `0c3017c6` (failure modes), `f8e27d53` (escalation), `58670ea5` (model tier).

--- a/docs/agents/sandcastle-setup.md
+++ b/docs/agents/sandcastle-setup.md
@@ -1,0 +1,158 @@
+# Sandcastle on Workshop PC — setup runbook
+
+Manual setup steps required to bring the sandcastle AFK loop up on a fresh
+Workshop PC. Lists the **unautomated** steps; everything in
+`scripts/sandcastle/Register-SandcastleTask.ps1` is automated.
+
+Goal of this doc: avoid the Sprint-3 "six unaccounted manual fixes" pattern
+(memory `sprint_plan_pillar7_sprint3_2026_04_25`). Every step here either has
+a script that performs it, or is listed below with a one-line justification
+for why it isn't automatable today.
+
+Decisions referenced:
+- `4890aa35` — Workshop PC = production target; Main PC = dev/test bench
+- `0c3017c6` — Failure modes: watchdog autostart + soft-stop window
+- `f8e27d53` — Multi-tier model escalation (Ollama → Ollama-small → DeepSeek)
+- `58670ea5` — Workshop model tier: 14b primary, 7b downgrade (#538)
+
+## One-time setup
+
+### 1. Docker Desktop
+
+Install Docker Desktop. Configure to start with Windows.
+
+> **Why manual:** Docker Desktop installer is a GUI MSI; silent install is
+> possible but the WSL2 + Hyper-V toggling has historically been brittle on
+> mixed Windows builds. Cheaper to install once by hand than to write+maintain
+> a silent-install path. Watchdog `Start-DockerDesktop` autostarts the daemon
+> from cold each run.
+
+### 2. Ollama
+
+Install Ollama from `https://ollama.com/download`. Pull the production models:
+
+```powershell
+ollama pull qwen2.5-coder:14b
+ollama pull qwen2.5-coder:7b   # Tier 1 OOM-downgrade
+```
+
+Set `OLLAMA_CONTEXT_LENGTH=65536` as a **machine-wide** environment variable
+(`setx /M OLLAMA_CONTEXT_LENGTH 65536`), then restart the Ollama service.
+Claude Code requires ≥64K context; Ollama's default 8K silently truncates the
+system prompt and tool definitions, causing small models to bail without
+invoking tools.
+
+> **Why manual:** the installer is a signed exe with no documented unattended
+> flag we have audited. Watchdog autostarts the `ollama serve` process per run
+> but can't install it.
+
+### 3. Repos on disk
+
+The jarvis repo lives at `D:\Github\jarvis` (this device's `config/device.json`
+sets `repos_path` to `D:\Github`). The redrobot repo lives at
+`D:\Github\redrobot\redrobot` (the inner directory is the actual repo). Both
+must be cloned and on `main`/`master` before scheduling.
+
+### 4. `.sandcastle/.env`
+
+Copy `.sandcastle/.env.example` to `.sandcastle/.env` inside each repo and
+fill in:
+
+- `GH_TOKEN` — fine-grained PAT scoped to that repo (Issues: RW, PRs: RW,
+  Contents: RW). One token per repo.
+- `SUPABASE_URL` + `SUPABASE_KEY` (anon key only — service-role key never goes
+  into the container; sandcastle slice #542 + #565 enforce RLS on
+  `source_provenance LIKE 'sandcastle:%'`).
+- `VOYAGE_API_KEY` (optional — only needed if the in-container memory MCP
+  re-embeds candidates).
+- `DEEPSEEK_API_KEY` (optional — only if Tier 2 escalation is enabled in the
+  scheduled task).
+
+`.sandcastle/.env` is gitignored. Never commit.
+
+### 5. Build the image
+
+```powershell
+cd D:\Github\jarvis
+npm install                                                  # one-time: pulls tsx + sandcastle
+docker build -t sandcastle:jarvis -f .sandcastle/Dockerfile .
+```
+
+Repeat with `-t sandcastle:redrobot` and `-f` pointing at the redrobot
+sandcastle Dockerfile once #546 lands the redrobot-side scaffolding.
+
+> **Why manual:** image builds are intentionally pinned per-host so a stale
+> base layer doesn't silently break overnight. Watchdog assumes the image
+> exists.
+
+## Register the scheduled task
+
+Once the prerequisites above are in place, the Task Scheduler entries are
+**fully automated**:
+
+```powershell
+# jarvis loop — 22:00 nightly, soft-stop at 02:00
+.\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo jarvis
+
+# redrobot loop — 02:00 nightly, soft-stop at 08:00 (non-overlapping)
+.\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo redrobot `
+    -RepoRoot D:\Github\redrobot\redrobot
+```
+
+The script is idempotent — running again replaces the existing task. It
+refuses to register on non-Workshop devices unless `-Force` is passed.
+
+Verify:
+
+```powershell
+Get-ScheduledTask -TaskName 'Sandcastle-Jarvis','Sandcastle-Redrobot' |
+    Select-Object TaskName, State, @{Name='NextRun'; Expression={
+        ($_ | Get-ScheduledTaskInfo).NextRunTime
+    }}
+```
+
+Trigger manually for smoke validation:
+
+```powershell
+Start-ScheduledTask -TaskName 'Sandcastle-Jarvis'
+# Watch the watchdog log:
+Get-ChildItem .sandcastle\runtime -Directory |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1 |
+    Get-ChildItem -Filter run.log |
+    Get-Content -Wait
+```
+
+## After the first overnight run
+
+The morning after the first overnight run, per slice #545 AC:
+
+1. Find the run dir under `.sandcastle/runtime/<timestamp>/` and read
+   `run.log` end-to-end for silent failures (timeouts that didn't bubble up,
+   git auth errors that got swallowed, etc.).
+2. If silent failures found, **file each as a follow-up issue** before
+   continuing — do not defer.
+3. Confirm the `outcome_record` row exists in Supabase with:
+   - `project = 'jarvis'` (or `redrobot`)
+   - `pattern_tags` includes both `sandcastle` and `afk`
+   - device tag matches `VividFormsPC4Workshop`
+4. Review the agent's PR using the `/delegate` §6 audit checklist
+   (scope-fit, value-change, interaction effects, symmetric fixes) before
+   merging or commenting.
+
+## Disable / remove
+
+```powershell
+Unregister-ScheduledTask -TaskName 'Sandcastle-Jarvis' -Confirm:$false
+Unregister-ScheduledTask -TaskName 'Sandcastle-Redrobot' -Confirm:$false
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Task fires but `run.log` empty | Working dir mismatch | Verify `WorkingDir` in Task Scheduler matches the repo root. |
+| `docker info` timeout in log | Docker Desktop not autostarting cold-boot | Open Docker Desktop manually once, enable "Start Docker Desktop when you sign in to your computer". |
+| Agent bails immediately with `<promise>COMPLETE</promise>` | `OLLAMA_CONTEXT_LENGTH` not set machine-wide | `setx /M OLLAMA_CONTEXT_LENGTH 65536`, restart Ollama. |
+| OOM during 14b run | Another VRAM consumer present (browser GPU accel, second model loaded) | Watchdog Tier 1 will downgrade to 7b automatically; check `outcome_record.llm.model` to confirm. |
+| Agent picks no issue | No issue currently labelled `sandcastle` + open | Queue is empty — expected; no action. |

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -1,0 +1,225 @@
+<#
+.SYNOPSIS
+    Register (or re-register) a Windows Task Scheduler entry for the sandcastle
+    AFK loop. Idempotent -- running again with the same -Repo replaces the
+    existing entry.
+
+.DESCRIPTION
+    Slices #545 (jarvis) and #546 (redrobot). The task fires Run-Sandcastle.ps1
+    nightly inside the chosen safe-hours window:
+        jarvis   : 22:00 → soft-stop at 02:00
+        redrobot : 02:00 → soft-stop at 08:00
+    Non-overlapping schedule prevents two Ollama jobs from contending for VRAM.
+
+    The script must run on the Workshop PC (decision 4890aa35 -- Workshop = prod,
+    Main = dev/test bench). On other devices the script refuses unless -Force.
+
+.PARAMETER Repo
+    Which sandcastle loop to wire up: jarvis or redrobot.
+
+.PARAMETER StartTime
+    Override the default start time. Default per-repo:
+        jarvis   = 22:00
+        redrobot = 02:00
+
+.PARAMETER WindowEnd
+    Override the soft-stop boundary passed to Run-Sandcastle.ps1. Default per-repo:
+        jarvis   = 02:00
+        redrobot = 08:00
+
+.PARAMETER Model
+    Tier 0 Ollama model. Defaults from #538 decision 58670ea5: qwen2.5-coder:14b.
+
+.PARAMETER Tier1Model
+    Tier 1 OOM-downgrade Ollama model. Defaults from #538: qwen2.5-coder:7b.
+
+.PARAMETER Tier2Provider
+    Empty (default) = no remote-API escalation in cron context. Set to
+    deepseek or claude only when explicitly enabling Tier 2 for AFK runs.
+
+.PARAMETER RepoRoot
+    Filesystem path to the target repo. Defaults to the jarvis repo discovered
+    from this script's own path (../../). For -Repo redrobot, pass the
+    redrobot worktree path explicitly.
+
+.PARAMETER WhatIf
+    Print the planned scheduled task XML without registering.
+
+.PARAMETER Force
+    Allow registration on non-Workshop devices. For dev rehearsal only.
+
+.EXAMPLE
+    .\Register-SandcastleTask.ps1 -Repo jarvis
+    # Registers Sandcastle-Jarvis daily at 22:00.
+
+.EXAMPLE
+    .\Register-SandcastleTask.ps1 -Repo redrobot -RepoRoot D:\Github\redrobot\redrobot
+    # Registers Sandcastle-Redrobot daily at 02:00 (non-overlapping).
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('jarvis', 'redrobot')]
+    [string]$Repo,
+
+    [string]$StartTime,
+
+    [string]$WindowEnd,
+
+    [string]$Model = 'qwen2.5-coder:14b',
+
+    [string]$Tier1Model = 'qwen2.5-coder:7b',
+
+    [ValidateSet('', 'deepseek', 'claude')]
+    [string]$Tier2Provider = '',
+
+    [string]$RepoRoot,
+
+    [int]$MaxIterations = 5,
+
+    [switch]$WhatIfOnly,
+
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Device guard -- decision 4890aa35 (Workshop = production target).
+# ---------------------------------------------------------------------------
+
+$expectedDevice = 'VividFormsPC4Workshop'
+$deviceJson     = Join-Path $PSScriptRoot '..\..\config\device.json'
+$currentDevice  = $null
+if (Test-Path $deviceJson) {
+    try {
+        $currentDevice = (Get-Content $deviceJson -Raw | ConvertFrom-Json).name
+    } catch {
+        Write-Warning "config/device.json present but unparsable: $($_.Exception.Message)"
+    }
+}
+
+if (-not $Force -and $currentDevice -ne $expectedDevice) {
+    throw "Refusing to register on '$currentDevice' -- sandcastle production target is '$expectedDevice'. Pass -Force for dev rehearsal."
+}
+
+# ---------------------------------------------------------------------------
+# Per-repo defaults
+# ---------------------------------------------------------------------------
+
+$defaults = @{
+    jarvis   = @{ Start = '22:00'; End = '02:00'; TaskName = 'Sandcastle-Jarvis' }
+    redrobot = @{ Start = '02:00'; End = '08:00'; TaskName = 'Sandcastle-Redrobot' }
+}
+
+if (-not $StartTime) { $StartTime = $defaults[$Repo].Start }
+if (-not $WindowEnd) { $WindowEnd = $defaults[$Repo].End }
+$taskName = $defaults[$Repo].TaskName
+
+if (-not $RepoRoot) {
+    if ($Repo -eq 'jarvis') {
+        $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    } else {
+        throw "For -Repo redrobot you must pass -RepoRoot explicitly (the redrobot worktree is outside the jarvis repo)."
+    }
+}
+
+if (-not (Test-Path $RepoRoot)) {
+    throw "RepoRoot '$RepoRoot' does not exist."
+}
+
+$watchdog = Join-Path $RepoRoot 'scripts\sandcastle\Run-Sandcastle.ps1'
+if ($Repo -eq 'jarvis' -and -not (Test-Path $watchdog)) {
+    throw "Watchdog not found at '$watchdog' -- wrong RepoRoot?"
+}
+# For redrobot, the watchdog ships with jarvis; redrobot uses the same file
+# under its own sandcastle scaffolding (lands as part of slice #546 prep).
+# We still validate that the path exists at registration time so a missing
+# file surfaces immediately instead of at 02:00.
+if ($Repo -eq 'redrobot' -and -not (Test-Path $watchdog)) {
+    Write-Warning "Watchdog not yet present at '$watchdog'. Register-SandcastleTask will create the task, but the first run will fail until the watchdog file is copied in (#546 scope)."
+}
+
+# ---------------------------------------------------------------------------
+# Build the action -- pwsh preferred, fallback to powershell.exe (5.1).
+# ---------------------------------------------------------------------------
+
+$pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
+$pwshExe = if ($pwshCmd) { $pwshCmd.Source } else { (Get-Command powershell -ErrorAction Stop).Source }
+
+# Quote the watchdog path in case RepoRoot contains spaces.
+$watchdogQuoted = '"' + $watchdog + '"'
+
+$argParts = @(
+    '-NoProfile',
+    '-ExecutionPolicy', 'Bypass',
+    '-File', $watchdogQuoted,
+    '-Repo', $Repo,
+    '-Model', $Model,
+    '-MaxIterations', $MaxIterations,
+    '-WindowEnd', $WindowEnd
+)
+if ($Tier1Model)    { $argParts += @('-Tier1Model', $Tier1Model) }
+if ($Tier2Provider) { $argParts += @('-Tier2Provider', $Tier2Provider) }
+
+$action = New-ScheduledTaskAction -Execute $pwshExe `
+    -Argument ($argParts -join ' ') `
+    -WorkingDirectory $RepoRoot
+
+# ---------------------------------------------------------------------------
+# Trigger -- daily including weekends, at the start of the safe-hours window.
+# ---------------------------------------------------------------------------
+
+$today = (Get-Date).Date
+$startDt = [datetime]::ParseExact("$($today.ToString('yyyy-MM-dd')) $StartTime", 'yyyy-MM-dd HH:mm', $null)
+# If StartTime already passed today, schedule starts firing tomorrow.
+if ($startDt -lt (Get-Date)) { $startDt = $startDt.AddDays(1) }
+
+$trigger = New-ScheduledTaskTrigger -Daily -At $startDt
+
+# ---------------------------------------------------------------------------
+# Principal + settings.
+# ---------------------------------------------------------------------------
+
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew `
+    -ExecutionTimeLimit ([timespan]::FromHours(6))
+
+# ---------------------------------------------------------------------------
+# Register (idempotent).
+# ---------------------------------------------------------------------------
+
+$existing = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+
+if ($WhatIfOnly) {
+    Write-Host "[whatif] Would register task '$taskName'"
+    Write-Host "         Execute   : $pwshExe"
+    Write-Host "         Arguments : $($argParts -join ' ')"
+    Write-Host "         WorkingDir: $RepoRoot"
+    Write-Host "         Trigger   : Daily at $StartTime (next fire: $startDt)"
+    Write-Host "         WindowEnd : $WindowEnd"
+    Write-Host "         Existing  : $(if ($existing) { 'YES (would be replaced)' } else { 'no' })"
+    return
+}
+
+if ($existing) {
+    Write-Host "[register] Unregistering existing '$taskName' (idempotent)"
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+}
+
+$description = "Sandcastle AFK loop for $Repo. Slice #$(if ($Repo -eq 'jarvis') { '545' } else { '546' }). Soft-stop at $WindowEnd. Decisions 4890aa35, 0c3017c6, f8e27d53, 58670ea5."
+
+Register-ScheduledTask -TaskName $taskName `
+    -Action $action -Trigger $trigger `
+    -Principal $principal -Settings $settings `
+    -Description $description | Out-Null
+
+Write-Host "[register] '$taskName' scheduled daily at $StartTime (window ends $WindowEnd)."
+Write-Host "           Model=$Model  Tier1=$Tier1Model  Tier2=$(if ($Tier2Provider) { $Tier2Provider } else { '<disabled>' })"
+Write-Host "           Inspect: Get-ScheduledTask -TaskName '$taskName'"
+Write-Host "           Trigger now: Start-ScheduledTask -TaskName '$taskName'"


### PR DESCRIPTION
## Summary

- New idempotent registrar `scripts/sandcastle/Register-SandcastleTask.ps1`. Per-repo defaults: jarvis 22:00 to 02:00, redrobot 02:00 to 08:00 (non-overlapping).
- `docs/agents/sandcastle-setup.md` runbook listing every manual prereq with a one-line "why manual" justification.
- `/setup-tasks` SKILL.md gets a Workshop-only Sandcastle section pointing at the registration script.
- Task registered live on this Workshop PC during the commit run -- next fire tonight 22:00. Idempotency verified by re-running.

Model defaults wired from #538 decision `58670ea5`: Tier 0 `qwen2.5-coder:14b`, Tier 1 `qwen2.5-coder:7b`. Decision episode for this slice: `4bfb4c6b`.

## AC ship-now items

- [x] `/setup-tasks` skill includes a `sandcastle:jarvis` entry, idempotent on re-run
- [x] Windows Task Scheduler shows `Sandcastle-Jarvis` on Workshop PC, daily 22:00 incl. weekends
- [x] Manual setup steps either automated by the registration script or explicitly listed in `docs/agents/sandcastle-setup.md`

## AC overnight items (operational follow-up, not code)

First overnight run, watchdog log review, outcome_record verification, and agent-PR audit are operational verification of the deploy, not code changes. They happen tomorrow morning. Follow-up issues filed if any silent failures surface.

## Test plan

- [x] `-WhatIfOnly` dry run on both `-Repo jarvis` and `-Repo redrobot`
- [x] Re-run replaces existing task cleanly (idempotency)
- [x] Device guard rejects non-Workshop devices without `-Force`
- [ ] Overnight run produces correct `outcome_record` row (verified tomorrow morning)

Closes #545.
