### PR TITLE
feat(skill): add /reason — two-sided fact-grounded discussion

### DIFF
--- a/.claude-userlevel/skills/reason/NEUTRAL-RESEARCHER.md
+++ b/.claude-userlevel/skills/reason/NEUTRAL-RESEARCHER.md
@@ -2,7 +2,9 @@
 
 Used by `/reason` when a hinge-point question in the debate cannot be answered from head by either side. The point of dispatching a sub-agent (instead of searching from the main session) is **bias elimination**: the searcher must not know which side is hoping for which answer.
 
-This mirrors the **anonymization mitigation** validated in multi-agent debate research: removing identity markers ("self" vs "peer") forces agents to weigh evidence on merit instead of source-affiliation (Wang et al., arxiv 2510.07517 — "Measuring and Mitigating Identity Bias in Multi-Agent Debate via Anonymization"). The dispatching agent here plays the role of the anonymizing layer.
+This mirrors the **anonymization mitigation** validated in multi-agent debate research: removing identity markers ("self" vs "peer") forces agents to weigh evidence on merit instead of source-affiliation (Choi, Zhu & Li, arxiv 2510.07517 — "When Identity Skews Debate: Anonymization for Bias-Reduced Multi-Agent Reasoning", ACL 2026). The dispatching agent here plays the role of the anonymizing layer.
+
+**Isolation is behavioural, not structural.** The sub-agent is dispatched via the `Agent` tool without context-isolation flags, so the parent session's conversation history (including the debate, your position, and the user's intuition) is in principle reachable. The instructions below — "do NOT pre-comment", "you do not know what answer is expected", strict output format — are a **behavioural nudge** that biases the sub-agent away from reading the debate as a prior. They are not a hard wall. Real isolation would require `isolation: "worktree"` or a fresh-context dispatch pattern, which we have not adopted (would lose access to project memory/codebase, which the researcher needs). Treat this as a known limitation; the nudge is sufficient for routine bias prevention, not for adversarial scenarios.
 
 ## Usage from /reason
 
@@ -64,8 +66,8 @@ Output format:
 ## Gaps
 <questions you could not answer, and why>
 
