### PR TITLE
fix(install): don't kill installer on native-exe stderr under PowerShell

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -18,7 +18,13 @@ param(
     [switch]$SkipHealthCheck
 )
 
-$ErrorActionPreference = "Stop"
+# Note: NOT setting $ErrorActionPreference = "Stop" globally.
+# Under "Stop", a native exe writing to stderr (e.g. installer.py's
+# "quarantined orphan ..." messages) triggers a NativeCommandError that
+# terminates the script *before* `exit $LASTEXITCODE` runs — leaving the
+# install half-applied (.jarvis-version not written). The python child
+# process owns its own exit code; we propagate it explicitly below.
+# Get-Command calls below pass -ErrorAction Stop locally where needed.
 
 # Guard: detect GNU-style double-dash args (e.g. --apply) which PowerShell won't
 # bind correctly and will silently mis-route to $Target as a positional string.


### PR DESCRIPTION
## Summary

`install.ps1` set `$ErrorActionPreference = "Stop"` globally. Under that mode, any stderr write from a native exe is wrapped as a `NativeCommandError` *terminating* error — which aborts the wrapper before `exit $LASTEXITCODE` ever runs.

`scripts/install/installer.py` writes `quarantined orphan ...` lines to stderr (intentional progress signal, not failure). On a device that has orphan skills to prune, this killed the script *between* the quarantine action and `write_version`, leaving the install half-applied:

- old skills got renamed to `.bak.orphan` ✔
- `.jarvis-version` never updated ✘ (so next run is still "outdated")
- retry re-quarantined `.bak.orphan` → `.bak.orphan.bak.orphan`

Reproduced today on DESKTOP-1H2KOOJ after pulling main with new orphan skills.

## Fix

Drop the global `Stop`. The python child owns its exit code and we propagate it explicitly with `exit $LASTEXITCODE`. The local `-ErrorAction Stop` on `Get-Command python3` still guards the no-python case, and the GNU-double-dash guard uses explicit `exit 1` so it's unaffected.

## Test plan

- [x] `.\install.ps1` dry-run from `.venv` (Python 3.14): EXIT=0, no actions, state=current
- [x] Native-exe stderr no longer aborts script flow (verified with `python -c "print(..., file=sys.stderr)"` — `EXIT=0 ReachedEnd=YES` reached after stderr)
- [ ] Smoke on second device next time it pulls

🤖 Generated with [Claude Code](https://claude.com/claude-code)