### PR TITLE
infra: add .gitattributes for encoding hygiene (CRLF/BOM bug class) (#705)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,38 @@
-# Auto detect text files and perform LF normalization
+# Encoding hygiene - prevent CRLF/BOM bugs across 3 devices
+# See docs/design/jarvis-v2-redesign.md section cross-device-sync
+# See also tests/ci/test_powershell_encoding_guard.py (write-side)
+
+# Default: normalise all text files to LF in the index
 * text=auto
+
+# .env files: LF only, never CRLF
+*.env         eol=lf -text
+.env.example  eol=lf -text
+
+# Shell scripts: LF only
+*.sh    eol=lf
+*.bash  eol=lf
+*.zsh   eol=lf
+
+# Python: LF only
+*.py    eol=lf
+
+# PowerShell: Windows-native (CRLF)
+*.ps1   eol=crlf
+*.psm1  eol=crlf
+*.psd1  eol=crlf
+
+# Binaries: never normalised
+*.png    -text diff
+*.jpg    -text diff
+*.jpeg   -text diff
+*.gif    -text diff
+*.ico    -text diff
+*.pdf    -text diff
+*.zip    -text diff
+*.exe    -text diff
+*.dll    -text diff
+*.woff   -text diff
+*.woff2  -text diff
+*.eot    -text diff
+*.ttf    -text diff


### PR DESCRIPTION
## Summary

Add `.gitattributes` at repo root enforcing encoding hygiene across 3 devices:

- `* text=auto` — git normalises text files to LF in the index
- `*.env` / `.env.example`: `eol=lf -text` — never CRLF (MCP parsers expect LF)
- `*.sh` / `*.bash` / `*.zsh` / `*.py`: `eol=lf`
- `*.ps1` / `*.psm1` / `.psd1`: `eol=crlf` (Windows-native)
- Common binary types (png, jpg, pdf, zip, ico, exe, dll, fonts): `-text diff`

Addressed bug class: CRLF/BOM encoding that silently kills MCP servers and regex-based tools. Three documented memory incidents trace to this (telegram_mcp_env_crlf_breaks_token, telegram_channel_env_bom_breaks_token, powershell_5_1_utf8_no_bom_breaks_on_em_dash).

## Acceptance criteria checklist

1. ✅ `.gitattributes` exists at repo root
2. ✅ Rule `*.env eol=lf -text` present (also covers `.env.example`)
3. ✅ `git check-attr eol -- .env.example` returns `lf`
4. ✅ `git check-attr text -- some-binary.png` returns `text: unset`
5. ✅ Renormalization verified: `git ls-files --eol` shows no mixed w/eolattr
6. ✅ No behaviour change to existing `.env` files (they're gitignored anyway)

## Test plan

```bash
git check-attr eol -- .env.example        # expect: lf
git check-attr eol -- install.ps1         # expect: crlf
git check-attr eol -- install.sh          # expect: lf
git check-attr text -- some-binary.png    # expect: text: unset
git ls-files --eol                        # verify no mixed endings
```

## Out of scope

- Migrating existing `.env*` files on dev machines (device-local; handled by installer health-check in sibling issue)
- Editor-level `.editorconfig` (separate concern)

Closes #705.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>