### PR TITLE
fix(installer): skip .bak.* children in orphan detection (#659)

### DIFF
--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -420,7 +420,7 @@ def build_plan(
                 for child in sorted(dest.iterdir()):
                     if child.name in allowed:
                         continue
-                    if ".bak.orphan" in child.name:
+                    if ".bak." in child.name:
                         continue
                     actions.append(
                         Action(

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -448,6 +448,37 @@ def test_directory_without_include_skips_orphan_check(
     assert not any(a.kind == "prune_orphan" for a in plan.actions)
 
 
+def test_existing_bak_orphan_is_not_re_quarantined(
+    manifest: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    """`.bak.orphan` leftovers from prior runs must not be re-detected as orphans (#659).
+
+    Without the skip, every subsequent install would nest the suffix one level
+    deeper: `dnd.bak.orphan` → `dnd.bak.orphan.bak.orphan` → ...
+    """
+    m = installer.load_manifest(manifest)
+    installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
+    target = tmp_path / "claude_home"
+    # Synthesize the state left by a previous quarantine pass.
+    leftover = target / "skills" / "dnd.bak.orphan"
+    leftover.mkdir()
+    (leftover / "SKILL.md").write_text("# previously quarantined\n", encoding="utf-8")
+    # Also a timestamped variant (same-day collision case from `_backup_dest`).
+    leftover_stamped = target / "skills" / "dnd-prep.bak.orphan-20260516-120000"
+    leftover_stamped.mkdir()
+    (target / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+
+    plan = installer.build_plan(m, fake_repo)
+    orphans = [a for a in plan.actions if a.kind == "prune_orphan"]
+    orphan_sources = {Path(a.source).name for a in orphans}
+    assert "dnd.bak.orphan" not in orphan_sources, (
+        "prior-run quarantine must not be re-quarantined into .bak.orphan.bak.orphan"
+    )
+    assert "dnd-prep.bak.orphan-20260516-120000" not in orphan_sources, (
+        "timestamped quarantine variant must also be skipped"
+    )
+
+
 def test_disabled_group_is_skipped(manifest: Path, fake_repo: Path) -> None:
     data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
     for g in data["groups"]:


### PR DESCRIPTION
Closes #659

## Summary

`scripts/install/installer.py` orphan-detection loop iterated every child of the destination directory — including names already ending in `.bak.orphan` from a prior install — and re-quarantined them. Each subsequent `install.ps1 -Apply` appended another `.bak.orphan`, producing `dnd.bak.orphan.bak.orphan` (observed live on Main PC).

## Fix (option A per issue body — skip-if-suffix)

```python
if ".bak." in child.name:
    continue
```

Broader than just `.bak.orphan` because `_backup_dest` is also called with the `pre-jarvis-migration` label (`_quarantine_dest`, line 199) and produces timestamped variants (`.bak.<label>-YYYYMMDD-HHMMSS`) on same-day collisions. The substring check covers all current and future quarantine labels.

## Tests

- New `test_existing_bak_orphan_is_not_re_quarantined` asserts both plain (`dnd.bak.orphan`) and timestamped (`dnd-prep.bak.orphan-20260516-120000`) leftovers do NOT generate `prune_orphan` actions.
- Full suite: **57 passed** in 9.7s.

## Out of scope

Per issue body:
- Removing existing `.bak.orphan*` directories from live mirrors (manual cleanup; orthogonal).
- Sweeping `.bak.<label>` paths beyond `orphan` (no non-orphan labels observed nesting in the wild yet).
- Claude Code skill-list filtering of `.bak.orphan/SKILL.md` (separate surface).

## Test plan

- [x] `pytest tests/test_installer.py` — all green locally.
- [ ] CI green.
- [ ] Verify on Main PC post-merge: next `install.ps1 -Apply` does not produce a new `.bak.orphan` nesting level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)