### PR TITLE
feat(sandcastle): redrobot watchdog + shared scheduler (jarvis-side #546)

### DIFF
--- a/.claude-userlevel/skills/setup-tasks/SKILL.md
+++ b/.claude-userlevel/skills/setup-tasks/SKILL.md
@@ -61,7 +61,7 @@ Implementation: invoke the registration script directly (idempotent, replaces ex
 
 ```powershell
 .\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo jarvis
-.\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo redrobot -RepoRoot D:\Github\redrobot\redrobot
+.\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo redrobot
 ```
 
 On non-Workshop devices the script refuses unless `-Force` (dev rehearsal). Full setup + troubleshooting: [`docs/agents/sandcastle-setup.md`](../../../docs/agents/sandcastle-setup.md).

--- a/docs/agents/sandcastle-setup.md
+++ b/docs/agents/sandcastle-setup.md
@@ -50,7 +50,7 @@ invoking tools.
 
 The jarvis repo lives at `D:\Github\jarvis` (this device's `config/device.json`
 sets `repos_path` to `D:\Github`). The redrobot repo lives at
-`D:\Github\redrobot\redrobot` (the inner directory is the actual repo). Both
+`D:\Github\redrobot` (the inner directory is the actual repo). Both
 must be cloned and on `main`/`master` before scheduling.
 
 ### 4. `.sandcastle/.env`
@@ -91,13 +91,18 @@ Once the prerequisites above are in place, the Task Scheduler entries are
 **fully automated**:
 
 ```powershell
+# One-time machine env so the redrobot watchdog finds the worktree at 02:00.
+setx /M REDROBOT_REPO_ROOT D:\Github\redrobot
+# (open a fresh shell after setx — Machine vars don't refresh in the current one)
+
 # jarvis loop — 22:00 nightly, soft-stop at 02:00
 .\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo jarvis
 
 # redrobot loop — 02:00 nightly, soft-stop at 08:00 (non-overlapping)
-.\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo redrobot `
-    -RepoRoot D:\Github\redrobot\redrobot
+.\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo redrobot
 ```
+
+Both repos share the **same** `Run-Sandcastle.ps1` watchdog (it lives in jarvis and is `-Repo`-aware) — no duplication into the redrobot repo. Redrobot only carries its own `.sandcastle/` (Dockerfile, prompt, .env), not the scheduler scripts.
 
 The script is idempotent — running again replaces the existing task. It
 refuses to register on non-Workshop devices unless `-Force` is passed.

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -116,28 +116,40 @@ if (-not $StartTime) { $StartTime = $defaults[$Repo].Start }
 if (-not $WindowEnd) { $WindowEnd = $defaults[$Repo].End }
 $taskName = $defaults[$Repo].TaskName
 
+# Watchdog always lives in the jarvis repo (same dir as this script). Both
+# jarvis and redrobot loops invoke the same parameterised watchdog -- it
+# handles per-repo dispatch internally via Get-RepoRoot. This avoids
+# duplicating the script across repos (epic #534 architectural commitment:
+# "config identical between jarvis and redrobot").
+$watchdog = Join-Path $PSScriptRoot 'Run-Sandcastle.ps1'
+if (-not (Test-Path $watchdog)) {
+    throw "Watchdog not found at '$watchdog'. Register-SandcastleTask must run from the jarvis repo's scripts/sandcastle directory."
+}
+
+# Working directory for the scheduled task -- cosmetic only (the watchdog
+# does its own Push-Location to the resolved repo root). Default to the
+# jarvis repo so logs / cwd-relative output land somewhere sane.
 if (-not $RepoRoot) {
-    if ($Repo -eq 'jarvis') {
-        $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
-    } else {
-        throw "For -Repo redrobot you must pass -RepoRoot explicitly (the redrobot worktree is outside the jarvis repo)."
-    }
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 }
 
 if (-not (Test-Path $RepoRoot)) {
     throw "RepoRoot '$RepoRoot' does not exist."
 }
 
-$watchdog = Join-Path $RepoRoot 'scripts\sandcastle\Run-Sandcastle.ps1'
-if ($Repo -eq 'jarvis' -and -not (Test-Path $watchdog)) {
-    throw "Watchdog not found at '$watchdog' -- wrong RepoRoot?"
-}
-# For redrobot, the watchdog ships with jarvis; redrobot uses the same file
-# under its own sandcastle scaffolding (lands as part of slice #546 prep).
-# We still validate that the path exists at registration time so a missing
-# file surfaces immediately instead of at 02:00.
-if ($Repo -eq 'redrobot' -and -not (Test-Path $watchdog)) {
-    Write-Warning "Watchdog not yet present at '$watchdog'. Register-SandcastleTask will create the task, but the first run will fail until the watchdog file is copied in (#546 scope)."
+# For redrobot, the watchdog uses REDROBOT_REPO_ROOT to find the redrobot
+# worktree at runtime. Surface a missing var loudly here rather than at 02:00.
+if ($Repo -eq 'redrobot') {
+    $machineEnv = [System.Environment]::GetEnvironmentVariable('REDROBOT_REPO_ROOT', 'Machine')
+    $userEnv    = [System.Environment]::GetEnvironmentVariable('REDROBOT_REPO_ROOT', 'User')
+    $envVal     = if ($machineEnv) { $machineEnv } elseif ($userEnv) { $userEnv } else { $null }
+    if (-not $envVal) {
+        Write-Warning "REDROBOT_REPO_ROOT machine env var not set. The scheduled task will fail at runtime. Set it once:  setx /M REDROBOT_REPO_ROOT D:\Github\redrobot"
+    } elseif (-not (Test-Path $envVal)) {
+        Write-Warning "REDROBOT_REPO_ROOT='$envVal' does not exist on disk. Fix before 02:00."
+    } else {
+        Write-Host "[register] REDROBOT_REPO_ROOT='$envVal' resolves to a real path."
+    }
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -663,7 +663,11 @@ function Invoke-Watchdog {
     }
 
     # 3. Iterate (soft-stop on window expiry between iterations)
-    $repoSlug = if ($Repo -eq 'jarvis') { 'Osasuwu/jarvis' } else { '' }
+    $repoSlug = switch ($Repo) {
+        'jarvis'   { 'Osasuwu/jarvis' }
+        'redrobot' { 'SergazyNarynov/redrobot' }
+        default    { '' }
+    }
     $totalUsage = @{ input_tokens = 0; output_tokens = 0; cache_read_input_tokens = 0; cache_creation_input_tokens = 0; model = $Model }
     $allCommits = @()
     $branch = $null


### PR DESCRIPTION
## Summary

Jarvis side of slice #546 — wires the watchdog and scheduler to support `-Repo redrobot` end-to-end. Redrobot side (`.sandcastle/` scaffold + `package.json`) landed at [SergazyNarynov/redrobot#767](https://github.com/SergazyNarynov/redrobot/pull/767), merged.

## Changes

### `scripts/sandcastle/Run-Sandcastle.ps1`
- `$repoSlug` now resolves to `SergazyNarynov/redrobot` for `-Repo redrobot` (was empty, silently breaking Tier 2 escalation and label application on redrobot runs).

### `scripts/sandcastle/Register-SandcastleTask.ps1`
- Watchdog path always derived from `$PSScriptRoot` (jarvis-local). Both jarvis and redrobot tasks call the **same** `-Repo`-aware watchdog — no duplication into redrobot. Matches the epic #534 architectural commitment.
- `-RepoRoot` becomes cosmetic-only (Task Scheduler WorkingDir); the watchdog does its own `Push-Location` to the resolved repo root.
- For `-Repo redrobot`, surface a clear warning if `REDROBOT_REPO_ROOT` is unset rather than failing silently at 02:00.

### Docs
- `docs/agents/sandcastle-setup.md` documents the shared-watchdog design + the `setx REDROBOT_REPO_ROOT` one-time setup step.
- `/setup-tasks` SKILL.md mirrors the change (no more `-RepoRoot` in the example).

## Live deploy

Both tasks registered on this Workshop PC during the commit run:

```
TaskName            State NextRun
--------            ----- -------
Sandcastle-Jarvis   Ready 2026-05-13 22:00:00
Sandcastle-Redrobot Ready 2026-05-14 02:00:00
```

`REDROBOT_REPO_ROOT=D:\Github\redrobot` (user-scope env var). Non-overlapping schedule preserves VRAM on the 16 GB card per #538 sizing.

## AC ship-now items
- [x] `/setup-tasks` skill adds `sandcastle:redrobot` entry, idempotent on re-run
- [x] Schedule confirmed non-overlapping with the jarvis loop
- [x] `sandcastle` agent prompt for redrobot blacklists `redrobot/planning/`, `driver/`, `mujoco/` regardless of issue label (in `SergazyNarynov/redrobot#767`)
- [x] `outcome_record` from redrobot loop will carry `project=redrobot` and `pattern_tags ⊇ {sandcastle, afk}` — wired via the existing watchdog code; the `$repoSlug` fix here ensures Tier 2 escalation can resolve the repo slug for label application
- [x] `sandcastle` label created in redrobot repo

## AC follow-up (deferred to follow-up issue per HITL alignment)
- Watchdog in-container `pytest` gate (AC #4 of #546) — interim enforcement is prompt-level discipline in redrobot's `.sandcastle/prompt.md`. Watchdog-enforced gate filed as a follow-up.

## AC overnight items (operational follow-up, not code)
- First overnight run produces ≥1 redrobot PR — verified tomorrow morning.
- Orchestrator review of that PR per `/delegate` §6 audit — verified tomorrow.

## Test plan
- [x] `-WhatIfOnly` confirms both task definitions reference the jarvis watchdog path
- [x] Re-register both tasks idempotently (verified live on Workshop)
- [x] REDROBOT_REPO_ROOT warning fires when the env var is missing

Closes #546.
