### PR TITLE
ci(pr-body-check): add [no-issue] body marker as third escape (#459)

### DIFF
--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -33,11 +33,20 @@ jobs:
               return;
             }
 
+            // Fix-inline escape: [no-issue] body marker bypasses the requirement.
+            // Mirrors the commit-msg convention in .pre-commit-config.yaml (#329) and
+            // matches CLAUDE.md "Fix > track for trivial reversible (#428)" — drive-by
+            // fixes shouldn't require filing a tracker just to satisfy paperwork.
+            if (/\[no-issue\]/i.test(body)) {
+              console.log('[no-issue] marker present — skipping linked-issue requirement (fix-inline per #428).');
+              return;
+            }
+
             const issueMatches = [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)];
             const issueNumbers = [...new Set(issueMatches.map(m => parseInt(m[1], 10)))];
 
             if (issueNumbers.length === 0) {
-              core.setFailed('PR body must include a linked issue reference, e.g. "Closes #123". For hotfixes, apply the priority:critical label instead.');
+              core.setFailed('PR body must include a linked issue reference (e.g. "Closes #123"), the [no-issue] marker for trivial fix-inline drive-bys (#428), or the priority:critical label for hotfixes.');
               return;
             }
 

--- a/tests/ci/test_pr_body_check_guard.py
+++ b/tests/ci/test_pr_body_check_guard.py
@@ -3,9 +3,10 @@
 Reimplements the workflow's decision rule in Python and asserts the
 escape hatches behave as the workflow promises:
 
-  - Closes #NNN in body                → allowed
+  - Closes #NNN in body                → allowed (linked)
   - priority:critical label             → allowed (hotfix bypass)
-  - neither                             → blocked
+  - [no-issue] marker in body           → allowed (fix-inline per #428/#459)
+  - none of the above                   → blocked
 
 Convention from CLAUDE.md §326 (path-filtered guards need meta-tests).
 PR Body Check isn't path-filtered, but the escape logic is non-trivial
@@ -32,6 +33,9 @@ def evaluate(body: str, labels: list[str]) -> tuple[bool, str]:
     """Mirror the workflow's decision rule. Returns (allowed, reason)."""
     if "priority:critical" in labels:
         return True, "hotfix"
+
+    if re.search(r"\[no-issue\]", body, re.IGNORECASE):
+        return True, "no-issue"
 
     matches = re.findall(r"(?:closes|fixes|resolves)\s+#(\d+)", body, re.IGNORECASE)
     if matches:
@@ -89,6 +93,41 @@ def test_workflow_yaml_keeps_closes_regex():
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "closes|fixes|resolves" in text.lower(), (
         "PR Body Check regex changed shape — update this test to match."
+    )
+
+
+def test_no_issue_marker_allows():
+    allowed, reason = evaluate("Drive-by docs fix.\n\n[no-issue]", [])
+    assert allowed
+    assert reason == "no-issue"
+
+
+def test_no_issue_marker_case_insensitive():
+    for marker in ("[no-issue]", "[NO-ISSUE]", "[No-Issue]"):
+        body = f"trivial fix\n\n{marker}"
+        allowed, reason = evaluate(body, [])
+        assert allowed, f"{marker} should be accepted"
+        assert reason == "no-issue"
+
+
+def test_no_issue_marker_with_unrelated_label():
+    allowed, reason = evaluate("[no-issue] inline doc fix", ["documentation"])
+    assert allowed
+    assert reason == "no-issue"
+
+
+def test_no_issue_phrase_without_brackets_blocked():
+    # Plain prose "no issue" must not satisfy the escape — only the bracketed token.
+    allowed, _ = evaluate("There is no issue with this change.", [])
+    assert not allowed
+
+
+def test_workflow_yaml_keeps_no_issue_escape():
+    """Config dimension: the workflow must still honor the [no-issue] marker."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "[no-issue]" in text, (
+        "PR Body Check workflow no longer references the [no-issue] escape; "
+        "this test (and CLAUDE.md fix>track rule #428) is now stale."
     )
 
 


### PR DESCRIPTION
## Summary

Adds `[no-issue]` body marker as a third escape clause in `pr-body-check.yml`, alongside the existing `Closes/Fixes/Resolves #NNN` keyword path and the `priority:critical` hotfix label path. Mirrors the `.pre-commit-config.yaml` commit-msg convention from #329 — the two policies were out of sync.

## Why

CLAUDE.md §\"Fix > track for trivial reversible (#428)\" explicitly endorses drive-by inline fixes without a tracker issue, but the existing two-escape PR Body Check forced exactly the paperwork #428 was meant to eliminate (symptom: PR #457 had to file #458 just to satisfy the check). The owner-filed issue #459 specified the exact JS snippet to add; this PR implements it.

Also unblocks two currently-red PRs in the queue (#675 probe-ollama script + #663 sibling-grep extension), which already use `[no-issue]` in their bodies but currently fail the check.

## Changes

- `.github/workflows/pr-body-check.yml` — third escape clause, case-insensitive `[no-issue]` regex, error message updated to mention all three paths.
- `tests/ci/test_pr_body_check_guard.py` — extended per CLAUDE.md §326 meta-test pattern:
  - `evaluate()` mirrors the YAML decision rule (now returns `\"no-issue\"` as a reason).
  - 4 new positive/negative cases (bracketed marker accepted, case variants accepted, prose \"no issue\" still blocked, marker + unrelated label still allowed).
  - Config-dimension test asserting the workflow YAML still contains the `[no-issue]` literal — moves with the workflow if anyone strips the escape.

## Test plan

- [x] `pytest tests/ci/test_pr_body_check_guard.py -v` → 13/13 passed locally.
- [ ] CI will exercise the workflow itself on this PR's body (which uses `Closes #459` — old path, sanity).

## Decision

`d4f71147-2c5f-4b27-88d8-06f325daa057` (reversible, confidence 0.85, memory 319d10ae-fe43-4b08-b0c6-50a9b9478553 superseded — predated #428).

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)