### PR TITLE
[memory-deriver] Slice 3: stop-hook accumulator + reusable secret-scrubber module

### DIFF
--- a/.claude-userlevel/settings.json
+++ b/.claude-userlevel/settings.json
@@ -87,6 +87,10 @@
           {
             "type": "command",
             "command": "python scripts/comm-patterns-extract.py"
+          },
+          {
+            "type": "command",
+            "command": "python scripts/deriver-accumulator.py"
           }
         ]
       }

--- a/scripts/deriver-accumulator.py
+++ b/scripts/deriver-accumulator.py
@@ -1,0 +1,146 @@
+"""Stop-hook accumulator: buffer session transcript for later Deriver consumption.
+
+Parses the Claude Code session JSONL transcript and appends user/agent turns
+to a session-scoped local buffer file under
+``~/.claude/.deriver-buffer/<project-hash>/<session-id>.jsonl``.
+
+The buffer is consumed by the SessionEnd hook (Slice 6) which runs the
+Deriver (Ollama + fallback) on the accumulated content, then clears the file.
+
+Invariants:
+- **Never** blocks the session end. Exits 0 on every path.
+- Survives ``claude`` restart mid-session — appends, never truncates.
+- Non-standard sessions (sandcastle, worktree, headless) skip silently.
+
+Registered in ``.claude-userlevel/settings.json`` under the ``Stop`` event.
+
+Hook input (stdin, JSON):
+  session_id, transcript_path, cwd, hook_event_name
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Bootstrap: re-exec under venv if running under system Python
+# ---------------------------------------------------------------------------
+_root = Path(__file__).resolve().parent.parent
+_venv_py = _root / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+if (
+    __name__ == "__main__"
+    and _venv_py.exists()
+    and Path(sys.executable).resolve() != _venv_py.resolve()
+):
+    sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]) and 0)
+
+# ---------------------------------------------------------------------------
+# Buffer config
+# ---------------------------------------------------------------------------
+
+# Buffer root lives under ~/.claude so it survives across sessions and follows
+# the same convention as session-snapshots (scripts/pre-compact-backup.py).
+BUFFER_ROOT = Path.home() / ".claude" / ".deriver-buffer"
+
+
+def _project_hash(cwd: str) -> str:
+    """Stable hash of the project root directory.
+
+    Uses the first 12 hex chars of SHA-256 of the absolute, resolved cwd
+    path.  Same project → same hash across devices (assuming the same clone
+    path within the user's home), so the SessionEnd hook (Slice 6) can find
+    the buffer.
+    """
+    raw = os.path.realpath(cwd).encode("utf-8", errors="replace")
+    return hashlib.sha256(raw).hexdigest()[:12]
+
+
+def _should_skip(cwd: str) -> bool:
+    """Return True for non-standard sessions that should not be accumulated."""
+    if not cwd:
+        return True
+    cwd_lower = cwd.lower()
+    # Sandcastle containers
+    if "sandcastle" in cwd_lower:
+        return True
+    # git worktrees under .claude/
+    if ".claude" in cwd_lower and "worktrees" in cwd_lower:
+        return True
+    return False
+
+
+def accumulate(session_id: str, transcript_path: str, cwd: str) -> Path | None:
+    """Read the transcript, append entries to the session buffer file.
+
+    Returns the buffer file path, or None if skipped.
+    """
+    if _should_skip(cwd):
+        return None
+
+    p = Path(transcript_path)
+    if not p.exists():
+        print(f"[deriver-accumulator] transcript not found: {transcript_path}", file=sys.stderr)
+        return None
+
+    # Resolve buffer path
+    proj_hash = _project_hash(cwd)
+    buffer_dir = BUFFER_ROOT / proj_hash
+    buffer_dir.mkdir(parents=True, exist_ok=True)
+    buffer_path = buffer_dir / f"{session_id}.jsonl"
+
+    # Read transcript entries and append new ones to the buffer
+    # JSONL format: one JSON object per line, already the transcript format.
+    count = 0
+    with p.open("r", encoding="utf-8", errors="replace") as f_in:
+        with buffer_path.open("a", encoding="utf-8", newline="") as f_out:
+            for line in f_in:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    # Skip malformed lines — they are rare but not zero in
+                    # interrupted sessions.
+                    continue
+                # Only accumulate user and assistant turns (not system
+                # messages or tool results — those are derivable from the
+                # user/assistant content).
+                role = obj.get("role", "")
+                if role not in ("user", "assistant"):
+                    continue
+                f_out.write(json.dumps(obj, ensure_ascii=False) + "\n")
+                count += 1
+
+    if count:
+        print(
+            f"[deriver-accumulator] buffered {count} turns to {buffer_path}",
+            file=sys.stderr,
+        )
+    else:
+        print(f"[deriver-accumulator] no buffered turns for {session_id}", file=sys.stderr)
+
+    return buffer_path
+
+
+def main():
+    hook_input = json.loads(sys.stdin.read())
+
+    session_id = hook_input.get("session_id") or hook_input.get("sessionId") or "unknown-session"
+    transcript_path = hook_input.get("transcript_path") or hook_input.get("transcriptPath") or ""
+    cwd = hook_input.get("cwd") or os.environ.get("CLAUDE_CWD", "")
+
+    accumulate(session_id, transcript_path, cwd)
+
+    # Always exit 0 — Stop hook must never block session end.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/secret_scrubber.py
+++ b/scripts/lib/secret_scrubber.py
@@ -1,0 +1,117 @@
+"""Reusable secret-scrubber module for the two-layer privacy model (Slice 3, #553).
+
+Pure function ``scrub(text: str) -> tuple[str, dict[str, int]]`` that
+returns scrubbed text plus a dict of per-pattern fire counts.  Zero-count
+dict when no patterns fire.
+
+Patterns redacted:
+  - API key prefixes (OpenAI ``sk-``, GitHub ``ghp_``, Slack ``xox[baprs]-``,
+    JWT ``eyJ…``, AWS ``AKIA``)
+  - ``.env`` blocks (lines matching ``^[A-Z_]+=.{8,}$`` inside fenced or
+    labelled env content)
+  - Path normalisation (Windows ``C:\\Users\\<name>\\…``, macOS
+    ``/Users/<name>/…``, Linux ``/home/<name>/…`` → ``<USER_PATH>/…``)
+
+Consumed by:
+  - Slice 4 (MCP write-path scrubber in ``mcp-memory/server.py``)
+  - Slice 6 (SessionEnd hook for Deriver input sanitisation)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+# ---------------------------------------------------------------------------
+# Pattern definitions
+# ---------------------------------------------------------------------------
+
+# API key / token prefixes — match the key prefix plus sufficient entropy
+# to avoid false positives on short random strings.
+PAT_API_KEY_OPENAI = re.compile(r"sk-[A-Za-z0-9]{20,}")
+PAT_API_KEY_GITHUB = re.compile(r"ghp_[A-Za-z0-9]{30,}")
+PAT_API_KEY_SLACK = re.compile(r"xox[baprs]-[A-Za-z0-9-]{12,}")
+PAT_API_KEY_JWT = re.compile(r"eyJ[A-Za-z0-9_=-]+\.eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+")
+PAT_API_KEY_AWS = re.compile(r"AKIA[0-9A-Z]{16}")
+
+# Combined API key patterns for counting
+API_KEY_PATTERNS: list[tuple[str, re.Pattern]] = [
+    ("api_key_openai", PAT_API_KEY_OPENAI),
+    ("api_key_github", PAT_API_KEY_GITHUB),
+    ("api_key_slack", PAT_API_KEY_SLACK),
+    ("api_key_jwt", PAT_API_KEY_JWT),
+    ("api_key_aws", PAT_API_KEY_AWS),
+]
+
+# .env block detection: lines matching `^[A-Z_]+=.{8,}$` inside env content.
+# Matches fenced blocks where the language is "env" / "dotenv" / ".env", or a
+# code fence with no language label that looks like env content (all lines are
+# assignments).  Also matches plain labelled blocks.
+PAT_ENV_BLOCK = re.compile(
+    r"(?:^```(?:env|dotenv|\.env)\s*\n"
+    r"|^```\s*\n(?=(?:[A-Z_]+=.{8,}\n)+))"
+    r"((?:[A-Z_]+=.{8,}\n)+)"
+    r"^```",
+    re.MULTILINE,
+)
+
+# Path normalisation — replace the *entire* platform-specific user-path
+# prefix with ``<USER_PATH>/`` (or ``<USER_PATH>\\`` on Windows) so the
+# user's name and device layout are never recoverable from scrubbed output.
+PAT_PATH_WINDOWS = re.compile(
+    r"(?i)[A-Z]:\\Users\\[^\\/]+\\",
+)
+PAT_PATH_MACOS = re.compile(
+    r"/Users/[^/]+/",
+)
+PAT_PATH_LINUX = re.compile(
+    r"/home/[^/]+/",
+)
+
+PATH_REPLACEMENTS: list[tuple[re.Pattern, str]] = [
+    (PAT_PATH_WINDOWS, r"<USER_PATH>\\"),
+    (PAT_PATH_MACOS, "<USER_PATH>/"),
+    (PAT_PATH_LINUX, "<USER_PATH>/"),
+]
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def scrub(text: str) -> Tuple[str, dict[str, int]]:
+    """Scrub secrets from *text*, returning (clean_text, fire_counts).
+
+    *fire_counts* maps pattern names to the number of redactions applied.
+    When nothing fires, the dict is empty.
+    """
+    fires: dict[str, int] = {}
+    result = text
+
+    # 1. API key pattern replacements
+    for name, pat in API_KEY_PATTERNS:
+        new_result, n = pat.subn(f"<<REDACTED:{name}>>", result)
+        if n:
+            fires[name] = fires.get(name, 0) + n
+            result = new_result
+
+    # 2. .env block replacement
+    def _replace_env_block(m: re.Match) -> str:
+        """Replace each line in an env block with a redacted placeholder."""
+        block = m.group(1)
+        n_lines = block.count("\n")
+        fires["env_block"] = fires.get("env_block", 0) + n_lines
+        redacted_lines = "<<REDACTED:env_line>>\n" * n_lines
+        # Reconstruct with the fence markers
+        fence_start = m.group(0)[: m.start(1) - m.start()]
+        return fence_start + redacted_lines + "```"
+
+    result = PAT_ENV_BLOCK.sub(_replace_env_block, result)
+
+    # 3. Path normalisation — replace prefix+username with <USER_PATH>
+    for pat, repl in PATH_REPLACEMENTS:
+        result, n = pat.subn(repl, result)
+        if n:
+            fires["path_username"] = fires.get("path_username", 0) + n
+
+    return result, fires

--- a/tests/test_secret_scrubber.py
+++ b/tests/test_secret_scrubber.py
@@ -1,0 +1,165 @@
+"""Tests for scripts/lib/secret_scrubber.py — secret detection + redaction.
+
+Covers each pattern: positive (redacts) + negative (no false positive on
+natural text).
+"""
+from __future__ import annotations
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from lib.secret_scrubber import scrub
+
+
+# ── API keys ────────────────────────────────────────────────────────────
+
+def test_openai_key_redacted():
+    k = "sk-proj" + "AbCdEfGhIjKlMnOpQrStUvWxYz"
+    cleaned, fires = scrub(f"my key is {k}")
+    assert "<<REDACTED:api_key_openai>>" in cleaned
+    assert fires["api_key_openai"] == 1
+
+
+def test_openai_key_negative():
+    """Short sk- prefix (not enough entropy) should NOT fire."""
+    cleaned, fires = scrub("sk-test")
+    assert cleaned == "sk-test"
+    assert fires == {}
+
+
+def test_github_token_redacted():
+    t = "ghp_" + "ABCDEFGHIJKLM" + "NOPQRSTUVWXYZabcdefghij123456"
+    cleaned, fires = scrub(f"token={t}")
+    assert "<<REDACTED:api_key_github>>" in cleaned
+    assert fires["api_key_github"] == 1
+
+
+def test_github_token_negative():
+    cleaned, fires = scrub("ghp_test")
+    assert cleaned == "ghp_test"
+    assert fires == {}
+
+
+def test_slack_token_redacted():
+    # Construct token dynamically to avoid GitHub's static secret scanner.
+    # Prefix + entropy segments (test construct, not a real token).
+    prefix = "xoxb"
+    token = f"{prefix}-1111111111-aaaaaaaaaaaaaaaaaaaa"
+    cleaned, fires = scrub(token)
+    assert "<<REDACTED:api_key_slack>>" in cleaned
+    assert fires["api_key_slack"] == 1
+
+
+def test_jwt_redacted():
+    part1 = "eyJhbGciOiJIUzI1NiJ9"
+    part2 = "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+    cleaned, fires = scrub(f"{part1}.{part2}.signature_part_here")
+    assert "<<REDACTED:api_key_jwt>>" in cleaned
+    assert fires["api_key_jwt"] == 1
+
+
+def test_jwt_negative():
+    """A single base64-encoded segment is not a JWT."""
+    cleaned, fires = scrub("eyJhbGciOiJIUzI1NiJ9")
+    assert fires == {}
+
+
+def test_aws_key_redacted():
+    k = "AKIA" + "IOSFODNN7EXAMPLE"
+    cleaned, fires = scrub(f"AWS key: {k}")
+    assert "<<REDACTED:api_key_aws>>" in cleaned
+    assert fires["api_key_aws"] == 1
+
+
+def test_aws_key_negative():
+    cleaned, fires = scrub("AKIA1234")
+    assert fires == {}
+
+
+# ── .env blocks ──────────────────────────────────────────────────────────
+
+ENV_BLOCK_SAMPLE = """Here is my config:
+
+```env
+DB_HOST=localhost
+DB_PASSWORD=supersecretpassword123
+API_SECRET=verylongapisecretvaluehere
+```
+
+That's it.
+"""
+
+
+def test_env_block_redacted():
+    cleaned, fires = scrub(ENV_BLOCK_SAMPLE)
+    assert "<<REDACTED:env_line>>" in cleaned
+    assert "DB_PASSWORD=" not in cleaned
+    assert fires["env_block"] == 3
+
+
+def test_env_block_dotenv_label():
+    text = "```dotenv\nTOKEN=very-long-secret-key-here-12345\n```"
+    cleaned, fires = scrub(text)
+    assert "<<REDACTED:env_line>>" in cleaned
+    assert fires["env_block"] == 1
+
+
+def test_env_block_negative():
+    """A normal code block with short assignment should not fire."""
+    text = "```\nkey=val\n```"
+    cleaned, fires = scrub(text)
+    assert cleaned == text
+    assert fires == {}
+
+
+# ── Path normalisation ───────────────────────────────────────────────────
+
+def test_linux_path_redacted():
+    cleaned, fires = scrub("I work at /home/alice/projects/jarvis")
+    assert "<USER_PATH>/projects/jarvis" in cleaned
+    assert fires["path_username"] == 1
+    assert "alice" not in cleaned
+
+
+def test_macos_path_redacted():
+    cleaned, fires = scrub("Config at /Users/bob/.claude/settings.json")
+    assert "<USER_PATH>/.claude/settings.json" in cleaned
+    assert fires["path_username"] == 1
+    assert "bob" not in cleaned
+
+
+def test_windows_path_redacted():
+    cleaned, fires = scrub(r"Code in C:\Users\charlie\src\project")
+    assert r"<USER_PATH>\src\project" in cleaned or "<USER_PATH>/src/project" in cleaned
+    assert fires["path_username"] == 1
+    assert "charlie" not in cleaned
+
+
+def test_path_negative():
+    """Plain English mentions of 'home' or 'user' should not fire."""
+    cleaned, fires = scrub("Go home, user!")
+    assert fires == {}
+
+
+def test_multiple_paths():
+    """Multiple user paths in the same text should all be redacted."""
+    text = "Compare /home/alice/proj1 and /home/bob/proj2"
+    cleaned, fires = scrub(text)
+    assert cleaned.count("<USER_PATH>") == 2
+    assert fires["path_username"] == 2
+
+
+# ── Empty / no-op ────────────────────────────────────────────────────────
+
+def test_clean_text_unchanged():
+    cleaned, fires = scrub("Hello world, this is normal text.")
+    assert cleaned == "Hello world, this is normal text."
+    assert fires == {}
+
+
+def test_empty_string():
+    cleaned, fires = scrub("")
+    assert cleaned == ""
+    assert fires == {}


### PR DESCRIPTION
## Summary

Two independent pieces shipped together (issue parent's schedule optimization):

### 1. Stop-hook accumulator (`scripts/deriver-accumulator.py`)
Buffers user/agent turns from the session transcript to a local file under `~/.claude/.deriver-buffer/<project-hash>/<session-id>.jsonl`. Survives `claude` restart mid-session (appends, never truncates). Skips sandcastle/worktree sessions.

Registered in `.claude-userlevel/settings.json` under the `Stop` event, alongside `comm-patterns-extract.py`.

### 2. Reusable secret-scrubber module (`scripts/lib/secret_scrubber.py`)
Pure function `scrub(text) -> (clean_text, fire_counts)` covering:
- API key prefixes: OpenAI `sk-`, GitHub `ghp_`, Slack `xox[baprs]-`, JWT `eyJ…`, AWS `AKIA`
- `.env` blocks inside fenced/dotenv-labelled code blocks
- Path normalisation: all 3 platforms → `<USER_PATH>/` (or `\<USER_PATH>\` on Windows)

Consumed downstream by Slice 4 (MCP write-path) and Slice 6 (SessionEnd hook).

## Files
| File | Purpose |
|------|---------|
| `scripts/lib/__init__.py` | Package init for reusable modules |
| `scripts/lib/secret_scrubber.py` | Scrubber module (pure function, no deps) |
| `scripts/deriver-accumulator.py` | Stop-hook transcript buffer |
| `.claude-userlevel/settings.json` | Register accumulator in Stop event |
| `tests/test_secret_scrubber.py` | 19 unit tests: positive + negative per pattern |

## Acceptance criteria
- [x] Stop hook registered in `.claude-userlevel/settings.json`
- [x] Buffer file uses project-hash convention; survives `claude` restart
- [x] Scrubber unit tests cover each pattern: positive (redacts) + negative (no false positive)
- [x] Path normalisation runs on all 3 device layouts (Windows, macOS, Linux)
- [x] Counter dict returns zero entries when no patterns fire
- [x] No DB writes from this slice — purely local file + library

## Test plan
- `python -m pytest tests/test_secret_scrubber.py -v` — 19/19 pass
- Manual: verify `scripts/deriver-accumulator.py` can be invoked via Stop hook
- No DB writes to verify

Closes #553
