### PR TITLE
fix(install): skip already-quarantined orphans in skill scan

### DIFF
--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -412,10 +412,15 @@ def build_plan(
             # and the destination already exists, anything under dest not in
             # the whitelist is a leftover from a previous install whose
             # source/manifest no longer lists it. Quarantine each leftover.
+            # Skip names containing `.bak.orphan` — they're already quarantined
+            # from a prior install; re-quarantining grows the suffix chain
+            # unboundedly (foo.bak.orphan → foo.bak.orphan.bak.orphan → ...).
             if include and dest.exists() and dest.is_dir():
                 allowed = set(include)
                 for child in sorted(dest.iterdir()):
                     if child.name in allowed:
+                        continue
+                    if ".bak.orphan" in child.name:
                         continue
                     actions.append(
                         Action(

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -399,6 +399,32 @@ def test_fresh_install_emits_no_orphan_actions(manifest: Path, fake_repo: Path) 
     assert not any(a.kind == "prune_orphan" for a in plan.actions)
 
 
+def test_orphan_scan_skips_already_quarantined_dirs(
+    manifest: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    """Already-quarantined `.bak.orphan` dirs must not be re-quarantined on next install.
+
+    Regression: without this filter, `foo.bak.orphan` becomes
+    `foo.bak.orphan.bak.orphan` on every outdated-state apply, growing
+    unboundedly. See issue/PR linked in the body.
+    """
+    m = installer.load_manifest(manifest)
+    installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
+    target = tmp_path / "claude_home"
+    # Two flavours of quarantine name: bare label and label-with-timestamp.
+    (target / "skills" / "deprecated-skill.bak.orphan").mkdir()
+    (target / "skills" / "deprecated-skill.bak.orphan" / "SKILL.md").write_text(
+        "# already quarantined\n", encoding="utf-8"
+    )
+    (target / "skills" / "other.bak.orphan-20260101-120000").mkdir()
+    (target / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+
+    plan = installer.build_plan(m, fake_repo)
+    orphan_sources = [Path(a.source).name for a in plan.actions if a.kind == "prune_orphan"]
+    assert "deprecated-skill.bak.orphan" not in orphan_sources
+    assert "other.bak.orphan-20260101-120000" not in orphan_sources
+
+
 def test_directory_without_include_skips_orphan_check(
     manifest: Path, fake_repo: Path, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Fixes #704

## Summary
- Orphan-detection loop in `build_plan` quarantined any child of an `include`-pinned dest that wasn't in the whitelist — including names that were *already* quarantined `.bak.orphan` dirs from a previous install.
- Each outdated-state apply extended the suffix: `foo.bak.orphan` → `foo.bak.orphan.bak.orphan` → ... (unbounded growth).
- Fix: filter `.bak.orphan` from orphan scanning before emitting `prune_orphan`. Existing quarantines stay where they are; user can delete them manually.

## Manual repro (pre-fix)
1. `.claude/skills/foo.bak.orphan/` left over from a prior install.
2. Bump HEAD so `.jarvis-version` differs → state goes `outdated`.
3. `install.ps1 -Apply` → installer renames `foo.bak.orphan` to `foo.bak.orphan.bak.orphan`.

## Test plan
- [x] New unit test `test_orphan_scan_skips_already_quarantined_dirs` — bare `.bak.orphan` and timestamped `.bak.orphan-<ts>` variants both skipped.
- [x] Failed pre-fix (chain growth observable), passes post-fix.
- [x] Full installer suite (80 tests across `tests/test_installer.py` + `tests/install/test_installer.py`) green.
- [x] No change to quarantine semantics for fresh orphans (`test_build_plan_emits_prune_orphan_for_stale_skill_dir` still passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)