### PR TITLE
fix(sandcastle): Resolve-WindowEnd rolls forward when HH:mm past today (#713)

### DIFF
--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -139,9 +139,14 @@ function Resolve-WindowEnd {
     if ($WindowEnd -match '^\d{2}:\d{2}$') {
         $today = (Get-Date).Date
         $end = $today.Add([TimeSpan]::Parse($WindowEnd + ':00'))
-        # If the wall clock has already passed HH:mm today, the window is
-        # already closed -- we treat it as "now" so the watchdog records
-        # window-expired before doing any work.
+        # AFK windows commonly straddle midnight (e.g. jarvis fires at 18:00
+        # with WindowEnd=01:00 meaning 01:00 *tomorrow*). If the resolved
+        # boundary is already in the past, roll it forward 24h. This also
+        # fixes the same-day case where the scheduled task is launched after
+        # WindowEnd has technically elapsed for today -- on-call manual runs
+        # should still get a fresh window, not record window-expired before
+        # any work begins.
+        if ($end -lt (Get-Date)) { $end = $end.AddDays(1) }
         return $end
     }
     return [datetime]::Parse($WindowEnd)

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -16,11 +16,29 @@ Describe 'Resolve-WindowEnd' {
         Resolve-WindowEnd -WindowEnd '' | Should BeNullOrEmpty
     }
 
-    It 'parses HH:mm as today' {
-        $end = Resolve-WindowEnd -WindowEnd '23:30'
-        $end.Hour   | Should Be 23
-        $end.Minute | Should Be 30
-        $end.Date   | Should Be (Get-Date).Date
+    It 'parses HH:mm in the future of today and keeps today date' {
+        # Pick a time guaranteed to be at least 1 minute in the future of the
+        # current wall clock so the roll-forward logic doesn't apply.
+        $future = (Get-Date).AddMinutes(15)
+        $hhmm = "{0:D2}:{1:D2}" -f $future.Hour, $future.Minute
+        $end = Resolve-WindowEnd -WindowEnd $hhmm
+        # End may equal (Get-Date).Date OR (Get-Date).Date.AddDays(1) if the
+        # 15-min offset crossed midnight; assert hour/minute round-trip only.
+        $end.Hour   | Should Be $future.Hour
+        $end.Minute | Should Be $future.Minute
+    }
+
+    It 'rolls HH:mm forward 24h when the boundary already passed today' {
+        # AFK regression (#711 follow-up): jarvis fires at 18:00 with
+        # WindowEnd=01:00 meaning 01:00 tomorrow. Without roll-forward the
+        # watchdog records partial:window-expired and exits without work.
+        $past = (Get-Date).AddHours(-2)
+        $hhmm = "{0:D2}:{1:D2}" -f $past.Hour, $past.Minute
+        $end = Resolve-WindowEnd -WindowEnd $hhmm
+        $end | Should Not BeNullOrEmpty
+        ($end -gt (Get-Date)) | Should Be $true
+        # Must NOT be in today's past; rolled to tomorrow.
+        $end.Date | Should Be (Get-Date).Date.AddDays(1)
     }
 
     It 'parses ISO datetime' {


### PR DESCRIPTION
## Summary

Latent bug exposed by #711: with `WindowEnd='01:00'` at 22:21, `Resolve-WindowEnd` returns *today* 01:00 → `Test-WindowExpired=true` → watchdog exits as `partial:window-expired` before any iteration. Roll the boundary forward 24h when it's already past.

Covers both AFK midnight-straddling (jarvis 18→01) and on-call manual runs after WindowEnd has elapsed.

## Test plan

- [x] `Invoke-Pester tests/sandcastle/Run-Sandcastle.Tests.ps1` — 72/72 cases (1 reformulated + 1 new under Resolve-WindowEnd)
- [x] Manual repro: at 22:21, `Resolve-WindowEnd('01:00')` now returns tomorrow 01:00, not today 01:00
- [ ] Post-merge: re-launch `Sandcastle-Jarvis` task and confirm runtime dir appears + sandcastle iteration begins

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)