### PR TITLE
feat(delegate): pre-dispatch gate refuses AFK dispatch on missing artefacts (#642)

### DIFF
--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -32,9 +32,72 @@ Memory recall and the `record_decision` contract come from user-level CLAUDE.md 
 
 **Jarvis judgment overrides the principal's "параллельно":** The principal has explicitly delegated this call to Jarvis (memory: this decision). If a task looks deceptively complex or a subagent will struggle (needs memory context, cross-file reasoning, recent-decisions awareness), keep it inline even if asked to delegate. Don't silently downgrade — tell the principal "keeping #X inline because <reason>".
 
+## Contract: pre-dispatch gate (binary AFK-readiness check, runs FIRST)
+
+Before any other routing, every issue in the batch passes through the
+pre-dispatch gate. The gate is a binary AFK-readiness check whose failure
+modes are mechanical (label present / absent, heading present / absent,
+regex match) — not judgement calls. Issue #642 introduced it because
+headless `/delegate` has no operator to grill the AC in real time, so the
+work of verifying AFK-readiness must happen *at* dispatch entry, not
+inside the dispatched sandcastle agent.
+
+**Four conditions, all required** (canonical implementation:
+[`scripts/delegate_predispatch_gate.py`](../../../scripts/delegate_predispatch_gate.py)):
+
+1. Issue has label `sandcastle` (applied by `/to-issues` per the AFK-fit
+   checklist at slice creation — never manually, never at grill time).
+2. Issue has **no** `needs-*` label (`needs-grill`, `needs-research`,
+   `needs-prd`, `needs-refactor`, …). Each requesting skill removes its own
+   label at terminal success.
+3. Issue body contains an `## Acceptance criteria` heading (case-insensitive
+   prefix match — `## Acceptance criteria`, `## ACCEPTANCE CRITERIA (brief)`,
+   etc. all match).
+4. Issue body cites at least one decision UUID (regex
+   `\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`).
+
+**Invocation** (per issue, before classification or claim):
+
+```bash
+gh issue view <N> --repo <owner/repo> --json number,body,labels \
+  | python scripts/delegate_predispatch_gate.py
+# exit 0 ⇒ allow; exit 1 ⇒ refuse, message on stdout names each missing element
+```
+
+**On refusal** (any one or more of the four conditions fail):
+
+1. `mcp__memory__outcome_record(task_type="delegation", outcome_status="failure", outcome_summary="pre-dispatch gate refused: <message>", project="<repo>", issue_url=...)` — recorded so `/reflect` and `/self-improve` can spot patterns.
+2. `gh issue edit <N> --add-label "status:owner-queue"` — surfaces in next `/status` run so the owner sees the backlog of issues needing a manual touch.
+3. Report to the principal in the batch summary: `#N refused — <verbatim gate message>`. The message names each missing element so the owner knows exactly what to fix.
+4. The issue is **not** claimed (no `status:in-progress`, no branch). `/grill` / `/research` / sandcastle-label-add are the unblock paths — once fixed, re-dispatch flips the route.
+
+**No Telegram escalation** even on repeat refuses — last-resort rule (decision `e9b9cfb8`). Owner discovers via `/status`.
+
+**Interactive `/implement` is NOT pre-dispatch-gated.** The gate guards
+*subagent* dispatch where no operator is present. Inline `/implement` keeps
+the SOUL.md grill-checkbox as its in-skill backstop and can run on any
+issue (including `status:owner-queue`-tagged ones) — the operator IS the
+gate. This is intentional asymmetry, not an oversight.
+
+**Known fragility** (decision `6b0a5bf7`): the gate runs once at
+`/delegate` entry and is **not re-validated** inside the sandcastle
+container. Pipeline changes that bypass `/delegate` entry (e.g. a future
+shortcut that hands work directly to a subagent) would silently bypass
+the gate. Re-surface this risk in any architectural change that restructures
+the dispatch chain.
+
 ## Contract: dispatch routing (per issue: mechanical / TDD-mode / `grill_required`)
 
-Per ADR-0001, skills do not self-trigger mid-task ("Type 3" is rejected). `/delegate` does **not** run `/grill` inline (and there is no standalone `/tdd` skill — TDD-mode is dispatched as inline operating discipline carrying `_shared/tdd/` reference docs). For **each** issue in the batch it inspects two inputs and routes to one of three branches. Routing is per-issue: a single batch can mix mechanical-mode and TDD-mode dispatches (and exclude grill-failing issues).
+Per ADR-0001, skills do not self-trigger mid-task ("Type 3" is rejected). `/delegate` does **not** run `/grill` inline (and there is no standalone `/tdd` skill — TDD-mode is dispatched as inline operating discipline carrying `_shared/tdd/` reference docs). For **each** issue that **passed** the pre-dispatch gate above, inspect two inputs and route to one of three branches. Routing is per-issue: a single batch can mix mechanical-mode and TDD-mode dispatches (and exclude grill-failing issues).
+
+**Pre-dispatch gate dominance**: when the gate's four artefacts are present
+(sandcastle label + no needs-* + `## Acceptance criteria` heading + decision
+UUID), the SOUL.md grill-checkbox below is **skipped** — the artefacts'
+presence is itself evidence the issue has been grilled and refined. The
+checkbox runs only as a **legacy backstop** for pre-#642 issues that have
+no artefacts and no `needs-grill` label (e.g. early milestones whose slices
+were authored before the AFK-fit checklist). New issues from `/to-issues`
+land with artefacts in place and bypass the checkbox entirely.
 
 **Inputs** (per issue — fetch the body first):
 
@@ -119,7 +182,7 @@ Produce a short split plan for the principal before acting. Example:
 
 ### 2. Claim all dispatchable issues
 
-Claim every issue that survived the per-issue `grill_required` check (label `status:in-progress` + comment), including the ones staying inline. Issues that exited `grill_required` are NOT claimed — they go back to the orchestrator for `/grill` + re-dispatch in a fresh session, which will run its own pre-flight and claim then. Claiming up front prevents races between concurrent Jarvis instances and the principal forgetting to route delegatable issues.
+Claim every issue that survived **both** the pre-dispatch gate (§Contract: pre-dispatch gate) **and** the per-issue `grill_required` check (label `status:in-progress` + comment), including the ones staying inline. Issues refused by the pre-dispatch gate are NOT claimed — they receive `status:owner-queue` and exit immediately. Issues that exited `grill_required` are also NOT claimed — they go back to the orchestrator for `/grill` + re-dispatch in a fresh session, which will run its own pre-flight and claim then. Claiming up front prevents races between concurrent Jarvis instances and the principal forgetting to route delegatable issues.
 
 ```bash
 for N in <N1> <N2> ...; do

--- a/.claude-userlevel/skills/grill/SKILL.md
+++ b/.claude-userlevel/skills/grill/SKILL.md
@@ -128,6 +128,16 @@ When a term is resolved, update `CONTEXT.md` right there. Don't batch these up â
 
 Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
 
+### Remove `needs-grill` on success
+
+When `/grill` resolves an issue's open questions and the AC is updated with verifiable bullets + decision UUIDs (whether inline or via working_state), remove the issue's `needs-grill` label as the final terminal step:
+
+```bash
+gh issue edit <N> --repo <owner/repo> --remove-label "needs-grill"
+```
+
+This is the contract that lets `/delegate`'s pre-dispatch gate (issue #642) trust that an unlabelled issue is genuinely grill-clean. Skipping the removal leaves the issue stuck in `status:owner-queue` forever. If `/grill` exits without resolution (owner walks away mid-session), leave the label in place â€” the issue still needs work.
+
 ### Offer ADRs sparingly
 
 Only offer to create an ADR when all three are true:

--- a/.claude-userlevel/skills/research/SKILL.md
+++ b/.claude-userlevel/skills/research/SKILL.md
@@ -1,170 +1,181 @@
----
-name: research
-description: "Investigate a topic, validate decisions, compare options, or run autonomous discovery. Absorbs intel and nightly-research. Trigger: 'Ð¸ÑÑÐ»ÐµÐ´ÑÐ¹', 'research', 'Ð¸Ð·ÑÑÐ¸', 'ÑÑÐ¾ Ð»ÑÑÑÐµ', 'ÑÑÐ°Ð²Ð½Ð¸'."
-version: 5.0.0
----
-
-# Research
-
-Investigate a topic and produce a sourced, confidence-rated finding.
-
-**Mode is determined by the argument shape, not a flag:**
-
-- **A topic is supplied** (`/research <topic>`, or principal asks a specific question) â interactive: focused on that one query.
-- **No topic supplied** (`/research`, or scheduled run) â discovery: load context, find genuine gaps, pick top 3, research each.
-
-The pipeline below works for both. Steps that only apply to one shape are flagged inline.
-
-## 4-Channel Mandatory Intake Protocol
-
-All non-trivial research must include explicit coverage from **all four channels**. Memory recall does not substitute for external channels (per decision [`6fd2df1d-defc-440d-ba30-71880409e533`](https://memory.example/decisions/6fd2df1d-defc-440d-ba30-71880409e533)). Research is incomplete if any channel is empty without explicit owner waiver.
-
-### Channel 1: Users
-**End-user experience** — how people actually feel using the thing, what they trip over.
-
-**Where to look:** Reddit (r/Python, r/MachineLearning, r/devops), Hacker News discussions, Medium posts, dev blogs, Twitter/X technical discussions, Stack Overflow threads, community Discord/Slack.
-
-**Example queries:**
-- Site:reddit.com "tool X" real experience
-- "tool X" pain points OR frustrations site:news.ycombinator.com
-- "I tried X and..." OR "X broke our..." (dev blogs)
-
-### Channel 2: Specialists
-**Domain specialist opinion** — expert blogs, engineering posts from labs, thoughtful retrospectives.
-
-**Where to look:** 
-- Expert individual blogs: Dan Luu, Julia Evans, Will Larson, David Beazley, Nora Codes
-- Lab/company engineering blogs: Anthropic, OpenAI, DeepMind, Latent Space guest posts, Eugene Yan, David Pocock, Simon Willison
-- Conference talks + write-ups
-- Technical RFC or discussion threads from maintainers
-
-**Example queries:**
-- Site:pocock.com OR site:willison.io "topic X"
-- "topic X" engineering blog OR "lessons learned" site:anthropic.com OR site:openai.com
-- "topic X" expert OR specialist OR practitioner (time-limited to last 6 months)
-
-### Channel 3: Data
-**Quantitative data / research** — arxiv papers, conference papers, benchmark numbers, published metrics.
-
-**Where to look:** arxiv.org, ACM Digital Library, Papers With Code, GitHub repo benchmarks, published research, performance comparisons with citations.
-
-**Example queries:**
-- Site:arxiv.org "topic X" (YYYY-YYYY)
-- "topic X" benchmark OR performance evaluation OR measurement study
-- "topic X" empirical study OR systematic review
-- Site:paperswithcode.com "topic X"
-
-### Channel 4: Adversarial
-**Failure modes & criticism** — post-mortems, GitHub issues, "X considered harmful" pieces, retrospectives, why something failed.
-
-**Where to look:** Post-mortem archives (PostmortemDB, GitHub issue threads), retrospectives, "lessons learned" + negative outcomes, abandoned projects + why, critical technical discussions, conference talks on failures.
-
-**Example queries:**
-- "topic X" post-mortem OR postmortem OR "what went wrong"
-- "topic X" considered harmful OR critique OR "lessons learned from failure"
-- Site:github.com "topic X" wontfix OR closed issues (looking for patterns)
-- Abandoned "topic X" OR "deprecated" OR "no longer using"
-
-## Scope
-
-**New research only.** This 4-channel protocol applies to research initiated after this decision. Existing research-pass-style memories (e.g. `research_aihero_principles`, `research_deep_dive_synthesis_2026_05_06`) are grandfathered — no retrofit required. They serve as reference; future research on related topics will apply the protocol fresh.
-
-## Pipeline
-
-### 1. Determine the question(s)
-
-**Topic supplied:** classify it.
-- **Decision validation** â focus on trade-offs, risks, real-world experience.
-- **Knowledge gap** â authoritative explanations, practical examples.
-- **Comparison** â objective criteria, benchmarks, community consensus.
-
-**No topic (discovery):** load context first.
-
-```
-memory_recall(type="decision", limit=10)
-memory_recall(query="working_state", type="project", limit=3)
-```
-
-Also scan recent GitHub issues for each repo in `config/repos.conf`.
-
-Find genuine gaps from that context:
-- Problems flagged as unsolved
-- Decisions made without sufficient research
-- Patterns that keep breaking
-- Capabilities mentioned but not explored
-
-Score `impact Ã— urgency`. Pick **top 3**. Each becomes a specific, concrete research question. Bad: "research AI agents". Good: "how do iterative planners detect premature convergence?"
-
-### 2. Search
-
-Primary: `firecrawl_search(query="<topic>", limit=3)`.
-Fallback: `WebSearch` if Firecrawl unavailable.
-
-Per topic: 2-3 searches with different angles. Preview results with `head -c 4000`.
-
-Prioritize: official docs, reputable blogs, GitHub discussions, benchmarks.
-Skip: SEO spam, articles >2 years old for fast-moving topics.
-
-For highly relevant results: `firecrawl_scrape(url=<url>, formats=["markdown"], onlyMainContent=true)` â max 2 scrapes per topic.
-
-### 3. Analyze
-
-1. Claims in multiple independent sources = strong signal
-2. Note contradictions between sources
-3. Distinguish facts (documented, benchmarked) from opinions
-4. For technical decisions: real-world usage at similar scale
-5. **Channel gaps:** if a channel yields <2 sources, flag in output and propose owner waiver or extended search
-
-### 4. Output
-
-One report per topic (single report when topic supplied, three when discovery):
-
-```markdown
-## Summary
-One paragraph, lead with recommendation if it's a decision.
-
-## Key Findings
-- **Finding** â explanation [source]
-
-## Trade-offs & Risks
-- **Risk** â when it matters, mitigation
-
-## Alternatives
-- **Alternative** â why rejected or when better
-
-## Sources
-1. [Title](URL) â what it contributed
-
-## Confidence: N/100
-One sentence: what makes this confident or uncertain.
-```
-
-### 5. Save
-
-Save to Supabase if finding is significant:
-
-```
-memory_store(type="reference", name="research_{slug}", description="...", content="...", source_provenance="skill:research")
-```
-
-If finding is actionable â create GitHub issue in appropriate repo:
-
-```
-gh issue create --repo <R> --title "[RESEARCH] <topic>" --body "..."
-```
-
-**Discovery-only**: also write a dedup marker so the next scheduled run doesn't repeat topics:
-
-```
-memory_store(type="project", name="research_last_run", content="{date} â topics: {t1}, {t2}, {t3}", source_provenance="skill:research")
-```
-
-Check for duplicate research-spawned issues before creating new ones.
-
-## Quality rules
-
-- Non-trivial claims: 3+ independent sources when available
-- Every finding references specific sources, with channel attribution
-- Source conflicts â list both sides
-- Call out unknowns and weak evidence
-- If confidence <50 â recommend follow-up
+---
+name: research
+description: "Investigate a topic, validate decisions, compare options, or run autonomous discovery. Absorbs intel and nightly-research. Trigger: 'Ð¸ÑÑÐ»ÐµÐ´ÑÐ¹', 'research', 'Ð¸Ð·ÑÑÐ¸', 'ÑÑÐ¾ Ð»ÑÑÑÐµ', 'ÑÑÐ°Ð²Ð½Ð¸'."
+version: 5.1.0
+---
+
+# Research
+
+Investigate a topic and produce a sourced, confidence-rated finding.
+
+**Mode is determined by the argument shape, not a flag:**
+
+- **A topic is supplied** (`/research <topic>`, or principal asks a specific question) â interactive: focused on that one query.
+- **No topic supplied** (`/research`, or scheduled run) â discovery: load context, find genuine gaps, pick top 3, research each.
+
+The pipeline below works for both. Steps that only apply to one shape are flagged inline.
+
+## 4-Channel Mandatory Intake Protocol
+
+All non-trivial research must include explicit coverage from **all four channels**. Memory recall does not substitute for external channels (per decision [`6fd2df1d-defc-440d-ba30-71880409e533`](https://memory.example/decisions/6fd2df1d-defc-440d-ba30-71880409e533)). Research is incomplete if any channel is empty without explicit owner waiver.
+
+### Channel 1: Users
+**End-user experience** — how people actually feel using the thing, what they trip over.
+
+**Where to look:** Reddit (r/Python, r/MachineLearning, r/devops), Hacker News discussions, Medium posts, dev blogs, Twitter/X technical discussions, Stack Overflow threads, community Discord/Slack.
+
+**Example queries:**
+- Site:reddit.com "tool X" real experience
+- "tool X" pain points OR frustrations site:news.ycombinator.com
+- "I tried X and..." OR "X broke our..." (dev blogs)
+
+### Channel 2: Specialists
+**Domain specialist opinion** — expert blogs, engineering posts from labs, thoughtful retrospectives.
+
+**Where to look:** 
+- Expert individual blogs: Dan Luu, Julia Evans, Will Larson, David Beazley, Nora Codes
+- Lab/company engineering blogs: Anthropic, OpenAI, DeepMind, Latent Space guest posts, Eugene Yan, David Pocock, Simon Willison
+- Conference talks + write-ups
+- Technical RFC or discussion threads from maintainers
+
+**Example queries:**
+- Site:pocock.com OR site:willison.io "topic X"
+- "topic X" engineering blog OR "lessons learned" site:anthropic.com OR site:openai.com
+- "topic X" expert OR specialist OR practitioner (time-limited to last 6 months)
+
+### Channel 3: Data
+**Quantitative data / research** — arxiv papers, conference papers, benchmark numbers, published metrics.
+
+**Where to look:** arxiv.org, ACM Digital Library, Papers With Code, GitHub repo benchmarks, published research, performance comparisons with citations.
+
+**Example queries:**
+- Site:arxiv.org "topic X" (YYYY-YYYY)
+- "topic X" benchmark OR performance evaluation OR measurement study
+- "topic X" empirical study OR systematic review
+- Site:paperswithcode.com "topic X"
+
+### Channel 4: Adversarial
+**Failure modes & criticism** — post-mortems, GitHub issues, "X considered harmful" pieces, retrospectives, why something failed.
+
+**Where to look:** Post-mortem archives (PostmortemDB, GitHub issue threads), retrospectives, "lessons learned" + negative outcomes, abandoned projects + why, critical technical discussions, conference talks on failures.
+
+**Example queries:**
+- "topic X" post-mortem OR postmortem OR "what went wrong"
+- "topic X" considered harmful OR critique OR "lessons learned from failure"
+- Site:github.com "topic X" wontfix OR closed issues (looking for patterns)
+- Abandoned "topic X" OR "deprecated" OR "no longer using"
+
+## Scope
+
+**New research only.** This 4-channel protocol applies to research initiated after this decision. Existing research-pass-style memories (e.g. `research_aihero_principles`, `research_deep_dive_synthesis_2026_05_06`) are grandfathered — no retrofit required. They serve as reference; future research on related topics will apply the protocol fresh.
+
+## Pipeline
+
+### 1. Determine the question(s)
+
+**Topic supplied:** classify it.
+- **Decision validation** â focus on trade-offs, risks, real-world experience.
+- **Knowledge gap** â authoritative explanations, practical examples.
+- **Comparison** â objective criteria, benchmarks, community consensus.
+
+**No topic (discovery):** load context first.
+
+```
+memory_recall(type="decision", limit=10)
+memory_recall(query="working_state", type="project", limit=3)
+```
+
+Also scan recent GitHub issues for each repo in `config/repos.conf`.
+
+Find genuine gaps from that context:
+- Problems flagged as unsolved
+- Decisions made without sufficient research
+- Patterns that keep breaking
+- Capabilities mentioned but not explored
+
+Score `impact Ã— urgency`. Pick **top 3**. Each becomes a specific, concrete research question. Bad: "research AI agents". Good: "how do iterative planners detect premature convergence?"
+
+### 2. Search
+
+Primary: `firecrawl_search(query="<topic>", limit=3)`.
+Fallback: `WebSearch` if Firecrawl unavailable.
+
+Per topic: 2-3 searches with different angles. Preview results with `head -c 4000`.
+
+Prioritize: official docs, reputable blogs, GitHub discussions, benchmarks.
+Skip: SEO spam, articles >2 years old for fast-moving topics.
+
+For highly relevant results: `firecrawl_scrape(url=<url>, formats=["markdown"], onlyMainContent=true)` â max 2 scrapes per topic.
+
+### 3. Analyze
+
+1. Claims in multiple independent sources = strong signal
+2. Note contradictions between sources
+3. Distinguish facts (documented, benchmarked) from opinions
+4. For technical decisions: real-world usage at similar scale
+5. **Channel gaps:** if a channel yields <2 sources, flag in output and propose owner waiver or extended search
+
+### 4. Output
+
+One report per topic (single report when topic supplied, three when discovery):
+
+```markdown
+## Summary
+One paragraph, lead with recommendation if it's a decision.
+
+## Key Findings
+- **Finding** â explanation [source]
+
+## Trade-offs & Risks
+- **Risk** â when it matters, mitigation
+
+## Alternatives
+- **Alternative** â why rejected or when better
+
+## Sources
+1. [Title](URL) â what it contributed
+
+## Confidence: N/100
+One sentence: what makes this confident or uncertain.
+```
+
+### 5. Save
+
+Save to Supabase if finding is significant:
+
+```
+memory_store(type="reference", name="research_{slug}", description="...", content="...", source_provenance="skill:research")
+```
+
+If finding is actionable â create GitHub issue in appropriate repo:
+
+```
+gh issue create --repo <R> --title "[RESEARCH] <topic>" --body "..."
+```
+
+**Discovery-only**: also write a dedup marker so the next scheduled run doesn't repeat topics:
+
+```
+memory_store(type="project", name="research_last_run", content="{date} â topics: {t1}, {t2}, {t3}", source_provenance="skill:research")
+```
+
+Check for duplicate research-spawned issues before creating new ones.
+
+### 6. Remove `needs-research` on success
+
+When `/research` was triggered against a specific issue carrying the `needs-research` label and the research produces an actionable answer (recommendation written into the issue, decision recorded, or follow-up issue created), remove the label as the final terminal step:
+
+```bash
+gh issue edit <N> --repo <owner/repo> --remove-label "needs-research"
+```
+
+This is the contract that lets `/delegate`'s pre-dispatch gate (issue #642) trust that an unlabelled issue is genuinely research-clean. Skipping the removal leaves the issue stuck in `status:owner-queue` forever. If `/research` exits without a confident answer (confidence <50), leave the label in place — the issue still needs work.
+
+
+## Quality rules
+
+- Non-trivial claims: 3+ independent sources when available
+- Every finding references specific sources, with channel attribution
+- Source conflicts â list both sides
+- Call out unknowns and weak evidence
+- If confidence <50 â recommend follow-up

--- a/.claude-userlevel/skills/to-issues/SKILL.md
+++ b/.claude-userlevel/skills/to-issues/SKILL.md
@@ -31,6 +31,24 @@ Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an
 - Prefer many thin slices over few thick ones
 </vertical-slice-rules>
 
+### 3a. AFK-fit checklist (apply per slice, decides `sandcastle` label)
+
+For each slice, answer four questions. Any "yes" ⇒ slice is **NOT** AFK-safe ⇒ do **NOT** apply the `sandcastle` label ⇒ the slice routes through interactive `/implement` rather than `/delegate`. All four "no" ⇒ apply `sandcastle`.
+
+This checklist is the upstream pair of the `/delegate` pre-dispatch gate. The gate refuses dispatch when `sandcastle` is missing — `/to-issues` is the canonical place where the label gets applied (decision `6e753417`). Sandcastle label is **never applied manually** and **never applied by `/grill`** (slice issues don't exist at grill time).
+
+**Q1 — protected-zone intersection (static)**: do this slice's declared-changed files intersect any glob in the per-repo path-list at [`config/protected-paths.json`](../../../config/protected-paths.json)? Mechanical check via [`scripts/to_issues_afk_fit.py`](../../../scripts/to_issues_afk_fit.py) — call `intersects_protected(declared_files, repo, config)`. If yes → AFK-no, q2-4 are moot. Unknown repo ⇒ no static match ⇒ fall through to LLM judgement below; flag "unknown repo, judge manually" in the slice notes.
+
+**Q2 — session-context dependency (LLM)**: does the slice require memory or session context beyond what the issue AC literally carries — e.g. "we already decided X in last week's grill" — to be implementable? If a fresh coding session reading only the AC would diverge from intent, AFK-no.
+
+**Q3 — mid-execution judgement call (LLM)**: does the slice need a human judgement mid-implementation that no programmatic test can verify — e.g. "pick a sensible default timeout", "match the existing visual style"? AFK-yes only when the AC fully constrains the answer.
+
+**Q4 — cross-cutting / multi-repo / external-state (LLM)**: does the slice touch multiple repos, external services that need credentials beyond what the sandcastle image carries, or side effects (Telegram send, prod DB write, Stripe charge) that need owner confirmation? AFK-no.
+
+**Hard constraint** (issue #642): adding a **new** repo to the system means appending one entry to `config/protected-paths.json` — never editing this SKILL.md and never editing `scripts/to_issues_afk_fit.py`. The lookup is keyed by `owner/repo`.
+
+Record the AFK decision per slice (yes/no + the one question that flipped it, when applicable) so the quiz in §4 can show the owner *why* a slice is HITL.
+
 ### 4. Quiz the user
 
 Present the proposed breakdown as a numbered list. For each slice, show:
@@ -51,7 +69,13 @@ Iterate until the user approves the breakdown.
 
 ### 5. Publish the issues to the issue tracker
 
-For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below.
+
+**Label application at publish time**:
+
+- Slice passed AFK-fit checklist (all four "no") → apply the `sandcastle` label. This is the canonical place the label is set — see §3a, decision `6e753417`.
+- Slice failed AFK-fit (any "yes") → do **NOT** apply `sandcastle`. The slice routes via interactive `/implement` instead of `/delegate`.
+- Slice carries unresolved scope or unclear AC discovered during §3a → apply the matching `needs-*` label (`needs-grill`, `needs-research`, `needs-prd`). The requesting skill removes its own `needs-*` label at terminal success — `/grill` removes `needs-grill`, `/research` removes `needs-research`, `/to-prd` removes `needs-prd`. `/delegate`'s pre-dispatch gate refuses any issue carrying a `needs-*` label.
 
 Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
 

--- a/config/protected-paths.json
+++ b/config/protected-paths.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Per-repo path-list consumed by /to-issues AFK-fit checklist (#642). Adding a new repo MUST NOT require editing any SKILL.md — only this file. Paths are gitignore-style globs evaluated against an issue's declared-changed file list; an intersection ⇒ AFK-no ⇒ slice does NOT receive the `sandcastle` label and routes via interactive /implement. For jarvis the list mirrors docs/security/agent-boundaries.md (canonical Tier-2 surface) — sync manually when that file changes; a future task may automate. For redrobot the list captures the safety-critical zones called out in jarvis CLAUDE.md (driver/, planning/, mujoco/).",
+  "Osasuwu/jarvis": [
+    ".mcp.json",
+    "config/SOUL.md",
+    "CLAUDE.md",
+    "mcp-memory/server.py",
+    "mcp-memory/client.py",
+    "mcp-memory/embeddings.py",
+    "mcp-memory/tools_schema.py",
+    "mcp-memory/classifier.py",
+    "mcp-memory/episode_extractor.py",
+    "mcp-memory/handlers/**",
+    ".claude/settings.json",
+    ".gitleaks.toml",
+    ".pre-commit-config.yaml",
+    ".claude-userlevel/settings.json",
+    ".claude-userlevel/.mcp.json",
+    ".claude-userlevel/CLAUDE.md",
+    ".claude-userlevel/SOUL.md"
+  ],
+  "SergazyNarynov/redrobot": [
+    "driver/**",
+    "planning/**",
+    "mujoco/**"
+  ]
+}

--- a/scripts/delegate_predispatch_gate.py
+++ b/scripts/delegate_predispatch_gate.py
@@ -1,0 +1,81 @@
+"""Pre-dispatch gate for /delegate (issue #642).
+
+Refuses to dispatch a sandcastle subagent unless the target GitHub issue
+satisfies four readiness conditions:
+
+  1. has the `sandcastle` label
+  2. has no `needs-*` label
+  3. body contains a `## Acceptance criteria` heading (case-insensitive)
+  4. body cites at least one decision UUID
+
+The gate is invoked from the /delegate skill prose. Usage:
+
+  gh issue view <N> --repo <R> --json number,body,labels \\
+    | python scripts/delegate_predispatch_gate.py
+
+Exit code 0 ⇒ allow; exit code 1 ⇒ refuse. Decision text is on stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+
+_UUID_RE = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+_AC_HEADING_RE = re.compile(r"(?m)^##\s+acceptance\s+criteria\b", re.IGNORECASE)
+_NEEDS_PREFIX = "needs-"
+_REQUIRED_LABEL = "sandcastle"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    failures: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def allow(self) -> bool:
+        return not self.failures
+
+    @property
+    def message(self) -> str:
+        if self.allow:
+            return "OK"
+        return "REFUSE: " + "; ".join(self.failures)
+
+
+def check_issue(issue: dict) -> GateResult:
+    failures: list[str] = []
+
+    label_names = {label.get("name", "") for label in (issue.get("labels") or [])}
+    body = issue.get("body") or ""
+
+    if _REQUIRED_LABEL not in label_names:
+        failures.append(f"missing required label `{_REQUIRED_LABEL}`")
+
+    needs = sorted(n for n in label_names if n.startswith(_NEEDS_PREFIX))
+    if needs:
+        failures.append(f"blocked by needs-* label(s): {', '.join(needs)}")
+
+    if not _AC_HEADING_RE.search(body):
+        failures.append("missing `## Acceptance criteria` section in body")
+
+    if not _UUID_RE.search(body):
+        failures.append("missing decision UUID reference in body")
+
+    return GateResult(failures=tuple(failures))
+
+
+def main(argv: list[str] | None = None) -> int:
+    payload = sys.stdin.read()
+    issue = json.loads(payload)
+    result = check_issue(issue)
+    print(result.message)
+    return 0 if result.allow else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/to_issues_afk_fit.py
+++ b/scripts/to_issues_afk_fit.py
@@ -1,0 +1,72 @@
+"""AFK-fit static path-grep helper for /to-issues (issue #642).
+
+The /to-issues AFK-fit checklist has four questions. Question 1 is static
+and lives here: do the slice's declared-changed files intersect any
+protected/safety-critical glob from the per-repo list in
+``config/protected-paths.json``?
+
+Questions 2-4 are LLM-judgement and live as prose in /to-issues SKILL.md.
+
+Adding a new repo to the system means adding an entry to the JSON config —
+never editing this module or any SKILL.md (issue #642 hard constraint).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+from pathlib import Path
+
+
+def load_protected_paths(path: str | Path) -> dict[str, list[str]]:
+    """Load the per-repo protected-path map from JSON.
+
+    Underscore-prefixed keys (`_comment`, etc.) are metadata and excluded.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return {k: list(v) for k, v in data.items() if not k.startswith("_")}
+
+
+def intersects_protected(
+    declared_files: list[str],
+    repo: str,
+    config: dict[str, list[str]],
+) -> list[str]:
+    """Return the subset of ``declared_files`` that match a protected glob.
+
+    Globs follow gitignore-style semantics translated into fnmatch — the leading
+    ``**/`` is implicit (we match against the repo-relative path). Unknown
+    repos return an empty list by design (fail-open); /to-issues prose must
+    surface "unknown repo" as a manual judgement prompt instead.
+    """
+    globs = config.get(repo, [])
+    if not globs:
+        return []
+
+    matched: list[str] = []
+    for declared in declared_files:
+        norm = declared.replace("\\", "/")
+        if norm.startswith("./"):
+            norm = norm[2:]
+        for glob in globs:
+            if _matches(norm, glob):
+                matched.append(declared)
+                break
+    return matched
+
+
+def _matches(path: str, glob: str) -> bool:
+    """fnmatch with `**` expanded to mean 'any depth'."""
+    # fnmatch treats `**` as `*` (no recursion). Translate explicit `prefix/**`
+    # into "starts with prefix/".
+    if glob.endswith("/**"):
+        prefix = glob[:-3].rstrip("/")
+        return path == prefix or path.startswith(prefix + "/")
+    if "/**/" in glob:
+        head, tail = glob.split("/**/", 1)
+        if not path.startswith(head + "/"):
+            return False
+        return fnmatch.fnmatchcase(path[len(head) + 1 :], "*/" + tail) or fnmatch.fnmatchcase(
+            path[len(head) + 1 :], tail
+        )
+    return fnmatch.fnmatchcase(path, glob)

--- a/tests/test_delegate_predispatch_gate.py
+++ b/tests/test_delegate_predispatch_gate.py
@@ -1,0 +1,211 @@
+"""Tests for scripts/delegate_predispatch_gate.py.
+
+Reference implementation of the /delegate pre-dispatch gate (issue #642).
+The gate refuses to dispatch a sandcastle subagent unless all four readiness
+conditions hold for the target issue.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+gate = importlib.import_module("delegate_predispatch_gate")
+check_issue = gate.check_issue
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+VALID_UUID = "6b0a5bf7-8ca9-47cc-81cf-ebae39c81d08"
+VALID_BODY = (
+    f"## Acceptance criteria\n- [ ] do thing\n- [ ] do other thing\n\nDecisions: {VALID_UUID}\n"
+)
+
+
+def _issue(body: str = VALID_BODY, labels: tuple[str, ...] = ("sandcastle",), number: int = 999):
+    return {
+        "number": number,
+        "body": body,
+        "labels": [{"name": n} for n in labels],
+    }
+
+
+# ── Allow path ──────────────────────────────────────────────────────────────
+
+
+def test_allows_when_all_four_conditions_present():
+    result = check_issue(_issue())
+    assert result.allow
+    assert result.message == "OK"
+    assert result.failures == ()
+
+
+def test_acceptance_criteria_heading_is_case_insensitive():
+    body = f"## ACCEPTANCE CRITERIA\n- [ ] x\n{VALID_UUID}"
+    assert check_issue(_issue(body=body)).allow
+
+
+def test_acceptance_criteria_heading_with_suffix_words_matches():
+    body = f"## Acceptance criteria (brief)\n- [ ] x\n{VALID_UUID}"
+    assert check_issue(_issue(body=body)).allow
+
+
+def test_uuid_anywhere_in_body_satisfies():
+    body = f"some prose {VALID_UUID} more prose\n## Acceptance criteria\n- [ ] x\n"
+    assert check_issue(_issue(body=body)).allow
+
+
+# ── Refusal: missing sandcastle label ───────────────────────────────────────
+
+
+def test_refuses_when_sandcastle_label_missing():
+    result = check_issue(_issue(labels=()))
+    assert not result.allow
+    assert "sandcastle" in result.message
+
+
+def test_refuses_when_only_unrelated_labels_present():
+    result = check_issue(_issue(labels=("task", "area:skills")))
+    assert not result.allow
+    assert "sandcastle" in result.message
+
+
+# ── Refusal: needs-* labels ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "needs_label",
+    ["needs-grill", "needs-research", "needs-prd", "needs-refactor"],
+)
+def test_refuses_when_any_needs_label_present(needs_label):
+    result = check_issue(_issue(labels=("sandcastle", needs_label)))
+    assert not result.allow
+    assert needs_label in result.message
+
+
+def test_refuses_on_unknown_needs_prefix_too():
+    """Future-proof: any needs-* label, not only the enumerated four."""
+    result = check_issue(_issue(labels=("sandcastle", "needs-design")))
+    assert not result.allow
+    assert "needs-design" in result.message
+
+
+# ── Refusal: missing ## Acceptance criteria heading ─────────────────────────
+
+
+def test_refuses_when_acceptance_criteria_section_missing():
+    body = f"Some body without the heading. {VALID_UUID}"
+    result = check_issue(_issue(body=body))
+    assert not result.allow
+    assert "Acceptance criteria" in result.message
+
+
+def test_refuses_when_acceptance_criteria_only_inline_text_not_a_heading():
+    body = f"acceptance criteria: do thing. {VALID_UUID}"
+    result = check_issue(_issue(body=body))
+    assert not result.allow
+
+
+def test_refuses_when_heading_wrong_level():
+    body = f"### Acceptance criteria\n- [ ] x\n{VALID_UUID}"
+    result = check_issue(_issue(body=body))
+    assert not result.allow
+
+
+# ── Refusal: missing decision UUID ──────────────────────────────────────────
+
+
+def test_refuses_when_no_uuid_anywhere():
+    body = "## Acceptance criteria\n- [ ] do thing"
+    result = check_issue(_issue(body=body))
+    assert not result.allow
+    assert "decision UUID" in result.message
+
+
+def test_refuses_on_non_canonical_uuid_shape():
+    body = "## Acceptance criteria\n- [ ] x\nsee abc12345-not-real-shape\n"
+    result = check_issue(_issue(body=body))
+    assert not result.allow
+    assert "decision UUID" in result.message
+
+
+# ── Multiple failures: all are reported ─────────────────────────────────────
+
+
+def test_refuses_lists_all_failures_when_everything_missing():
+    result = check_issue(_issue(body="", labels=()))
+    assert not result.allow
+    # All four readiness gaps should be present in the message
+    assert "sandcastle" in result.message
+    assert "Acceptance criteria" in result.message
+    assert "decision UUID" in result.message
+    assert len(result.failures) == 3  # no needs-* label here, so only 3
+
+
+def test_refuses_with_three_simultaneous_gaps_and_needs_label():
+    result = check_issue(_issue(body="", labels=("needs-grill",)))
+    assert not result.allow
+    assert len(result.failures) == 4
+    assert "sandcastle" in result.message
+    assert "needs-grill" in result.message
+    assert "Acceptance criteria" in result.message
+    assert "decision UUID" in result.message
+
+
+# ── Edge cases ──────────────────────────────────────────────────────────────
+
+
+def test_handles_null_body():
+    issue = {"number": 1, "labels": [{"name": "sandcastle"}], "body": None}
+    result = check_issue(issue)
+    assert not result.allow
+
+
+def test_handles_missing_body_key():
+    issue = {"number": 1, "labels": [{"name": "sandcastle"}]}
+    result = check_issue(issue)
+    assert not result.allow
+
+
+def test_handles_missing_labels_key():
+    issue = {"number": 1, "body": VALID_BODY}
+    result = check_issue(issue)
+    assert not result.allow  # no sandcastle label
+
+
+# ── CLI smoke (stdin JSON → exit code) ──────────────────────────────────────
+
+
+def test_main_returns_zero_on_allow(monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", _StringStream(json.dumps(_issue())))
+    rc = gate.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "OK" in out
+
+
+def test_main_returns_nonzero_on_refuse(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "sys.stdin",
+        _StringStream(json.dumps(_issue(body="", labels=()))),
+    )
+    rc = gate.main([])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "REFUSE" in out
+    assert "sandcastle" in out
+
+
+class _StringStream:
+    """Minimal sys.stdin stub for the CLI test."""
+
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    def read(self) -> str:
+        return self._payload

--- a/tests/test_to_issues_afk_fit.py
+++ b/tests/test_to_issues_afk_fit.py
@@ -1,0 +1,175 @@
+"""Tests for scripts/to_issues_afk_fit.py — AFK-fit static check (issue #642).
+
+The full AFK-fit checklist has four questions (1 static, 3 LLM-judgement).
+This module covers question 1 only: does any declared-changed file match a
+protected-path glob from the per-repo list in config/protected-paths.json?
+
+Tests use synthetic config dicts to avoid coupling to the live JSON shape.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+afk_fit = importlib.import_module("to_issues_afk_fit")
+
+intersects_protected = afk_fit.intersects_protected
+load_protected_paths = afk_fit.load_protected_paths
+
+
+# ── Synthetic config used across tests ──────────────────────────────────────
+
+
+SYNTHETIC_CONFIG = {
+    "Osasuwu/jarvis": [
+        ".mcp.json",
+        "config/SOUL.md",
+        "mcp-memory/handlers/**",
+        ".pre-commit-config.yaml",
+    ],
+    "SergazyNarynov/redrobot": [
+        "driver/**",
+        "planning/**",
+    ],
+}
+
+
+# ── Allow path (no intersection) ────────────────────────────────────────────
+
+
+def test_no_intersection_when_files_outside_protected_zone():
+    matched = intersects_protected(
+        ["docs/foo.md", "src/bar.py"],
+        repo="Osasuwu/jarvis",
+        config=SYNTHETIC_CONFIG,
+    )
+    assert matched == []
+
+
+def test_no_intersection_for_empty_declared_list():
+    matched = intersects_protected([], repo="Osasuwu/jarvis", config=SYNTHETIC_CONFIG)
+    assert matched == []
+
+
+# ── Refusal path (intersection) ─────────────────────────────────────────────
+
+
+def test_intersection_on_literal_file_match():
+    matched = intersects_protected([".mcp.json"], repo="Osasuwu/jarvis", config=SYNTHETIC_CONFIG)
+    assert matched == [".mcp.json"]
+
+
+def test_intersection_on_glob_match():
+    matched = intersects_protected(
+        ["mcp-memory/handlers/foo.py"],
+        repo="Osasuwu/jarvis",
+        config=SYNTHETIC_CONFIG,
+    )
+    assert "mcp-memory/handlers/foo.py" in matched
+
+
+def test_intersection_on_nested_glob_match():
+    matched = intersects_protected(
+        ["mcp-memory/handlers/sub/bar.py"],
+        repo="Osasuwu/jarvis",
+        config=SYNTHETIC_CONFIG,
+    )
+    assert "mcp-memory/handlers/sub/bar.py" in matched
+
+
+def test_intersection_returns_all_matching_files():
+    matched = intersects_protected(
+        [".mcp.json", "docs/safe.md", "config/SOUL.md", "other/file.py"],
+        repo="Osasuwu/jarvis",
+        config=SYNTHETIC_CONFIG,
+    )
+    assert set(matched) == {".mcp.json", "config/SOUL.md"}
+
+
+def test_intersection_for_redrobot_safety_zones():
+    matched = intersects_protected(
+        ["driver/main.py", "ui/page.tsx"],
+        repo="SergazyNarynov/redrobot",
+        config=SYNTHETIC_CONFIG,
+    )
+    assert matched == ["driver/main.py"]
+
+
+# ── Repo lookup semantics ───────────────────────────────────────────────────
+
+
+def test_unknown_repo_returns_no_intersection_by_default():
+    """An unlisted repo has no protected-paths entry — AFK-yes by default.
+
+    Failing closed (treating unknown as protected) would block any new repo
+    until edited; AC explicitly says adding a new repo MUST NOT require
+    editing the SKILL.md, so failing open with a clear marker is right.
+    The skill prose must surface 'unknown repo' as an LLM-judgement prompt.
+    """
+    matched = intersects_protected([".mcp.json"], repo="Unknown/repo", config=SYNTHETIC_CONFIG)
+    assert matched == []
+
+
+def test_repo_with_empty_glob_list_returns_no_intersection():
+    config = {"Some/repo": []}
+    matched = intersects_protected([".mcp.json"], repo="Some/repo", config=config)
+    assert matched == []
+
+
+# ── Load from JSON file ─────────────────────────────────────────────────────
+
+
+def test_load_protected_paths_skips_underscore_keys(tmp_path):
+    """The `_comment` key in the canonical JSON is metadata, not a repo entry."""
+    path = tmp_path / "paths.json"
+    path.write_text(
+        json.dumps(
+            {
+                "_comment": "explanatory metadata",
+                "Owner/repo": [".mcp.json"],
+            }
+        )
+    )
+    config = load_protected_paths(path)
+    assert "_comment" not in config
+    assert config == {"Owner/repo": [".mcp.json"]}
+
+
+def test_load_protected_paths_real_config_has_both_repos():
+    """Smoke against the actual config/protected-paths.json shipped with this PR."""
+    repo_root = Path(__file__).resolve().parents[1]
+    config = load_protected_paths(repo_root / "config" / "protected-paths.json")
+    assert "Osasuwu/jarvis" in config
+    assert "SergazyNarynov/redrobot" in config
+    # Jarvis list must cover the canonical Tier-2 surface (sample check)
+    assert ".mcp.json" in config["Osasuwu/jarvis"]
+    assert "CLAUDE.md" in config["Osasuwu/jarvis"]
+    # Redrobot list must cover the documented safety-critical zones
+    assert any(p.startswith("driver/") for p in config["SergazyNarynov/redrobot"])
+
+
+def test_real_config_redrobot_blocks_driver_path():
+    repo_root = Path(__file__).resolve().parents[1]
+    config = load_protected_paths(repo_root / "config" / "protected-paths.json")
+    matched = intersects_protected(
+        ["driver/joint_controller.py"],
+        repo="SergazyNarynov/redrobot",
+        config=config,
+    )
+    assert matched == ["driver/joint_controller.py"]
+
+
+def test_real_config_jarvis_blocks_protected_file():
+    repo_root = Path(__file__).resolve().parents[1]
+    config = load_protected_paths(repo_root / "config" / "protected-paths.json")
+    matched = intersects_protected(
+        [".mcp.json", "docs/foo.md"],
+        repo="Osasuwu/jarvis",
+        config=config,
+    )
+    assert matched == [".mcp.json"]


### PR DESCRIPTION
## Summary

Adds the binary AFK-readiness check `/delegate` runs **before** spawning any sandcastle subagent. Headless `/delegate` has no operator to grill the AC in real time, so verifying readiness must happen at dispatch entry — not inside the dispatched agent (decision `6e753417`). Builds on the grill artefacts already in `CONTEXT.md` (committed [03be1e3](https://github.com/Osasuwu/jarvis/commit/03be1e3) from the 2026-05-17 grill).

Four mechanical checks (label / heading / regex — no judgement calls):

1. issue carries `sandcastle` label
2. issue has **no** `needs-*` label
3. body has `## Acceptance criteria` heading (case-insensitive)
4. body cites >=1 decision UUID

Any failure → `outcome_record(failure)` + `status:owner-queue` label + named refusal message on stdout. No Telegram (last-resort rule).

Closes #642.

## Why

Without the gate, `/delegate` could spawn a sandcastle agent on an under-specified issue. The agent then runs SOUL.md grill-checkbox *inside* the container — too late, no operator present, leads to vibe-coding under the hood (`subagent_acceptance_criteria_dodged_as_out_of_scope`, `subagent_test_coverage_overclaim`). Moving the check upstream of dispatch makes the failure visible to the owner via the `status:owner-queue` backlog instead of producing a partial PR three hours later.

## Decisions & Alternatives

All 7 grill decisions from 2026-05-17 are referenced in the issue body — implementation honours each:

- **Canonical implementation in Python (`scripts/delegate_predispatch_gate.py`)** instead of pure SKILL.md prose. Mirrors the `scripts/protected-files.py` pattern. Rejected: prose-only — drifts silently, can't smoke-test refusal semantics that the AC explicitly demands.
- **Per-repo path-list in `config/protected-paths.json`** (new file) instead of extending `repos.conf` with structured fields. Hard #642 constraint: adding a new repo MUST NOT require editing any SKILL.md. JSON keyed by `owner/repo` ⇒ append one entry, done. The jarvis list mirrors `docs/security/agent-boundaries.md`; redrobot lists `driver/`, `planning/`, `mujoco/` per CLAUDE.md.
- **`status:owner-queue` label colour `#F9A03C`** (warm amber). Distinct from `status:in-progress` (`#FBCA04` yellow), `status:ready` (`#C2E0C6` green), `status:blocked` (`#B60205` red). Signals "needs attention" without screaming "broken".
- **`/refactor` skipped from needs-* removal convention** — skill does not exist yet. Documented in `/grill` and `/research` SKILL.md only; the convention will land in `/refactor` SKILL.md when that skill ships.
- **AFK-fit Q1 fails open on unknown repos** (returns no intersection rather than blocking) — failing closed would force a SKILL.md edit every time a new repo is added, violating the hard constraint. Skill prose flags "unknown repo, judge manually" so the LLM-judgement portion handles it.

Trade-offs:
- **Gained**: deterministic, testable refusal; named missing elements; AFK-pipeline shielded from under-grilled issues; pre-dispatch dominance over the legacy grill-checkbox.
- **Gave up**: a single point of failure if `/delegate` is bypassed (decision `6b0a5bf7` — accepted fragility). If a future pipeline shortcut hands work directly to a subagent, the gate silently bypasses. Re-surface this risk in any architectural change touching dispatch.

## Risk Assessment

- **LOW**: 4 SKILL.md docs (`/delegate`, `/to-issues`, `/grill`, `/research`); `config/protected-paths.json` is new (no callers yet); two new pure Python helpers under `scripts/` with no project imports.
- **MEDIUM** (none here).
- **HIGH** (none — gate is gated to /delegate which is owner-driven; no autonomous loops touch this in v1).
- **CRITICAL** (none).

## Testing

- `python -m pytest tests/test_delegate_predispatch_gate.py tests/test_to_issues_afk_fit.py` → **36/36 passed**
  - 23 gate tests cover: allow path (4), missing sandcastle (2), needs-* (5), missing AC heading (3), missing UUID (2), multiple-failure aggregation (2), edge cases (3), CLI smoke (2)
  - 13 AFK-fit tests cover: allow path (2), intersection (5), repo lookup semantics (2), JSON loader (4)
- `python -m pytest tests/test_protected_files.py` → 44 passed (regression check on sibling module)
- `ruff check` clean, `ruff format` clean
- **Live label creation verified**: `gh label list` confirms `status:owner-queue` exists in both `Osasuwu/jarvis` and `SergazyNarynov/redrobot` with matching colour/description

**Manual end-to-end smoke** required from owner (per AC item 9): run `/delegate <N>` against synthetic issues missing each of the four elements in turn, verify the refusal message names the specific missing element and `status:owner-queue` was applied. Cannot be automated from inside Claude Code.

## M#41 Backfill (rollout step — owner action required)

Per AC item 11: before merging this PR, **owner must manually verify** that issues #633–#640 (any still open from M#41) carry `sandcastle` label + `## Acceptance criteria` section + >=1 decision UUID. If any are missing pieces, the gate will refuse them on next `/delegate` and they'll land in `status:owner-queue`.

Issues touched by this PR: **none** (#642 only — this slice creates the gate, doesn't backfill predecessors).

## Files Changed

- `.claude-userlevel/skills/delegate/SKILL.md` — new \"Pre-dispatch gate\" section + grill_required dominance note + claim-step pre-gate ordering
- `.claude-userlevel/skills/to-issues/SKILL.md` — new §3a \"AFK-fit checklist\" + §5 label application rule
- `.claude-userlevel/skills/grill/SKILL.md` — \"Remove \`needs-grill\` on success\" section
- `.claude-userlevel/skills/research/SKILL.md` — \"Remove \`needs-research\` on success\" section
- `config/protected-paths.json` — NEW; per-repo path-list, two entries (jarvis + redrobot)
- `scripts/delegate_predispatch_gate.py` — NEW; four-check gate as testable Python module + stdin CLI
- `scripts/to_issues_afk_fit.py` — NEW; q1 static path-grep helper
- `tests/test_delegate_predispatch_gate.py` — NEW; 23 tests
- `tests/test_to_issues_afk_fit.py` — NEW; 13 tests

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>