### PR TITLE
docs(design): drop stale line refs in c17/c18/memory-fok (sibling-grep)

### DIFF
--- a/docs/design/c17-events-substrate.md
+++ b/docs/design/c17-events-substrate.md
@@ -27,7 +27,7 @@ Single canonical `events_canonical` table. All observability writes go through i
 | `redacted` | `bool NOT NULL DEFAULT false` | True when secret-redaction was applied to `payload`. |
 | `degraded` | `bool NOT NULL DEFAULT false` | True for events replayed from in-memory buffer after a transient pg outage (§4). |
 
-**Why one table not many:** views are cheap; tables drift. Past pain (`audit_log` declared in code but not in schema; `*_last_run` memories abusing `memories` as task-heartbeat store) was the cost of denormalizing observability. Per [`jarvis-v2-redesign.md:439`](jarvis-v2-redesign.md#substrate).
+**Why one table not many:** views are cheap; tables drift. Past pain (`audit_log` declared in code but not in schema; `*_last_run` memories abusing `memories` as task-heartbeat store) was the cost of denormalizing observability. Per [`jarvis-v2-redesign.md` §substrate](jarvis-v2-redesign.md#substrate).
 
 **Why `degraded` is a column not just a payload key:** it must be queryable as a first-class filter (e.g., "exclude degraded replays from cost reconciliation").
 
@@ -35,7 +35,7 @@ Single canonical `events_canonical` table. All observability writes go through i
 
 ## 2. OTel column naming convention
 
-When `payload` carries GenAI attributes, use **OpenTelemetry GenAI semantic conventions verbatim** — no abbreviations, no rename to camelCase. Per [`jarvis-v2-redesign.md:1730`](jarvis-v2-redesign.md#c17--observability--audit-1).
+When `payload` carries GenAI attributes, use **OpenTelemetry GenAI semantic conventions verbatim** — no abbreviations, no rename to camelCase. Per [`jarvis-v2-redesign.md` §C17 L3](jarvis-v2-redesign.md#c17--observability--audit-1).
 
 | OTel key | Type | When |
 |---|---|---|
@@ -53,13 +53,13 @@ When `payload` carries GenAI attributes, use **OpenTelemetry GenAI semantic conv
 | `gen_ai.operation.name` | text | `chat`, `tool_call`, `embedding`, `generate_content`. |
 | `gen_ai.operation.duration_ms` | int | Wall-clock duration; from `PostToolUse` hook `duration_ms` field. |
 
-**Why verbatim:** future-proofs against OTel ecosystem tooling (Honeycomb, Grafana Tempo, OpenLLMetry exporters) reading our events table without column-rename middleware. Per [L3 lean 1733](jarvis-v2-redesign.md#c17--observability--audit-1) — `traceloop-sdk` with custom Supabase exporter is the deferred-but-planned path; it expects OTel-shaped attributes.
+**Why verbatim:** future-proofs against OTel ecosystem tooling (Honeycomb, Grafana Tempo, OpenLLMetry exporters) reading our events table without column-rename middleware. Per [§C17 L3](jarvis-v2-redesign.md#c17--observability--audit-1) — `traceloop-sdk` with custom Supabase exporter is the deferred-but-planned path; it expects OTel-shaped attributes.
 
 ---
 
 ## 3. Trace propagation contract
 
-Every initiating context creates a `trace_id`; downstream actors inherit. Implementation: `contextvars.ContextVar[str]` + `uuid.uuid4().hex`. Per [`jarvis-v2-redesign.md:1732`](jarvis-v2-redesign.md#c17--observability--audit-1).
+Every initiating context creates a `trace_id`; downstream actors inherit. Implementation: `contextvars.ContextVar[str]` + `uuid.uuid4().hex`. Per [`jarvis-v2-redesign.md` §C17 L3](jarvis-v2-redesign.md#c17--observability--audit-1).
 
 ### Four rules
 
@@ -80,7 +80,7 @@ If a caller of `record_decision` (or any future writer) doesn't set the ContextV
 
 ## 4. Write semantics
 
-Per [`jarvis-v2-redesign.md:308`](jarvis-v2-redesign.md#c3--memory) — **observability MUST NOT block C3**.
+Per [`jarvis-v2-redesign.md` §C3](jarvis-v2-redesign.md#c3--memory) — **observability MUST NOT block C3**.
 
 ### Happy path
 
@@ -130,7 +130,7 @@ Open vocabulary; new values added by PR. Reserved values for the first wave (Spr
 | `episode_started` / `episode_ended` | session lifecycle | Folds existing `episodes` table |
 | `signal_dropped` | substrate buffer overflow | Sprint 35 (#477) |
 
-**Why explicit reserved values:** owner-facing dashboards and reflection (C5) query failure modes by category, not text-search payloads. Per [`jarvis-v2-redesign.md:479`](jarvis-v2-redesign.md#self-detection).
+**Why explicit reserved values:** owner-facing dashboards and reflection (C5) query failure modes by category, not text-search payloads. Per [`jarvis-v2-redesign.md` §self-detection](jarvis-v2-redesign.md#self-detection).
 
 ---
 
@@ -142,9 +142,9 @@ Not implemented in Sprint 35. Listed here so #476 implementer doesn't accidental
 
 Sprint 35 creates a **new** table named `events_canonical` (NOT an `ALTER` of the existing `events` table). Reasons:
 
-1. The existing `events` table (current [`mcp-memory/schema.sql:151`](../../mcp-memory/schema.sql#L151)) is GH-Actions-perception-shaped: `event_type` enum, `severity` check constraint, `repo`, `source`, `processed`/`processed_at`/`processed_by`/`action_taken` workflow fields. None of these fit the canonical actor/action/trace_id shape, and the columns have NOT-NULL constraints that an in-place ALTER cannot retrofit safely.
+1. The existing `events` table (current [`mcp-memory/schema.sql`](../../mcp-memory/schema.sql)) is GH-Actions-perception-shaped: `event_type` enum, `severity` check constraint, `repo`, `source`, `processed`/`processed_at`/`processed_by`/`action_taken` workflow fields. None of these fit the canonical actor/action/trace_id shape, and the columns have NOT-NULL constraints that an in-place ALTER cannot retrofit safely.
 2. `fok_judgments.recall_event_id` references `events(id) ON DELETE CASCADE` (Sprint #34 [#443](https://github.com/Osasuwu/jarvis/issues/443)). An in-place rename or schema-rewrite breaks the FK.
-3. Two-mode coexistence per [`jarvis-v2-redesign.md:1566`](jarvis-v2-redesign.md#migration-order-what-ships-first) explicitly calls for new and legacy paths running in parallel until C3 path-parity proves cutover safety.
+3. Two-mode coexistence per [`jarvis-v2-redesign.md` §Bootstrap protocol & migration order](jarvis-v2-redesign.md#bootstrap-protocol--migration-order) explicitly calls for new and legacy paths running in parallel until C3 path-parity proves cutover safety.
 
 **Final state (cutover wave, post-Sprint 35):** legacy `events` rows migrate into `events_canonical`; FK on `fok_judgments` rewires; legacy table drops; canonical renames to `events`. Single canonical name restored.
 
@@ -174,7 +174,7 @@ Sprint 35 creates a **new** table named `events_canonical` (NOT an `ALTER` of th
 - **`pg_cron` refresh schedule** — covered by #476.
 - **Subagent / hook propagation implementation** — substrate-consumer wave (Sprint 38+).
 - **Other writers beyond `record_decision`** — substrate-consumer wave.
-- **OTel exporter library** (`traceloop-sdk` per [L3 lean 1733](jarvis-v2-redesign.md#c17--observability--audit-1)) — deferred until volume justifies; bespoke `events_insert()` is fine for cold-start.
+- **OTel exporter library** (`traceloop-sdk` per [§C17 L3](jarvis-v2-redesign.md#c17--observability--audit-1)) — deferred until volume justifies; bespoke `events_insert()` is fine for cold-start.
 
 ---
 

--- a/docs/design/c18-proactive-challenger.md
+++ b/docs/design/c18-proactive-challenger.md
@@ -42,7 +42,7 @@ Lives at `config/recalibration_thresholds.yaml`. Loaded at C18 detector startup.
 ```yaml
 # recalibration_thresholds.yaml
 # C18 Proactive Challenger detection thresholds.
-# Edit class: M2-strong — reviewer + smoke required (per redesign §C18 L3 line 1765).
+# Edit class: M2-strong — reviewer + smoke required (per redesign §C18 L3).
 # Wrong thresholds = surfacing storm; protect against bypass.
 
 surfacing_enabled: false   # bootstrap gate, see §5
@@ -77,7 +77,7 @@ signals:
 
 ### Edit class: M2-strong
 
-Per [redesign L3 line 1765](jarvis-v2-redesign.md#c18--proactive-challenger-1) — **wrong thresholds cause a surfacing storm**, which trains the principal to dismiss without reading (the exact failure mode #C18 is meant to prevent). Treat threshold edits as M2-strong:
+Per [redesign §C18 L3](jarvis-v2-redesign.md#c18--proactive-challenger-1) — **wrong thresholds cause a surfacing storm**, which trains the principal to dismiss without reading (the exact failure mode #C18 is meant to prevent). Treat threshold edits as M2-strong:
 
 - PR with reviewer (Copilot or human) + smoke run (#C18.2 ships smoke as `scripts/c18-dryrun.py` — replays last 30 days of events through current YAML, prints surfacing count by class).
 - One-line owner override allowed via direct commit if a surfacing storm is already in progress (incident-response, not steady state).
@@ -182,7 +182,7 @@ Cooldown reset on `surfacing_outcome.action='acted'` — once principal acts, th
 
 ### Cap per brief
 
-**Max 5 surfacings per batched brief** (per [redesign L3 line 1766](jarvis-v2-redesign.md#c18--proactive-challenger-1) — Haiku call budget under C13).
+**Max 5 surfacings per batched brief** (per [redesign §C18 L3](jarvis-v2-redesign.md#c18--proactive-challenger-1) — Haiku call budget under C13).
 
 If detection produces more than 5 candidates after cooldown filter:
 1. Sort by `severity` desc.

--- a/docs/design/memory-fok.md
+++ b/docs/design/memory-fok.md
@@ -30,8 +30,8 @@ What FOK gives:
 
 | Component | Status | File / Object |
 |---|---|---|
-| Recall event emit (fire-and-forget) | shipped | `_emit_recall_event` in `mcp-memory/handlers/memory.py:588`; payload: `{query, returned_ids, returned_similarities, returned_count, top_sim, threshold, project, type_filter, show_history}` |
-| Events table | shipped | `events` (mcp-memory/schema.sql:151), `event_type='memory_recall'` |
+| Recall event emit (fire-and-forget) | shipped | `_emit_recall_event` in `mcp-memory/handlers/memory.py`; payload: `{query, returned_ids, returned_similarities, returned_count, top_sim, threshold, project, type_filter, show_history}` |
+| Events table | shipped | `events` (`mcp-memory/schema.sql`), `event_type='memory_recall'` |
 | Batch judge | shipped | `scripts/fok-batch.py` — Haiku judges last-24h unfudged events, writes verdict back to `events.payload` |
 | Known-unknowns table | shipped | `known_unknowns` (#249) |
 | Known-unknowns from FOK | shipped (batch) | `try_insert_known_unknown` in `fok-batch.py` — `verdict=insufficient AND confidence<0.7 AND top_sim<0.6` triggers insert |


### PR DESCRIPTION
﻿## Summary

Sibling-grep extension of PR #661 commit `2e628f6` (iter:40). That commit narrowed sibling-grep to ``(line N)`` / ``(lines N-M)`` patterns and missed line refs embedded in markdown link text (`` `file:NNN` ``) and inline labels (`L3 lean NNN`, `L3 line NNN`). 13 more stale citations found across 3 design docs.

Each cited line verified by reading the target file. Most point at unrelated content after heading-rename + insertion drift:

| Citation site | What it cites | Actual content at that line |
|---|---|---|
| `c17:38` → `v2-redesign.md:1730` | C17 OTel verbatim | C5 conflict-classifier table row |
| `c17:62` → `v2-redesign.md:1732` | C17 trace propagation | C5 stale-challenge row |
| `c17:56,177` → `v2-redesign.md:1733` | C17 OTel exporter | C5 judge calibrator row |
| `c18:45,80` → `v2-redesign.md:1765` | C18 wrong-thresholds | C1 "no real alternatives" |
| `c18:185` → `v2-redesign.md:1766` | C18 max-5 surfacings | blank line |
| `c17:133` → `v2-redesign.md:479` | self-detection failure modes | trace_id propagation bullet (anchor `#self-detection` correct, only line stale) |
| `c17:83` → `v2-redesign.md:308` | "obs MUST NOT block C3" | C3 storage shape (roughly C3-area) |
| `c17:147` → `v2-redesign.md:1566` | two-mode coexistence | drifted AND anchor renamed; both fixed |
| `c17:145, fok:34` → `schema.sql:151` | events table | `goals` RLS (events now at L165) |
| `fok:33` → `memory.py:588` | `_emit_recall_event` | defined at L426 |

## Strategy

Same as iter:40 commit `2e628f6`: drop line numbers (fragile under heading rename + insertion), keep section anchors (durable, verified by `anchor-audit.py` iter:41 clean pass). Section labels in link text preserve scope hints.

## What's NOT in this PR

- `memory-fok.md:38` and `memory-fok.md:147` reference call sites at `memory.py:374` and `:397` inside `_hybrid_recall`. Grep shows `_upsert_known_unknown` defined at L92 with calls in other functions, not `_hybrid_recall`. This is **substance drift** (code paths removed?), not line-number drift. Out of scope; needs a separate audit + possible tracker.
- The 4 anchor breakages flagged by `anchor-audit.py` at `c17:5, c17:199, c17:200, c18:325` are PR #661 territory (heading-rename `#migration-order-what-ships-first` → `#bootstrap-protocol--migration-order`). PR #661 is parked `status:review`; those will land when it merges.

## Test plan

- [x] `python .scratch/anchor-audit.py` — broken refs: 5 (pre-existing on `origin/main`) → 4 (1 incidentally fixed by `c17:147` anchor update bundled with line-number drop).
- [x] Sibling-grep regex `(L3 lean \d+|L3 line \d+|v2-redesign\.md[:#]\d+|schema\.sql:\d+|schema\.sql#L\d+|memory\.py:\d+)` over `docs/design/*.md`: 13 hits before → 2 hits after (both are out-of-scope substance-drift cases in `memory-fok.md` flagged above).
- [x] Manual diff review: 14 single-line replacements, no semantic content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[no-issue]
