### PR TITLE
chore(skills): /triage adds verify-before-ready-for-agent step

### DIFF
--- a/.claude-userlevel/skills/triage/SKILL.md
+++ b/.claude-userlevel/skills/triage/SKILL.md
@@ -64,11 +64,13 @@ Show counts and a one-line summary per issue. Let the maintainer pick.
 
 2. **Recommend.** Tell the maintainer your category and state recommendation with reasoning, plus a brief codebase summary relevant to the issue. Wait for direction.
 
-3. **Reproduce (bugs only).** Before any grilling, attempt reproduction: read the reporter's steps, trace the relevant code, run tests or commands. Report what happened — successful repro with code path, failed repro, or insufficient detail (a strong `needs-info` signal). A confirmed repro makes a much stronger agent brief.
+3. **Verify the fix isn't already on main.** Before recommending `ready-for-agent`, grep for the issue's proposed-fix symbol/path on `main`. Issues drift: a fix can land via an adjacent PR and the original issue never gets closed. If the fix is already there, recommend closing with a verification comment (commit + test reference) instead of stamping `ready-for-agent`. A `ready-for-agent` label on an already-implemented issue wastes an AFK agent slot and confuses the audit trail.
 
-4. **Grill (if needed).** If the issue needs fleshing out, run a `/grill` session.
+4. **Reproduce (bugs only).** Before any grilling, attempt reproduction: read the reporter's steps, trace the relevant code, run tests or commands. Report what happened — successful repro with code path, failed repro, or insufficient detail (a strong `needs-info` signal). A confirmed repro makes a much stronger agent brief.
 
-5. **Apply the outcome:**
+5. **Grill (if needed).** If the issue needs fleshing out, run a `/grill` session.
+
+6. **Apply the outcome:**
    - `ready-for-agent` — post an agent brief comment ([AGENT-BRIEF.md](AGENT-BRIEF.md)).
    - `ready-for-human` — same structure as an agent brief, but note why it can't be delegated (judgment calls, external access, design decisions, manual testing).
    - `needs-info` — post triage notes (template below).


### PR DESCRIPTION
## Summary

Adds explicit step 3 in `.claude-userlevel/skills/triage/SKILL.md` § "Triage a specific issue": **Verify the fix isn't already on main** — grep for the proposed-fix symbol/path before stamping `ready-for-agent`. If the fix is already there, recommend closing with a verification comment instead.

Closes #647.

## Why

Promotes a rule that currently only lives in the AFK chain baton (ephemeral) to the user-level skill (persistent, cross-project).

**Lesson source:** AFK chain iter:3 outcome. Issue #486 was stamped `status:ready` in iter:2 triage without grepping for the proposed fix. The fix was already on main (commit `9193338` + `tests/test_installer.py:1206`); iter:3 re-discovered this and closed the issue as already-implemented. That cost one AFK iter — fine once, expensive at scale. Decision `3e356a9f-b29f-4148-9c52-b2783edada81`.

## What changed

- `.claude-userlevel/skills/triage/SKILL.md`: insert new step 3, renumber 3→4 (Reproduce), 4→5 (Grill), 5→6 (Apply). +5 / -3.
- No behavior change to existing steps; only addition + renumbering.

## Test plan

- [x] `git diff` reviewed — diff matches description (5 insertions, 3 deletions; only numbering shift around the new step).
- [x] Skill remains generic (uses canonical role names `ready-for-agent`, not jarvis-specific `status:ready`).
- [x] No protected-file paths touched (`.claude-userlevel/*` is source of truth; `~/.claude/*` mirror is propagated by `install.ps1 -Apply`).

> *Autonomous PR — AFK chain iter:9, body fix iter:10 (link tracking issue #647). Owner action: merge or request changes.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)