### PR TITLE
docs: add minimal llms.txt router doc (#708)

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,14 @@
+# Jarvis — single-principal AI agent for software work
+
+> Auto-discovered by external LLM tools via llms.txt convention.
+> Pointers only — see the target files for authoritative content.
+
+- [CLAUDE.md](CLAUDE.md): Project rules, process conventions, skill routing, engineering posture
+- [config/SOUL.md](config/SOUL.md): Agent identity, personality, judgment calibration
+- [CONTEXT.md](CONTEXT.md): Domain glossary, invariants, architectural model
+- [README.md](README.md): Project overview and setup instructions
+- [Design doc](docs/design/jarvis-v2-redesign.md): Architecture, component model, data flow
+- [Research](docs/research/): Exploration notes and design studies (unfinished drafts)
+- [ADRs](docs/adr/): Architecture Decision Records
+
+Authoritative decision log: Supabase `record_decision` memory table (not in this repo).


### PR DESCRIPTION
## Summary

Create `llms.txt` at repo root — a minimal pointer-only router doc following [llmstxt.org](https://llmstxt.org/) convention (≤50 lines, 14 lines actual). Enables external LLM tools that fetch a single URL to discover the canonical entry points.

## Acceptance criteria checklist

1. ✅ File `llms.txt` exists at repo root
2. ✅ ≤50 lines total (14 lines)
3. ✅ Each pointer follows llmstxt.org convention: `- [Title](relative-path): one-line description`
4. ✅ No content duplication — pointers only
5. ✅ No state (no "last updated", percentages, sprint dates)
6. ✅ `git ls-files llms.txt` returns the path

## Test plan

```bash
wc -l llms.txt          # expect: ≤50
git ls-files llms.txt   # expect: llms.txt
```

Closes #708.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>