### PR TITLE
docs(design): fix 5 broken anchor links in C17/C18 design docs

### DIFF
--- a/docs/design/c17-events-substrate.md
+++ b/docs/design/c17-events-substrate.md
@@ -2,7 +2,7 @@
 
 **Status:** design-locked 2026-04-29 (Sprint #35, [#475](https://github.com/Osasuwu/jarvis/issues/475)). Migration → [#476](https://github.com/Osasuwu/jarvis/issues/476). First writer → [#477](https://github.com/Osasuwu/jarvis/issues/477).
 **Parent:** [`jarvis-v2-redesign.md` § C17](jarvis-v2-redesign.md#c17--observability--audit) (lines 408–518, L3 leans 1728–1737).
-**Migration order:** position #1 — nothing else has somewhere to write until this ships ([line 1553](jarvis-v2-redesign.md#migration-order-what-ships-first)).
+**Migration order:** position #1 — nothing else has somewhere to write until this ships ([line 1553](jarvis-v2-redesign.md#bootstrap-protocol--migration-order)).
 
 This doc locks the schema, column naming, propagation rules, write semantics, and initial action vocabulary so #476 (SQL) and #477 (first writer) can land without re-design. SQL is **not** in this doc.
 
@@ -144,7 +144,7 @@ Sprint 35 creates a **new** table named `events_canonical` (NOT an `ALTER` of th
 
 1. The existing `events` table (current [`mcp-memory/schema.sql:151`](../../mcp-memory/schema.sql#L151)) is GH-Actions-perception-shaped: `event_type` enum, `severity` check constraint, `repo`, `source`, `processed`/`processed_at`/`processed_by`/`action_taken` workflow fields. None of these fit the canonical actor/action/trace_id shape, and the columns have NOT-NULL constraints that an in-place ALTER cannot retrofit safely.
 2. `fok_judgments.recall_event_id` references `events(id) ON DELETE CASCADE` (Sprint #34 [#443](https://github.com/Osasuwu/jarvis/issues/443)). An in-place rename or schema-rewrite breaks the FK.
-3. Two-mode coexistence per [`jarvis-v2-redesign.md:1566`](jarvis-v2-redesign.md#migration-order-what-ships-first) explicitly calls for new and legacy paths running in parallel until C3 path-parity proves cutover safety.
+3. Two-mode coexistence per [`jarvis-v2-redesign.md:1566`](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) explicitly calls for new and legacy paths running in parallel until C3 path-parity proves cutover safety.
 
 **Final state (cutover wave, post-Sprint 35):** legacy `events` rows migrate into `events_canonical`; FK on `fok_judgments` rewires; legacy table drops; canonical renames to `events`. Single canonical name restored.
 
@@ -196,6 +196,6 @@ Sprint 35 creates a **new** table named `events_canonical` (NOT an `ALTER` of th
 - [`jarvis-v2-redesign.md` §C17 (lines 408–518)](jarvis-v2-redesign.md#c17--observability--audit) — full design rationale.
 - [`jarvis-v2-redesign.md` §C17 L3 leans (lines 1728–1737)](jarvis-v2-redesign.md#c17--observability--audit-1) — OTel verbatim, materialized views from day one, contextvars + uuid, traceloop-sdk deferred.
 - [`jarvis-v2-redesign.md` §C3 write semantics (line 308)](jarvis-v2-redesign.md#c3--memory) — `degraded=true` fallback.
-- [`jarvis-v2-redesign.md` §Migration order (lines 1549–1564)](jarvis-v2-redesign.md#migration-order-what-ships-first) — substrate ships first.
-- [`jarvis-v2-redesign.md` §Two-mode coexistence (line 1566)](jarvis-v2-redesign.md#migration-order-what-ships-first) — cutover gate is C3-defined path-parity test.
+- [`jarvis-v2-redesign.md` §Migration order (lines 1549–1564)](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) — substrate ships first.
+- [`jarvis-v2-redesign.md` §Two-mode coexistence (line 1566)](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) — cutover gate is C3-defined path-parity test.
 - [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) — column-name source of truth.

--- a/docs/design/c17-events-substrate.md
+++ b/docs/design/c17-events-substrate.md
@@ -1,8 +1,8 @@
 # C17 — Events Substrate (Design 1-pager)
 
 **Status:** design-locked 2026-04-29 (Sprint #35, [#475](https://github.com/Osasuwu/jarvis/issues/475)). Migration → [#476](https://github.com/Osasuwu/jarvis/issues/476). First writer → [#477](https://github.com/Osasuwu/jarvis/issues/477).
-**Parent:** [`jarvis-v2-redesign.md` § C17](jarvis-v2-redesign.md#c17--observability--audit) (lines 408–518, L3 leans 1728–1737).
-**Migration order:** position #1 — nothing else has somewhere to write until this ships ([line 1553](jarvis-v2-redesign.md#bootstrap-protocol--migration-order)).
+**Parent:** [`jarvis-v2-redesign.md` § C17](jarvis-v2-redesign.md#c17--observability--audit) (L2), with L3 leans at [§C17 L3](jarvis-v2-redesign.md#c17--observability--audit-1).
+**Migration order:** position #1 — nothing else has somewhere to write until this ships ([§Bootstrap protocol & migration order](jarvis-v2-redesign.md#bootstrap-protocol--migration-order)).
 
 This doc locks the schema, column naming, propagation rules, write semantics, and initial action vocabulary so #476 (SQL) and #477 (first writer) can land without re-design. SQL is **not** in this doc.
 
@@ -144,7 +144,7 @@ Sprint 35 creates a **new** table named `events_canonical` (NOT an `ALTER` of th
 
 1. The existing `events` table (current [`mcp-memory/schema.sql:151`](../../mcp-memory/schema.sql#L151)) is GH-Actions-perception-shaped: `event_type` enum, `severity` check constraint, `repo`, `source`, `processed`/`processed_at`/`processed_by`/`action_taken` workflow fields. None of these fit the canonical actor/action/trace_id shape, and the columns have NOT-NULL constraints that an in-place ALTER cannot retrofit safely.
 2. `fok_judgments.recall_event_id` references `events(id) ON DELETE CASCADE` (Sprint #34 [#443](https://github.com/Osasuwu/jarvis/issues/443)). An in-place rename or schema-rewrite breaks the FK.
-3. Two-mode coexistence per [`jarvis-v2-redesign.md:1566`](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) explicitly calls for new and legacy paths running in parallel until C3 path-parity proves cutover safety.
+3. Two-mode coexistence per [`jarvis-v2-redesign.md` §Bootstrap protocol & migration order](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) explicitly calls for new and legacy paths running in parallel until C3 path-parity proves cutover safety.
 
 **Final state (cutover wave, post-Sprint 35):** legacy `events` rows migrate into `events_canonical`; FK on `fok_judgments` rewires; legacy table drops; canonical renames to `events`. Single canonical name restored.
 
@@ -193,9 +193,8 @@ Sprint 35 creates a **new** table named `events_canonical` (NOT an `ALTER` of th
 
 ## References
 
-- [`jarvis-v2-redesign.md` §C17 (lines 408–518)](jarvis-v2-redesign.md#c17--observability--audit) — full design rationale.
-- [`jarvis-v2-redesign.md` §C17 L3 leans (lines 1728–1737)](jarvis-v2-redesign.md#c17--observability--audit-1) — OTel verbatim, materialized views from day one, contextvars + uuid, traceloop-sdk deferred.
-- [`jarvis-v2-redesign.md` §C3 write semantics (line 308)](jarvis-v2-redesign.md#c3--memory) — `degraded=true` fallback.
-- [`jarvis-v2-redesign.md` §Migration order (lines 1549–1564)](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) — substrate ships first.
-- [`jarvis-v2-redesign.md` §Two-mode coexistence (line 1566)](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) — cutover gate is C3-defined path-parity test.
+- [`jarvis-v2-redesign.md` §C17](jarvis-v2-redesign.md#c17--observability--audit) — full design rationale.
+- [`jarvis-v2-redesign.md` §C17 L3 leans](jarvis-v2-redesign.md#c17--observability--audit-1) — OTel verbatim, materialized views from day one, contextvars + uuid, traceloop-sdk deferred.
+- [`jarvis-v2-redesign.md` §C3 write semantics](jarvis-v2-redesign.md#c3--memory) — `degraded=true` fallback.
+- [`jarvis-v2-redesign.md` §Bootstrap protocol & migration order](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) — substrate ships first; two-mode coexistence gate is C3-defined path-parity test.
 - [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) — column-name source of truth.

--- a/docs/design/c18-proactive-challenger.md
+++ b/docs/design/c18-proactive-challenger.md
@@ -322,5 +322,5 @@ Auto-disable would silently remove a signal class without owner awareness — ex
 - [`jarvis-v2-redesign.md` §C18 L3 leans (lines 1763–1767)](jarvis-v2-redesign.md#c18--proactive-challenger-1) — SQL detection, YAML thresholds, Haiku surfacing renderer, C12 routing.
 - [`c17-events-substrate.md`](c17-events-substrate.md) — events table contract; C18 is the second writer (after `record_decision` in #477).
 - [`c17-events-substrate.md` §5](c17-events-substrate.md) — action vocabulary; C18 extends with `recalibration_proposed` + `surfacing_outcome`.
-- [`jarvis-v2-redesign.md` §Tier-A migration order (line 243)](jarvis-v2-redesign.md#tier-a-deep) — C18 sequenced after C5/C16; this design 1-pager is forward-locking and ships ahead, but #C18.2 implementation respects the dependency by gating `calibration_drift` and `principal_override` signals behind `enabled: false` until C5/C16 land.
+- [`jarvis-v2-redesign.md` §Methodology (line 243, Tier-A migration order)](jarvis-v2-redesign.md#methodology) — C18 sequenced after C5/C16; this design 1-pager is forward-locking and ships ahead, but #C18.2 implementation respects the dependency by gating `calibration_drift` and `principal_override` signals behind `enabled: false` until C5/C16 land.
 - Memory `c18_proactive_challenger_2026_04_28` (decision/jarvis) — owner-stated motivation and L1 framing.

--- a/docs/design/c18-proactive-challenger.md
+++ b/docs/design/c18-proactive-challenger.md
@@ -1,7 +1,7 @@
 # C18 — Proactive Challenger (Design 1-pager)
 
 **Status:** design-locked 2026-04-29 (Sprint #36, [#483](https://github.com/Osasuwu/jarvis/issues/483)). Detection engine → #C18.2 (TBD). Surfacing renderer → #C18.3 (TBD).
-**Parent:** [`jarvis-v2-redesign.md` § C18](jarvis-v2-redesign.md#c18--proactive-challenger) (lines 657–717, L3 leans 1763–1767).
+**Parent:** [`jarvis-v2-redesign.md` § C18](jarvis-v2-redesign.md#c18--proactive-challenger) (L2), with L3 leans at [§C18 L3](jarvis-v2-redesign.md#c18--proactive-challenger-1).
 **Substrate dependency:** reads from C17 [`events_canonical`](c17-events-substrate.md), C2 `goals`, C3 `memories`. Emits `recalibration_proposed` events back to C17.
 
 This doc locks the drift-signal taxonomy, threshold-config schema, emit shape, surfacing routing, bootstrap protocol, and false-positive calibration loop so #C18.2 (detection engine) and #C18.3 (surfacing renderer) can land without re-design. **No SQL** in this doc — query shapes are logical only.
@@ -191,7 +191,7 @@ If detection produces more than 5 candidates after cooldown filter:
 
 ### No real-time interrupt
 
-Per [redesign §C18 rejected list](jarvis-v2-redesign.md#rejected) — "real-time interrupt on first signal — drowns the principal in noise". C18 detection writes to `events_canonical`; **C12 batched brief is the only delivery path.** No webhook, no Telegram push, no PreToolUse interrupt.
+Per [redesign §C18 rejected list](jarvis-v2-redesign.md#rejected-2) — "real-time interrupt on first signal — drowns the principal in noise". C18 detection writes to `events_canonical`; **C12 batched brief is the only delivery path.** No webhook, no Telegram push, no PreToolUse interrupt.
 
 If a future signal class requires real-time delivery, that's a redesign change, not a YAML edit.
 
@@ -236,7 +236,7 @@ Auto-flip removes the principal's calibration step. The exact failure mode of "a
 
 ## 6. False-positive calibration loop
 
-Per [redesign §C18 measurement (lines 705–707)](jarvis-v2-redesign.md#how-measured-7) — surfacing acceptance rate is C18's primary success metric. Below-target acceptance is a signal that thresholds are wrong, not that the principal is ignoring a real problem.
+Per [redesign §C18 measurement](jarvis-v2-redesign.md#how-measured-2) — surfacing acceptance rate is C18's primary success metric. Below-target acceptance is a signal that thresholds are wrong, not that the principal is ignoring a real problem.
 
 ### Outcome events
 
@@ -318,9 +318,9 @@ Auto-disable would silently remove a signal class without owner awareness — ex
 
 ## References
 
-- [`jarvis-v2-redesign.md` §C18 (lines 657–717)](jarvis-v2-redesign.md#c18--proactive-challenger) — full L1+L2 spec.
-- [`jarvis-v2-redesign.md` §C18 L3 leans (lines 1763–1767)](jarvis-v2-redesign.md#c18--proactive-challenger-1) — SQL detection, YAML thresholds, Haiku surfacing renderer, C12 routing.
+- [`jarvis-v2-redesign.md` §C18](jarvis-v2-redesign.md#c18--proactive-challenger) — full L1+L2 spec.
+- [`jarvis-v2-redesign.md` §C18 L3 leans](jarvis-v2-redesign.md#c18--proactive-challenger-1) — SQL detection, YAML thresholds, Haiku surfacing renderer, C12 routing.
 - [`c17-events-substrate.md`](c17-events-substrate.md) — events table contract; C18 is the second writer (after `record_decision` in #477).
 - [`c17-events-substrate.md` §5](c17-events-substrate.md) — action vocabulary; C18 extends with `recalibration_proposed` + `surfacing_outcome`.
-- [`jarvis-v2-redesign.md` §Methodology (line 243, Tier-A migration order)](jarvis-v2-redesign.md#methodology) — C18 sequenced after C5/C16; this design 1-pager is forward-locking and ships ahead, but #C18.2 implementation respects the dependency by gating `calibration_drift` and `principal_override` signals behind `enabled: false` until C5/C16 land.
+- [`jarvis-v2-redesign.md` §Methodology — Tier-A migration order](jarvis-v2-redesign.md#methodology) — C18 sequenced after C5/C16; this design 1-pager is forward-locking and ships ahead, but #C18.2 implementation respects the dependency by gating `calibration_drift` and `principal_override` signals behind `enabled: false` until C5/C16 land.
 - Memory `c18_proactive_challenger_2026_04_28` (decision/jarvis) — owner-stated motivation and L1 framing.


### PR DESCRIPTION
﻿## Summary

5 broken intra-repo anchor links in design 1-pagers pointed at headings that don't exist in `jarvis-v2-redesign.md`:

- `#migration-order-what-ships-first` (4 refs in `docs/design/c17-events-substrate.md`) → `#bootstrap-protocol--migration-order` (actual heading at line 1681 in target).
- `#tier-a-deep` (1 ref in `docs/design/c18-proactive-challenger.md`) → `#methodology` (Tier-A discussed inline within `### Methodology` at line 237; no dedicated "Tier A" heading exists).

Probable cause: target headings were renamed during a prior pass on `jarvis-v2-redesign.md` without sweep for inbound refs.

## How found

Mechanical audit script (`.scratch/anchor-audit.py`, gitignored) — scans `docs/**/*.md` (excluding `docs/research/` drafts) and validates every internal markdown link target against actual headings using GitHub's slug algorithm (lowercase → spaces-to-dash → strip non-alnum → de-dup with `-N` suffix). After fixes the audit returns clean.

## Class context

This is a drive-by under the [Fix > track for trivial reversible](https://github.com/Osasuwu/jarvis/blob/main/CLAUDE.md#fix--track-for-trivial-reversible-428) policy — small, reversible, sibling-grepped via mechanical audit. No issue.

The audit script itself is intentionally NOT shipped in this PR (scope discipline). If owner wants it as a CI guard (similar to the path-filter meta-test pattern from #326), it can land as a follow-up.

## Test plan

- [x] Audit script reports OK on the diff (was 5 broken, now 0).
- [ ] Reviewer spot-checks that `#bootstrap-protocol--migration-order` resolves on GitHub render for `jarvis-v2-redesign.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — autonomous chain iter:36


[no-issue]