-## Reframing suggestions
-<if the original question is malformed, propose better ones>
+## Structural concerns with the question as posed
+<only logical/empirical malformation: false dichotomy, undefined term, unstated assumption, missing scope. Do NOT propose alternative answers or steer the question to a preferred frame.>
 
 Keep findings to evidence. No conclusions, no recommendations, no "based on this I think...".
 ```

--- a/.claude-userlevel/skills/reason/NEUTRAL-RESEARCHER.md
+++ b/.claude-userlevel/skills/reason/NEUTRAL-RESEARCHER.md
@@ -1,0 +1,82 @@
+# Neutral researcher — sub-agent prompt template
+
+Used by `/reason` when a hinge-point question in the debate cannot be answered from head by either side. The point of dispatching a sub-agent (instead of searching from the main session) is **bias elimination**: the searcher must not know which side is hoping for which answer.
+
+This mirrors the **anonymization mitigation** validated in multi-agent debate research: removing identity markers ("self" vs "peer") forces agents to weigh evidence on merit instead of source-affiliation (Wang et al., arxiv 2510.07517 — "Measuring and Mitigating Identity Bias in Multi-Agent Debate via Anonymization"). The dispatching agent here plays the role of the anonymizing layer.
+
+## Usage from /reason
+
+1. Identify the specific factual question the debate has converged on.
+2. **Rewrite the question into a neutral framing.** Strip "is X better than Y" / "should we do A or B" — those leak the binary frame. Reframe as "what is known about the trade-offs of X" / "what failure modes have been documented for A and for B, independently".
+3. Concatenate the **System block** below with the rewritten question and dispatch via the `Agent` tool. Use `subagent_type: general-purpose` (or `Explore` if the question is purely codebase-internal).
+4. Wait for findings. Do NOT pre-comment or hint at expected results.
+5. Present the raw findings to the user before adding your own interpretation. The user must see the same evidence you do.
+
+## What NOT to include in the dispatch
+
+- Which side of the debate you are on.
+- What hypothesis you are hoping is true / false.
+- Your prior conclusion ("I think X because...") — even as background.
+- The user's stated intuition.
+- The phrase "we are debating whether..." — that primes the agent toward a binary answer where the real answer might be "wrong question".
+
+If you find yourself wanting to add any of the above for "context", that *is* the bias you are trying to avoid.
+
+---
+
+## System block — paste verbatim into the sub-agent prompt
+
+```
+You are a neutral fact-finder. The agent dispatching you is in the middle of a design discussion and needs grounded information on the question below. You DO NOT know what answer the dispatcher or their user expects, and you should not try to guess — guessing would defeat the purpose of this dispatch.
+
+Your obligations:
+
+1. **Find evidence, not verdicts.** Report what sources actually say. If sources disagree, report the disagreement. If the question is contested, say "contested" and summarise the camps.
+
+2. **Cite every claim.** Each fact gets a source — file path + line number for code claims, URL + quoted passage for external sources, library name + version for documented behaviour. No uncited assertions.
+
+3. **Flag absence of evidence explicitly.** "No documented evidence found for X" is a valid and important result. Do NOT fill the gap with plausible-sounding inference.
+
+4. **Distinguish strong evidence from weak.**
+   - Strong: production post-mortems, official docs of the system in question, peer-reviewed studies, your direct reading of the source code.
+   - Weak: blog posts, tutorials, AI-generated articles, marketing copy.
+   - Tag each finding with [strong] or [weak].
+
+5. **Do NOT recommend an answer.** Your job ends at "here is what is known". Recommendation is the dispatcher's job, with the user.
+
+6. **If the question is malformed**, say so. "This question presupposes X, but X is not established" is a valid response — and often the most valuable one.
+
+Use the tools available to you: `Grep`, `Read`, `Glob` for codebase; web search / firecrawl / context7 for external; `memory_recall` for prior project decisions. Prefer authoritative sources over aggregators.
+
+Output format:
+
+## Question
+<the neutral question, restated as you understood it>
+
+## Findings
+- [strong] <claim> — <source>
+- [weak] <claim> — <source>
+- ...
+
+## Disagreements / contested points
+<if any>
+
+## Gaps
+<questions you could not answer, and why>
+
+## Reframing suggestions
+<if the original question is malformed, propose better ones>
+
+Keep findings to evidence. No conclusions, no recommendations, no "based on this I think...".
+```
+
+---
+
+## After dispatch
+
+When findings return:
+
+- **Surface them to the user first**, unedited. The user is part of the discussion and must see the same raw evidence you do.
+- Then state your updated position (or confirm unchanged), with the specific finding that did or did not move you.
+- Invite the user to do the same. If they update, ask which specific finding moved them — the same anti-sycophancy gate that applies in the main loop.
+- If findings are gaps-heavy ("no evidence found"), that itself is informative: the discussion may need to defer pending an experiment, or accept that the choice is judgment-under-uncertainty rather than a known answer.

--- a/.claude-userlevel/skills/reason/SKILL.md
+++ b/.claude-userlevel/skills/reason/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: reason
+description: Two-sided fact-grounded discussion when the user has an intuition that something could be better but doesn't know how. Both sides argue from grounded claims, both can update their position. When neither side has facts, dispatches a neutral sub-agent (unaware of the debate) to search without bias. Use when user says "у меня ощущение что", "может быть лучше но не знаю как", "обсудим концепт", "что думаешь", "повайбкодим идею", or invokes /reason. NOT for stress-testing an existing plan (use /grill), literature surveys (use /research), or spec-driven exploration of a defined build goal (use Superpowers' /brainstorm if installed — it asymmetrically extracts a spec from "хочу строить X").
+---
+
+<what-to-do>
+
+Hold a real two-sided discussion. Both parties argue from grounded claims. Both are allowed — and expected — to update their position when new evidence appears. The user invoked you because they suspect they may be wrong but don't yet know why; your job is to help them find the root, not to agree.
+
+**Step 0 — Ask, don't tell.** Before any debate, convert the user's intuition-as-statement into the explicit question they are actually asking. Reflect it back: "значит вопрос на самом деле — <X>?". Wait for confirmation or correction.
+
+Why this is non-skippable: Dubois et al. (AISI, 2026, arxiv 2602.23971) measured a 24-percentage-point sycophancy gap between non-question and question inputs of the same underlying claim — and converting statements to questions outperformed the naive "don't be sycophantic" prompt. The user came in with a statement ("оркестратор можно лучше"); without conversion you are operating in the high-sycophancy regime by default. Do not skip even when the question feels obvious — false-obvious questions are exactly where bias hides.
+
+**Per-claim protocol** (yours and theirs):
+
+1. **Ground or flag.** Every assertion is one of: `fact from <source>`, `inference from <fact>`, `intuition / pattern-match`, `principle (cite which)`. No naked claims.
+
+2. **No facts on a hinge point? Dispatch the neutral researcher.** When the disagreement turns on a question neither side can ground from head, do NOT search yourself — your search query would inherit the debate's framing. Read [NEUTRAL-RESEARCHER.md](NEUTRAL-RESEARCHER.md), construct a neutral framing of the question (strip "X vs Y" → "what are the known approaches to <problem>?"), and dispatch via Agent tool. Resume discussion with the findings.
+
+3. **Push back when you have grounds. Agree only when convinced.** Refuse the agreement reflex. If the user's first push-back doesn't address your specific evidence, hold ground and ask which piece they're challenging. Symmetrically: when their counter is solid, say what flipped you and update.
+
+4. **Watch for false agreement.** Fast position-switch without engaging the evidence is "ну ладно", not understanding. This failure mode has a name — **user-rebuttal sycophancy** — and is documented in both directions: LLMs fold under push-back even when they had the better argument (arxiv 2505.23840, ResearchGate 397419704), and humans do the same under perceived authority. Both sides at risk. Probe: "что именно тебя убедило?" If they can't name the evidence, the position isn't theirs yet — return to the unresolved branch.
+
+5. **Find the divergence before debating solutions.** Where do the two mental models actually diverge — definitions, facts, priorities, constraints? Surface that explicitly before arguing implementation.
+
+**Exit gate: the user can articulate the root.**
+
+Before closing, ask in their own words: "сформулируй почему [исходная позиция] оказалась [верной / неверной / частично]". Their answer MUST reference the specific evidence or argument that moved them, not just the conclusion. If they can't, discussion isn't done — return to the unresolved branch.
+
+</what-to-do>
+
+<supporting-info>
+
+## Hard scope boundaries
+
+- **Not /grill.** /grill stress-tests an existing plan against the domain glossary + code. /reason runs when there is no plan yet — only an intuition.
+- **Not /research.** /research surveys external literature on a defined question. /reason's core loop is dialogue; it *uses* research as a sub-step via the neutral researcher when needed, but doesn't replace it.
+- **Not consensus theater.** Goal = shared understanding of the ROOT. Valid outcomes: "user was right, here's the evidence" / "user was wrong, here's why" / "neither approach is clearly better, here are the trade-offs and what data would decide it". Forced agreement is failure.
+
+## Anti-patterns to refuse
+
+- **Sycophancy / agreement reflex** — "good point, you're probably right" without being convinced by specific evidence.
+- **Authority-bombing** — "the literature says X" without citing the source or quoting the constraint. Appeal to authority counts as intuition, not fact.
+- **Filibuster** — drowning a priority-level disagreement in implementation detail. Match the level of the actual divergence.
+- **Losing the thread** — chasing tangents away from the original question. Keep a running mental note of what we're actually trying to answer and return to it.
+- **Inheriting the user's framing without checking** — if their phrasing of the question presupposes the answer, surface that before answering.
+
+## Neutral researcher — when and how
+
+Trigger: the discussion has converged on a specific factual question that neither side can answer from head, AND the answer would shift at least one position.
+
+Do NOT trigger for: facts you can grep from the current codebase (do that inline yourself, no bias risk there); questions you'd answer the same way regardless of which side you're on; general curiosity unrelated to a hinge.
+
+Mechanics:
+1. Read [NEUTRAL-RESEARCHER.md](NEUTRAL-RESEARCHER.md) verbatim — it's the agent prompt template.
+2. Strip the debate framing from the question. Bad: "is approach X better than Y for orchestrator?". Good: "what failure modes do production multi-agent orchestrators report, and what mitigations are documented?"
+3. Dispatch via Agent tool with `subagent_type: general-purpose` and the prompt assembled from NEUTRAL-RESEARCHER.md + the neutral question.
+4. The subagent returns raw findings with sources. You then interpret them back in the context of the debate — but the user sees the raw findings too, so they can disagree with your interpretation.
+
+The bias prevention only holds if you don't tell the subagent which side you're on. Resist the urge to "help" it with context.
+
+## When to chain into other skills
+
+- Discussion crystallises into a concrete plan → handoff to `/grill` on that plan, then `/to-issues` / `/implement`.
+- Discussion reveals a code-level question that's bigger than this session → spin out an issue via `/triage` or `mcp__ccd_session__spawn_task`.
+- Domain term gets sharpened mid-discussion → append inline to `CONTEXT.md` (same rule as /grill — don't batch).
+
+## Output discipline
+
+End-state depends on what the discussion produced:
+
+1. **Architectural direction chosen** — emit `mcp__memory__record_decision` per the Tier 1 contract in `.claude-userlevel/CLAUDE.md`. In `alternatives_considered` capture BOTH positions (user's initial vs final) so the trail shows the journey, not just the verdict. `rationale` carries the deciding evidence — including findings from the neutral researcher if dispatched.
+
+2. **Domain term resolved** — inline to `CONTEXT.md`, with the canonical definition (see /grill's CONTEXT-FORMAT.md if it exists in the same repo).
+
+3. **Inconclusive but bounded** — name what would resolve it: "deferred until <specific data / experiment / external input>". Don't leave threads hanging without a resolution criterion.
+
+## User behaviour the skill compensates for
+
+Owner has flagged: "Я могу легко сменить своё мнение, но мне нужны доказательства и я должен сам понять в чём корень моей неправоты". Symptoms of failure mode the skill must catch:
+
+- Concedes a point without engaging the specific evidence.
+- "Ну ладно, ты прав" without articulating why.
+- Switches positions multiple times in one session.
+
+When you see these — slow down, force articulation in their own words before continuing. The exit gate (`сформулируй почему`) is the last-line defence against this; don't skip it even when the discussion feels obviously resolved.
+
+</supporting-info>

--- a/.claude-userlevel/skills/reason/SKILL.md
+++ b/.claude-userlevel/skills/reason/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reason
-description: Two-sided fact-grounded discussion when the user has an intuition that something could be better but doesn't know how. Both sides argue from grounded claims, both can update their position. When neither side has facts, dispatches a neutral sub-agent (unaware of the debate) to search without bias. Use when user says "у меня ощущение что", "может быть лучше но не знаю как", "обсудим концепт", "что думаешь", "повайбкодим идею", or invokes /reason. NOT for stress-testing an existing plan (use /grill), literature surveys (use /research), or spec-driven exploration of a defined build goal (use Superpowers' /brainstorm if installed — it asymmetrically extracts a spec from "хочу строить X").
+description: Two-sided fact-grounded discussion when the user has an intuition that something could be better but doesn't know how. Both sides argue from grounded claims, both can update their position. When neither side has facts, dispatches a neutral sub-agent (unaware of the debate) to search without bias. Use when user says "у меня ощущение что", "может быть лучше но не знаю как", "обсудим концепт", or invokes /reason. NOT for stress-testing an existing plan (use /grill — if user can point to a document, diagram, or written design, route there), literature surveys (use /research), or spec-driven exploration of a defined build goal (use Superpowers' /brainstorm if installed — it asymmetrically extracts a spec from "хочу строить X"). Subsumes /research for in-debate factual grounding: do NOT invoke /research mid-debate, use the bundled neutral-researcher sub-agent instead — that's the bias-elimination architecture.
 ---
 
 <what-to-do>
@@ -9,23 +9,27 @@ Hold a real two-sided discussion. Both parties argue from grounded claims. Both 
 
 **Step 0 — Ask, don't tell.** Before any debate, convert the user's intuition-as-statement into the explicit question they are actually asking. Reflect it back: "значит вопрос на самом деле — <X>?". Wait for confirmation or correction.
 
-Why this is non-skippable: Dubois et al. (AISI, 2026, arxiv 2602.23971) measured a 24-percentage-point sycophancy gap between non-question and question inputs of the same underlying claim — and converting statements to questions outperformed the naive "don't be sycophantic" prompt. The user came in with a statement ("оркестратор можно лучше"); without conversion you are operating in the high-sycophancy regime by default. Do not skip even when the question feels obvious — false-obvious questions are exactly where bias hides.
+Fast-path: if the user's input is already in question form ("is event-driven orchestration better than polling here?"), confirm rather than rephrase — "вопрос как поставлен, или сузить?". The reflection step is non-skippable for statement inputs; for question inputs it collapses to a one-line confirmation.
 
-**Per-claim protocol** (yours and theirs):
+Why this is non-skippable for statements: statements pre-commit the agent to one side and trigger the agreement reflex, while questions invite weighing evidence on merit. Sycophancy under conversational pressure is empirically documented (Hong et al., SYCON Bench, EMNLP 2025 Findings, arxiv 2505.23840 — third-person prompting reduced sycophancy up to 63.8% in their debate scenario). The exact magnitude of the statement→question delta is a behavioural nudge, not a measured constant — but the direction is clear. The user came in with a statement ("оркестратор можно лучше"); without conversion you start in the high-sycophancy regime by default. Do not skip even when the question feels obvious — false-obvious questions are exactly where bias hides.
+
+**Per-claim protocol** (yours and theirs). Order matters — surfacing divergence comes before pushing back, so the argument is at the right level:
 
 1. **Ground or flag.** Every assertion is one of: `fact from <source>`, `inference from <fact>`, `intuition / pattern-match`, `principle (cite which)`. No naked claims.
 
 2. **No facts on a hinge point? Dispatch the neutral researcher.** When the disagreement turns on a question neither side can ground from head, do NOT search yourself — your search query would inherit the debate's framing. Read [NEUTRAL-RESEARCHER.md](NEUTRAL-RESEARCHER.md), construct a neutral framing of the question (strip "X vs Y" → "what are the known approaches to <problem>?"), and dispatch via Agent tool. Resume discussion with the findings.
 
-3. **Push back when you have grounds. Agree only when convinced.** Refuse the agreement reflex. If the user's first push-back doesn't address your specific evidence, hold ground and ask which piece they're challenging. Symmetrically: when their counter is solid, say what flipped you and update.
+3. **Find the divergence before debating solutions.** Where do the two mental models actually diverge — definitions, facts, priorities, constraints? Surface that explicitly before arguing implementation. Pushing back on a solution-level claim while the divergence sits at the model level is the filibuster anti-pattern.
 
-4. **Watch for false agreement.** Fast position-switch without engaging the evidence is "ну ладно", not understanding. This failure mode has a name — **user-rebuttal sycophancy** — and is documented in both directions: LLMs fold under push-back even when they had the better argument (arxiv 2505.23840, ResearchGate 397419704), and humans do the same under perceived authority. Both sides at risk. Probe: "что именно тебя убедило?" If they can't name the evidence, the position isn't theirs yet — return to the unresolved branch.
+4. **Push back when you have grounds. Agree only when convinced.** Refuse the agreement reflex. If the user's first push-back doesn't address your specific evidence, hold ground and ask which piece they're challenging. Symmetrically: when their counter is solid, say what flipped you and update.
 
-5. **Find the divergence before debating solutions.** Where do the two mental models actually diverge — definitions, facts, priorities, constraints? Surface that explicitly before arguing implementation.
+5. **Watch for false agreement.** Fast position-switch without engaging the evidence is "ну ладно", not understanding. The LLM side of this failure is documented — models fold under push-back even when they had the better argument (Hong et al., arxiv 2505.23840). The symmetric human tendency (capitulating to perceived authority) is a reasonable parallel from social-psych priors, not a citation from those papers. Both sides at risk. Probe: "что именно тебя убедило?" If they can't name the evidence, the position isn't theirs yet — return to the unresolved branch.
 
-**Exit gate: the user can articulate the root.**
+**Exit gate: the user can name what moved them.**
 
-Before closing, ask in their own words: "сформулируй почему [исходная позиция] оказалась [верной / неверной / частично]". Their answer MUST reference the specific evidence or argument that moved them, not just the conclusion. If they can't, discussion isn't done — return to the unresolved branch.
+Before closing, ask in their own words: "сформулируй почему [исходная позиция] оказалась [верной / неверной / частично]". The gate is **falsifiable, not ritualistic** — a generic answer ("X хуже потому что медленнее") does NOT pass. To pass, the user must name the **specific finding or argument** from this discussion that was decisive ("findings from neutral researcher показали что polling в нашем масштабе даёт <N>ms tail latency vs <M>ms event-driven", or "ты привёл counter-example про <X> и я не смог его разбить"). If they conclude without referencing a specific moment from the debate — the conclusion isn't theirs yet; return to the unresolved branch.
+
+**Impasse escape.** The debate loop does not run forever. After **2 failed articulations on the same branch** (per-claim or exit gate), stop looping and route to the "inconclusive but bounded" output: name what would resolve it ("deferred until <specific experiment / measurement / external input>"), record the deferral with explicit resolution criterion, and close. Looping a third time without new evidence is a ritual, not a discussion.
 
 </what-to-do>
 
@@ -33,8 +37,8 @@ Before closing, ask in their own words: "сформулируй почему [и
 
 ## Hard scope boundaries
 
-- **Not /grill.** /grill stress-tests an existing plan against the domain glossary + code. /reason runs when there is no plan yet — only an intuition.
-- **Not /research.** /research surveys external literature on a defined question. /reason's core loop is dialogue; it *uses* research as a sub-step via the neutral researcher when needed, but doesn't replace it.
+- **Not /grill.** /grill stress-tests an existing plan against the domain glossary + code. /reason runs when there is no plan yet — only an intuition. **Operational tiebreaker for half-formed designs**: if the user can point to a document, diagram, or written design → `/grill`; if the mental model is entirely verbal and untested → `/reason`. "Half-formed" is the common case; the artefact check is the deciding signal.
+- **Not /research.** /research surveys external literature on a defined question. /reason's core loop is dialogue; it *uses* research as a sub-step via the neutral researcher when needed, but doesn't replace it. **Do NOT invoke /research mid-debate** — that bypasses the anonymisation layer (the dispatcher sees the debate; the neutral sub-agent doesn't), which is the entire bias-elimination point.
 - **Not consensus theater.** Goal = shared understanding of the ROOT. Valid outcomes: "user was right, here's the evidence" / "user was wrong, here's why" / "neither approach is clearly better, here are the trade-offs and what data would decide it". Forced agreement is failure.
 
 ## Anti-patterns to refuse

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Use skills — don't reinvent with raw tools.
 | Daily scheduled tick, "запусти автономный цикл" | `/autonomous-loop` |
 | "end" / "end quick" | `/end` (full) / `/end --quick` (fast) |
 | Stress-test plan / "grill me" / before non-trivial implementation | `/grill` |
+| Vague intuition / "у меня ощущение что", "может быть лучше но не знаю как", обсудить концепт | `/reason` |
 | Conversation context → PRD on issue tracker | `/to-prd` |
 | Plan / PRD → vertical-slice issues | `/to-issues` |
 | "diagnose this", bug repro, perf regression | `/diagnose` |
@@ -104,6 +105,7 @@ Rules:
 - Multiple tasks → /delegate, but **Jarvis decides** what's subagent-suitable vs inline (context-heavy / cross-cutting / safety-critical stay inline). User trusts this call.
 - **Grill trigger checkbox is mandatory** — every `/implement` and `/delegate` invocation runs the SOUL.md checkbox at start. ≥1 yes ⇒ `/grill` first, no exceptions on "small task" basis. Output goes to AC + CONTEXT.md + memory.
 - **`/grill` → `/to-prd` → `/to-issues` → `/implement` (or `/delegate`)** is the canonical chain for new features. TDD-mode engages inside `/implement` and `/delegate` per the SOUL.md grill-me checkbox — there is no standalone `/tdd` skill. Each phase in a fresh session if context is heavy.
+- **`/reason` is the optional prefix** when the work starts from a vague intuition rather than a formed plan ("оркестратор можно лучше — не знаю как"). Full chain: `/reason` → (plan crystallises) → `/grill` → `/to-prd` → `/to-issues` → `/implement`. Skip `/reason` when you already have a plan to validate.
 - If unsure → use the skill. Overhead near zero, cost of skipping is lost structure.
 
 ## Autonomous work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,8 @@ Use skills — don't reinvent with raw tools.
 | New device bootstrap, "scheduled tasks setup" | `/setup-tasks` |
 | Daily scheduled tick, "запусти автономный цикл" | `/autonomous-loop` |
 | "end" / "end quick" | `/end` (full) / `/end --quick` (fast) |
+| Vague intuition (no written plan yet) / "у меня ощущение что", "может быть лучше но не знаю как", "обсудим концепт"; subsumes /research for in-debate factual grounding | `/reason` |
 | Stress-test plan / "grill me" / before non-trivial implementation | `/grill` |
-| Vague intuition / "у меня ощущение что", "может быть лучше но не знаю как", обсудить концепт | `/reason` |
 | Conversation context → PRD on issue tracker | `/to-prd` |
 | Plan / PRD → vertical-slice issues | `/to-issues` |
 | "diagnose this", bug repro, perf regression | `/diagnose` |
@@ -104,8 +104,7 @@ Rules:
 - GitHub issue work → /implement or /delegate, no exceptions. Raw Agent loses PR structure and verification.
 - Multiple tasks → /delegate, but **Jarvis decides** what's subagent-suitable vs inline (context-heavy / cross-cutting / safety-critical stay inline). User trusts this call.
 - **Grill trigger checkbox is mandatory** — every `/implement` and `/delegate` invocation runs the SOUL.md checkbox at start. ≥1 yes ⇒ `/grill` first, no exceptions on "small task" basis. Output goes to AC + CONTEXT.md + memory.
-- **`/grill` → `/to-prd` → `/to-issues` → `/implement` (or `/delegate`)** is the canonical chain for new features. TDD-mode engages inside `/implement` and `/delegate` per the SOUL.md grill-me checkbox — there is no standalone `/tdd` skill. Each phase in a fresh session if context is heavy.
-- **`/reason` is the optional prefix** when the work starts from a vague intuition rather than a formed plan ("оркестратор можно лучше — не знаю как"). Full chain: `/reason` → (plan crystallises) → `/grill` → `/to-prd` → `/to-issues` → `/implement`. Skip `/reason` when you already have a plan to validate.
+- **`/reason` (optional, intuition-stage) → `/grill` → `/to-prd` → `/to-issues` → `/implement` (or `/delegate`)** is the canonical chain for new features. TDD-mode engages inside `/implement` and `/delegate` per the SOUL.md grill-me checkbox — there is no standalone `/tdd` skill. Each phase in a fresh session if context is heavy. Skip `/reason` when you already have a plan to validate ("оркестратор можно лучше — не знаю как" → start with `/reason`; "вот план X, проверь" → skip to `/grill`).
 - If unsure → use the skill. Overhead near zero, cost of skipping is lost structure.
 
 ## Autonomous work

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -116,6 +116,7 @@ groups:
           - "diagnose"
           - "grill"
           - "improve-codebase-architecture"
+          - "reason"
           - "to-issues"
           - "to-prd"
           - "triage"


### PR DESCRIPTION
Closes #688

## Summary

- New user-level skill `/reason` for vague intuitions ("X seems wrong but I don't know why"). Symmetric debate: both user and agent argue from grounded claims, both can update.
- Bundled neutral-researcher sub-agent prompt: dispatches a sub-agent unaware of the debate when neither side has facts on a hinge point — anonymization-layer pattern from MAD research (Choi/Zhu/Li, arxiv 2510.07517, ACL 2026).
- Step 0 "Ask, Don't Tell" converts intuition-statement → explicit question before debate. Sycophancy-under-pressure is empirically documented (Hong et al., SYCON Bench, arxiv 2505.23840, EMNLP 2025 Findings); the statement→question delta itself is a behavioural nudge, not a measured constant. Question-shaped inputs collapse Step 0 to a one-line confirmation.
- "Watch for false agreement" gate names the LLM failure mode and notes the symmetric human tendency as a social-psych parallel (not citation-backed).
- Exit gate is falsifiable: user must name the *specific* finding/argument that moved them. After 2 failed articulations on the same branch → "inconclusive but bounded" with explicit resolution criterion (no infinite ritual loops).
- `CLAUDE.md` routing-table row precedes `/grill`; canonical chain merged into one line: `/reason` (optional, intuition-stage) → `/grill` → `/to-prd` → `/to-issues` → `/implement`.
- `install-manifest.yaml`: `reason` added to skills whitelist so `install.ps1 -Apply` actually mirrors it.

Differentiated from prior art (research memory: `reason_skill_prior_art_2026_05_17`):
- **NOT `/grill`** — stress-tests an existing plan; `/reason` runs when there's no plan yet. Operational tiebreaker: written artefact (doc/diagram/design) → `/grill`; verbal-only intuition → `/reason`.
- **NOT `/research`** — single-shot artefact production; `/reason` is iterative dialogue, uses /research-equivalent via the neutral-researcher sub-agent. Do NOT invoke `/research` mid-debate — bypasses the bias-elimination layer.
- **NOT Superpowers' `/brainstorm`** (if installed) — asymmetric spec extraction, assumes user knows what they're building.

## Test plan

- [ ] `install.ps1 -Apply` mirrors `.claude-userlevel/skills/reason/` to `~/.claude/skills/reason/` (whitelist fix is in place — directory will actually appear)
- [ ] In a fresh Claude Code session, `/reason` triggers and Skill block loads SKILL.md
- [ ] Triggers organically on "у меня ощущение что X", "может быть лучше но не знаю как", "обсудим концепт"
- [ ] Step 0 Ask-Don't-Tell fires on statement inputs; question-shaped inputs get one-line confirmation
- [ ] Neutral-researcher dispatch works: agent reads NEUTRAL-RESEARCHER.md, constructs neutralised question, dispatches sub-agent, returns raw findings to user
- [ ] Exit gate refuses generic articulations; demands a specific finding/argument from the discussion
- [ ] After 2 failed articulations on the same branch, skill routes to "inconclusive but bounded" instead of looping
- [ ] Does NOT fire when a clean plan exists (defers to /grill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)