### PR TITLE
feat(sandcastle): -Tier2AsPrimary switch + widen AFK windows to 18-08 (#711)

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -21,7 +21,7 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 # Restart Ollama with `OLLAMA_CONTEXT_LENGTH=65536` (server-side env var)
 # before running, or smaller models will silently bail to <promise>COMPLETE</promise>
 # without invoking tools because the system prompt gets truncated.
-OLLAMA_MODEL=qwen2.5-coder:14b
+OLLAMA_MODEL=qwen3-coder:30b
 
 # GitHub token forwarded to the container so the agent can claim issues +
 # open PRs. Use a fine-grained PAT scoped to this repo (Issues: RW, PRs: RW,

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -19,7 +19,7 @@ import { dirname } from "node:path";
 const agentModel =
   process.env.SANDCASTLE_AGENT_MODEL ??
   process.env.OLLAMA_MODEL ??
-  "qwen2.5-coder:14b";
+  "qwen3-coder:30b";
 const agentBaseUrl =
   process.env.SANDCASTLE_AGENT_BASE_URL ??
   process.env.OLLAMA_BASE_URL ??

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -32,17 +32,23 @@
 
 .PARAMETER Model
     Tier 0 Ollama model. Default flipped from qwen2.5-coder:14b → qwen3-coder:30b
-    on 2026-05-14: 14b failed the tool_use fidelity probe (emits skill dispatch as
-    markdown JSON text through Ollama's Anthropic shim — see memory
-    ollama_bench_must_measure_tool_use_fidelity). 30b passes the probe with
-    structured tool_use blocks at 43 tok/s warm.
+    on 2026-05-14 to track the #538 benchmark winner. Both models still fail the
+    real-Claude-Code tool_use fidelity probe (14b: markdown JSON fence;
+    30b: Hermes-XML — see memory ollama_bench_must_measure_tool_use_fidelity),
+    which is why AFK scheduled tasks use -Tier2AsPrimary to bypass the Ollama
+    chain entirely; this parameter only matters for interactive smoke runs
+    that opt back into the local chain.
 
 .PARAMETER Tier1Model
     Tier 1 OOM-downgrade Ollama model. Defaults from #538: qwen2.5-coder:7b.
 
 .PARAMETER Tier2Provider
-    Empty (default) = no remote-API escalation in cron context. Set to
-    deepseek or claude only when explicitly enabling Tier 2 for AFK runs.
+    deepseek (default) routes AFK runs through DeepSeek's Anthropic-compatible
+    endpoint as Tier 2 primary (paired with the auto-appended -Tier2AsPrimary
+    on Run-Sandcastle.ps1). Pass an empty string to disable Tier 2 entirely
+    (interactive Ollama-only smoke runs). Set to claude to use the Anthropic
+    API key from .env instead (carries Max-subscription quota risk -- prefer
+    deepseek for unattended cron).
 
 .PARAMETER RepoRoot
     Filesystem path to the target repo. Defaults to the jarvis repo discovered

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -7,9 +7,12 @@
 .DESCRIPTION
     Slices #545 (jarvis) and #546 (redrobot). The task fires Run-Sandcastle.ps1
     nightly inside the chosen safe-hours window:
-        jarvis   : 22:00 → soft-stop at 02:00
-        redrobot : 02:00 → soft-stop at 08:00
-    Non-overlapping schedule prevents two Ollama jobs from contending for VRAM.
+        jarvis   : 18:00 → soft-stop at 01:00  (7h)
+        redrobot : 01:00 → soft-stop at 08:00  (7h)
+    Non-overlapping schedule covers all non-working hours (18 → 08) end-to-end.
+    Earlier 22:00 / 02:00 defaults were Ollama-VRAM-contention-driven; with
+    Tier 2-as-primary (#711) the local Ollama is bypassed in AFK runs, so the
+    contention constraint no longer applies and the windows can grow.
 
     The script must run on the Workshop PC (decision 4890aa35 -- Workshop = prod,
     Main = dev/test bench). On other devices the script refuses unless -Force.
@@ -19,12 +22,12 @@
 
 .PARAMETER StartTime
     Override the default start time. Default per-repo:
-        jarvis   = 22:00
-        redrobot = 02:00
+        jarvis   = 18:00
+        redrobot = 01:00
 
 .PARAMETER WindowEnd
     Override the soft-stop boundary passed to Run-Sandcastle.ps1. Default per-repo:
-        jarvis   = 02:00
+        jarvis   = 01:00
         redrobot = 08:00
 
 .PARAMETER Model
@@ -54,11 +57,11 @@
 
 .EXAMPLE
     .\Register-SandcastleTask.ps1 -Repo jarvis
-    # Registers Sandcastle-Jarvis daily at 22:00.
+    # Registers Sandcastle-Jarvis daily at 18:00, soft-stop 01:00.
 
 .EXAMPLE
     .\Register-SandcastleTask.ps1 -Repo redrobot -RepoRoot D:\Github\redrobot\redrobot
-    # Registers Sandcastle-Redrobot daily at 02:00 (non-overlapping).
+    # Registers Sandcastle-Redrobot daily at 01:00, soft-stop 08:00 (non-overlapping).
 #>
 [CmdletBinding()]
 param(
@@ -112,8 +115,8 @@ if (-not $Force -and $currentDevice -ne $expectedDevice) {
 # ---------------------------------------------------------------------------
 
 $defaults = @{
-    jarvis   = @{ Start = '22:00'; End = '02:00'; TaskName = 'Sandcastle-Jarvis' }
-    redrobot = @{ Start = '02:00'; End = '08:00'; TaskName = 'Sandcastle-Redrobot' }
+    jarvis   = @{ Start = '18:00'; End = '01:00'; TaskName = 'Sandcastle-Jarvis' }
+    redrobot = @{ Start = '01:00'; End = '08:00'; TaskName = 'Sandcastle-Redrobot' }
 }
 
 if (-not $StartTime) { $StartTime = $defaults[$Repo].Start }
@@ -210,7 +213,7 @@ $settings = New-ScheduledTaskSettingsSet `
     -DontStopIfGoingOnBatteries `
     -StartWhenAvailable `
     -MultipleInstances IgnoreNew `
-    -ExecutionTimeLimit ([timespan]::FromHours(6))
+    -ExecutionTimeLimit ([timespan]::FromHours(8))
 
 # ---------------------------------------------------------------------------
 # Register (idempotent).

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -28,7 +28,11 @@
         redrobot = 08:00
 
 .PARAMETER Model
-    Tier 0 Ollama model. Defaults from #538 decision 58670ea5: qwen2.5-coder:14b.
+    Tier 0 Ollama model. Default flipped from qwen2.5-coder:14b → qwen3-coder:30b
+    on 2026-05-14: 14b failed the tool_use fidelity probe (emits skill dispatch as
+    markdown JSON text through Ollama's Anthropic shim — see memory
+    ollama_bench_must_measure_tool_use_fidelity). 30b passes the probe with
+    structured tool_use blocks at 43 tok/s warm.
 
 .PARAMETER Tier1Model
     Tier 1 OOM-downgrade Ollama model. Defaults from #538: qwen2.5-coder:7b.
@@ -66,12 +70,12 @@ param(
 
     [string]$WindowEnd,
 
-    [string]$Model = 'qwen2.5-coder:14b',
+    [string]$Model = 'qwen3-coder:30b',
 
     [string]$Tier1Model = 'qwen2.5-coder:7b',
 
     [ValidateSet('', 'deepseek', 'claude')]
-    [string]$Tier2Provider = '',
+    [string]$Tier2Provider = 'deepseek',
 
     [string]$RepoRoot,
 
@@ -172,7 +176,13 @@ $argParts = @(
     '-WindowEnd', $WindowEnd
 )
 if ($Tier1Model)    { $argParts += @('-Tier1Model', $Tier1Model) }
-if ($Tier2Provider) { $argParts += @('-Tier2Provider', $Tier2Provider) }
+if ($Tier2Provider) {
+    $argParts += @('-Tier2Provider', $Tier2Provider)
+    # 2026-05-14: Tier 2 runs as primary for AFK scheduled tasks. Local Ollama
+    # tiers fail the real-Claude-Code tool_use fidelity check on qwen2.5-coder:14b
+    # and qwen3-coder:30b — see memory ollama_bench_must_measure_tool_use_fidelity.
+    $argParts += '-Tier2AsPrimary'
+}
 
 $action = New-ScheduledTaskAction -Execute $pwshExe `
     -Argument ($argParts -join ' ') `

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -43,6 +43,12 @@ param(
     [ValidateSet('', 'deepseek', 'claude')]
     [string]$Tier2Provider = '',
 
+    # 2026-05-14: skip Tier 0/1 Ollama and run Tier 2 as primary. Local Ollama
+    # models fail the real-Claude-Code tool_use fidelity check (memory
+    # ollama_bench_must_measure_tool_use_fidelity). Recommended for AFK runs;
+    # the OOM-escalation chain stays available when this flag is off.
+    [switch]$Tier2AsPrimary,
+
     # Runtime-dir retention: keep the N most-recent .sandcastle/runtime/<stamp>/
     # directories on watchdog entry, prune older ones. -1 disables the sweep.
     # Env var SANDCASTLE_RUNTIME_RETENTION overrides this if set (#572).
@@ -587,6 +593,12 @@ function Invoke-Watchdog {
         # Slice 5 (#543) tier overrides; empty disables the corresponding tier.
         [string]$Tier1Model,
         [string]$Tier2Provider,
+        # 2026-05-14: when set, skip Tier 0/1 Ollama entirely and run Tier 2
+        # (DeepSeek / Anthropic API) as the primary invocation. Local Ollama
+        # models fail the real-Claude-Code tool_use fidelity check — see memory
+        # ollama_bench_must_measure_tool_use_fidelity. Default $false preserves
+        # the original OOM-escalation chain used by existing tests.
+        [switch]$Tier2AsPrimary,
         # #572: runtime-dir retention; env var SANDCASTLE_RUNTIME_RETENTION wins.
         [int]$RuntimeRetention = 30
     )
@@ -652,22 +664,43 @@ function Invoke-Watchdog {
         }
     }
 
-    # 2. Ollama
-    if (-not (Test-OllamaRunning)) {
-        Write-Host "[watchdog] Ollama not running -- autostarting."
-        Start-OllamaServer
-        if (-not (Wait-OllamaReady -TimeoutSec $OllamaTimeoutSec)) {
-            Record 'failure' "ollama-down: server not ready within ${OllamaTimeoutSec}s" @{} 'ollama-down'
-            throw "ollama-down: server did not come up within ${OllamaTimeoutSec}s"
-        }
-    }
-
-    # 3. Iterate (soft-stop on window expiry between iterations)
+    # 2. Resolve Tier 2 primary (DeepSeek / Anthropic API) — when set, the
+    #    watchdog skips local Ollama tiers entirely. Local Ollama failed the
+    #    real-Claude-Code tool_use fidelity check on qwen2.5-coder:14b (markdown
+    #    JSON fence) and qwen3-coder:30b (Hermes-XML) — see memory
+    #    ollama_bench_must_measure_tool_use_fidelity + smoke 2026-05-14. Remote
+    #    Anthropic-compat endpoints (DeepSeek native, Anthropic itself) emit
+    #    structured tool_use blocks reliably.
     $repoSlug = switch ($Repo) {
         'jarvis'   { 'Osasuwu/jarvis' }
         'redrobot' { 'SergazyNarynov/redrobot' }
         default    { '' }
     }
+    $tier2Primary = $null
+    if ($Tier2AsPrimary -and $Tier2Provider) {
+        $tier2Primary = Resolve-Tier2Config -Provider $Tier2Provider -Issue '' `
+            -RepoSlug $repoSlug -EnvVars $envVars
+        if (-not ($tier2Primary -and $tier2Primary.AuthToken)) {
+            Write-Warning "[watchdog] Tier 2 ($Tier2Provider) requested as primary but config incomplete (key missing) — falling back to local Ollama tiers."
+            $tier2Primary = $null
+        } else {
+            Write-Host "[watchdog] Tier 2 ($($tier2Primary.Provider): $($tier2Primary.Model)) is primary — Tier 0/1 Ollama disabled for this run."
+        }
+    }
+
+    # 3. Ollama (skipped when Tier 2 is primary — no local model will be invoked)
+    if (-not $tier2Primary) {
+        if (-not (Test-OllamaRunning)) {
+            Write-Host "[watchdog] Ollama not running -- autostarting."
+            Start-OllamaServer
+            if (-not (Wait-OllamaReady -TimeoutSec $OllamaTimeoutSec)) {
+                Record 'failure' "ollama-down: server not ready within ${OllamaTimeoutSec}s" @{} 'ollama-down'
+                throw "ollama-down: server did not come up within ${OllamaTimeoutSec}s"
+            }
+        }
+    }
+
+    # 4. Iterate (soft-stop on window expiry between iterations)
     $totalUsage = @{ input_tokens = 0; output_tokens = 0; cache_read_input_tokens = 0; cache_creation_input_tokens = 0; model = $Model }
     $allCommits = @()
     $branch = $null
@@ -684,16 +717,27 @@ function Invoke-Watchdog {
         $iter++
         Write-Host "[watchdog] iteration $iter/$MaxIterations"
 
-        # ----- Tier 0: primary Ollama model -----
-        $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $Model `
-            -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
-            -TargetIssue ''
-        $tierUsed = 'tier0'
-        $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
-        $oomDetected = (-not $invocation.ok) -and (Test-IsOOM -Reason $invocation.reason -LogFile $logFile)
+        if ($tier2Primary) {
+            # ----- Tier 2 primary: remote Anthropic-compat endpoint (DeepSeek / Anthropic API) -----
+            $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $tier2Primary.Model `
+                -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
+                -BaseUrl $tier2Primary.BaseUrl -AuthToken $tier2Primary.AuthToken `
+                -TargetIssue ''
+            $tierUsed = "tier2:$($tier2Primary.Provider)"
+            $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+            $oomDetected = $false
+        } else {
+            # ----- Tier 0: primary Ollama model -----
+            $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $Model `
+                -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
+                -TargetIssue ''
+            $tierUsed = 'tier0'
+            $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+            $oomDetected = (-not $invocation.ok) -and (Test-IsOOM -Reason $invocation.reason -LogFile $logFile)
+        }
 
-        # ----- Tier 1: smaller Ollama model on OOM/crash -----
-        if (-not $invocation.ok -and $Tier1Model -and $oomDetected) {
+        # ----- Tier 1: smaller Ollama model on OOM/crash (only when Tier 2 is NOT primary) -----
+        if (-not $tier2Primary -and -not $invocation.ok -and $Tier1Model -and $oomDetected) {
             Write-Host "[watchdog] Tier 0 OOM detected -- escalating to Tier 1 model: $Tier1Model"
             $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $Tier1Model `
                 -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
@@ -709,7 +753,7 @@ function Invoke-Watchdog {
         # and the chain still hasn't recovered. Tier 1 may have been skipped
         # entirely (no $Tier1Model) or it may have run and failed for any
         # reason -- both qualify per AC #3 ("persistent failure after Tier 1").
-        if (-not $invocation.ok -and $oomDetected -and $Tier2Provider) {
+        if (-not $tier2Primary -and -not $invocation.ok -and $oomDetected -and $Tier2Provider) {
             $tier2 = Resolve-Tier2Config -Provider $Tier2Provider -Issue $targetIssue `
                 -RepoSlug $repoSlug -EnvVars $envVars
             if ($tier2 -and $tier2.AuthToken) {
@@ -778,5 +822,6 @@ if (-not $NoExecute -and $Repo) {
         -WindowEnd $WindowEnd -DockerTimeoutSec $DockerTimeoutSec `
         -OllamaTimeoutSec $OllamaTimeoutSec `
         -Tier1Model $Tier1Model -Tier2Provider $Tier2Provider `
+        -Tier2AsPrimary:$Tier2AsPrimary `
         -RuntimeRetention $RuntimeRetention
 }

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -678,7 +678,11 @@ function Invoke-Watchdog {
     }
     $tier2Primary = $null
     if ($Tier2AsPrimary -and $Tier2Provider) {
-        $tier2Primary = Resolve-Tier2Config -Provider $Tier2Provider -Issue '' `
+        # -Issue 0 == "no issue picked yet" -- Get-IssueLabels short-circuits to
+        # @() in that case, so the use-claude-api flip stays issue-scoped.
+        # Using 0 (explicit int) avoids the parser quirk of empty-string-to-int
+        # coercion that varies across PowerShell versions.
+        $tier2Primary = Resolve-Tier2Config -Provider $Tier2Provider -Issue 0 `
             -RepoSlug $repoSlug -EnvVars $envVars
         if (-not ($tier2Primary -and $tier2Primary.AuthToken)) {
             Write-Warning "[watchdog] Tier 2 ($Tier2Provider) requested as primary but config incomplete (key missing) — falling back to local Ollama tiers."

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -552,7 +552,9 @@ Describe 'Invoke-Watchdog Tier 2-as-primary (AFK quota split, 2026-05-14)' {
                 SUPABASE_KEY       = 'k'
                 TELEGRAM_BOT_TOKEN = 't'
                 TELEGRAM_CHAT_ID   = '1'
-                # No DEEPSEEK_API_KEY -- Tier 2 primary resolution must fail closed
+                # No DEEPSEEK_API_KEY -- Tier 2 primary resolution fails open
+                # to the Ollama chain (warn + downgrade, not throw) so a
+                # mis-provisioned .env still produces work via local models.
             }
         }
         $script:calls = @()

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -453,6 +453,180 @@ Describe 'Invoke-Watchdog tier escalation matrix (slice 5, #543)' {
     }
 }
 
+Describe 'Invoke-Watchdog Tier 2-as-primary (AFK quota split, 2026-05-14)' {
+    # When -Tier2AsPrimary is set with a Tier 2 provider, the watchdog must
+    # skip Tier 0/1 Ollama entirely and dispatch the first iteration straight
+    # to the remote endpoint. Rationale: local Ollama models fail real-Claude-
+    # Code tool_use fidelity probes (memory ollama_bench_must_measure_tool_use_fidelity)
+    # and the upcoming Anthropic interactive/automatic quota split makes
+    # subscription-first AFK strategically expensive. DeepSeek is the cheapest
+    # tier that emits structured tool_use blocks reliably.
+    BeforeEach {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }       # default; overridden where relevant
+        Mock Start-DockerDesktop { }
+        Mock Start-OllamaServer  { }
+        Mock Get-RepoRoot { $env:TEMP }
+        Mock Read-DotEnvFile {
+            @{
+                SUPABASE_URL       = 'https://x'
+                SUPABASE_KEY       = 'k'
+                TELEGRAM_BOT_TOKEN = 't'
+                TELEGRAM_CHAT_ID   = '1'
+                DEEPSEEK_API_KEY   = 'ds-key'
+                ANTHROPIC_API_KEY  = 'cl-key'
+            }
+        }
+        Mock New-RuntimeDir { Join-Path $env:TEMP "sandcastle-tier2primary-$([guid]::NewGuid())" }
+        Mock Invoke-RuntimeSweep { @() }
+        Mock Write-OutcomeRecord { 'mocked' }
+        Mock Send-TelegramAlert  { 'mocked' }
+        Mock Add-IssueLabel      { $true }
+        Mock Get-IssueLabels     { @() }
+    }
+
+    It 'AC: Tier 2 as primary -> first call hits deepseek directly, no Tier 0/1 invocation' {
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Model = $Model; BaseUrl = $BaseUrl; Token = $AuthToken }
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = 'feat/700-deepseek-primary'; commits = @(); iterations = @()
+                }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -Tier2AsPrimary `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 1 -Exactly -Scope It
+        $script:calls[0].Token | Should Be 'ds-key'
+        $script:calls[0].BaseUrl | Should Be 'https://api.deepseek.com/anthropic'
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' -and $LlmMetrics.tier -eq 'tier2:deepseek' }
+    }
+
+    It 'AC: Tier 2 as primary skips Ollama daemon check (does not autostart, does not throw on ollama-down)' {
+        Mock Test-OllamaRunning { $false }   # Ollama is down -- must NOT matter
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/710-no-ollama'; commits = @(); iterations = @() }
+            }
+        }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -Tier2AsPrimary `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Start-OllamaServer -Times 0 -Exactly -Scope It
+        Assert-MockCalled Invoke-Sandcastle  -Times 1 -Exactly -Scope It
+    }
+
+    It 'AC: Tier 2 as primary failure does NOT cascade to Tier 0/1 (no escalation when primary itself is remote)' {
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Model = $Model; Token = $AuthToken }
+            [pscustomobject]@{
+                ok = $false; exitCode = 1; reason = 'exit=1'
+                result = [pscustomobject]@{ branch = 'feat/720-tier2-fail' }
+            }
+        }
+        Mock Test-IsOOM { $true }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+              -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -Tier2AsPrimary `
+              -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        Assert-MockCalled Invoke-Sandcastle -Times 1 -Exactly -Scope It
+        $script:calls[0].Token | Should Be 'ds-key'
+    }
+
+    It 'AC: Tier 2 as primary but DEEPSEEK_API_KEY missing -> warning + falls back to Ollama chain' {
+        Mock Read-DotEnvFile {
+            @{
+                SUPABASE_URL       = 'https://x'
+                SUPABASE_KEY       = 'k'
+                TELEGRAM_BOT_TOKEN = 't'
+                TELEGRAM_CHAT_ID   = '1'
+                # No DEEPSEEK_API_KEY -- Tier 2 primary resolution must fail closed
+            }
+        }
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Model = $Model; Token = $AuthToken }
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/730-fallback'; commits = @(); iterations = @() }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -Tier2AsPrimary `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        # When primary resolution fails, Ollama chain takes over -> first call is Tier 0
+        $script:calls[0].Model | Should Be 'qwen-large'
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $LlmMetrics.tier -eq 'tier0' }
+    }
+
+    It 'AC: -Tier2AsPrimary without -Tier2Provider stays on Ollama chain (no-op switch)' {
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Model = $Model }
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/740-noop'; commits = @(); iterations = @() }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider '' -Tier2AsPrimary `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        $script:calls[0].Model | Should Be 'qwen-large'
+    }
+
+    It 'AC: Tier 2 as primary ignores use-claude-api label because no issue is known yet' {
+        # Real Get-IssueLabels short-circuits to @() when Issue is 0/empty (the
+        # state at primary-resolution time, before an issue is picked from the
+        # queue). Mirror that here so the test exercises production behavior
+        # and not the test harness's blanket mock.
+        Mock Get-IssueLabels {
+            param([int]$Issue, [string]$RepoSlug)
+            if (-not $Issue) { return @() }
+            return @('use-claude-api')
+        }
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Model = $Model; Token = $AuthToken; BaseUrl = $BaseUrl }
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/750-claude-primary'; commits = @(); iterations = @() }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -Tier2AsPrimary `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        # Documents the invariant: the use-claude-api label flip is issue-scoped
+        # and only fires on Tier 2 *escalation* (where a target issue is known),
+        # not on Tier 2 *primary* (where Issue=0 by construction). Owner must
+        # set CLAUDE_MODEL/CLAUDE_BASE_URL/ANTHROPIC_API_KEY env vars to make
+        # Claude the configured provider when Tier 2 primary is desired with
+        # Anthropic instead of DeepSeek.
+        $script:calls[0].Token | Should Be 'ds-key'
+    }
+}
+
 Describe 'Invoke-Watchdog daemon-state matrix' {
     BeforeEach {
         Mock Start-DockerDesktop { }


### PR DESCRIPTION
## Summary

Two commits, same theme — make AFK actually pick up tasks tonight:

1. **`-Tier2AsPrimary` switch** — `Run-Sandcastle.ps1` skips Tier 0/1 Ollama and dispatches straight to DeepSeek (Tier 2). Local Ollama models fail real-Claude-Code tool_use fidelity probes, so the existing OOM-only escalation chain (#543) wastes every iteration on a non-functional Tier 0. `Register-SandcastleTask.ps1` auto-appends the switch when a Tier 2 provider is set.
2. **Widen AFK windows** — with Ollama bypassed in AFK mode, the VRAM-contention rationale for the original 22:00 / 02:00 four-hour windows is gone. New windows cover all non-working hours end-to-end: jarvis 18:00→01:00 (7h), redrobot 01:00→08:00 (7h). `ExecutionTimeLimit` bumped 6h → 8h so the scheduler hard cap sits above WindowEnd.

Subscription-first Tier 0 (claude CLI in container via Max OAuth) was rejected: Anthropic is splitting subscription quota into interactive vs automatic buckets and the automatic bucket will be smaller — strategically expensive for AFK. Decision UUID `b5fb4825-e307-49e4-8e11-1163931d6a15`.

## Test plan

- [x] `Invoke-Pester tests/sandcastle/Run-Sandcastle.Tests.ps1` — 71/71 cases pass (6 new under "Invoke-Watchdog Tier 2-as-primary")
- [x] `-Tier2AsPrimary` + valid config → first Invoke-Sandcastle uses Tier 2 (token=ds-key, baseurl=api.deepseek.com), no Tier 0/1 invocation
- [x] `-Tier2AsPrimary` skips Ollama daemon check entirely
- [x] `-Tier2AsPrimary` primary failure does NOT cascade to Tier 0/1
- [x] Missing `DEEPSEEK_API_KEY` → warning + falls back to Ollama chain (fail-open)
- [x] `-Tier2AsPrimary` without `-Tier2Provider` is a no-op switch
- [x] `use-claude-api` label flip documented as issue-scoped only (does not fire at primary-resolution with Issue=0)
- [x] Register-SandcastleTask dry-runs (jarvis + redrobot) produce expected argument lists and trigger times
- [x] Both scheduled tasks registered on Workshop PC; `Get-ScheduledTask` shows State=Ready, NextRun matches new windows

## Out of scope, deferred

- Proper "subscription-first" architecture (M#41 watcher daemon dispatching host-side `claude -p`) — separate work, depends on Anthropic's quota-split rollout.
- `use-claude-api` flip extension to primary path — owner sets `CLAUDE_*` env vars instead if Anthropic-as-primary is wanted.

Closes #711
