### PR TITLE
feat(skills): /last-work-report skeleton (#606)

### DIFF
--- a/.claude-userlevel/skills/last-work-report/SKILL.md
+++ b/.claude-userlevel/skills/last-work-report/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: last-work-report
+description: "Summarise the most-recently-closed milestone (or one named explicitly) before running `/improve-codebase-architecture`. Type 2 (intent-triggered). SKELETON — body intentionally minimal until `/improve-codebase-architecture` consumes it; triggers on \"last sprint report\", \"what did we ship\", \"milestone closeout\", or \"/last-work-report\"."
+---
+
+# Last Work Report
+
+Type 2 skill. Reads the recently-shipped capability slice (one closed milestone) and emits a structured summary the architecture-sweep skill can consume cold, without re-loading the session that closed it.
+
+**Status: SKELETON.** Per #606 acceptance: contract + trigger phrasings are pinned here; the gathering/rendering logic is deliberately deferred until [`/improve-codebase-architecture`](../improve-codebase-architecture/SKILL.md) wires it in. Invoking the skill today should print this section and exit.
+
+## Why
+
+The milestone-close architecture sweep is meant to run in a **fresh session** (per `CLAUDE.md` → "Architecture sweep at milestone close"). A fresh session has no recollection of what just closed — `/improve-codebase-architecture` either explores the repo blind, or the owner mentally reconstructs the last sprint before invoking it. Both modes lose nuance.
+
+`/last-work-report` is the explicit-entry alternative to the auto-surface in `scripts/session-context.py` (#605). When that detection proves brittle, the owner says "last sprint report" and gets the same payload `session-context.py` would inject.
+
+## Inputs
+
+- **Default:** the most-recently-closed milestone in `Osasuwu/jarvis` (highest `closed_at`).
+- **Explicit:** `/last-work-report <milestone-number-or-title>` — disambiguate when multiple closed recently.
+- **Scope:** single milestone per invocation. Cross-milestone analysis is `/improve-codebase-architecture`'s job, not this skill's.
+
+## Outputs
+
+A markdown block matching the contract `/improve-codebase-architecture` consumes. Shape (TBD-locked once that skill is updated to read it):
+
+```markdown
+# Milestone <N> — <title>
+
+Closed <YYYY-MM-DD>. <one-line capability shipped>.
+
+## Slices (closed issues)
+- #<n>: <title> — PR #<p> (merged <date>) — <one-line outcome>
+
+## Decisions recorded
+- <decision-uuid>: <one-line> (memory: <name>)
+
+## Outcomes recorded
+- <task_outcomes-id>: <status> — <one-line>
+- <task_outcomes-id>: <status> — <one-line>
+
+## Open follow-ups (not closed by this milestone)
+- #<n>: <title> — <status:* label>
+```
+
+Field rules:
+
+- **Slices** — issues with `milestone == <N>` and `state == closed`, ordered by `closed_at`. Include the merging PR if linked.
+- **Decisions recorded** — `decision_made` episodes with `created_at` between milestone `open_at` and `closed_at`, scoped to the project. Include UUID so `/improve-codebase-architecture` can pull rationale on demand without re-rendering it here.
+- **Outcomes recorded** — `task_outcomes` rows with the same time window. `outcome_status` (success/partial/failure) belongs in the line — failure clusters are exactly what the sweep cares about.
+- **Open follow-ups** — issues created during the milestone window that weren't closed by it, labelled `status:*`. Signals scope leakage and incomplete capability shipping.
+
+## Trigger phrasings
+
+Owner says any of:
+
+- `/last-work-report` (canonical slash)
+- `/last-work-report <milestone-number-or-title>`
+- "last sprint report"
+- "what did we ship"
+- "milestone closeout"
+
+All four must match the same skill — the description field above carries them so the model matches at session start (Type 2 per ADR-0001).
+
+## What this skill is NOT
+
+- **Not a `/status` replacement.** That's `/status-record` + `memory_recall(query="status-snapshot")`. This skill is post-milestone, structured for architecture-sweep input — not an ambient state dump.
+- **Not a `/reflect`.** No comms-pattern analysis, no calibration. Just "what shipped, what we decided, what failed".
+- **Not analysis.** Reports facts. The sweep does the thinking.
+
+## Boundary with #605
+
+Issue #605 wires `scripts/session-context.py` to auto-surface "Milestone N closed — architecture sweep recommended" at SessionStart. This skill is the **manual-trigger fallback**. Both deliver the same payload shape; #605 is the path of least friction (owner sees the surface, runs the sweep), this skill is the explicit-ask path (owner forgot, or the auto-detect missed).
+
+If #605 ships first and proves reliable for ≥3 milestone closes, this skill stays a fallback. If #605 is brittle, this skill becomes primary.
+
+## Implementation notes (for the future PR that fleshes this out)
+
+When the body is filled in:
+
+- Read `closed_at` from `gh api repos/Osasuwu/jarvis/milestones?state=closed --jq 'max_by(.closed_at)'`.
+- Fetch slices via `gh issue list --milestone <N> --state closed --json number,title,closedAt,timelineItems`.
+- Fetch decisions via `memory_recall(query="<milestone-title>", type="decision", project="jarvis")` PLUS a direct query on `episodes` filtered by time window (decisions don't always tag the milestone).
+- Fetch outcomes via `outcome_list(project="jarvis", since=<milestone open_at ISO>)` filtered to the close window.
+- Render the markdown block in Step 4. Single tool call.
+- No memory write — this is a synchronous read-and-render skill, not a recorder. (Cross-reference: `/status-record` writes snapshots; this skill emits to the caller.)
+
+Until the body is fleshed out, this skill prints the "SKELETON" notice in its second paragraph and exits.
+
+## Refs
+
+- #606 (this issue) — skeleton.
+- #605 — SessionStart auto-surface (sibling).
+- #548 (grill Q5 fallback) — original motivation.
+- #568 — parent (split).
+- [`/improve-codebase-architecture`](../improve-codebase-architecture/SKILL.md) — downstream consumer.
+- ADR-0001 — Type 2 trigger model.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Use skills — don't reinvent with raw tools.
 | Plan / PRD → vertical-slice issues | `/to-issues` |
 | "diagnose this", bug repro, perf regression | `/diagnose` |
 | "improve architecture", find shallow modules, refactoring opportunities | `/improve-codebase-architecture` |
+| "last sprint report", "what did we ship", "milestone closeout", pre-sweep brief | `/last-work-report` (skeleton — #606) |
 | "zoom out", unfamiliar code area, need higher-level map | `/zoom-out` |
 | Issue triage / state machine / "ready for agent" | `/triage` |
 | Author/edit a skill | `/write-a-skill` |

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -104,6 +104,7 @@ groups:
           - "end"
           - "goals"
           - "implement"
+          - "last-work-report"
           - "reflect"
           - "research"
           - "self-improve"


### PR DESCRIPTION
## Summary

- Adds `.claude-userlevel/skills/last-work-report/SKILL.md` — Type 2 (intent-triggered) skill skeleton briefing a fresh session on the most-recently-closed milestone before `/improve-codebase-architecture` runs.
- Skeleton only per #606 AC ("don't pre-build until `/improve-codebase-architecture` consumes it" — YAGNI). Body is deliberately deferred; today the skill prints the SKELETON notice and exits.
- Registered in `install-manifest.yaml` skills whitelist so it mirrors to `~/.claude/skills/` on next install.
- Routed in `CLAUDE.md` table (flagged "skeleton — #606").

Closes #606.

## Acceptance check

- [x] Skill skeleton in `.claude-userlevel/skills/last-work-report/` per ADR-0001 trigger shape — Type 2, description matches at session start.
- [x] Inputs: most-recently-closed milestone (or explicit `/last-work-report <milestone>` arg).
- [x] Output shape: closed slices, merged PRs, decisions recorded, outcomes recorded — markdown block contract pinned for `/improve-codebase-architecture` to consume when wired.
- [x] Trigger phrasings: "last sprint report", "what did we ship", "milestone closeout", `/last-work-report`.
- [x] YAGNI scope discipline: contract pinned, behavior deferred.

## Boundary with sibling #605

#605 wires `scripts/session-context.py` to auto-surface "Milestone N closed — sweep recommended" at SessionStart (path of least friction).
`/last-work-report` is the manual-trigger fallback (explicit-ask path). Same payload shape; this skill stays a fallback if #605 proves reliable, becomes primary if it doesn't.

## Test plan

- [x] Skill file lints (markdown well-formed, frontmatter valid YAML).
- [x] `install-manifest.yaml` skills whitelist entry alphabetically placed; no other manifest fields touched.
- [x] `CLAUDE.md` skill routing row added between `/improve-codebase-architecture` and `/zoom-out` rows; no other content shifted.
- [x] `CONTEXT.md` not touched (owner has uncommitted local edits per AFK chain hard rule).
- [ ] Owner runs `install.ps1 -Apply` on a device and verifies `/last-work-report` discovers as a slash command and prints the SKELETON notice. (Cannot be verified in this AFK iteration — system boundary.)

## Notes

- Filed during AFK autonomous chain iter:5 (2026-05-16).
- No body behavior to test yet — that's the whole point of the skeleton; the follow-up PR that fleshes it out will land tests.
- Hard rules respected: no `.env`, no `.claude/*` direct edits, explicit paths only, no `CONTEXT.md` touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)