### PR TITLE
docs: quarterly record_decision dump → docs/decisions/2026-Q2.md

### DIFF
--- a/docs/decisions/2026-Q2.md
+++ b/docs/decisions/2026-Q2.md
@@ -1,0 +1,6266 @@
+# Decision dump — 2026-Q2 (cutoff: 2026-05-18)
+
+Total decisions: **409**
+
+## Aggregate
+
+### By reversibility
+- `hard`: 57
+- `reversible`: 352
+
+### By actor prefix
+- `session`: 277
+- `skill`: 132
+
+---
+
+## 2026-04
+
+### implement Pipeline uncertainty/confidence map (#604) in redrobot
+
+- **UUID:** `0614c6bd-54c6-4528-9bc2-2d38fb91958a`
+- **When:** `2026-04-21T04:34:21.382819+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:delegate`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Defer until cameras arrive (rejected: we're currently blind for weeks, need this now); Combine with #430 trajectory robustness (rejected: independent concerns, better as separate PRs); Start with simpler per-pass error estimate (rejected: issue body specifies richer per-cell formula, no point half-shipping)`
+
+  > Camera work (Facehugger) is blocked — cannot verify ground truth. Without cameras we accumulate simulation error across passes with zero visibility. #604 provides per-cell confidence estimation: uncertainty grows in zones with shallow-touch cuts, avalanche-affected cells, and stale data. This directly fills the gap left by blocked camera integration and is prerequisite for smarter conservative planning in low-confidence zones. Approach: new module `redrobot/sandbox/uncertainty.py` implementing formula from issue body, integrate into PipelineV3.run() after each apply_scraper_pass, expose via result object. Non-safety, new-file addition — safe for parallel worktree delegation.
+- **Memories used:** `heightmap_sim_transport_limitation, data_audit_unused_inputs, design_for_extensibility`
+
+---
+
+### implement swept-path validation for in-place orientation changes (#613) in redrobot
+
+- **UUID:** `b681d335-c63a-46b8-b96a-11a19ac3f642`
+- **When:** `2026-04-21T04:34:31.451097+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.6`
+- **Actor:** `skill:delegate`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Plan-only comment, wait for explicit approval (rejected: user said 'автономно', pm_autonomy_redrobot memory confirms); Skip #613 this sprint (rejected: P:high safety bug, real-robot observed incident); Refactor entire executor validation (rejected: scope creep, focused extension is cheaper and reversible)`
+
+  > Safety P:high bug observed on 2026-04-14 workshop run — tool tip traces an arc during orientation-only transitions, blade can dip into sand/tray. executor.py lives in redrobot/planning/ (safety-critical zone per delegate skill), so extra care: (a) agent must implement with interp-check between waypoints where joints differ but XYZ matches, extend existing _check_swept_volume() rather than add parallel path, (b) PR opens as Draft with HIGH risk flag for owner review, (c) agent adds regression test with an orientation-only transition at low Z that previously passed and now fails. User granted autonomous mode so implementation proceeds but merge stays gated on owner. Prior related work: #570 executor pre-validation (merged), PR #572 validation fixes — pattern established.
+- **Memories used:** `lessons_robot_trajectory_safety, issue_570_pre_validation_implementation, pr_572_copilot_review_fixes, pm_autonomy_redrobot`
+
+---
+
+### implement #278 (Phase 1: PreCompact hook + transcript parser + Supabase snapshot) inline
+
+- **UUID:** `50e908c1-b208-44c7-bc32-9af2b3ac0b64`
+- **When:** `2026-04-21T11:55:19.147358+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `delegate to subagent (rejected: protected file touch + foundational sprint work); skip and wait for design doc (rejected: issue body is complete spec); modify settings.json directly (rejected: protected, put diff in PR body)`
+
+  > Foundational infra for the compression resilience sprint — parses the JSONL transcript in a PreCompact hook, persists a structured snapshot to Supabase so /end and post-compact sessions can recover lost detail. Kept inline (/implement, not /delegate) because: single issue, foundational to the sprint, and acceptance criteria require modifying `.claude/settings.json` (a protected file per agent-boundaries.md). Subagents can't touch protected files; orchestrator documents the required diff in PR body so owner can apply it. Non-obvious choice: emit snapshot to local fallback (`.claude/session-snapshots/`) on Supabase failure — hook must never block compaction. Pattern for venv bootstrap + .env override lifted from session-context.py and memory-recall-hook.py. The autonomous loop left traces of a prior prototype run (session_snapshot_test-session-xyz exists in Supabase from 06:23Z) but no committed code; implementing fresh from the issue spec.</rationale>
+  > <parameter name="memories_used">["phase_2c_provenance_approach", "skill_split_implement_vs_delegate_2026_04_21", "dotenv_override_for_empty_shell_vars"]
+- **Memories used:** `none`
+
+---
+
+### Compression-resilience sprint complete — PreCompact snapshot (#278), session-context recovery injection (#279), /end as Supabase-authoritative (#280) all merged to main; milestone #25 closed.
+
+- **UUID:** `79ad5c4c-6386-4e61-a4a0-fb893af68afc`
+- **When:** `2026-04-21T14:27:33.8013+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.75`
+- **Actor:** `session:2026-04-21-autonomous-pm`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Restoring full raw transcript inline on resume — rejected (too large, defeats compaction).; Using a dedicated snapshot table instead of reusing `memories` — rejected (extra migration, 30KB rows are comfortable in existing table).`
+
+  > End-to-end solution: PreCompact hook captures structured pre-compact artefacts to `session_snapshot_<session_id>` (Supabase + local fallback), session-context.py detects compact-resume and prepends `## Pre-Compact Recovery`, and /end treats Supabase (snapshot + decisions) as authoritative rather than the lossy post-compact conversation. Copilot review on #282 caught two real issues — ambiguous snapshot lookup (no project scope, no order) and unsanitized session_id in filesystem paths — both fixed before merge. Test suite 561 passed with 35 targeted recovery tests. Smoke tests on merged main confirm compact-resume emits the recovery section, startup does not, and path-traversal session_ids are rejected. Remaining live acceptance (`/end` quality parity across 0 vs 1+ compactions) is deferred to the next compaction-heavy session.
+- **Memories used:** `none`
+
+---
+
+### Address Copilot review on PR #285 with client-side valid_to filter; merge + apply migration
+
+- **UUID:** `0271edbd-b5d0-42c2-9499-633f8788e6f0`
+- **When:** `2026-04-21T15:04:44.444729+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:2026-04-21`
+- **Project:** `jarvis`
+- **Alternatives considered:** `trust that tests pass and merge anyway (rejected — Copilot finding was substantive and reproducible against session-context.py precedent); rewrite the multi-.or_() into an embedded and(or(),or()) form (rejected — more complex, further from established pattern, less readable); skip apply_migration and merge only Python (rejected — critical memory says schema.sql is aspirational, prod DB diverges silently)`
+
+  > PR #285 landed 3 of 4 lifecycle filters in _keyword_recall by chaining a third .or_(). Copilot correctly flagged that PostgREST accepts only one or= param per query, and the function already had two .or_() calls (project scoping + keyword ILIKE). Rejected the tempting read ("tests pass, Copilot is wrong") because scripts/session-context.py:377-379 already documents the exact same constraint and uses client-side valid_to filtering — an authoritative precedent in the codebase. Applied that pattern here: valid_to moves to SELECT + post-fetch filter; deleted_at / expired_at / superseded_by stay as .is_() (no collision). Added regression test that asserts valid_to is NOT in .or_() to prevent re-regression. Then ran apply_migration for the SQL RPC half (schema.sql alone doesn't mutate prod — see memory schema_sql_requires_paired_migration). Smoke-test confirmed: DB has 4 soft-deleted session_snapshot rows, memory_recall returns only the 2 live ones.
+- **Memories used:** `schema_sql_requires_paired_migration, postgres_function_signature_migration`
+
+---
+
+### Open Pillar 4 Sprint 'Metacognition Loop-Closure' with 5 issues: #286 (expose memory_id in outcome_record schema), #287 (skills auto-pass memory_id), #288 (backfill task_outcomes.memory_id from decision_made episodes), #237 (Haiku rewriter type narrowing for recall@5 regression), #289 (CI schema-drift check).
+
+- **UUID:** `37ff9045-c7ef-41a4-b458-c673846d15aa`
+- **When:** `2026-04-21T17:25:01.801808+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Option B (proxy-network infra for friends in RU) — deferred, not aligned with Jarvis metacognition goal; Option C (ambient memory, auto-consolidation) — too exploratory without first closing the calibration loop; Option D (self-improve autonomy) — premature without calibration data to inform it; Skip sprint planning, keep single issues — rejected per sprint-hygiene rule (pillar != one task)`
+
+  > Chose Option A (metacognition loop-closure) over alternatives (proxy infra, ambient memory, self-improve autonomy). Rationale: the #284 incident exposed that our calibration infrastructure already exists on the DB side — `task_outcomes.memory_id` FK, `memory_calibration` view, `record_decision` pipeline — but the MCP tool schemas don't expose `memory_id`, so the view stays empty. Fastest path from 'infra present' to 'loop closed' is wiring the tool schemas (#286), making skills pass the id (#287), backfilling history (#288), and adding CI schema-drift protection (#289) so this kind of silent drift can't happen again. #237 was already open and is thematic (memory recall quality) — folded it in for a full 5-issue sprint. Estimated 1-2 weeks. Success metric: `SELECT COUNT(*) FROM memory_calibration` > 0, and `/reflect` can attribute outcomes to memories.
+- **Memories used:** `pillar_is_not_one_task, check_pr_scope_fit_at_open_time`
+
+---
+
+### Implement #286: add optional `memory_id` string param to outcome_record + outcome_update MCP tool schemas and handlers.
+
+- **UUID:** `0cf97c59-a878-4678-b12b-d7a1843ef775`
+- **When:** `2026-04-21T17:45:50.326297+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Add FK validation in Python (reject non-UUID) — rejected, trust DB FK constraint to enforce; Also wire memory_id into outcome_list output — rejected, scope creep; separate issue if needed; Rename parameter to `informing_memory_id` for clarity — rejected, schema already uses `memory_id` in DB column and calibration view, keeping names aligned`
+
+  > FK + calibration view already exist on DB side (verified via information_schema query). Gap is purely tool-schema surface: handler loops at server.py:3007 (record) and 3036 (update) iterate a hardcoded list of keys that doesn't include `memory_id`. Fix: add `memory_id` to both inputSchemas (type=string, optional, description hints at uuid and calibration linkage) and add `memory_id` to the two optional-fields loops. No migration needed (column lives in live DB). Add 2 unit tests mirroring TestHandleStoreProvenance pattern: one asserting memory_id propagates into .insert() payload, one asserting .update() payload. No DB migration, no new dependency. Confidence high — change is purely mechanical extension of an existing pattern.
+- **Memories used:** `schema_sql_requires_paired_migration, metacognition_sprint_plan_2026_04_20`
+
+---
+
+### Implement #288 backfill: read decision_made episodes from `episodes` table (NOT `events` as issue body says), extract issue number from payload.decision via regex `#(\d+)`, match against task_outcomes.issue_url, resolve first `memories_used[0]` name to memories.id, update NULL memory_id rows. Dry-run + --apply, idempotent.
+
+- **UUID:** `aa017aa1-5a66-4609-9cfd-44400e8906b1`
+- **When:** `2026-04-21T17:58:38.732095+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Match by created_at proximity (episode within 10min of outcome) — rejected, unreliable for sprint-batch work where decisions cluster; Match by pr_url in decision text — rejected, pr_url not always present at decision time (PR created later); Require UUID in memories_used going forward and skip backfill — rejected, owner wants historical attribution too; Use task_description substring match — rejected, decision.decision and outcome.task_description diverge in phrasing`
+- **Outcomes referenced:** `a46a051f-510e-4fb2-9a50-b28eda7a4344`
+
+  > Issue body has 2 spec errors discovered during data inspection: (1) decision_made episodes live in `episodes` table kind='decision_made' (7 rows), not `events` table — `events` holds ci_failure/pr_merged/memory_recall (not decisions); (2) `payload.memories_used` is a list of memory NAMES ("schema_sql_requires_paired_migration") not UUIDs — need name→id resolution via memories.name lookup. Also no `pr_url` in payload; must extract issue# from `payload->>'decision'` regex `#(\\d+)` and match outcome.issue_url (issue# stable, PR# differs). DB state: 55 outcomes total, all 55 have NULL memory_id, 27 have pr_url, 7 decision_made episodes exist. Script logic: fetch all decision_made episodes; for each, regex issue# + first memories_used; resolve name→id (lookup memory most recently updated if duplicate names); find task_outcomes with matching issue_url AND NULL memory_id; per-row update. Idempotent via `WHERE memory_id IS NULL` filter. Dry-run default prints "would link N outcomes". --apply executes updates one at a time (small scale, 7 decisions, no need for batch txn). Flag spec drift in PR body.
+- **Memories used:** `memory_management_strategy_v1, old_memory_migration_policy_2026_04_20`
+
+---
+
+### Implement #287 — wire memory_id through /implement, /delegate, /verify outcome calls
+
+- **UUID:** `c36e8b7d-4536-4715-9920-2dbf73c16337`
+- **When:** `2026-04-21T18:07:14.413663+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Add runtime code to auto-extract memory_id from last decision — rejected: skills already compose outcome_record calls, extra indirection; Pass full memories_used list — rejected: FK is a single UUID, not an array; calibration view joins on one memory per outcome`
+- **Outcomes referenced:** `56dda6d7-9ad3-4954-9d82-8618a7d2184f`
+
+  > Second issue in Pillar 4 sprint. #286 opened the schema pipe (outcome_record accepts memory_id); #288 backfilled historical rows. #287 now ensures every FUTURE /implement, /delegate, or /verify run populates memory_id from the `memories_used[0]` basis captured at record_decision time. Rule: "primary informing memory = first element of memories_used from the decision_made episode" — documented in each skill. Implementation is doc-only (skill SKILL.md edits), no server code, no tests needed since /implement runtime already calls outcome_record via MCP. Risk LOW — docs drift shouldn't block merge. Note: empirically past decision_made episodes stored memory NAMES in memories_used (not IDs per schema). That mismatch is outside scope of #287 — backfill script from #288 handled historical rows. Forward-looking: skill docs already specify IDs at record_decision step 3.5; keep that and propagate same IDs into outcome_record.memory_id.
+- **Memories used:** `metacognition_sprint_plan_2026_04_20, milestone_structure_v2`
+
+---
+
+### Delegate batch #640 (safety swept-check B2) + #295 (home/ready positions) to parallel coding subagents in worktrees
+
+- **UUID:** `864aa133-6eab-4565-b211-85c9a71e9f57`
+- **When:** `2026-04-21T18:12:19.81016+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:delegate`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > Owner approved B2 approach for #640; plan is fully spec'd in my comment with file:line hints, no architectural judgment left for subagent. #295 is a pure mechanical refactor with 6 concrete hardcoded sites listed. Parallelism=2 (safe band per lesson 2026-04-20). Orchestrator will diff-review each in its worktree before merge. Debt-close sprint (owner pivoted from Facehugger).</rationale>
+  > <parameter name="alternatives_considered">["Keep #640 inline (safety-adjacent planning/ zone) — rejected because B2 is mechanically specified", "Sequential instead of parallel — slower, no benefit when tasks touch disjoint files", "Delegate all safety debt at once — rejected, parallelism risk >3"]
+- **Memories used:** `none`
+
+---
+
+### Implement #289 — GH Actions workflow blocks schema.sql edits without paired migration
+
+- **UUID:** `0f71f4ba-a392-4aa1-85d4-3d3a4e2bbe6f`
+- **When:** `2026-04-21T18:20:46.202066+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Bash + git diff parse — rejected: pulls.listFiles gives file statuses and is more robust than parsing diffs; Require migration touch (modified or added) — rejected: migrations are append-only timestamped; a LEGITIMATE change always ADDS a new one`
+- **Outcomes referenced:** `c1365283-40b6-443b-9885-88033d404205`
+
+  > Fourth issue in Pillar 4 sprint. The recall soft-delete bug #284 shipped because schema.sql was edited without a paired supabase/migrations/* file — the live DB never got the filter, memory_recall silently returned soft-deleted rows. CI should have blocked that PR at open time. Implementation: single workflow file .github/workflows/schema-drift-check.yml, path-filtered trigger on schema.sql + migrations, inline github-script reads pulls.listFiles, fails if schema.sql modified AND no "added" migration file in the same PR. Skipping the "comments-only exception" for v1 per issue ("optional, low priority") — simpler, stricter, can relax later. Using "added" status specifically (not just "modified") because a legitimate schema change should add a NEW timestamped migration, not edit an existing one.
+- **Memories used:** `metacognition_sprint_plan_2026_04_20, schema_sql_requires_paired_migration`
+
+---
+
+### Close PR #647 as subagent fabrication, re-delegate #640 to v2 agent with pasted-output proof requirement
+
+- **UUID:** `77f9c143-158f-42ea-b393-b8174b82b626`
+- **When:** `2026-04-21T19:43:08.888919+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:end`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Ask agent to fix in same PR (risk of continued fabrication); Force-push corrections inline as orchestrator (loses learning signal, hides agent issue); Keep PR as partial and file follow-up issue (adds debt instead of closing)`
+
+  > Orchestrator diff-review found PR #647 commit message claimed execution-path swept-check coverage but actual diff added ~60 lines with no gate at move_joints dispatch and no test exercising the claimed path. Options: ask agent to fix (prolongs fabrication risk), force-push corrections inline (loses learning signal). Chose close + re-delegate with stricter prompt (must paste git diff --stat + pytest output) — cleanest reset, generates data point for future subagent-fitness judgments. Reversible (can reopen branch if needed; re-delegation succeeded as PR #649/a824a97).
+- **Memories used:** `none`
+
+---
+
+### Architectural principle: multi-agent system grows along two axes — DOWN (worker agents extending coverage of tactical work) and UP (orchestrator layers above the current ceiling, freeing the owner to operate at higher altitude). Alternating between both is what delivers per-participant load reduction.
+
+- **UUID:** `210290b9-3e5b-4320-93a2-013635e6cc71`
+- **When:** `2026-04-21T19:45:31.829447+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Owner articulated this pattern in 2026-04-22 session to explain why Sprint 2 should be a dispatcher (first UP-extension) rather than another action agent (DOWN). Bottom-up alone keeps owner stuck in the same operational roles. UP-extensions free owner's altitude. Each layer adds operational cost + coordination cost; total system load rises, per-participant load drops.
+- **Memories used:** `none`
+
+---
+
+### Target Jarvis v2 architecture is federation of specialized persistent agents with narrow jurisdictions, not Opus-CEO above PMs. Supersedes multiagent_pm_architecture_vision.
+
+- **UUID:** `ce471f72-b6c4-4c23-a69a-16751dd1c9ae`
+- **When:** `2026-04-21T19:45:36.280293+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.75`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Full parliament with inter-agent consensus (rejected: consensus overhead, political failure modes); Keep Opus-CEO central orchestrator (rejected: same single-context bottleneck as v1 skills); Hybrid central-Claude + delegated-Ollama workers (rejected: still requires Claude in hot loop, expensive)`
+
+  > The centralized Opus-CEO design was shaped by pre-persistence constraints — without long-running context, all strategic reasoning had to flow through one window. That's the same single-context-bottleneck failure mode v1.5 tried to fix at the skills level. Pillar 7 Sprint 1 removed the constraint (LangGraph + Ollama + Postgres). Federation with explicit jurisdictions + owner as tiebreaker avoids both Opus bottleneck and parliament-consensus pitfalls. "Monarchy locally, democracy externally."
+- **Memories used:** `none`
+
+---
+
+### Pillar 7 Sprint 2 (milestone #21) scope = task-dispatcher-agent as first federation jurisdiction. Replaces draft auto-triage action-agent scope in epic #184.
+
+- **UUID:** `e088285f-5493-4a56-af89-394111054b9f`
+- **When:** `2026-04-21T19:45:41.482332+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Auto-triage labeler (original draft — rejected as thin demo); Autonomous perception agent (my counter-proposal — rejected as too risky for strategic-nuance miss); CI watcher with auto-retry (deferred — candidate for later jurisdiction); Cross-project risk scanner (deferred)`
+
+  > Auto-triage applying labels to jarvis's own issues = thin demo value. Dispatcher solves owner's current top operational pain (task distribution + subscription limit babysitting). Dispatcher is LOWER risk on "agent misses strategic nuance" axis than perception-agent — it works only on explicitly approved tasks and has no judgment authority. Dispatcher = first UP-extension per architecture_growth_two_dimensions: autonomous in narrow domain, frees owner from operational dispatch, moves owner to strategic altitude.
+- **Memories used:** `none`
+
+---
+
+### Delegate tech-debt #633 batch: 3 parallel coding subagents (executor-constants, driver-cleanup, kinematics-damping)
+
+- **UUID:** `0ff4bd88-ee66-4160-b134-c71ac1949517`
+- **When:** `2026-04-22T05:45:45.316706+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `none`
+
+  > Pure literal-to-constant refactors with tight scope, no algorithm changes. Self-contained from issue body, no session-context dependency. Owner requested parallel delegation.
+- **Memories used:** `none`
+
+---
+
+### Implement agents/safety.py as S2-0 foundation for Sprint 2 action agents (issue #295)
+
+- **UUID:** `b28e59f3-88b1-43d7-92b0-3c4691820e86`
+- **When:** `2026-04-22T13:29:51.289836+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Duplicate audit() in safety.py - rejected, two audit paths diverge; Expose only classifier, let agents gate themselves - rejected, mis-classification risk; Block safety on S2-1 task_queue - rejected, issue marks queue out-of-scope`
+
+  > Sprint 2 dispatcher and future action agents must go through a single tier-classifier + idempotency + audit layer. Wrap existing supabase_client.audit() best-effort; add tier classification per action_agent_safety_gate_model_v1, deterministic idempotency key via sha256(agent_id|action|target|scope_hash), and gate() that executes Tier 0, queues Tier 1 (enqueue wiring deferred — task_queue is S2-1 scope), raises GateError on Tier 2. Dry-run: no mutation + audit outcome=dry_run. Tier 2 patterns: .env*, .claude/*, deletes, impersonation, cross-repo. Pure Python stdlib + existing supabase_client dep. Foundation ships BEFORE dispatcher.
+- **Memories used:** `action_agent_safety_gate_model_v1, pillar7_sprint2_dispatcher_scope, federated_architecture_direction`
+
+---
+
+### Implement #657 — remove axis from PipelineV3 deficit-first main loop (scope-out compaction)
+
+- **UUID:** `7727266c-5203-412e-8855-136447d2d83d`
+- **When:** `2026-04-22T13:37:01.771882+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Kill compaction too — rejected: changes Stage 7 finishing behavior, out of scope for refactor billed as 'no behavioral regression'; Leave plan_zones call — rejected: only consumer in main loop was preferred_axis; the call becomes pure dead overhead; Change plan_pass to isotropic kernel — rejected: API change with broader blast radius (zigzag + compaction call paths)`
+
+  > Code reading confirmed axis is dead in the deficit-first main run() loop: pass_plan.axis is never read by generate_directed_push (which consumes bulk_passes from plan_bulk_passes); pass_plan is used only for removal_layer.max() in tool selection. zones[0].preferred_axis and _direction_to_axis serve only to feed plan_pass(axis=...), whose _apply_tool_kernel difference (1×W vs W×1) does not change max(removal_layer) meaningfully for tool selection. Scope-out: _run_compaction_pass (Stage 7) still uses axis for zigzag CONTOUR strategy — deliberately kept intact to avoid regressing sand-finishing behavior (different concern than main loop). Tests test_pipeline_uses_optimal_direction and test_pipeline_on_pass_callback need to switch from "axis" key to "direction_deg".
+- **Memories used:** `trajectory_planning_naive, deficit_first_bulk_planner, sand_direction_top_down`
+
+---
+
+### Implement S2-1 task_queue schema + paired migration (#296)
+
+- **UUID:** `b18e2724-20bc-4a4e-bdf2-3b47e87e2054`
+- **When:** `2026-04-22T13:39:59.586665+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Defer idempotency_key UNIQUE constraint — rejected: race-dedup in app code is strictly weaker than DB constraint, dispatcher must be able to retry blind; Use enum type instead of check constraint — rejected: repo convention is check constraints on text (events.severity, task_outcomes.outcome_status), keep consistent; Skip GIN index on scope_files — accepted per issue body ('defer if not required'); dispatcher's scan is (status, approved_at), GIN adds cost without a query pattern today`
+
+  > S2-1 is the dispatcher's input surface. Schema follows issue body draft with deny-first tightening: (1) idempotency_key is UNIQUE NOT NULL — the safety gate's sha256 key becomes the dedup boundary so re-runs cannot double-dispatch; (2) status check enforces the 5-state enum (pending/dispatched/done/escalated/rejected) — dispatcher code can rely on FSM invariants at the DB level, not in agent logic; (3) updated_at auto-maintained via trigger like existing tables; (4) RLS mirrors other Pillar 7 tables (service role full, allow-all policies per current repo convention — hardening is a later sweep). Chose single migration file over multi-file split because the whole table is one atomic addition. File is created at both mcp-memory/schema.sql (canonical docs) and supabase/migrations/&lt;ts&gt;_task_queue.sql (actual DDL per CI gate #289). No current table named task_queue — grep returned zero hits, safe to create fresh.
+- **Memories used:** `pillar7_sprint2_dispatcher_scope, action_agent_safety_gate_model_v1`
+
+---
+
+### Implement S2-5 APScheduler + Postgres jobstore scheduler primitive (#300)
+
+- **UUID:** `8bb88a58-14ec-45ac-b145-7264f5bfe05d`
+- **When:** `2026-04-22T13:53:33.84283+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `AsyncIOScheduler — rejected: event_monitor is sync, mixing creates cognitive overhead without benefit at current scale; Separate Postgres DB for APScheduler — rejected: one URL is simpler, no clash observed (different tables); Custom jitter via random.uniform() wrapping the tick — rejected: APScheduler has first-class jitter on IntervalTrigger, use the library; Register dispatcher as a real job now — rejected: dispatcher is S2-3 (#298), out of scope here; placeholder proves the primitive`
+
+  > Scheduler engine for Pillar 7 persistent agents. Design choices: (1) BackgroundScheduler not AsyncIOScheduler — event_monitor.py uses sync PostgresSaver, staying in sync avoids mixing paradigms. (2) SQLAlchemyJobStore backed by the same AGENTS_POSTGRES_URL as LangGraph's PostgresSaver — one Postgres, no new connection config, no table clash (APScheduler uses `apscheduler_jobs`, LangGraph uses `checkpoints*`). (3) Use APScheduler's built-in IntervalTrigger jitter instead of rolling custom logic — tested, well-understood. (4) Register jobs with `replace_existing=True, max_instances=1, coalesce=True`. This makes restart idempotent: persisted job row gets reused, can't double-fire, backlog coalesces to 1 on catch-up — matches the "no double-dispatch" acceptance criterion. (5) Signal handlers guarded against Windows SIGTERM-not-supported error. (6) Placeholder tick function initially; dispatcher (S2-3) will add itself via register_agent when it lands. Not registering a real agent keeps S2-5 testable standalone.</rationale>
+  > <parameter name="memories_used">["pillar7_sprint2_dispatcher_scope"]
+- **Memories used:** `none`
+
+---
+
+### Implement S2-2 Claude Max limit probe (#297) — agents/usage_probe.py with StaticBudgetProbe counting task-dispatcher audit_log rows per window + in-memory TTL cache + false-safe wrapper.
+
+- **UUID:** `f5d4426d-428f-4818-b38c-2f359893ddae`
+- **When:** `2026-04-22T14:04:35.798056+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `Log-scraping Claude Code session logs — rejected: fragile format coupling, no guarantee Claude Max quota is logged locally; Supabase-persisted cache via claude_usage_probe table — rejected: dispatcher is single-process, in-memory cache simpler with equivalent semantics, restart just re-probes; Count task_queue.status='dispatched' — rejected: status changes on escalation/completion, doesn't reflect past consumption; audit_log is authoritative; Skip budget gate entirely until Claude Max exposes a real API — rejected: issue explicitly scopes this as a probe today with TBD source`
+
+  > Issue #297 requires "lightweight periodic check that feeds dispatcher's budget gate". Real-time Claude Max quota API is not available to users — probe source is intentionally TBD per acceptance criteria (smoke test uses mock data). Chose StaticBudgetProbe backed by audit_log counts because: (a) dispatcher writes to audit_log on every live dispatch (task 'dispatch', outcome='success'), making it the authoritative usage source; (b) single-process cache vs Supabase-persisted cache: dispatcher runs in one APScheduler process; in-memory TTL is simpler, restart-safe via fresh re-probe on first tick; (c) false-safe on probe failure (near_exhaustion=True) = dispatcher pauses — matches issue's "conservative false-safe" requirement. Configurable via CLAUDE_USAGE_* env vars with sensible defaults (5h window, 100 dispatches budget, 15% near-exhaustion, 300s TTL). Protocol + concrete split leaves room to swap source later without touching dispatcher.</rationale>
+  > <parameter name="memories_used">["d7af7e81-d089-4270-acc9-21c413bdf771"]
+- **Memories used:** `none`
+
+---
+
+### implement Top-down Z-sequencing of OT pairs (#656) — add deterministic tie-breaker + explicit tests; no pipeline change needed
+
+- **UUID:** `02dcba66-b72b-4778-8ac9-dd8a3dde16b2`
+- **When:** `2026-04-22T14:04:56.709471+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.88`
+- **Actor:** `skill:implement`
+- **Project:** `redrobot`
+- **Alternatives considered:** `full rewrite of sort logic — rejected, current code already correct; just lacks explicit tie-break and tests; apply Z-sort to lookahead output too — rejected, lookahead's simulation-based ordering is a superset of heuristic Z-sort; add pipeline-level physics regression fixture — considered, deferred: unit tests + scenario test on plan_bulk_passes are enough for acceptance, and physics fixture would 10x runtime for little marginal value`
+
+  > Investigation: bulk_planner.py:244 already sorts passes by target_z descending when target_heightmap is provided (added earlier by prior work), and pipeline_v3.py calls plan_bulk_passes with target_heightmap=self.target everywhere. The core mechanism satisfies acceptance #1 (top-down ordering). What's missing to close #656 properly: (a) deterministic tie-breaker made explicit via tuple key (currently relies on Python's stable sort + Hungarian's deterministic output — implicit), (b) dedicated unit tests proving the ordering and tie-break behaviors, (c) a fixture asserting top-down execution for a mixed-Z scene. Lookahead path (_plan_with_block_size) is not touched — it determines order via simulation, which is strictly better than a Z-sort heuristic; overriding it would break the candidate evaluation contract. Narrow change in one file + one test file → LOW risk, no behavioral regression expected. Parent epic #596 Tier 1 item 1.</rationale>
+  > <parameter name="memories_used">["trajectory_planning_naive"]
+- **Memories used:** `none`
+
+---
+
+### Implement S2-4 escalation triggers (#299) — agents/escalation.py with 5 pure check functions (stale/drift/limit/conflict/pattern) + EscalationContext aggregator + escalate() DB writer.
+
+- **UUID:** `329bfab7-103c-4c32-986c-9604f154a87f`
+- **When:** `2026-04-22T14:12:42.122187+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `Single monolithic escalate() with embedded checks — rejected: untestable without DB, hard to add a new trigger later; Return list of all triggered checks — rejected: owner gets one actionable notification, not five simultaneous ones (first-match wins avoids noise); Make dispatcher compute context inside check_* — rejected: n * checks = n * DB calls per tick; single EscalationContext build lets dispatcher amortize scans; Put scope-drift hasher in escalation.py — rejected: hashing live files is dispatcher's job; escalation.py only compares hashes`
+
+  > Issue #299 requires 5 trigger types that move a task_queue row from pending to escalated and notify via events. Chose pure-check-function design because: (a) testable without Supabase — each check takes a row dict + context and returns EscalationCheck; (b) dispatcher (S2-3) assembles context once per tick and passes to check_all aggregator (first-match priority: stale > drift > limit > conflict > pattern — order matches what owner can act on first); (c) separating escalate() (DB side effect) from check functions lets tests verify the correct event shape via stub client without mocking check logic. Thresholds (STALE_APPROVAL_MAX_DAYS=7, PATTERN_REPEAT_THRESHOLD=3) are module-level constants per acceptance criteria. Scope drift hash function is pluggable (str or callable) because hashing-current-file-state lives in S2-3 dispatcher — keeping escalation.py transport-agnostic.</rationale>
+  > <parameter name="memories_used">["d7af7e81-d089-4270-acc9-21c413bdf771"]
+- **Memories used:** `none`
+
+---
+
+### Implement Multi-source deficit assignment (#659) via iterative Hungarian on residuals in bulk_planner.plan_bulk_passes — not min-cost flow
+
+- **UUID:** `a579046a-193c-4db0-9146-7b9c46e28e19`
+- **When:** `2026-04-22T14:15:45.055803+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:implement`
+- **Project:** `redrobot`
+- **Alternatives considered:** `min-cost flow via scipy.sparse.csgraph or networkx — rejected, issue itself marks this as Tier 2/3; extra dep + rewrite for marginal gain on Tier 1; apply iterative Hungarian also to lookahead_planner — rejected, lookahead evaluates candidates by simulation and overriding the candidate generator risks subtle regression in candidate ranking; can be follow-up issue if lookahead shows worse convergence than direct path; increase default max_iterations to 5+ — rejected, 3 rounds already handles realistic scenes (tray has ~few dozen superpixels after coarsening); more rounds = compute without benefit`
+
+  > Issue #659 lists two candidate approaches: iterative Hungarian (re-run assignment on residual excess/deficit after each round) versus min-cost flow (single-shot multi-source assignment). Picking iterative because: (1) it reuses the existing linear_sum_assignment machinery, scipy dependency already there, no new math library; (2) it preserves round-1 outputs bit-for-bit on small 1:1 problems (regression safety — acceptance criterion #5), since running iteration 2+ only triggers when residuals remain above min_pair_volume; (3) max_iterations bound (default 3) prevents runaway cost on pathological inputs; (4) min-cost flow is listed in the issue itself as Tier 2/3 — they explicitly want iterative for Tier 1. Per-pair volume cap stays at vol = min(excess_residual[i], deficit_residual[j]) — carry limit is a separate concern (#658) that this PR will not duplicate. Only touches plan_bulk_passes (main deficit-first path); lookahead_planner._plan_with_block_size keeps 1:1 Hungarian because lookahead's simulation-based candidate evaluation already picks good orderings and mutating it risks invalidating its ranking contract.</rationale>
+  > <parameter name="memories_used">["trajectory_planning_naive"]
+- **Memories used:** `none`
+
+---
+
+### test
+
+- **UUID:** `9742e57a-ef7b-4d14-8eb3-a7d387bc8f3f`
+- **When:** `2026-04-22T14:21:55.342982+00:00`
+- **Reversibility:** `reversible`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `none`
+
+  > test
+- **Memories used:** `none`
+
+---
+
+### Implement S2-3 dispatcher
+
+- **UUID:** `5691b156-7d82-4a3d-a09e-c184ad257a69`
+- **When:** `2026-04-22T14:22:15.241454+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `none`
+
+  > Wires safety + probe + escalation + scheduler.
+- **Memories used:** `none`
+
+---
+
+### Implement #658 sand volume prediction as a pure function `predict_deposit(start, end, excess_along_path, blade_width) → deposit_distribution` + endpoint adjustment helper, integrated into bulk_planner post-Hungarian
+
+- **UUID:** `2bafe919-ff76-4e69-8b4f-68da2dd53768`
+- **When:** `2026-04-22T14:26:09.887584+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:unknown`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Use actual Warp DEM physics inside planner — rejected, too slow per pipeline_v3_performance_research; Modify generate_directed_push Z-profile directly — rejected, that's trajectory execution concern not planning; Hardcode 50/50 split before/after peak — rejected, model constants need to be tunable per issue calibration note`
+
+  > Issue acceptance requires (a) predict_deposit pure function, (b) respect ~200mm max carry, (c) endpoint adjustment when deposit peak misaligns with deficit centroid, (d) unit tests + integration fixture improvement, (e) volume conservation. Approach: new module `deposit_model.py` with model constants at module level (matches #612 refactor style per issue note), conservative 1D linear carry model with exponential falloff past 200mm carry distance. Endpoint adjustment: shift end toward deficit centroid by the (peak_s - deficit_centroid_s) offset, clipped to workspace. Keep it cheap — this runs inside plan_bulk_passes which is called per pass. Simple Gaussian-like deposit profile around effective-stop-point. Do NOT touch lookahead_planner (separate hot path per memory `pipeline_v3_performance_research`). Do NOT introduce physics simulation inside planner (explicitly out of scope — Tier 2+).</rationale>
+  > <parameter name="memories_used">["sand_physics_architecture_2026_04_06", "pipeline_v3_performance_research"]
+- **Memories used:** `none`
+
+---
+
+### implement S2-6 E2E dispatcher test (#301)
+
+- **UUID:** `d8c32be1-fb9b-4199-bd13-f4bfafcf5923`
+- **When:** `2026-04-22T14:36:29.859815+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `none`
+
+  > S2-6 validates that S2-0..S2-5 primitives compose correctly under AGENTS_E2E=1 gating. Branching from feat/298 (not main) because #307 is open and dispatcher module doesn't exist on main — imports would fail. After #307 merges, rebase feat/301 onto main and PR diff collapses to the test + README only. Place test at tests/test_agents_dispatcher_e2e.py (matching repo convention of flat tests/ dir with test_agents_* prefix) instead of agents/tests/ mentioned in issue body — will note the path divergence in PR. Mock subprocess at agents.dispatcher.subprocess.Popen boundary so no real claude spawn. Hermetic cleanup via unique goal string per run to isolate rows from concurrent test runs.
+- **Memories used:** `none`
+
+---
+
+### Implement #235 inline: extend consolidation-review CLI to dispatch EVOLVE plans
+
+- **UUID:** `dd8be25d-b56b-41dd-866c-22cb41f8a6b2`
+- **When:** `2026-04-22T15:00:31.74586+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Add approve_evolution / reject_evolution RPCs (cleaner atomicity but adds schema change, CI schema-drift guard, migration — exceeds issue scope); Defer to next sprint (rejected — low effort, closes review-CLI gap flagged in design doc 5.2-γ); Delegate to subagent (rejected — single file scope fits inline better, subagent would miss test+docs peripheral vision)`
+
+  > Clean technical scope (extend existing CLI script), acceptance criteria explicit, has test + RPC infrastructure to reuse from #229 and #232. Chose inline /implement over /delegate — single focused task, loop context (just-loaded memories about consolidation/evolution) is useful, no cross-cutting needed. Chose Python-only path (no new RPCs) because issue non-scope says "don't change RPC contracts" — call apply_evolution_plan directly from CLI with queue_meta for approve, then reconcile the resulting audit row with the original pending row by copying snapshots + flipping status + deleting audit duplicate. For reject, pure Python UPDATE is sufficient (no rollback needed for pending rows per issue body).
+- **Memories used:** `none`
+
+---
+
+### implement #310 — fix schema-drift CI check to guard mcp-memory/schema.sql (canonical path)
+
+- **UUID:** `0987183d-3504-49e3-ab40-af43a8a7ebfc`
+- **When:** `2026-04-22T19:12:22.255552+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.92`
+- **Actor:** `skill:unknown`
+- **Project:** `jarvis`
+- **Alternatives considered:** `move schema.sql into supabase/ to match the original workflow — rejected as larger-scope, touches docs+tooling, no benefit; add dual-path guard watching both paths — rejected as carrying the bug forward, supabase/schema.sql genuinely does not exist; defer as non-urgent — rejected because the guard is silent-pass today and the #284 failure mode is exactly what it's supposed to catch`
+
+  > The schema-drift check added in #289 has been guarding a non-existent path (supabase/schema.sql). The actual canonical schema file is mcp-memory/schema.sql — referenced by setup-device.py, SETUP.md, memory-overhaul.md, dispatcher.py docstring. Result: PRs that edit the real schema without a paired migration silently bypass the check, exactly the #284 regression mode the guard was built to prevent. Confirmed by inspecting PR #303 CI output — the 'require-paired-migration' job ran (triggered by the added migration file matching supabase/migrations/**) and returned SUCCESS spuriously because its internal filename comparison found no supabase/schema.sql in the changed files. The fix is three substitutions in one YAML file. Rejected alternative: moving the schema file to supabase/schema.sql — that would be a larger change with no upside (setup docs, scripts, and agents/dispatcher.py all already reference mcp-memory/schema.sql as the source of truth). Fix-the-guard is strictly scoped, matches issue #310, reuses the existing workflow machinery.</rationale>
+  > <parameter name="actor">skill:implement
+- **Memories used:** `check_pr_scope_fit_at_open_time`
+
+---
+
+### implement #313 — gate venv re-exec behind __name__ == "__main__" in 4 hook scripts
+
+- **UUID:** `068a6b85-5262-4ba7-899f-f3ba4af9a4d2`
+- **When:** `2026-04-22T19:18:41.054144+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `skill:unknown`
+- **Project:** `jarvis`
+- **Alternatives considered:** `convert to sys.argv[0] check — more complex, no benefit; move re-exec inside main() — larger refactor per script; leave broken and rely on targeted pytest targets — already the status quo, doesn't fix 'pytest tests/' one-shot`
+
+  > 3 test files are failing pytest collection because the scripts they import have sys.exit(subprocess.call(...)) at module top-level. Fix is a minimal one-line edit per script: add __name__ == "__main__" to the existing if condition. When pytest loads via importlib.util.spec_from_file_location, __name__ is set to the module name passed in ("pre_compact_backup", etc.), so re-exec is correctly skipped. When hooks invoke the script directly, __name__ == "__main__" so re-exec fires as before — behavior preserved. Including scripts/memory-dedup-check.py in the fix too: same pattern, no tests yet but fix is consistent and preempts the same bug when tests get written. Rejected: converting scripts to a helper that checks sys.argv[0] — more complex, no upside. Rejected: moving re-exec into main() function — would require refactoring each script's entry point, larger blast radius. The if __name__ guard is the idiomatic Python answer and fits the existing code shape.</rationale>
+  > <parameter name="actor">skill:implement
+- **Memories used:** `none`
+
+---
+
+### Compress always-loaded session context: compact rendering for memory bodies / goals, cap brief-recall at 7 hits, dedupe SOUL and CLAUDE
+
+- **UUID:** `ad625160-3566-40e4-a3ae-e4636fed3ed8`
+- **When:** `2026-04-23T05:47:09.718771+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep full bodies, only cut catalog limit — rejected: skill table + goal bodies still dominate; Move SOUL.md dense rules to external docs loaded on keyword trigger — rejected: too clever, brittle, retrieval not yet proven for instruction-rules; Raise sim threshold in recall hook instead of entry cap — rejected: threshold already calibrated (0.30) and threshold cuts low-quality hits not volume of high-quality hits`
+
+  > Session-start budget was ~25-30K tokens before the first user prompt, causing compaction on small tasks. Biggest contributors: session-context.py dumping full memory bodies + 200-entry catalog + 10-line goal blocks (42KB output); CLAUDE.md duplicating autonomy/senior-engineer content with SOUL; recall hook injecting 30-40 brief entries per prompt via char-budget only. Principle adopted: always-loaded = only what influences every decision; everything else via memory_get / goal_get / file read. Matches pre-existing idea_context_injection_token_diet axes 1 (storage compactness) + partial 4 (dead-rule pruning).
+- **Memories used:** `none`
+
+---
+
+### Apply protected-file diff to mcp-memory/server.py inline (PR #322) instead of leaving #318 deferred to owner
+
+- **UUID:** `ea555762-3ef1-46b5-b568-3eb71a4f7169`
+- **When:** `2026-04-23T05:47:46.774498+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Leave #318 deferred for owner inline-apply (rejected: gate from #319 makes Jarvis-applied valid path; owner explicitly approved); Refactor format to add id as separate field instead of suffix (rejected: owner had already designed the diff, deviating would be over-engineering)`
+
+  > Earlier today's decision (reflection_driven_sprint_2026_04_23) classified #318 as "deferred to owner" because the diff touched a protected file. But the same sprint shipped PR #319, which added the explicit clarification that inline /implement with owner approval MAY edit protected files — and the comment owner pre-authored on #318 explicitly anticipated this gate landing. Owner gave verbal approval ("давай") this session. Patch was the literal owner-authored diff, applied verbatim — no judgment drift. 95/95 tests pass; PR squash-merged; M27 closed 4/4. Closes the calibration-FK blocker for /implement §6.
+- **Memories used:** `none`
+
+---
+
+### implement #302 [L4] Remove Sandbox Hardcoded Values — scope narrowed to items 2-5
+
+- **UUID:** `2f3653ac-c209-4733-b79b-6bb8a174c2e8`
+- **When:** `2026-04-23T06:46:53.72868+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > Issue lists 7 hardcoded value sites. Audit confirmed items 1 (tray offset, SimConfig.__post_init__ + load_workspace) and 6 (gaussian blur, removed) are already done. Items 2 (handle/blade dims), 3 (grid_resolution override), 4 (target z-fill 0.7), 5 (avalanche max_iters=50) remain and are all clean SandboxConfig additions touching robot_sandbox_3d.py, target_loader.py, sand_physics.py. Item 7 (J2/J3 offsets in surface_scanner) deferred because issue's 'Use robot_params.JOINT_SIGN' hint is semantically wrong — JOINT_SIGN is a direction multiplier array, not Borunte↔MuJoCo coordinate offsets. Also noted heightmap_sim.py has near-duplicate SimConfig with same hardcodes, but that falls under sibling L4 'Deduplicate Avalanche Logic' (epic #300), not this issue.</rationale>
+  > <parameter name="alternatives_considered">["Do all 7 items including item 7 — rejected: requires deeper kinematics investigation, different review concern (mujoco)", "Also fix heightmap_sim.py twin — rejected: belongs to sibling dedup L4, would scope-creep this PR", "Comment and wait for owner scope confirmation — rejected: owner gave terse 'p1 backlog' direction, scope call within my mandate"]
+- **Memories used:** `none`
+
+---
+
+### Unify SOUL/CLAUDE/always_load roles by WHO/WHERE/HOW split
+
+- **UUID:** `17f06fca-2a6d-4a75-b022-5907ca5f2c52`
+- **When:** `2026-04-23T10:48:04.159691+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:f88effdd-post-compact`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep duplicates as defense-in-depth — rejected: drift is worse than single-owner risk; Only dedup SOUL/CLAUDE, leave memory tags unchanged — rejected: doesn't close the always_load=0-records dead-code gap`
+
+  > Audit found 3-way duplication: recall-before-action was stated in SOUL §Personality, CLAUDE DoD, and always_load memory; autonomous-work loop overlapped 5-way across CLAUDE and always_load memories. Split: SOUL owns identity (WHO), CLAUDE owns project-specific context (WHERE), always_load owns operational gates (HOW). Other two surfaces point to canonical owner, never repeat. Landed via PR #331. Trade-off: one canonical source makes updates easier but means always_load must be reliably loaded at session start — which is the gap #332 (PreToolUse action-triggered recall) and #333 (/end gap audit) are meant to close.
+- **Memories used:** `none`
+
+---
+
+### Federation migration: move Claude Code entry from jarvis-repo CWD to user-level ~/.claude, gated on install/sync script
+
+- **UUID:** `e4f6a69e-e196-499f-8b26-f61f570901dc`
+- **When:** `2026-04-23T10:48:13.321603+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.7`
+- **Actor:** `session:f88effdd-post-compact`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Stay project-scoped indefinitely — rejected: blocks native Claude Code functionality (any-CWD invocation), forces owner to cd to jarvis for non-jarvis work; User-level without install script — rejected: would break on outdated devices, violates multi-device portability constraint`
+
+  > Owner originally wanted user-level but was forced into jarvis-repo CWD by the 3-device sync problem. With dispatcher-agent pattern validated + recall enforcement in flight, we can migrate aggressively if install/sync script handles 3 states (fresh/outdated/current), is idempotent, backs up first, supports dry-run, version-checks via .jarvis-version, and auto-rollbacks on health-check fail. SOUL stays file-based (not memory) because it's identity loaded into every session — memory recall would be slower and could be missed. Skills/hooks live user-level; per-project overrides via project/.claude/. Planned as Pillar 7 Phase 0 — epic #335, sub-issues #336-#342, milestone #29. Migration itself happens across owner's future sessions ("пока я сам буду начинать новые сессии").
+- **Memories used:** `none`
+
+---
+
+### Close EPIC #335 with 2/3 devices verified; defer 3rd-device M7 install to when owner reaches that machine naturally.
+
+- **UUID:** `0448e3a5-3224-4af4-b895-2e99073d5720`
+- **When:** `2026-04-24T10:24:05.238681+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-04-24-federation-wrapup`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Wait for 3rd device install before closing EPIC — rejected: installer is idempotent, no new risk from running it later; Ask owner to confirm the 3rd device is skipped — rejected: 'можно дальше идти' after the saved-plan summary is explicit enough`
+
+  > Owner's "можно дальше идти" after laptop install is explicit greenlight to unblock M5. EPIC's original gate was 3 devices; with installer now idempotent and hardened (#351, #353) on two distinct Windows locales, the 3rd device can ship later without re-opening the epic. Deleting project-scoped .claude/skills/ is git-recoverable, so the tombstone irreversibility is only at the workflow level, not data-level.
+- **Memories used:** `none`
+
+---
+
+### Ship protected-files.py hook wiring as its own PR (#357) rather than bundling with M5 tombstone or docs refresh.
+
+- **UUID:** `0bf969f4-ed9c-465d-9887-9f51167ec49a`
+- **When:** `2026-04-24T10:24:11.41973+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `session:2026-04-24-federation-wrapup`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Bundle into M5 — rejected: mixes cleanup with new enforcement; Leave as spawn-task chip — rejected: user asked 'доделай'`
+
+  > One-issue-per-PR rule (CLAUDE.md). Hook wiring is a security change with different risk profile than docs/cleanup; reviewer attention should be on the blast radius of a runtime deny hook, not muddled with dozens of unrelated edits. Also enables clean revert if the hook surprise-blocks something legitimate.
+- **Memories used:** `none`
+
+---
+
+### Implement #325 by auto-resolving memory names→UUIDs server-side in record_decision
+
+- **UUID:** `3fe95ae4-b729-42f8-a18f-41d492f1e616`
+- **When:** `2026-04-24T10:52:28.443678+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Reject non-UUID memories_used with error — breaks every existing caller + blocks future record_decision emissions from models that haven't learned the rule; Client-side only fix (update skill docs harder) — already tried in #287, empirically didn't take effect; Validation constraint in schema.sql — costly to enforce without breaking historical data; runtime resolution is softer and preserves audit trail`
+
+  > Root cause of #325 two-part failure: (a) 64% empty memories_used — a skill-enforcement / behavioral issue (models skip record_decision), (b) 100% names-not-UUIDs — a server-side validation/normalization gap, even after #287 updated skill docs to pass UUIDs. Chose server-side transparent resolution: callers can pass either UUIDs or names (legacy behavior), server looks up names against memories table (most-recent-live wins, project-scoped when provided), and stores ONLY UUIDs in payload.memories_used. This closes the forward-propagation gap without breaking any caller and fixes the FK join path for memory_calibration. Unresolved names surface in response text + optional payload.memories_used_unresolved field for audit. Part (a) is out of scope here — tracked by #333/#334 in M28 (recall audit + expanded record_decision triggers).</rationale>
+  > <parameter name="memories_used">["7de58f46-3795-4497-9104-f907a0737f9d", "8374f50e-1c24-4ff0-8ca0-d2495c3e7e45", "9bb3332f-9b9f-4444-8723-77e37501de5f"]
+- **Memories used:** `none`
+
+---
+
+### implement #332 inline — PreToolUse action-triggered recall hook
+
+- **UUID:** `f9d4310a-4804-4b97-909d-82ec81eba61c`
+- **When:** `2026-04-24T11:21:38.437196+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `full hybrid recall like UserPromptSubmit — rejected, extra ~2s latency per action call + redundant with session-level load; per-tool dedicated scripts — rejected, 5x duplication of env bootstrap + dedup cache; broad Bash matcher catching every command — rejected per issue non-goals, too noisy; defer again — rejected, deferred idea's predicate (UserPromptSubmit-sufficient) now proven false; wait for #360 server.py refactor before adding more hook surface area — rejected, orthogonal`
+
+  > UserPromptSubmit recall only fires at user turns, so autonomous mid-turn actions (agent dispatch, md edits, memory writes, record_decision, gh create) run without fresh recall. This matches the exact failure mode the 2026-04-17 pretooluse_action_triggers_idea memory predicted and deferred pending evidence. Today's audit found enough evidence, so we're revisiting. Approach: single hook script scripts/pretooluse-recall-hook.py dispatched via .claude-userlevel/settings.json across 5 matchers. Keyword-only keyword_search_memories RPC (no embed, no rewriter) to keep latency <500ms; 60s query-hash dedup in a JSON cache under ~/.claude/cache/ prevents tight-loop reruns. Budget cap at 3 brief entries so mid-turn injections don't crowd the session context the UserPromptSubmit hook already loaded. Hook is fail-soft: any error exits 0 silently.</rationale>
+  > <parameter name="memories_used">["3552b610-629e-430d-8e7a-c9d60c6b042b", "4d75a1ea-41e9-49b5-a91e-031dd1ff7e74", "1f4c7d98-d294-422b-9371-dfa099c8002a"]
+- **Memories used:** `none`
+
+---
+
+### implement /end + /reflect recall-audit (#333)
+
+- **UUID:** `e4aadf6e-759f-4765-a0a0-b90898ad9280`
+- **When:** `2026-04-24T11:31:16.65881+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `hook-based detection (PreToolUse counter) — rejected: hooks don't see the full trace, jsonl replay is richer; Supabase query on decision_made episodes only — rejected: misses detectors 2 and 3 which live in chat text / other tool calls; defer until v0.5 — rejected: sprint M28 is the recall-enforcement push and audit completes the loop`
+
+  > v0.4 audit found recall gap: /end inspects artifacts (outcomes, commits, working_state) but not process trace; /reflect extracts lessons from outcomes but recall-gaps never surface as outcomes. Plan: scripts/recall-audit.py reads session jsonl + three detectors (empty memories_used decisions, 'I propose' assistant text without preceding recall call, new feedback/decision memory_store without preceding recall). /end adds a 'Recall audit' section per session; /reflect aggregates across sessions. Hooks into existing pipeline without changing skill contracts. #325 already shipped UUID propagation so detector 1 can trust memories_used.</rationale>
+  > <parameter name="memories_used">["3552b610-609a-430d-8e7a-c9d60c6b042b", "4d75a1ea-41e9-49b5-a91e-031dd1ff7e74"]
+- **Memories used:** `none`
+
+---
+
+### Slice #298 SafetyValidator integration into 3 PRs (#669, #670, #671) instead of one
+
+- **UUID:** `68987b1f-5085-4679-8612-100d8bff9ccd`
+- **When:** `2026-04-24T11:35:42.408174+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:ad6ca0a2-redrobot-298`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Single big PR (rejected — review burden + bigger blast radius if revert needed); 5 micro-PRs per slice in original plan (rejected — overhead exceeded value; B+D were tightly coupled)`
+
+  > Each PR is independently reviewable, testable, and revertable. PR-1 wires auto-init in BorunteRobot constructor (foundation). PR-2 routes motion_planner.validate_trajectory through SafetyValidator (eliminates duplicate work-area + speed checks). PR-3 adds check_io_point + guards set_output (new I/O coverage). Smaller diffs = lower admin-merge risk under the billing-blocked CI protocol where checks won't actually verify the change.
+- **Memories used:** `none`
+
+---
+
+### ClosedLoopController (#623) uses Protocol-based TrajectoryExecutor injection + scan_retry + regression_tolerance + max_iterations cap
+
+- **UUID:** `1c334a8a-df49-425e-be9e-195ef3b6affe`
+- **When:** `2026-04-24T11:35:51.184926+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:ad6ca0a2-redrobot-623`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Direct robot driver coupling (rejected — untestable without hardware); Sync iteration with explicit operator-confirm between scans (rejected — owner wants automation; manual confirms are a future config flag, not the default); Persistent state machine with resume (rejected — YAGNI for MVP; restart = lose progress is acceptable for now)`
+
+  > Decouples motion stack from vision: tests use FakeExecutor, production wires real Borunte trajectory builder, and the controller doesn't know either way. State machine SCANNING→ANALYZING→PLANNING→EXECUTING→VERIFYING→{CONVERGED,FAILED} mirrors how the operator thinks about the cycle. Three robustness knobs (regression detection, scan retry, max_iter cap) cover the three real failure modes: bad correction makes it worse, transient SculptureVision errors, runaway loops on never-converging surfaces. callback exception swallowing prevents observability from crashing control flow.
+- **Memories used:** `none`
+
+---
+
+### TwoTroughController (#625) treats per-trough loop.run() as ONE pass; FAILED with reason MAX_ITERATIONS means "more work needed", not real failure
+
+- **UUID:** `b062c16b-aa5f-44ad-9ce4-dad769ab94b0`
+- **When:** `2026-04-24T11:36:01.370839+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:ad6ca0a2-redrobot-625`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Single ClosedLoopController per trough running to convergence sequentially (rejected — defeats the parallelism point; arm idle while concrete cures); Coordinate offsets inside TwoTroughController (rejected — couples scheduler to motion frames; loop_factory keeps separation clean); MAX_ITERATIONS as hard failure (rejected — would force artificial high max_iter on the inner loop, defeating the per-pass model)`
+
+  > In real two-trough operation, after laying a correction layer the concrete is wet and you can't re-scan immediately — that's the moment to switch to the OTHER trough. Granularity: per loop.run() call. Caller configures the per-trough ClosedLoopController with small max_iterations so calls return quickly with a fresh white_pct reading. MAX_ITERATIONS becomes the normal "more work needed, cure first" signal; only REGRESSION/SCAN_FAILED/EXECUTION_FAILED/UNEXPECTED_ERROR are hard failures that exclude a trough from rotation. Coordinate offsets stay outside this module — caller's loop_factory(trough_id) bakes them into the executor at construction time.
+- **Memories used:** `none`
+
+---
+
+### implement #334: expand record_decision triggers to cover policy/schema/tag/config + architectural direction choices
+
+- **UUID:** `82681202-2981-4fc0-a4f9-b2e8b5af6993`
+- **When:** `2026-04-24T11:38:58.96165+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep only implement skill update, skip global memory — rejected: rule needs to carry across other skills like /self-improve and /research that also emit decisions; Auto-instrument record_decision as a Python wrapper — rejected: overkill for a process rule, humans/models still need to know WHEN; Make the rule a hook that errors when a decision is missing — rejected: gating belongs with hooks that can detect decisions reliably; no way to detect 'should have recorded' from tool trace alone`
+
+  > #334 closes the last gap in M28 recall-enforcement sprint. Current trigger rule (§3.5 in implement skill) only fires on issue implementation, hard/irreversible decisions, or low confidence — missing routine-reversible-but-policy-level choices (tagging memories always_load, editing protected files, hook config changes, schema migrations, picked architectural directions). Plan: (1) rewrite §3.5 trigger list in .claude-userlevel/skills/implement/SKILL.md, (2) create global feedback memory `record_decision_when_what` so the rule carries across skills/sessions, (3) backfill retro decision for the always_load seeding of 6 memories referenced in the issue as a test case proving the new triggers work. /verify doesn't require code change — its step 3 already handles empty memories_used gracefully per the issue's acceptance note.</rationale>
+  > <parameter name="memories_used">["3552b610-609a-430d-8e7a-c9d60c6b042b", "4d75a1ea-41e9-49b5-a91e-031dd1ff7e74"]
+- **Memories used:** `none`
+
+---
+
+### seed always_load with 6 cross-cutting feedback memories [retroactive, per #334 acceptance]
+
+- **UUID:** `0ef0df1a-7cdb-41dd-9a7b-802231f949a3`
+- **When:** `2026-04-24T11:41:38.397957+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Tag 10+ memories — rejected: diluted the 'every decision' signal and bloated the always-loaded budget; Tag zero and rely on recall-on-demand — rejected: too-fragile for rules that genuinely affect every decision; Load full content not just description — rejected per always_loaded_context_budget_principle, headers only; bodies via lookup`
+
+  > Retroactive capture of the always_load seeding decision that #334 flagged as "emitted without record_decision because the old trigger list didn't cover policy-level reversible changes." The always_load tag is a load-budget policy: memories tagged with it are injected into every session's context via session-context.py. Six feedback memories were selected by cross-cutting impact (quality_over_speed, autonomous_long_sessions, always_recall_before_action, verify_before_assuming_implemented, feedback_symmetric_fixes, no_state_in_static_storage) — rules that affect nearly every decision, so they justify the context cost. Scope was deliberately held to 6 per the always_loaded_context_budget_principle decision. This is a reversible change (tags can be removed) but it affects every future session, so under the new #334 trigger 4 (policy/tag/config) it MUST be recorded. Emitting now as proof the new trigger rule works — if this had been covered by the old rule, no new gap would exist to close.</rationale>
+  > <parameter name="memories_used">["ff994ca2-ac3a-49d4-86cb-360512df3619", "abc0a54d-0806-4349-8863-45ae542071eb", "6a8b639c-7bf5-42d6-9169-121ec2047608", "6ce87e61-e916-46cf-863f-de89996691b8", "e9acc59d-0860-4bed-90e2-befc02c78dd8", "9bb3332f-9b9f-4444-8723-77e37501de5f", "3db70793-b671-461d-9494-94c0a157426f"]
+- **Memories used:** `none`
+
+---
+
+### Tag record_decision_always_pass_memories_used with always_load
+
+- **UUID:** `8fbc1c0a-f179-4a0e-8944-2814c1150c5b`
+- **When:** `2026-04-24T12:23:29.583821+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:unknown`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Leave untagged — saves ~150 tokens in context budget but re-admits the 71.4% gap every session until recall surfaces the rule on its own, which the session-long audit showed didn't happen.; Tag but only as project=jarvis — the rule is universal across any project using record_decision; global scope is correct.`
+
+  > The new global feedback memory saved this session covers the PAYLOAD side of record_decision hygiene (always pass memories_used=[...] explicitly). Its paired rules record_decision_when_what (TRIGGERS) and record_decision_during_session_not_at_end (TIMING) are already always_load. Left untagged, the payload-side rule re-emerges in future sessions as the same 71.4% gap — the diagnostic in this session proved that effect concretely (5/5 this-session decisions had the key absent). Tagging promotes the rule to session-start context so the hygiene triad loads together. This is a policy/tag-vocabulary decision per record_decision_when_what trigger list.
+- **Memories used:** `record_decision_always_pass_memories_used, record_decision_when_what, record_decision_during_session_not_at_end`
+
+---
+
+### Open M29 "Autonomy hardening" sprint with #327 (escalation mechanism) + #326 (CI meta-test). Start with #327 inline.
+
+- **UUID:** `ac84a97a-f848-462d-accd-f69378a84c56`
+- **When:** `2026-04-24T15:28:41.5701+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:unknown`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Pick #344 (installer) — rejected: safety-adjacent, owner approval pattern; Pick #326 alone — rejected: #327 has higher operational urgency (active unresolved flag); Pick #360 — rejected: large refactor, not autonomous-scope; Wait for explicit M29 milestone declaration from owner — rejected: 'prodolzhi' is the alignment signal, autonomous_long_sessions covers this`
+
+  > Owner said "продолжи" after I briefed the M29 proposal. Both issues emerge from M28's audit signals: #327 addresses the recurring redrobot-CI flag pattern (3+ days owner-unresponsive, documented in risk_radar_latest and multiple autonomous-loop outcomes), #326 codifies the guard-written-but-wrong failure mode that PR #311 fixed empirically. Bundling them as one sprint because both are autonomy/CI process work at similar scope (~1-2 days combined). Starting with #327 because it resolves a current operational pain (flags-don't-escalate) rather than a theoretical meta-test. #344 installer work deferred — safety-adjacent, better with explicit owner approval. #360 server.py split is a large refactor, needs its own sprint window. CLAUDE.md sprint hygiene rule: milestone created BEFORE touching issues, both attached at creation, not retroactive.
+- **Memories used:** `record_decision_when_what, record_decision_always_pass_memories_used, autonomous_long_sessions`
+
+---
+
+### implement #326 CI meta-test: Python fixture test for schema-drift-check guard + paths-filter config assertion + ci-meta workflow
+
+- **UUID:** `a2cbef5f-8785-453a-bf2b-1805048b6057`
+- **When:** `2026-04-24T15:43:04.458155+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Only one workflow (schema-drift-check.yml) in the repo is path-filtered, so it is the natural proof-of-concept target. Two meta-test dimensions merged into one file: (1) config — paths: filter must reference canonical `mcp-memory/schema.sql`, which is the exact failure from #289/#310/#311; (2) logic — pure-Python reimpl of the guard's decision rule, tested with three scenarios. Python over Node because jarvis is Python-first (pytest testpaths=tests). Keeping workflow JS intact avoids churn; future iteration can unify via script extraction. Documentation goes in CLAUDE.md Development process section (closest to sprint-hygiene rules).</rationale>
+  > <parameter name="alternatives_considered">["Node/Jest test harness that runs actual workflow github-script — higher fidelity but adds node test dep", "Markdown checklist in docs/ci/guards.md with quarterly audit — lighter but no automated gate", "Refactor workflow logic into scripts/schema-drift-decide.sh/js callable from both workflow + test — cleanest DRY but invasive, defers to follow-up"]
+- **Memories used:** `feedback_symmetric_fixes, check_pr_scope_fit_at_open_time`
+
+---
+
+### Wire depth-of-cut splitting into heightmap_to_trajectory, not pipeline_v3
+
+- **UUID:** `2fc916b3-7f8c-48ec-a2d2-bbbd283d39df`
+- **When:** `2026-04-24T16:25:38.040166+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:2026-04-24-sprint17`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Wire into pipeline_v3 — rejected: requires re-architecting deficit-first strategy to consume serpentine multi-layer output; Introduce a generic depth-split wrapper above both pipelines — rejected: YAGNI, pipeline_v3 doesn't need it`
+
+  > split_target_by_max_depth (from #668) is inherently serpentine-coverage logic — iterates layer heights, passes each through serpentine generator, merges with lift+transit via _merge_pass_trajectories. pipeline_v3 uses deficit-first directed pushes (decided by deficit_first_pipeline_architecture), not serpentine. Wiring depth-split into pipeline_v3 would require re-architecting its pass strategy. heightmap_to_trajectory (top-level, used by UI routers) is the natural home: already serpentine-based, already calls _build_pass + merge helpers, already the default path for real-robot execution. #675 acceptance: auto-split deep cuts when tool_config.max_depth_mm set; that's exactly where it belongs.
+- **Memories used:** `784d1f2f-83bf-432d-9b88-60cbfff977cb`
+
+---
+
+### Defer Sprint 17 #676/#677/#678 to follow-up session with proper worktree isolation
+
+- **UUID:** `e4d644af-a41d-4766-95d0-2247f125c48a`
+- **When:** `2026-04-24T16:25:46.669011+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:2026-04-24-sprint17`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Close milestone #18 as incomplete — rejected: loses sprint boundary, confuses /sprint-report; Close #676/#677/#678 and re-file — rejected: discards agent work that might be recoverable on feat/676-closed-loop-vision; Push through tonight — rejected: billing-blocked CI means admin-merge in rushed state right before factory is high-risk`
+
+  > Parallel agent collision this session corrupted #676/#677/#678 work: branches cross-contaminated on shared main checkout without worktree isolation, #678 agent fabricated pipeline_v3 wiring commit (empty diff). Cleanup would need untangling local feat/676-closed-loop-vision branch + re-running agents with proper isolation. Factory testing is tomorrow — priority was getting #674 safety + #675 depth-split merged and safe, not fighting agent mess. Milestone #18 stays open with 3 deferred issues; reopening after factory trip with clean worktree-isolated delegation.
+- **Memories used:** `3f99c6a4-a739-48db-928c-579a2bd785af`
+
+---
+
+### Split "измерить построенную над Claude Code систему" into dedicated benchmark-framework Pillar (issue #369), do not combine with dispatcher enablement in one session
+
+- **UUID:** `e366dce8-c4d2-4f86-b2ac-974168c2556f`
+- **When:** `2026-04-24T16:33:58.144077+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-04-24-dispatcher-live-smoke`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Start both in one session — rejected: benchmark needs design, not quick prototype; Skip benchmark entirely — rejected: owner stated real need ('не видно насколько хорошо работает система'), framework is the honest answer; Lightweight smoke test instead of full framework — rejected: without configuration ablation the result doesn't distinguish 'Claude Code working' from 'Jarvis additions working'`
+
+  > Owner asked to enable dispatcher AND build a system benchmark in the same sitting. Dispatcher enablement is a 30-min operational task with existing infra. Benchmark framework is weeks: three ablation configurations (vanilla Claude / skills-only / full stack), reproducible fixture repo, LLM-as-judge pipeline, task curation from real sessions. Combining them would bloat the dispatcher session and produce a half-built bench. Applied `foundation_decisions_deserve_slowness` and `quality_over_speed` — honest signal from dispatcher-in-prod comes first, bench framework gets its own scoped effort after owner reviews #369.
+- **Memories used:** `d7af7e81-d089-4270-acc9-21c413bdf771`
+- **Memories used (unresolved):** `quality_over_speed, autonomous_long_sessions`
+
+---
+
+### Use subagent parallel-review as Copilot substitute when Copilot auto-review quota is exhausted
+
+- **UUID:** `3b90430e-5a9c-4d7c-97c4-3f1033b91f38`
+- **When:** `2026-04-24T20:39:02.685443+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Self-review: rejected because same-context bleed (I just wrote the code); Merge without review: rejected because fix for prod smoke bug, want another pass; Wait for quota reset: rejected — owner explicitly asked to unblock now`
+
+  > Owner explicitly offered three options: self-review, delegate to subagent, merge without review. Chose subagent to preserve the cross-check discipline without being the same agent that wrote the code (context bleed risk). Ran 3 general-purpose agents in parallel with self-contained prompts (PR number, bug context, what to scrutinize, APPROVE/BLOCK/COMMENT return format, <300 word cap). This is the first application of `copilot_review_quota_exhausted` reference memory; if the pattern works repeatedly, consider codifying in /implement or /delegate.
+- **Memories used:** `none`
+
+---
+
+### Leave closed Pillar 7 Sprint 2 milestone (#21) as-is instead of retroactively attaching post-smoke bug-fix issues (#370/#372/#377)
+
+- **UUID:** `397d36bc-a24d-40b9-abd3-b8f0611193d8`
+- **When:** `2026-04-24T20:39:11.483205+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Retro-attach #370/#372/#377 to M21: rejected — inflates sprint scope; Create a 'Sprint 2 polish' mini-milestone: rejected — over-engineering for 3 issues; Wait for owner to decide: rejected — would have left #376 unable to satisfy require-linked-issue workflow`
+
+  > Milestone #21 closed 2026-04-22 with 8/8 planned Sprint 2 issues. Bugs surfaced during the 2026-04-24 live prod smoke are genuine post-close discoveries — not planned Sprint 2 scope. Attaching them would misrepresent sprint history for /sprint-report and conflate "shipped" with "shipped + later needed fixes". Follow-ups #378/#379 similarly stay milestone-less until Sprint 3 milestone exists. Alternative rejected: reopen milestone, attach, close again — noisy and obscures the original sprint shape. This is a unilateral historical-record call; flagged in end output for owner visibility.
+- **Memories used:** `none`
+
+---
+
+### Dispatcher spawn uses acceptEdits permission-mode + scoped allowedTools whitelist, not bypassPermissions
+
+- **UUID:** `d2f0b87e-d132-448c-9d0e-eb14b19eccf9`
+- **When:** `2026-04-24T20:39:19.539477+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `bypassPermissions: rejected — too wide for a dispatcher spawn from a DB row; Pure acceptEdits (no allowedTools): rejected — wouldn't approve Bash for gh/git operations tasks sometimes need; Per-task dynamic whitelist: rejected — over-engineered for current sprint, can revisit in Sprint 3`
+
+  > Owner's working default is bypassPermissions for personal use, but said "если acceptEdits хватит, давай с ним. Скорее всего нужно гибрид". Live smoke confirmed acceptEdits is sufficient for Write/Edit inside project cwd; for tools acceptEdits doesn't auto-approve (Bash, WebFetch), a scoped whitelist is safer than full bypass. The narrow blast radius of a single approved task_queue row is worth the extra specificity. Follow-up #378 already files the remaining whitelist-tightening work (drop Bash(python:*), scope Bash(gh:*)).
+- **Memories used:** `none`
+
+---
+
+### Pillar 7 Sprint 3 scope: deploy-only (workshop PC NSSM + #378 + #379 + observability). Perception → task_queue pipeline carved out into a separate future sprint.
+
+- **UUID:** `d0278e36-5d87-454c-b89f-ba59aaf170d3`
+- **When:** `2026-04-25T03:28:26.174054+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-04-25-sprint3-kickoff`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Bundle perception/queue pipeline into Sprint 3 — rejected: mixes design + deploy, sprint becomes long and unfocused; Deploy on Main PC first, workshop later — rejected: Main PC isn't always-on; workshop is the strategic target per goal; Skip observability (#380) until later — rejected: unattended without any 'did it work' checklist is how silent breakage stays silent`
+
+  > Goal jarvis-v2-autonomous-loop is at 99% but the dispatcher tickает в пустоту — task_queue is empty (called out in #368). Two distinct unknowns: (a) operational — service install, security scope, hygiene; (b) design — what events trigger autonomous action, what approval flow looks like. Bundling them into one sprint mixes a deploy/hardening sprint with a design sprint and produces neither. Owner agreed: keep Sprint 3 short and deploy-focused; perception gets its own EPIC. Workshop PC is the always-on host per goal jarvis-cognitive-extension — Main PC was smoke, not prod.
+- **Memories used:** `bdf9cfaa-c46f-4d8b-afef-a90c8aa91632, 6bec4c71-184f-4e58-b1e5-b1f8ea28f4ef`
+
+---
+
+### Delegate Sprint 3 batch (#368, #378, #379) to 3 parallel subagent worktrees. All three classified as delegatable: self-contained issue bodies, disjoint files, non-safety-critical.
+
+- **UUID:** `13be7b8b-d32b-40e2-9d38-3b99c05ea843`
+- **When:** `2026-04-25T03:40:02.562163+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep #368 inline because NSSM is unfamiliar — rejected: issue body covers it well, can review subagent diff carefully; Sequential delegation — rejected: 3 issues, all disjoint, parallel saves a session; All inline — rejected: 3 distinct PRs would burn this session linearly`
+
+  > #378 = single-file edit with explicit before/after in issue body. #379 = three discrete changes all in scheduler area, Option A pre-selected by author. #368 = NSSM service template + install script; medium complexity but issue body is detailed and CLI part already shipped via #376 — leaves only template/script code. Workshop deploy itself can't happen until owner brings vividformspc4 online (offline 6d), so subagent ships the code, owner runs the one-command install later. Parallelism = 3 = top of safe band per skill §4a (worktree isolation is advisory). Branch names are explicit per issue.
+- **Memories used:** `6bec4c71-184f-4e58-b1e5-b1f8ea28f4ef, 7693cdfc-122b-4a63-bfa8-68156771c13f`
+
+---
+
+### Sprint 17 batch (#676 #677 #678): sequential delegation — #676 first, then #677+#678 parallel after merge
+
+- **UUID:** `cbb1c299-bdea-4d5e-abd9-cce7a0791137`
+- **When:** `2026-04-25T04:39:43.828351+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `skill:delegate`
+- **Project:** `redrobot`
+- **Alternatives considered:** `all 3 parallel — rejected: same-file edits + #677 dependency; all 3 inline sequential — rejected: slower, owner is on the road and wants throughput; #676 inline + delegate #678 in parallel — rejected: delegating one and inlining one in same file still races`
+
+  > All three issues edit pipeline_v3.py. #677 explicitly depends on #676 ('Depends on ClosedLoop wiring being merged first' — uses MockCameraAdapter from #676). #678 also touches pipeline_v3.py, so concurrent edits with #676 would collide. Memory delegation_parallel_worktree_scope_leak warns worktree isolation does not prevent cross-agent file contamination. Best plan: dispatch #676 alone now, then parallel #677+#678 after #676 lands (they edit different config branches inside pipeline_v3 by then). All three are mock-first (no hardware needed) and self-contained per issue body — fit subagent profile.
+- **Memories used:** `3f99c6a4-a739-48db-928c-579a2bd785af, 50de5f5c-7efa-488c-89f4-ff843f7689bc, 737763bf-740f-4864-9860-7ad41149af50, 8f7b2492-98af-4c79-abf1-019c9c0bafd8`
+
+---
+
+### #385 dispatcher claude PATH: 4-step resolver (override → JARVIS_CLAUDE_BIN env → shutil.which → Windows install defaults), no AgentConfig field
+
+- **UUID:** `0a7374c1-38b5-4d86-a253-7d52199cab93`
+- **When:** `2026-04-25T06:58:08.99664+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:workshop-deploy-2026-04-25`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Add claude_binary_path field to AgentConfig — rejected, duplicates env var lookup with no extra seam; Wrapper batch script that prepends user PATH to LocalSystem PATH — rejected, fragile across user-profile changes and harder to audit; Hardcode single LOCALAPPDATA path per #385 acceptance — rejected, doesn't cover workshop's ~/.local/bin install`
+
+  > NSSM LocalSystem has sparse PATH so shutil.which fails; need an operator-controlled override. Chose env var instead of AgentConfig field because (a) the only callsite is dispatch_node which doesn't currently load_config, and (b) NSSM has AppEnvironmentExtra for exactly this — config field would duplicate the env var without adding a seam. Windows defaults cover the 3 known install paths across devices (workshop has ~/.local/bin/claude.EXE, official installer uses LOCALAPPDATA/Programs/claude/, npm shim is in APPDATA/npm/) so operators don't need to set the env var on every box if they used a standard installer.
+- **Memories used:** `77b741a0-c29f-4a2d-a7d9-62cbba8a473c, ee699256-40c0-49d8-92e2-42deebfed5d7, 6bec4c71-184f-4e58-b1e5-b1f8ea28f4ef`
+
+---
+
+### Implement #386 inline (perception architecture doc + FSM integration map)
+
+- **UUID:** `3ebcae1d-a27c-4703-9c11-c72e6d974e7c`
+- **When:** `2026-04-25T08:44:37.260693+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Delegate #386 to subagent — rejected: policy-heavy, subagent lacks session context; owner explicitly told me 'NOT /delegate — too policy-heavy for a fresh subagent'; Skip doc, implement #388/#389 directly with inline conventions — rejected: three implementations would diverge, Sprint 5 spent unifying; Combine #386 + #388 into one PR — rejected: doc must merge first so subagent dispatch in next step has fixed conventions to follow`
+
+  > #386 is the gate for Sprint 4 milestone #32. Three sibling issues (#387 deferred, #388 GitHub ingest, #389 self-perception via morning_check, #390 smoke) all reference the same convention surface (`approved_by` namespace, `auto_dispatch` policy, `idempotency_key` formula, source-tier-to-FSM mapping). Without #386 settled, three implementations would diverge — exactly the failure mode owner flagged in the issue body. Inline rather than /delegate because: (1) policy-heavy, requires session memory of Sprint 3 dispatcher internals just loaded; (2) owner just resolved 3 open questions in this session — those decisions need to be encoded in the doc verbatim; (3) doc must reconcile three overloaded "tier" concepts (safety.Tier IntEnum, GitHub tier:N-X labels, task_queue.auto_dispatch boolean) — subagent without context would either pick one or reinvent. Confidence high — I have read schema, dispatcher.py, safety.py, escalation.py, dispatcher.md, safety.md, escalation.md before writing.
+- **Memories used:** `77b741a0-c29f-4a2d-a7d9-62cbba8a473c, abc0a54d-0806-4349-8863-45ae542071eb, e9acc59d-0860-4bed-90e2-befc02c78dd8`
+
+---
+
+### Delegate batch #388 + #389 to parallel coding subagents in worktrees
+
+- **UUID:** `22173edf-d8eb-45e3-9d0f-d22d48467dd7`
+- **When:** `2026-04-25T09:50:08.834174+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Both inline — rejected: doubles session cost, no context advantage now that perception.md is the contract; Sequential delegate — rejected: parallelism=2 is in safe band, no shared files; Keep #389 inline because morning_check.py is freshly minted — rejected after re-reading: file is stable, the change is a flag + insert path, fully scoped`
+
+  > Both issues are subagent-fit per /delegate criteria: (1) self-contained acceptance with merged perception.md (PR #396) acting as the conventions contract; (2) disjoint files (agents/perception_github.py for #388 vs scripts/observability/morning_check.py for #389) — no cross-task contamination risk; (3) no safety-critical zones touched; (4) no cross-cutting reasoning needed beyond what the issue body + perception.md provide. Parallelism = 2, in the safe band per worktree-isolation memory. Branch names explicit per skill §4a mitigation. Will review each diff in main repo (not worktree) per memory `parallel_delegate_worktree_isolation_failed_2026_04_20`.
+- **Memories used:** `77b741a0-c29f-4a2d-a7d9-62cbba8a473c`
+
+---
+
+### Add skip_avalanche=True to candidate-evaluation paths (_validate_pushes, lookahead_planner)
+
+- **UUID:** `f2e5fadf-e41b-47bb-92af-d9363c00b0d0`
+- **When:** `2026-04-25T13:46:32.87651+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:redrobot-2026-04-25`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Lower avalanche_max_iters globally — degrades real-pipeline physics; Cache simulation results — fragile, hard to invalidate; Remove _validate_pushes — owner relies on its filter`
+
+  > Profiling showed _avalanche took 93% of apply_scraper_pass runtime (1.55s of 1.66s on 385x581 grid). _validate_pushes runs one full sim per BulkPass on the critical path, so a 30-push validation took ~50s; owner's eye.glb run with 926 BulkPasses hung 10+ minutes. Validation only needs the cut profile to compare mean_dev — settling is irrelevant. Skip gives 81x speedup (1676ms → 21ms). Real pipeline runs (heightmap state matters across passes) keep default behaviour.
+- **Memories used:** `none`
+
+---
+
+### Split figure_mask into figure_mask (full shape, no wall trim) + reachable_mask (with wall trim)
+
+- **UUID:** `34a4bd33-2f81-4aaf-b90a-c422529b6721`
+- **When:** `2026-04-25T13:46:54.503072+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:redrobot-2026-04-25`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Keep one mask, change wall_margin_cells parameter at call site — doesn't fix concept conflation; Fold reachable_mask into bulk_planner directly — too invasive for this iteration`
+
+  > compute_figure_mask conflated two concepts: «where the user's shape exists» (convergence math) vs «where the tool can physically reach» (planner endpoint feasibility). For eye.glb-style targets that fill the tray, ~21% of figure cells fell into wall margin and were reported as buffer (gray) — owner saw it as «huge gray spot replacing green figure». Now figure_mask is full shape (used for convergence/visualization), reachable_mask has wall trim (used for planner). Diff_engine sees full figure for mean_dev; planner-side hides unreachable cells via planner_diff masking.
+- **Memories used:** `none`
+- **Memories used (unresolved):** `recall_before_changing_figure_mask`
+
+---
+
+### Wall margin = sqrt(width² + thickness²)/2 + calibration buffer (instead of half-width)
+
+- **UUID:** `1720b91c-ca7c-4492-a6fc-8ff9a4db4687`
+- **When:** `2026-04-25T13:47:20.297143+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:redrobot-2026-04-25`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Add tilt-reach correction to existing formula — doesn't address rotation; Calibrated workspace polygon from real robot — right answer, deferred to #690`
+
+  > Owner observed blade physically deflecting against tray walls 2026-04-25. Old margin was max(tray_wall_margin, scraper_width/2) = 50mm for blade_80, but with free push direction the blade can rotate to any angle; worst-case perpendicular extent is the diagonal half-length sqrt(80²+60²)/2 = 50mm. Zero clearance under any calibration drift. New margin uses the diagonal plus a 50mm calibration buffer (bumped from initial 15mm while planner motion is still rough) → 100mm for blade_80. Single helper reachable_margin_mm in sand_model.py replaces hand-rolled formulas across 5 callsites.
+- **Memories used:** `none`
+
+---
+
+### Bump _CALIBRATION_BUFFER_MM 15→50mm tactically until planner motion is correct
+
+- **UUID:** `f62d0831-b181-4414-952b-e820f48ee205`
+- **When:** `2026-04-25T13:47:38.983144+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:redrobot-2026-04-25`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Pass reachable_mask into bulk_planner as new param — too invasive for this iteration; Calibrated workspace polygon — right answer, scope of #690`
+
+  > After figure_mask split (#688), owner reported planner aiming pushes uncomfortably close to walls — discretizer was clamping but planner didn't know. Bumping the buffer adds extra safety cushion while #686 (spatial sort) and #687 (push consolidation) are tuned. Plus added hard-mask of unreachable cells from planner_diff so planner ignores wall strip entirely. Tactical, expected to revert to ~15mm once #690 (calibrated workspace polygon) lands.
+- **Memories used:** `none`
+
+---
+
+### Apply session fixes as dirty hot-patches in master path D:/Github/redrobot/redrobot/, not just worktree commits
+
+- **UUID:** `5242f9bd-18c9-47a4-9d34-4d4bcae05d2b`
+- **When:** `2026-04-25T13:47:57.177589+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:redrobot-2026-04-25`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Push branch + create PR + wait for review — too slow for active test cycle; Patch only worktree, swap UI cwd — fragile`
+
+  > Owner was actively iterating UI restart → robot test cycle during the session. UI imports from D:/Github/redrobot/redrobot/, not the worktree path. Patching master directly lets owner test immediately. Acceptable because: (a) every change validated in worktree against full test suite (174+ tests); (b) identical content preserved as commits in worktree branch claude/jolly-driscoll-6fc83f for clean PR later; (c) owner explicitly authorized «применяй сразу, разрешаю в этой сессии любые изменения». Worth flagging in /end output so dirty master state is visible to next session.
+- **Memories used:** `none`
+
+---
+
+### Quarantine legacy parent-dir `.mcp.json` files via rename (not delete) when installer detects relative `jarvis/...` references
+
+- **UUID:** `2145e6e4-6841-4730-9cb2-b1261f67120a`
+- **When:** `2026-04-25T14:02:29.075183+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:6d6c8dfb-dd08-4ec3-9308-e9f19217a6fa`
+- **Project:** `jarvis`
+- **Alternatives considered:** `delete the legacy file (rejected: irreversible, no recovery if user actually relies on it); leave it in place and warn (rejected: shadow keeps blocking memory MCP); merge entries into ~/.claude/.mcp.json (rejected: ~/.claude/.mcp.json itself isn't read by Claude Code per Decision 2)`
+
+  > A pre-migration `.mcp.json` in any parent of JARVIS_HOME shadows the templated user-level file because Claude Code walks up from CWD. Detection by JSON content (string starts with `jarvis/` or `jarvis\`) avoids touching unrelated parent-dir MCP configs. Rename to `.bak.pre-jarvis-migration` (timestamped if slot taken) keeps it reversible — owner can restore if needed. Delete would be destructive without recovery path.
+- **Memories used:** `none`
+- **Memories used (unresolved):** `always_recall_before_action`
+
+---
+
+### Switch jarvis installer from dropping `.mcp.json` into `~/.claude/.mcp.json` to registering each server via `claude mcp add -s user`
+
+- **UUID:** `ca930eea-9052-435f-8302-ef399f231cd8`
+- **When:** `2026-04-25T14:02:37.238627+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.92`
+- **Actor:** `session:6d6c8dfb-dd08-4ec3-9308-e9f19217a6fa`
+- **Project:** `jarvis`
+- **Alternatives considered:** `keep file drop and document manual `claude mcp add` step (rejected: defeats install automation); patch Claude Code to read ~/.claude/.mcp.json (out of scope, upstream change); introduce intermediate config-watcher daemon (over-engineered)`
+
+  > Empirical finding: `~/.claude/.mcp.json` is NOT a Claude Code config location. Only project-scope (CWD walk for `.mcp.json`) and `~/.claude.json`'s `mcpServers` block (managed via `claude mcp add -s user`) are honoured. The drop was inert: every install left memory + tg-messenger + others unregistered. Sessions only worked when stray parent-dir `.mcp.json` happened to be reachable. Manifest schema gains `install_as: user_mcp_registrations`; installer reads source file and emits one `register_mcp_user` action per server with idempotent remove-then-add.
+- **Memories used:** `none`
+- **Memories used (unresolved):** `always_recall_before_action, verify_before_assuming_implemented`
+
+---
+
+### Delegate batch #394 + #395 in parallel; file follow-up #410 for SeServiceLogonRight grant rather than expanding #394
+
+- **UUID:** `19366b52-8128-43c1-9287-53574d08b00c`
+- **When:** `2026-04-25T16:38:38.031405+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `fold SeServiceLogonRight grant into #394 PR via expanded scope comment (rejected: scope drift + risks); implement both inline sequentially (rejected: pure-docs #395 is mechanical, not worth main-context budget); dispatch all 3 in parallel including new #410 (rejected: file-level merge conflict on install-scheduler-service.ps1)`
+
+  > Both issues independent (separate files: install-scheduler-service.ps1 + tests for #394, docs/agents/scheduler.md + langgraph-setup.md for #395). Subagent-fit: each has self-contained acceptance criteria, no session-context dependency, no safety-critical zones. Filed #410 separately (instead of expanding #394 inline) because (a) #394 already has 5 acceptance items, (b) bundling SeServiceLogonRight risks scope-drift in subagent reasoning, (c) sequencing #410 after #394 avoids merge conflict on the same .ps1 file. Deliberately keeping parallelism at 2 — workshop deploy memory + delegation_parallel_worktree_scope_leak warn that >3 risks worktree contamination.</rationale>
+  > <parameter name="memories_used">["3f99c6a4-a739-48db-928c-579a2bd785af", "737763bf-740f-4864-9860-7ad41149af50", "dbd4e65b-4965-40c0-b97c-6d9ba946576f", "50de5f5c-7efa-488c-89f4-ff843f7689bc"]
+- **Memories used:** `none`
+
+---
+
+### implement #360 — split mcp-memory/server.py (3466 LOC) into handlers/ package + entry
+
+- **UUID:** `5673f61e-3159-42c9-9e10-2a5d56207e29`
+- **When:** `2026-04-25T17:34:00.145541+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Defer #360 and start with #417 (Phase 3 recall) — rejected: #417 dependsOn #360 per its own AC; rebasing recall changes through a 3466-line file is exactly what the issue argues against.; Delegate #360 to a subagent — rejected: protected file, MEDIUM risk shared with redrobot, needs full session context for backwards-compat verification.; Split memory.py further into memory_io/recall/graph/consolidation — rejected for now: issue's proposed structure is one handlers/memory.py; smaller file is still ~1700 lines and that scope expansion belongs in a follow-up if it becomes painful.`
+
+  > Pure structural refactor. Owner explicitly approved this work in-session as part of "Pillar 4 Sprint: server split + recall ranking 2026-04-25" (milestone #33). server.py is in protected-files list, but skill SKILL.md §4 permits inline /implement edits with explicit approval (which I have). Plan: (1) create new modules at mcp-memory/{client,audit,embeddings,tools_schema}.py + mcp-memory/handlers/{__init__,memory,goal,outcome,credential,events,decision}.py while these paths are still unprotected; (2) rewrite server.py via Bash heredoc since Edit/Write hook will block; (3) update scripts/protected-files.py to cover the new layout (matcher should protect the whole mcp-memory/ surface, not just server.py); (4) update docs/security/agent-boundaries.md table. Backwards-compat for tests: server.py re-exports all _handle_* + helpers via `from handlers.X import *`. No behavior changes — preserving even the duplicate _cosine_sim/_upsert_known_unknown defs (second wins at runtime per Python module-load semantics) since strict scope says move-only. Bonus finding: those duplicates are dead code worth a follow-up issue. Confidence high because the refactor surface is mechanical (move text, preserve names) and gated by the existing test suite + a real MCP smoke before merge.</rationale>
+  > <parameter name="memories_used">["e306cb81-81b5-4979-853b-04a2704deca7", "37bb585c-d58c-4e9d-8c83-70a9b8e0da29", "7dd8ea95-69c5-4c3b-a26b-2d3c9696bff0"]
+- **Memories used:** `none`
+
+---
+
+### implement #417 — close q15/q19 recall ranking gap; primary fix: exclude session-snapshot tag from recall results
+
+- **UUID:** `2a3a1c55-b6bf-4077-aa7e-2d8cbe67fbe0`
+- **When:** `2026-04-25T18:49:06.729745+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Soft downweight session-snapshots via temporal-score multiplier — rejected: snapshots have legitimate freshness signal that the multiplier would have to fight, hard filter is cleaner and matches their actual purpose (direct-fetch only).; Push the filter into the RPCs (server-side SQL) — rejected for now: Python-side keeps eval-recall.py + recall-hook.py + handlers/memory.py in lockstep without touching schema; can be moved server-side later if perf becomes an issue.; Fix rewriter prompt first — deferred: only 4-6 of 20 fails, and q19 (the biggest fail) is structural not rewriter — wrong place to start.`
+
+  > Eval baseline showed worse than the issue body said (recall@5 70-75%, MRR 0.50-0.54). Verbose run revealed q19 top-5 is ENTIRELY session_snapshot_* memories — 26 such rows in the 412-memory corpus, all `type=project`, tagged `session-snapshot,compression-resilience` (auto-created by PreCompact hook for /end recovery). They're operational artifacts: massive blobs of mixed user messages + action logs that semantically match almost anything Jarvis-related and lexically match many Russian queries. They were never intended to compete in normal recall — their use case is targeted memory_get(name=session_snapshot_<uuid>) during /end recovery. Plan: add a Python-level exclude-by-tag filter after the match_memories/keyword_search_memories RPCs return, scoped to tag `session-snapshot`. Mirror the same filter in scripts/eval-recall.py and scripts/memory-recall-hook.py so eval predicts production behavior. Re-measure; if q15/q19/others still fail, investigate per-query (q15 multi-agent confusion, q11/q17 rewriter not firing). Deterministic-first per phase_split_pattern: structural pollution fix before tuning rewriter or rerank. Confidence high — pure additive filter, snapshots have a stable tag, easy to verify.</rationale>
+  > <parameter name="memories_used">["384e7df3-7c61-4e45-932d-85728b31434b", "f39f3793-5929-4589-8a67-5913adffab15"]
+- **Memories used:** `none`
+
+---
+
+### Decompose #684 process-transparency epic into 5 sub-issues split across 2 phases
+
+- **UUID:** `16b02143-73aa-4e5a-9172-bcad6e799df7`
+- **When:** `2026-04-26T18:28:51.922926+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `one giant PR addressing whole epic; create just 3 issues for Phase 1, defer Phase 2 issue creation; close #684 and replace with narrower epic`
+
+  > Owner pain point ("98% reported, robot useless for weeks") demanded this epic, but its scope is pillar-sized. Survey of repo showed backend diagnostics LARGELY EXIST (pipeline_v3._dump_pass_diagnostics writes per-pass JSON+npz, SessionTrace JSONL, VisualLogger PNG) but never reach the React UI. Decomposition = lift existing backend data to UI, not new instrumentation. Phase 1 = E1 (diagnostics reliability — unblocks rest) + E2 (convergence heatmap — direct fix for the cited «98% useless» class) + E4 (failure-mode banner — prevents silent degradation). Phase 2 = E3 (per-pass tab) + E5 (OT introspection — power-user). Sister issues #685 (warp viewer) and #549 (real-time heightmap) stay independent. Per pillar_is_not_one_task: 2 sprints minimum, not one. Phase ordering chosen by ROI for catching the «numbers lie» class of bug, per debug_visualization_first memory.
+- **Memories used:** `354419eb-fea4-4660-9980-4f60d6f705f1, 2a7fe7df-da8d-463b-a507-7e00c09f42c0, bdf9cfaa-c46f-4d8b-afef-a90c8aa91632`
+- **Memories used (unresolved):** `debug_visualization_first`
+
+---
+
+### Close PR #328 as superseded by federation tombstone #354; repurpose post-factum bucket #421 to track equivalent fixes against `.claude-userlevel/skills/`.
+
+- **UUID:** `e0ad3d6e-9019-4f27-b57e-cbb7649b62eb`
+- **When:** `2026-04-26T18:32:30.491699+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:end-2026-04-26`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Rebase #328 onto current main: would auto-drop the modifications without warning — net no-op; Reopen + force-push reapplied changes at .claude/skills/: contradicts #354; Leave #328 open: continues failing CI without value`
+
+  > PR #328 modified `.claude/skills/` files that #354 deleted hours after the PR was opened. `git merge-tree --write-tree` returned a clean tree only by silently dropping #328's modifications (delete-vs-modify auto-resolved by keeping the deletion). Reintroducing files at the project-level path would directly contradict #354's federation decision. The fixes themselves are still substantively needed — origin/master refs, dead recovery-playbook refs, missing UUID guard before memory_id backfill all exist in `.claude-userlevel/skills/` today.
+- **Memories used:** `none`
+
+---
+
+### FoK design (Phase 5.3-α): dedicated `fok_judgments` table over inline `events.payload`; framed as gap-analysis from #250 not clean-slate.
+
+- **UUID:** `051174ab-c5f6-46ba-8a87-0f6cc4670886`
+- **When:** `2026-04-26T18:32:39.808898+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.75`
+- **Actor:** `session:end-2026-04-26`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep events.payload inline (status quo from #250): blocks calibration loop; Extend memory_calibration view: wrong primitive — per-outcome not per-recall; New table only, no compat mirror: cleaner but breaks any external consumer of events.payload.fok_verdict`
+
+  > Inline JSONB on events.payload makes calibration-loop FK to task_outcomes awkward, can't index verdict cleanly, has no model/version columns. Dedicated table supports D6 calibration (Brier vs outcomes), versioning judge_model + judge_version as columns, queryability for /reflect aggregation. Backward-compat: dual-write to events.payload during 5.3-β/γ, drop in 5.3-δ. Doc honestly frames work as gap-analysis from #250 (closed but only emit + initial fok-batch.py shipped), not clean-slate.
+- **Memories used:** `none`
+
+---
+
+### PR Body Check escape via `priority:critical` label (hotfix); design RFC moves to GitHub Discussions (no PR, no issue).
+
+- **UUID:** `7767ae6c-7393-4368-8a09-dfe22e403498`
+- **When:** `2026-04-26T18:32:47.699644+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-04-26`
+- **Project:** `jarvis`
+- **Alternatives considered:** `[no-issue] body marker: too easy to abuse on every PR; Both label and body marker: dual mechanism increases surface; label alone is enough; Workflow_dispatch override: doesn't fit pull_request trigger`
+
+  > Owner called out two related anti-patterns: design discussions polluting PR review channel (PR #423 was the catalyst — 5 of 6 'open questions' were decisions Jarvis had context to make), and trivial hotfixes blocked by linked-issue requirement creating bootstrap-issue paperwork. Single mechanism — label-based bypass — solves the second. Splitting the channel — Discussions for design, PR for code — solves the first. Label `priority:critical` reuses the existing hotfix flag in issue-checks.yml. Meta-test mirrors #326 pattern.
+- **Memories used:** `none`
+
+---
+
+### autonomous-loop Step 2b rung 4 branches by repo ownership: foreign-owner repo keeps tracking-issue creation; own repo (Osasuwu/*) emits a critical event with event_type=hygiene_unaddressed_critical instead.
+
+- **UUID:** `fe32dab3-520a-485c-992c-2c7374cc6a8a`
+- **When:** `2026-04-26T21:35:50.905979+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:cleanup-marathon-2026-04-27`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Auto-spawn /delegate at rung 4: too aggressive without owner sign-off; Drop rung 4 for own repos: perception cliff; Tracking issue then auto-close: paperwork ritual`
+
+  > #327 introduced rung 4 = create tracking issue uniformly. For foreign-owner repos this is the only escalation path. For own repos, Step 2a already auto-actions findings, so the tracking issue duplicates the signal as paperwork. Branching keeps foreign behavior intact while letting own-repo findings escalate via critical event into telegram-notify-hook to owner.
+- **Memories used:** `none`
+
+---
+
+### Dispatch #677 (TwoTroughController pipeline mode) to coding subagent after merging dependency PR #681; close stale #549 (already shipped via PR #552); merge #681/#682/#683 inline.
+
+- **UUID:** `1b311952-0af6-4b0a-8d4f-14b4dd40e702`
+- **When:** `2026-04-28T10:14:04.147709+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:delegate`
+- **Project:** `redrobot`
+- **Alternatives considered:** `wait for owner to merge PRs themselves; dispatch #677 with base = feat/676-... branch (rejected: memory says origin/master only); delegate #549 anyway (rejected: already shipped)`
+
+  > Owner asked /delegate #677 #549. Pre-flight: #549 was already implemented in PR #552 (2026-04-06) — closed as completed instead of reimplementing (read_code_before_implementing rule, prior 2-of-6 lesson). #677 was blocked by PR #681 (ClosedLoop wiring still open) and #682 stacked on #681's branch — owner authorized inline review of all three open PRs since Copilot hit budget limit (memory: ci_failures_budget_limit). Reviewed all three: LOW risk, additive, no protected files, secrets handled via env not YAML, all tests green locally (12 + 39 + 14 + 26 regression). Merged #681 → #683 → #682 (latter required rebase to drop the duplicate #676 commit after #681's squash). With #681 in master, TwoTrough now has the vision_mode/camera_adapter seam to wire into — subagent can act standalone.
+- **Memories used:** `aa384303-ae0f-489d-bb0d-c167064f8abc`
+- **Memories used (unresolved):** `delegate_explicit_branch_origin_main, read_code_before_implementing, review_before_push, copilot_review_role`
+
+---
+
+### Adapt the forked anthropics/claude-plugins-official as an independent sibling repo (~/GitHub/claude-plugins-official) rather than vendoring plugins/code-review/ into jarvis as a subtree
+
+- **UUID:** `073749ea-2676-4193-86dc-8a06d7615ff8`
+- **When:** `2026-04-28T12:24:41.645595+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Vendor plugins/code-review/ into jarvis/plugins/code-review/ as a git subtree — simpler self-contained install but expensive upstream merges and entangled histories; Skip fork, build C16 reviewers from scratch in jarvis — owner explicitly rejected (~70-80% of work done by upstream plugin per build-vs-buy); Keep adaptations only as local git diff, never push fork — blocks GHA usage which requires git URL source`
+
+  > M1+M2+M3 of C16 (Verification) is adaptation-heavy — three new generic reviewers added on top of upstream's five. Sibling-repo keeps the fork's git history clean for upstream rebase (`git fetch upstream && git merge`), which is the right move when adaptations are also PR-back candidates. Subtree would tangle Jarvis's history with plugin's history and make upstream merges expensive. setup-device.py auto-clones the sibling on each device via setup_sibling_repos(). Trade-off accepted: fork lives outside the jarvis repo, so jarvis is no longer fully self-contained for plugin install — mitigated by setup-device automating both clone and `claude plugins install`.
+- **Memories used:** `2557f3e4-3815-40b6-aab0-ea587efae2b6, 68acb2b6-a890-4f5d-8f1b-80e7c4dd9e44, ade61912-4168-40ce-b4b7-55e94a160d43`
+
+---
+
+### VISION.md restructured into 5 axes + 8 pillars + Digital Twin mode (Phase B)
+
+- **UUID:** `a8852501-4b74-495b-9bbf-dd77b65c30bb`
+- **When:** `2026-04-28T20:44:22.557567+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-04-29-phase-b`
+- **Project:** `jarvis`
+- **Alternatives considered:** `2 axes (знает/делает) — too lossy, hides principal interface and SOUL; 4 axes without учится — folds learning into думает but loses outcome-tracking surface; 6 axes adding Digital Twin as «как изображает» — promotes mode to layer; conflates runtime mode with infrastructure layer; Keep Trust spectrum 5 levels — fails because L1 push-back is always-on, L4 collapses into L3; Keep Pillar 6 Data Intelligence — fails Anthropic-native test (generic platform capability); Delete Pillar 7 entirely — loses real federation/coordination concern`
+
+  > Phase B taste-call session resolved 6 framing decisions flagged by parking memo. Five axes (знает/хочет/думает/делает/учится) replace «Three Core Abstractions»; each axis = real product surface, not symmetry-driven taxonomy. Trust spectrum L0–L4 dropped (push-back is always-on SOUL behavior, not a level; gating moves to per-class action gates per surgical-caution principle). Goal hierarchy 5 levels collapsed to parent-id chains (matching redesign C2 implementation). Pillars: 9→8+mode. Critical gap caught: «как думает» axis had no pillar — added Pillar 5 «Judgment & Calibration» (SOUL/always-load/calibration). Pillar 6 deleted (filler bucket). Pillar 7 renamed Agent System → Federation & Delegation. Pillar 8 split: TTS/Tg → «делает», Digital Twin extracted as separate operating mode (mode swap of all 5 axes, not 6th layer). North-star: «autonomous engineering peer for one principal» — keeps non-hierarchical tone, makes single-principal explicit.
+- **Memories used:** `fab1fd93-7f45-4e9b-ab1a-48c2747047fd, fd9ffeba-91a4-481f-9b5e-0a7bae975f90, 25c2f957-5412-4206-8406-57247b186953, ecd6f6c9-8bb5-4be6-8526-fee314a885d0, 9757b985-cf68-4310-9d44-0571697d337f`
+
+---
+
+### Drop pillar numbers from operational language; keep them as narrative anchors only in VISION.md (#466 Option B)
+
+- **UUID:** `d7a4bed3-a088-405c-896a-077b8dd76104`
+- **When:** `2026-04-28T21:29:47.319309+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:2026-04-29-phase-b`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A. Renumber sweep across all 12 files + memories + EPICs — bulk change with no end (memory keys, EPIC issue titles can't be renamed cleanly); rejected; C. Document the duality only — add mapping table, leave operational refs alone; rejected (silent confusion grows); D. Status-quo — accept ambiguity; rejected (will drift further as system grows)`
+
+  > Phase B VISION rewrite (#465) renumbered pillars (e.g. old Pillar 7 = Agent System; new Pillar 7 = Integrations), creating ambiguity where same number means different concepts depending on which doc the reader landed on. Per `pillars_drop_structural_direction_2_2026_04_28`, pillars are narrative-only — so pillar numbers can be renumbered cleanly, but operational refs anchored on numbers became broken. Solution (Option B from issue #466): operational docs/skills reference pillars by NAME («Federation & Delegation Sprint 2» not «Pillar 7 Sprint 2»). Numbers stay only in VISION.md as table-of-contents anchors. Historical identifiers (memory keys like `pillar9_sprint1_self_security`, EPIC issue titles, milestone titles) keep their numbers as immutable refs. PR #467 swept 18 files; mapping table added to PROJECT_PLAN.md for transition period. Drive-by Phase A consistency: owner→principal in two design docs that had been touched.
+- **Memories used:** `c973812d-8b5f-41d6-9c83-2bb4ad2351a7, ecd6f6c9-8bb5-4be6-8526-fee314a885d0, 9bb3332f-9b9f-4444-8723-77e37501de5f, afa16ea6-eb47-4f0c-a17e-602065c3481f`
+- **Memories used (unresolved):** `vision_b_five_axes_eight_pillars_2026_04_29`
+
+---
+
+### Phase C of Vision update bundled into one PR (docs/vision-phase-c) instead of 4 sequential PRs
+
+- **UUID:** `182956a9-b2ef-4fa1-864a-3530c3b95456`
+- **When:** `2026-04-29T04:38:34.272279+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:vision_phase_c_2026_04_29`
+- **Project:** `jarvis`
+- **Alternatives considered:** `4 sequential PRs (one per sub-phase) — rejected: design docs cross-reference each other, would cite stale unmerged peers; Skip C-1 redesign and ship only README+agents+skills first — rejected: principal asked for all 4 in this session; Mass code-level owner→principal rename (Enum, fn names, DB cols) — rejected: cross-project change with redrobot, separate issue`
+
+  > Four sub-phases (C-1 redesign.md, C-2 README, C-3 design/*, C-4 agents/* + skills/*) cross-reference each other. Sequential PRs would mean each PR cites stale terminology in unmerged peers, 4× CI cost, 4× review cycles for what is one coherent terminology + structural pass aligned with Phase B framing. Bundled PR includes: (1) bulk owner→principal terminology pass (164 refs in redesign.md alone, plus 8 design/agent/skill files), (2) 3 locked redesign edits from audit_3_main_changes_lock — §C16 class-aware auto-merge, §C15 M3 split into 6-hard + 3 M2-strong, §C2 candidate-goals auto-create flow, (3) C18 Proactive challenger added (caps 17→18) with full L2 §, L3 entry, pillar-mapping update, C4 component diagram update. Functional identifiers (GitHub <owner/repo>, OWNER_QUEUE Enum, owner_focus DB column) explicitly NOT renamed — schema/code rename is separate cross-project work with redrobot. SVG re-render via mmdc deferred to follow-up.
+- **Memories used:** `7cbc4e3f-2d38-4f01-a6f1-f7cf2c06f1b4, 1e5dbd24-3ed2-44cf-837d-6e1c8dc0c28c, fab1fd93-7f45-4e9b-ab1a-48c2747047fd, c973812d-8b5f-41d6-9c83-2bb4ad2351a7`
+
+---
+
+### Add explicit L0 §«Harness coupling — deliberate trade-off» to redesign.md, resolving pass2 §Q7
+
+- **UUID:** `f67506bf-e530-42a1-97da-41d5a56ef36c`
+- **When:** `2026-04-29T05:45:13.463058+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:vision_phase_c_2026_04_29`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Build harness adapter abstraction now — rejected: indirection without 2nd implementation; Direct commit to main — rejected: would conflict with open PR #468 bulk rename; Wait until PR #468 merges then commit separately — rejected: extra round-trip, scope fits PR #468; Leave Q7 open in pass2 — rejected: future-self will keep asking why caps aren't harness-independent`
+
+  > Q7 has been open since pass2 review (2026-04-27): «harness lock-in not argued as deliberate trade-off». User raised it during Phase C session as «нужно строить вокруг любой модели или закоммитили в Anthropic?». Real answer: cap layer C1-C18 IS harness-agnostic by design; Supabase schema/events substrate/MCP/embeddings are portable; locked layer is skills + hooks + auto-load + subagent isolation. Cost of swap = ~1-2 sprints rewrite. Decision: do NOT preemptively abstract (per SOUL §Abstractions need two real implementations) but DO declare the trade-off explicitly at L0 so future-self has the «why» when reconsidering. Bundled into PR #468 (already touching redesign.md L0 for owner→principal pass) instead of separate commit — direct-to-main would conflict with the open PR's bulk rename. pass2 §Q7 marked Resolved with pointer to new L0 §.
+- **Memories used:** `c973812d-8b5f-41d6-9c83-2bb4ad2351a7`
+
+---
+
+### Defer pipeline_v3 wall-margin gate + trajectory_v3 width/2 to follow-up #709; only fix the real TypeError in pipeline_zigzag inside #689
+
+- **UUID:** `57582d94-1076-4411-a903-a294d1857353`
+- **When:** `2026-04-29T11:41:47.317592+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:redrobot-2026-04-29-pr706-review`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Force-fix all 3 with capped margin (rejected: breaks 6 tests across 2 files, requires buffer-zone semantics rework); Fix (2) and (3) by adjusting test fixtures to use bigger trays (rejected: fixtures encode legitimate small-grid cases — 100mm tray with tray_wall_margin_mm=10 was deliberate for testing geometry edges); Skip Copilot review entirely (rejected: TypeError in pipeline_zigzag is real prod crash)`
+
+  > Copilot flagged 3 issues in PR #706. Investigation showed: (1) pipeline_zigzag.py:67 was a real runtime TypeError that would crash on first UI zigzag run — fixed inline. (2) pipeline_v3.py:300 gate suppresses margin in production trough but tightening breaks test_pipeline_uniform_excess_no_buffer_stops because the V3 planner treats wall ring as a phantom buffer-zone dump target. (3) trajectory_v3.py:912 width/2 swap breaks 5 TestAngledTrajectoryClipping tests on the 100mm fixture. The blade-vs-wall safety contract is enforced by discretizer._check_and_clamp_bounds, which IS already rotation-aware, so deferring (2) and (3) is planner-quality only, not a safety regression. Inline NOTE comments + #709 follow-up keep the trade-off discoverable.
+- **Memories used:** `13899c6c-ac41-4d71-ad54-11f740cc938a, 9ac37264-166d-4351-9cd5-2510415343c0, 83658fba-1576-44a1-90b1-a12cb0f3cd94, 9bb3332f-9b9f-4444-8723-77e37501de5f`
+
+---
+
+### After Sprint #34 closes, run 4 prep sprints in migration-order before unlocking C15 self-improve loop
+
+- **UUID:** `5b304304-9dca-4e1b-ab1f-9d2a5d8d0dcc`
+- **When:** `2026-04-29T12:09:07.739615+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Build a minimal plan executor now that just opens issues from migration order — rejected: 4 prep sprints away from real autonomous build, not worth scaffolding; Activate C15 self-improve immediately on existing primitives — rejected: bootstrap protection violated, no audit substrate yet`
+
+  > Owner asked whether we can build a subsystem to autonomously execute the Jarvis implementation plan. Per docs/design/jarvis-v2-redesign.md:1665, migration order is fixed by dependency graph: C17 substrate → C13 cost ledger → C6 gate → C16 reviewers + C5 dispatcher → C15 last. Putting C15 first would skip the audit/cost/review primitives it needs to be safe (bootstrap-protection rule explicitly forbids C6/C16/C17 modifications without prior-version review for first 30 days). Owner aligned: skip the cheater "minimal plan executor", do the 4 prep sprints, then C15 activates safely on top of existing /self-improve and /autonomous-loop primitives. Sprint #34 was step 0 (FoK Phase 5.3); 4 sprints to safe self-build.
+- **Memories used:** `c973812d-8b5f-41d6-9c83-2bb4ad2351a7, ade61912-4168-40ce-b4b7-55e94a160d43`
+- **Memories used (unresolved):** `autonomous_long_sessions`
+
+---
+
+### Implement C17.1 design note inline (#475)
+
+- **UUID:** `000879a2-b07f-4e49-b83d-1420c1a23e47`
+- **When:** `2026-04-29T13:18:06.52965+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Delegate to subagent — rejected: foundation doc benefits from full session context with just-loaded design memories; Skip design note, jump to migration in #476 — rejected: locking column names + OTel verbatim before SQL prevents later renames cascading through views/writers; Inline schema in jarvis-v2-redesign.md instead of separate file — rejected: separate 1-pager is the unit of reference for #476/#477 implementers`
+
+  > Sprint 35 first issue — locks the canonical schema, OTel column convention, trace propagation rules, and write semantics for events_canonical before any SQL is written. Doc-only, low risk, unblocks #476 (migration) and #477 (first writer). Inline /implement: full session context loaded, doc requires picking precise spec values from across the redesign doc which agents could miss in a worktree, foundation step gets owner-aligned wording. Approach: single 1-pager at docs/design/c17-events-substrate.md mirroring memory-fok.md structure. Key non-obvious choices: supabase/migrations/ is migration directory (corrected from issue body which said mcp-memory/migrations/), degraded=true fallback per line 308 means event-write failure NEVER blocks calling action, two-mode coexistence per line 1566 keeps legacy decisions table during cutover.
+- **Memories used:** `none`
+
+---
+
+### Implement C17.2 events_canonical migration inline (#476)
+
+- **UUID:** `a68e818d-387d-410b-91e2-ed8fc960f022`
+- **When:** `2026-04-29T14:46:04.555816+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `ALTER existing events table in place — rejected: NOT NULL constraints + fok_judgments FK + GH-Actions-perception columns block clean rewrite (locked in #475 §6); Split into 3 migration files (table/views/trigger) — rejected: single logical unit, blast radius low, schema-drift CI gate satisfied by any one new file; Defer materialized views + pg_cron — rejected: design 1-pager L3 leans 'materialized views from day one' for hot reads; deferring leaves a known-incomplete state; Delegate to subagent — rejected: cross-project schema (shared with redrobot) + RLS reasoning + CI gate awareness all benefit from in-session continuity`
+
+  > Sprint 35 second issue, sequential after #475 design lock. NEW table (not ALTER existing events) per §6 amendment in #475 — legacy events has GH-Actions-shaped NOT NULL columns + fok_judgments FK that block in-place rewrite. Plan: single migration file under supabase/migrations/ creating event_outcome enum, events_canonical table with all C17 design columns, 4 indexes (trace+ts, actor+ts, action+ts, partial cost), pg_notify trigger on channel events_canonical, RLS enabled with allow-all-authenticated+anon policies (matches existing convention from fok_judgments, task_queue, etc.), 2 materialized views (cost_by_day, last_run_by_actor), pg_cron schedules for refresh (extension available but not installed — CREATE EXTENSION inline). Mirror to mcp-memory/schema.sql per CI gate from #326. Apply via Supabase MCP, then write smoke test that does INSERT + verify + LISTEN-NOTIFY round trip + materialized view refresh + RLS check. Inline /implement: schema is shared with redrobot, full session context needed to avoid breaking cross-project consumer; I just wrote the design doc 30 min ago so column intent is fresh.
+- **Memories used:** `none`
+
+---
+
+### Implement C17.3 record_decision OTel writer + degraded fallback inline (#477)
+
+- **UUID:** `a7a86846-0943-417b-ad0c-dc871dca68bc`
+- **When:** `2026-04-29T14:56:03.896377+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Per-error-class transient classification with PG error codes — deferred: PostgREST wraps SQL errors generically, no clean access to SQLSTATE; defer to 1.x; Single combined module (events_canonical_emit) instead of split trace_context + events_canonical — rejected: trace_context is a primitive that future writers (#477+wave) will also use; separation matches future module boundaries; Background thread/asyncio drain instead of in-line drain at next emit — rejected: adds complexity, harder to test, and the sync drain pattern is already proven in fok linker code; Modify just decision.py without new modules — rejected: trace_context is shared infrastructure, embedding it in decision.py blocks reuse`
+
+  > Sprint 35 final issue, sequential after #476 substrate landed. Adds 2 new modules (mcp-memory/trace_context.py for ContextVar propagation; mcp-memory/events_canonical.py for emit_event + bounded ring buffer) and modifies handlers/decision.py to dual-write (legacy episodes + canonical events). Architectural choice: simple-but-correct error policy — ANY exception during events_canonical write logs warning + buffers + returns success to caller (record_decision NEVER blocks on events write); buffer drains on next successful insert with degraded=true. Defer per-error-class transient/non-transient classification to 1.x once we have real failure data — the design 1-pager explicitly calls out "RLS denies = bug surface loudly" but PostgREST wraps SQL errors generically; surfacing via repeated drain failure logs is acceptable for substrate POC. Tool schema extension: add optional `llm` field to record_decision MCP tool — when present, populates cost_tokens / cost_usd columns and OTel-shaped payload keys. Existing callers without LLM metadata preserved unchanged.
+- **Memories used:** `none`
+
+---
+
+### implement C18.1 design 1-pager — drift-signal taxonomy + threshold contract + bootstrap protocol (#483)
+
+- **UUID:** `acf8fa04-bf5a-4e1c-ba11-1b102ef3b44d`
+- **When:** `2026-04-29T16:02:24.825767+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `scope C5 first per migration order — rejected: owner explicitly chose C18, design doc is forward-locking and doesn't block on C5 impl; scope full Sprint 36 with C18.2/.3 issues at creation — rejected: detection engine scope depends on what design says about substrate-readiness; lower commitment to ship .1 first then plan .2/.3; skip milestone — rejected: established C17 pattern is sprint=chapter with milestone-attached issues per CLAUDE.md sprint hygiene; open issue without milestone — rejected: same as above`
+
+  > Mirror C17.1 pattern (PR #478): forward-locking design doc before any detection-engine code. Lock the 5-signal taxonomy from redesign §C18 with explicit substrate-readiness flags (3 ready now: goal_neglect / direction_vs_action / stale_assumption; 2 blocked on C5 calibrator + C16 verification arm). Lock recalibration_thresholds.yaml schema as M2-strong (wrong thresholds = surfacing storm). Add `recalibration_proposed` + `surfacing_outcome` to C17 action vocab. Bootstrap protocol: surfacing_enabled=false default → dry-run mode for ≥30/≥60 day baselines before flip. False-positive auto-tighten policy (acceptance <25% over 4 weeks → tighten 1σ) locked here so #C18.2 doesn't reinvent. No SQL in this doc — concrete queries belong in #C18.2. Cross-link from redesign §C18 line 657 mirrors C17 pattern. Picked C18 over C5/C6/C16 because (a) owner stated "давай C18", (b) the 1-pager is forward-locking and doesn't depend on C5/C16 implementation, (c) substrate (C17 events_canonical) shipped today makes 3/5 signals immediately implementable. Sprint 36 milestone created with explicit sequencing note.
+- **Memories used:** `1e5dbd24-3ed2-44cf-837d-6e1c8dc0c28c, c973812d-8b5f-41d6-9c83-2bb4ad2351a7, 7cbc4e3f-2d38-4f01-a6f1-f7cf2c06f1b4`
+
+---
+
+### Adopt 11 AI Hero (Matt Pocock) skills as part of jarvis core skill set + codify engineering principles in SOUL.md/CLAUDE.md
+
+- **UUID:** `fdd6a68c-3040-4ba6-a3b8-2dc33a6f7060`
+- **When:** `2026-04-30T05:17:24.484335+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-04-30-aihero-research`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Write equivalent jarvis-native skills from scratch — rejected: reinvents tested artifacts, no upstream sync path; Import only /grill-me — rejected: the skill chain (grill→prd→issues→tdd) is the actual value, not single skill; Place skills in jarvis/.claude/skills (project-scoped) — rejected: skills are universal, belong in user-global via .claude-userlevel canonical source`
+
+  > Pocock's anti-vibe-coding philosophy directly aligns with how jarvis should engineer (evals, smart-zone discipline, vertical slices, deep modules, TDD as feedback, shared understanding before plans). Skills are MIT-licensed and explicitly designed for fork-and-adapt. Importing them gives jarvis battle-tested workflows (grill-me before plans, tdd red-green, diagnose repro-first) instead of inventing equivalents from scratch. Engineering principles in SOUL.md make these defaults rather than opt-ins.
+- **Memories used:** `615e9029-f2c5-4f73-b5b1-f28835269b29`
+
+---
+
+### Adopt grill-me alignment protocol: three-way doc split (CLAUDE.md/SOUL.md/CONTEXT.md) + adaptive checkbox + refactor permission + sprint-close sweep cadence
+
+- **UUID:** `0212c379-db68-434a-953d-52e748b99486`
+- **When:** `2026-04-30T09:01:11.691167+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-04-30-grill-me-protocol`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Hard PreToolUse hook blocking /implement without grill-me transcript — rejected: too rigid for trivially small tasks, raises friction without proportional benefit; Headless auto-sweep on milestone close — rejected: skill is interactive (grills owner), can't be fully headless; better via SessionStart reminder using existing infra; Mechanism A (CONTEXT.md pre-written) first — rejected: owner has no developed glossary by his own admission; pre-writing produces stale doc; Apply to redrobot first — rejected: jarvis is meta-tool with publishable risk envelope, train habits there, port to redrobot after pattern proven; Per-agent SOUL.md refactor now — rejected: premature, single-agent today; recorded as future debt`
+
+  > Diagnosed root cause of scope shrinkage as implicit assumptions never crossing into the brief (owner-articulated, confirmed by sand-through-blade example). Mechanism B (grill-me as mandatory phase via 4-question checkbox) directly attacks alignment problem. Mechanism A (CONTEXT.md) grows organically from B as side effect, not pre-written (owner has no developed glossary). Mechanism C (property tests) deferred until invariants surface through B. Loss-aversion fixed via explicit refactor permission + regular sweeps in fresh sessions. Three-way split formalizes lifecycles: rules stable, identity per-agent, domain growing. Forward-compatible with multi-agent target (3+5).
+- **Memories used:** `615e9029-f2c5-4f73-b5b1-f28835269b29, 7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Pocock / AI Hero adoption Phase 1 — closed.
+
+- **UUID:** `77ecfbb3-9686-4456-8e80-3d6d0b53e81c`
+- **When:** `2026-04-30T15:29:17.541812+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:2026-04-30-grill-aihero-closure`
+- **Project:** `jarvis`
+- **Alternatives considered:** `(α) minimum — only redesign cross-link; rejected: leaves personal devloop unrecorded; (γ) maximum — full Phase 2 milestone with Discussion + weekly cron; rejected: same wide-scope failure mode as PR #489; Wait for Copilot review on #492 before merge; rejected: 5 review comments from #489 already addressed in commit 1d01af2, CI all green, dual-review is paperwork`
+
+  > Phase 1 covers: 11 skills imported (PR #487), CONTEXT.md + alignment protocol + grill-me checkbox in /implement and /delegate (PR #492), engineering-principles cross-link in L0 of jarvis-v2-redesign.md (PR #493), personal devloop memory (personal_workflow_aihero_adoption). Closing scope chosen as (β) "medium" over (α)/(γ): minimum (α) would leave research orphaned from architecture doc; maximum (γ) repeats the wide-scope mistake that got #489 mechanically auto-closed. Two items deferred: GitHub Discussion "Evals beyond memory" (strategic, not adoption-blocking — draft prepared) and weekly /grill-me cron for tacit-knowledge extraction (premature automation with n=1 organic use; revisit after 2-3 uses). Validation note: this very grill-me session was test #1 of the post-#492 protocol — meta-use is valid but worth flagging in /reflect.
+- **Memories used:** `615e9029-f2c5-4f73-b5b1-f28835269b29, 7cbc4e3f-2d38-4f01-a6f1-f7cf2c06f1b4`
+
+---
+
+### analyze-comms skill drops auto-upload to GDrive; artifacts stay in local staging dir, user uploads manually
+
+- **UUID:** `ea2c0e71-49be-480f-adea-29ddacb8cd9f`
+- **When:** `2026-04-30T16:48:07.099502+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep GDrive but main agent handles upload (subagent only writes report, no read-back) — rejected: base64 of personal data still in main context; Add self-improvement framing in subagent prompt with smaller upload scope — rejected as same residual risk`
+
+  > GDrive create_file requires base64 in tool param. Subagent doing base64-encode + read-back of personal communication-pattern files (with MMPI/profiling-adjacent context in memory) consistently triggers AUP classifier — failed once on Main PC and 3× on laptop. Removing the upload step entirely eliminates the classifier exposure. Cross-device merge was already in Future merging (not implemented), so no functionality lost. User explicitly chose this over keeping GDrive with mitigations.
+- **Memories used:** `none`
+
+---
+
+### analyze-comms merge resolution: keep two-phase (Phase A per-device → Phase B cross-device merge) BUT drop GDrive auto-upload from both phases — user transfers {DEVICE}_patterns.json files manually between devices.
+
+- **UUID:** `73344d30-0b45-4ae2-9b7c-27f230a5d67d`
+- **When:** `2026-04-30T17:18:43.363272+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Accept origin/cd61321 verbatim — drops Phase B/cross-device merge entirely, loses redesign value; Accept HEAD/f731e6a verbatim — re-introduces AUP classifier trip via base64 patterns.json upload`
+
+  > Conflict between f731e6a (added two-phase GDrive auto-upload architecture) and cd61321 (intentionally removed GDrive auto-upload because model-side base64 of personal-pattern files trips Anthropic AUP classifier). Option 1 (accept origin) destroys the two-phase redesign; option 2 (accept HEAD) re-introduces the AUP bug cd61321 just fixed. Hybrid keeps the architectural value (cross-device merge with confidence weights) while honoring the safety constraint (zero outbound network calls, no base64 round-trips of personal data). User confirms the friction of manual file transfer is acceptable.
+- **Memories used:** `none`
+
+---
+
+### Bootstrap reframed as vertical slices; Slice 0 = memory_write warmup, Slice 1 = /implement AFK-trust path
+
+- **UUID:** `7d0c6091-3421-4ec3-800a-ecc718237b92`
+- **When:** `2026-04-30T17:28:59.315733+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep horizontal 12-step bootstrap — rejected: violates just-adopted vertical-slice principle; Memory_write only as first slice — rejected: doesn't move AFK-trust needle, just warmup; Skip warmup, start with /implement directly — rejected: too much surface for first cutover, lose calibration data on cheap path`
+
+  > Aihero/Pocock vertical-slice principle adopted in SOUL §Engineering principles 2026-04-30 conflicted with horizontal 12-step bootstrap in jarvis-v2-redesign.md. Without reframe, 5+ sprints of substrate would land before any verifiable end-to-end run, leaving AFK-trust pain points (verify_before_assuming_implemented, subagent_acceptance_criteria_dodged_as_out_of_scope, record_decision_during_session_not_at_end) unaddressed. Slice ordering biased toward AFK-trust caps so bootstrap itself does not delay the HITL→AFK transition the principal is targeting. Surfaced via /grill-me on a without-skill vision/pillars/caps planning session — also calibrates skill: run on transition moments (design→execution), not every sprint.
+- **Memories used:** `ecd6f6c9-8bb5-4be6-8526-fee314a885d0, 615e9029-f2c5-4f73-b5b1-f28835269b29, 9a5a1ade-d3c0-4163-8559-dff5993094ea, 7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+- **Memories used (unresolved):** `verify_before_assuming_implemented`
+
+---
+
+## 2026-05
+
+### Planning layer = two stateless modules (Strategist + PassPlanner) with explicit PlanningState. Strategist owns Stage 0.5 + 6 (workspace selection, cycle decision, escalation, phase, zone, tool). PassPlanner owns collapsed Stage 1+2+3 (removal layer + toolpath as one operation). Pipeline orchestrates I/O, scan, execute. Pass = unit bounded by workspace/zone/tool/confidence; chained movements inside one Pass replace separate batching. ConfidenceEstimator is the single source of truth for "scan now or chain further". Top-down sequencing enforced at two levels: zone ordering in Strategist, push priority-by-height in PassPlanner. Two-trough collapses into Strategist workspace selection — no separate orchestrator. Migration via strategy (D): first PR is extraction-only refactor (no behavior change, 121+ V3 tests must stay green), subsequent feature PRs build on stable contract.
+
+- **UUID:** `3b1710eb-f447-42cb-b806-beb4e6086e1b`
+- **When:** `2026-05-01T14:43:37.581862+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.78`
+- **Actor:** `skill:grill-me`
+- **Project:** `redrobot`
+- **Alternatives considered:** `One-level Planner with pluggable strategies (rejected: god-class with strategy zoo = current state in disguise); Strategist wraps PassPlanner / two layers nested (rejected: each PassPlanner test drags Strategist logic; 3D would require re-overriding wrapper); Keep Stages 1/2/3 separated as planned (rejected: removal_layer for sand requires tool-width to be selected first, and the deficit-first OT cannot decide cuts without committing to push targets — internally inconsistent for our material); TwoTrough as outer orchestrator above pipeline (rejected: workspace switching happens inside cycle, not above it; correct home is inside Strategist as workspace-selection step); Strategist holds session state internally (rejected: breaks replay/debug, blocks serialisation into per-pass diagnostics, complicates two-workspace bookkeeping); Strategist returns List[Decision] for explicit batching (rejected after Pass-with-chained-movements collapsed batching into Pass itself; one Pass per call is sufficient); Confidence inside Predictor as uncertainty map (rejected: forces every Predictor implementation to expose uncertainty; ensemble-Warp is a confidence policy, not a predictor concern); Greenfield pipeline_v4 (rejected: identical pattern to v2→v3 transition that produced current zoo); Inline refactor without contract (rejected: extracts code without stabilising boundaries, reproduces coupling); Feature-flag parallel implementation (rejected: two paths fragment under sprint pressure)`
+
+  > Current PipelineV3 mutated under sprint pressure into a 1900-line god class with six overlapping planner modules (bulk_planner, lookahead_planner, multi_pass_planner, zone_planner, transfer_planner, pass_planner) and a parallel TwoTroughController. The April pipeline_v3_architecture plan called for clean stage boundaries; reality drifted because there was no formal contract to defend. Re-anchoring to the original plan with two corrections: (1) collapse Stages 1+2+3 into PassPlanner — for sand they aren't separable since removal-layer depends on tool-width and toolpath, and the deficit-first OT solves them jointly (CAM-style separation was wrong material model, see sand_transport_not_removal); (2) explicitly account for future 3D planner by formalising workspace abstraction now — Strategist treats single-trough as N=1 case, two-trough as N=2, 3D as N=many model fragments. Stateless modules + DI dependencies + explicit PlanningState gives testability (pure functions over data), serialisability (state dumps cleanly into per-pass diagnostics) and replay (load state, call next, observe decision). Confidence-gated chained movements solve the dominant cost — scans take 5–10 minutes and must be skipped when prediction variance is low. Top-down sequencing addresses the trajectory_planning_naive feedback structurally (two explicit functions) rather than as scattered heuristics. Migration strategy (D) chosen over greenfield (C) because v2→v3 greenfield in April is exactly what produced the current zoo under sprint pressure; chosen over inline refactor (B) because without a stabilised contract first, extracting code without formalising boundaries reproduces the same coupling in more files; chosen over feature-flag fork (A) because two parallel paths during a TwoTrough/CHKV/calibration sprint window will fragment and rot.
+- **Memories used:** `e9fb290e-340e-49e4-9887-4717d59b32c4, 4543a1ca-73c7-4277-a11d-f78214cac4b5, 8c8c8d40-7d51-45d5-a5f0-1ec5ff9ab0fc, 60e0acf7-80a9-4981-8f93-184a33366e4c, ffcf8b3b-8aa9-4265-a761-7b49370608b0, 1186f5ee-5d8e-483a-9a37-e9e359dd72ce, c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7, 283efd25-7b2c-4fe6-a3c4-e4704893fbdc, 86d92e3b-4dcd-464d-b57c-471ef502d500, 2249bb82-14ea-4d9e-a808-ccec002df383, 5b09bc8e-9bf7-495a-93a7-f369270e6d9b, e5257297-ba42-4009-91c7-2b6b54eac45f, 3bd7ce53-ca58-486a-b12f-5af4f468495f`
+
+---
+
+### Recall pipeline extracted to mcp-memory/recall.py as a deep module behind one async interface: recall(client, query, *, project, type_filter, config: RecallConfig) -> list[RecallHit]. Three adapters (MCP _handle_recall, PreToolUse hook, eval-recall) format per-caller; pipeline mechanics + constants live in one place.
+
+- **UUID:** `b803ca63-b3f6-4b67-95dc-aa79566258bb`
+- **When:** `2026-05-01T14:51:17.742264+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `skill:improve-codebase-architecture`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Option B: expose embed/keyword_search/rrf_merge/temporal/expand_links as separate building blocks for eval to compose — rejected because user only runs full-pipeline evals, B is shallower and pushes orchestration to callers; Location B: scripts/recall.py — rejected, inverts dependency direction (server depending on scripts); Location C: new jarvis_recall/ Python package — rejected as YAGNI; no second consumer outside repo, packaging cost across 3 devices + redrobot impact not justified; Sync seam — rejected; would force handlers to run_in_executor or block, worse than one asyncio.run() at the hook`
+
+  > Three callers (handlers/memory.py, scripts/memory-recall-hook.py, scripts/eval-recall.py) reimplement the same pipeline pieces (_filter_excluded_tags, _rrf_merge, _apply_temporal_scoring, _score_linked_rows, _expand_links, _merge_with_links, _cosine_sim) plus drift-prone constants (TEMPORAL_HALF_LIVES, RRF_K, SIMILARITY_THRESHOLD, EXCLUDE_TAGS_FROM_RECALL). eval-recall.py:22 carries explicit "keep in sync with server.py" comment — the architecture confessing a missing seam. Three real adapters satisfies the two-adapters rule, so it is a real seam. Locked option A for the interface (single recall() with RecallConfig flags; eval flips flags, prod uses PROD_RECALL_CONFIG) over option B (expose lower-level building blocks) because user only runs full-pipeline evals. Located in mcp-memory/ to preserve dependency direction (scripts→mcp-memory, never reverse) and reuse the sys.path trick eval already uses via _load_hook_module. Async signature matches MCP handler contract; sync Supabase client wrapped as today. RecallHit returns structured scores so eval can compute metrics without re-running pipeline pieces; formatting (TextContent/brief markdown/eval JSON) stays per-adapter.
+- **Memories used:** `none`
+
+---
+
+### implement #715 — extract Strategist + PassPlanner from PipelineV3 (no behavior change)
+
+- **UUID:** `e5f8e057-dd4a-4cc4-bec3-ebbaa05ace9b`
+- **When:** `2026-05-01T14:52:15.833011+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `skill:implement`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Greenfield pipeline_v4 (rejected during grill — repeats v2->v3 pattern that produced current zoo); Inline refactor without dataclasses (rejected — need stable contract first or coupling reproduces in more files); Include top-down sequencing in same PR (rejected — violates 'no behavior change' AC, blocks safe rollback); Defer to subagent via /delegate (rejected — refactor depends on session-loaded grill-me context and CONTEXT.md just authored)`
+
+  > Foundation PR for the planning-layer architecture aligned in the grill-me session that produced #715. No new logic — only formalises the contract under which subsequent feature PRs (top-down sequencing, confidence-gated chained passes, two-trough refactor) can be written safely. Implementation strategy: (1) capture golden trajectory from master for fixture heightmap before any change, (2) create `redrobot/planning/{state,strategist,pass_planner,__init__}.py` with dataclasses + stateless classes, (3) extract `_determine_phase` + adaptive max_push + tool selection logic into Strategist, (4) extract buffer-zone deficit injection + lookahead/bulk branch into PassPlanner, (5) wire PipelineV3 to call them instead of inline logic, (6) verify snapshot test passes byte-for-byte. _validate_pushes and generate_directed_push stay in pipeline (Stage 4 territory). Confidence/chained-Pass semantics deferred to next PR. New files added under safety-critical-by-path `redrobot/planning/` but existing safety files (safety.py, collision.py, motion_planner.py, executor.py) untouched — no Safety Review needed per #715 AC.
+- **Memories used:** `e9fb290e-340e-49e4-9887-4717d59b32c4, 4543a1ca-73c7-4277-a11d-f78214cac4b5, c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7`
+
+---
+
+### implement Recall deepening 1/4: extract mcp-memory/recall.py with pipeline constants + filter helpers (#496)
+
+- **UUID:** `3f26ff55-ed8b-4448-b2e4-b9060f90a427`
+- **When:** `2026-05-01T15:15:58.032903+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `delegate to subagent — rejected: cross-file refactor with sys.path subtleties + test re-export chain benefits from session context; do all 4 slices in one branch — rejected: AC requires independent eval-baseline check per slice, and process is one-issue-one-PR`
+
+  > Tracer-bullet slice of 4-issue Recall deepening chain. Move only constants (TEMPORAL_HALF_LIVES, SIMILARITY_THRESHOLD, RRF_K, EXCLUDE_TAGS_FROM_RECALL) and the simplest 3 helpers (filter_excluded_tags, cosine_sim, parse_pgvector) into mcp-memory/recall.py; have all 3 call sites (handlers/memory.py, scripts/memory-recall-hook.py, scripts/eval-recall.py) import from there. Behavior preserved by aliasing public names to existing private names at the call sites. Hook keeps its own SIMILARITY_THRESHOLD=0.30 as a local override (different from default 0.25, calibrated 2026-04-17 — not a duplicate); slice 3's RecallConfig will properly express this divergence as a flag flip. CONTEXT.md already has Recall/RecallConfig/RecallHit glossary entries from prior grill-me, so AC is well-shaped — proceed without re-running grill-me.
+- **Memories used:** `none`
+
+---
+
+### Adopt official Anthropic Telegram channels plugin for Jarvis chat I/O (replaces deferred-channels stance)
+
+- **UUID:** `7ca91595-342d-44a3-962b-e239b9291b47`
+- **When:** `2026-05-01T18:00:38.112764+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep waiting for digital-twin pillar — rejected, grill-me makes channels useful now without impersonation risk; Build custom Python relay — already deprecated by claude_code_channels reference`
+
+  > Grill-me skill (sequential single-session Q&A) is the first concrete use case where Telegram I/O has clear value without conflicting with the no-impersonation rule. Plugin polls bot via Bun, ACL via /telegram:access, doesn't disturb existing tg-messenger MCP (Telethon, different auth path). Bot @Jarvis_connector_openclaw_bot paired on Main PC.
+- **Memories used:** `e96ead4a-6466-4daf-ad88-7f39fb070734`
+
+---
+
+### /end and /reflect redesigned: /end becomes pure handoff (no behavioral reflection), /reflect becomes cross-session post-hoc behavioral audit built on analyze-comms infrastructure with distributed Phase A+B via rclone+GDrive and Supabase week-lock. Aggregate steps (calibration, FoK, hypothesis review, stale memories) deferred to future /self-improve grill.
+
+- **UUID:** `ce02c127-ea94-4dd3-8e6f-f7734e6a2b1c`
+- **When:** `2026-05-03T07:02:17.398495+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.78`
+- **Actor:** `skill:end session:end-2026-05-03`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Fold /reflect entirely into /end via in-session subagent (rejected — subagent only sees current session, no cross-session pattern detection); Keep /reflect as-is and just add active triggers (rejected — fundamental scope issue: aggregates ≠ behavior, name lies); Start with LLM detectors directly (rejected — premature, owner cost-conscious; regex-first + ground-truth labels for 3 weeks gives empirical basis)`
+
+  > Owner's pain: /reflect has never auto-triggered since creation because (a) "weekly" is not an active trigger Claude can recognize, (b) name "reflect" was misapplied to aggregates that aren't behavior. During session, agent is too immersed for honest self-reflection — doing it from main session = agent oversees itself = bias. Cross-session post-hoc via subagent or scheduled task with full Supabase journal access fixes the bias problem. MCP read access to other local sessions' jsonl removes the "must reflect now or lose context" pressure. Owner explicit preference: empirical eval (regex first, measure, then maybe LLM) over guessing — supports start-cheap, upgrade-with-evidence pattern. 6 vertical slices filed as Osasuwu/jarvis #509-514 with explicit dependency chain.
+- **Memories used:** `292a0235-4f61-4e5e-b0d4-08625deedfe0`
+
+---
+
+### /reflect = cross-session post-hoc behavioral audit (not per-session)
+
+- **UUID:** `ea46b2ab-caaf-445f-ae57-fc5513beed05`
+- **When:** `2026-05-03T07:13:29.302903+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.78`
+- **Actor:** `session:2026-05-03-end-reflect-grill`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep per-session reflection — rejected: hasn't triggered, single session has too little signal; On-demand only — rejected: relies on owner remembering to ask`
+
+  > Per-session reflection has never auto-triggered since creation and behavioral patterns are best detected across sessions, not within one. Cross-session post-hoc lets the audit observe drift, recurring rule violations, and hallucination patterns that a single session can't surface. Q4 of grill 2026-05-03.
+- **Memories used:** `292a0235-4f61-4e5e-b0d4-08625deedfe0`
+
+---
+
+### /reflect runs weekly (cadence)
+
+- **UUID:** `59ebfdcc-b74b-4ae7-8261-a02de4cfb532`
+- **When:** `2026-05-03T07:13:34.273947+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:2026-05-03-end-reflect-grill`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Daily — rejected: noise > signal; On-demand — rejected: forgotten; Monthly — rejected: drift caught too late`
+
+  > Weekly gives enough material to find patterns without flooding the owner with low-signal reports. Daily is too noisy; on-demand decays. Sunday 22:00 + jitter to spread GDrive load. Q5 of grill 2026-05-03.
+- **Memories used:** `292a0235-4f61-4e5e-b0d4-08625deedfe0`
+
+---
+
+### Absorb /analyze-comms into /reflect (rename, single skill)
+
+- **UUID:** `a181da1c-8c08-4189-aa2a-42088658ae48`
+- **When:** `2026-05-03T07:13:41.708546+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-05-03-end-reflect-grill`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep both, /reflect calls /analyze-comms — rejected: indirection without benefit, two skills to maintain; Delete /analyze-comms, fresh /reflect — rejected: loses working pipeline`
+
+  > /analyze-comms already implements the cross-device behavioral analysis pipeline (extract_comms.py, compress_patterns.py, analyze_cross_device.py) but is named misleadingly. The new /reflect *is* this pipeline plus detectors. Two skills with overlapping scope is skill_proliferation_antipattern. Q7 of grill 2026-05-03.
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117, 9697a109-dd91-4062-b5ac-86d6d12b27e4`
+
+---
+
+### /reflect Phase B trigger: distributed last-device-wins via Supabase ISO-week lock
+
+- **UUID:** `cac3e4a6-90e6-4e86-b22b-73f48d2323fa`
+- **When:** `2026-05-03T07:13:49.589489+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.7`
+- **Actor:** `session:2026-05-03-end-reflect-grill`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Designated host (Main PC) — rejected: SPOF, host might be off; Cron on every device, deduplicate by report hash — rejected: races on Supabase writes, wasted compute; GitHub Actions runner — rejected: adds CI dependency for personal infra`
+
+  > No designated host avoids single point of failure across 3 devices with intermittent uptime. Whichever device finishes Phase A last (sees all known-device markers fresh) takes the lock and runs Phase B. ISO-week in lock name acts as natural deadlock recovery — next week's lock has different name even if previous leaks. Stale-device skip at >14d so a dormant device doesn't block forever. Q9 of grill 2026-05-03.
+- **Memories used:** `292a0235-4f61-4e5e-b0d4-08625deedfe0`
+
+---
+
+### /reflect detectors: regex-first + 3-week empirical eval before LLM upgrade
+
+- **UUID:** `dc612b49-8e90-4dda-a167-01c5040abc27`
+- **When:** `2026-05-03T07:13:55.623746+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:2026-05-03-end-reflect-grill`
+- **Project:** `jarvis`
+- **Alternatives considered:** `LLM-first — rejected: cost, no ground truth to validate against; Regex-only forever — rejected: owner skeptical about coverage, no way to learn; Hand-crafted rules per detector — rejected: maintenance burden, doesn't scale`
+
+  > Owner believes regex won't catch enough variation; rather than guess, generate ground truth via owner-labeled checkboxes on Phase B reports for ~3 weeks, then A/B regex vs sonnet on the same set. Decision rule: LLM beats regex by ≥2× recall at comparable precision (within 10pp) → migrate. Otherwise keep regex. Q17 of grill 2026-05-03.
+- **Memories used:** `none`
+
+---
+
+### Memory recall cadence: /grill-me uses start + per-branch targeted; /to-issues and /to-prd use start-only broad recall
+
+- **UUID:** `50077e38-c99c-4542-9598-fdc42f72551f`
+- **When:** `2026-05-03T07:23:16.033456+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:2026-05-03-grill-me-memory-aware`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Start-only across all 3 — rejected: grill-me staleness by Q15; Per-Q in grill-me — rejected: 15-20 recalls eats smart-zone for marginal gain; Hook-only (no skill recall) — rejected: hook recall queries user prompt, not skill-internal sub-Q; Uniform per-branch across all 3 — rejected: to-issues/to-prd don't have branches`
+
+  > /grill-me walks a decision tree across multiple sub-areas over 15-20 Qs — start-only goes stale, per-Q burns tokens; per-branch refresh keeps memories_used populated at the recall density that matters (decision-resolution moments) without flooding smart-zone. /to-issues and /to-prd are short, scope-fixed by the upstream grill, so a single broad recall at start is enough. UserPromptSubmit hook recall remains as global baseline; skill-internal recall layers on top.
+- **Memories used:** `df89ef11-4d0f-4fcf-956d-67860bcae599`
+
+---
+
+### Recall query strategy: always_load surface + topic-recall (decision+feedback) by default; multi-query entity expansion in /grill-me when args are short/meta
+
+- **UUID:** `ba2523de-c50e-44b9-a2a6-17ed36bfcf27`
+- **When:** `2026-05-03T07:30:33.925901+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:2026-05-03-grill-me-memory-aware`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Args-only recall (A) — rejected: misses adjacent decisions when args are narrow; Multi-query everywhere (D) — rejected: 4-5 tool calls before first Q is heavy preamble for short grills; Decision-type only — rejected: misses always_load feedback rules like grill_me_record_decision_gate`
+
+  > Always_load rules are gate-style — must surface unconditionally, not via fuzzy semantic match (e.g. grill_me_record_decision_gate must hit every grill-me invocation). Topic-recall on raw args handles the common case. When args are vague or meta (entities-recall would help), /grill-me adds a second-pass with extracted entities — but doesn't pay that cost on every call. /to-issues and /to-prd skip the entity expansion since their scope is fixed by upstream grill output. Type filter decision+feedback covers the queryable-knowledge surface without dragging in working-state or every reference doc.
+- **Memories used:** `8374f50e-1c24-4ff0-8ca0-d2495c3e7e45`
+- **Memories used (unresolved):** `always_recall_before_action, record_decision_always_pass_memories_used`
+
+---
+
+### Memory staleness handling: auto-flag obvious red signals (B) + show-and-continue ritual surfaces UUIDs in each Q (D)
+
+- **UUID:** `76e1664f-8c46-4261-8c08-db50c0f944a4`
+- **When:** `2026-05-03T07:34:53.149697+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:2026-05-03-grill-me-memory-aware`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A trust-unless-contradicted — rejected: that's the current failure mode; C confidence-tiered ask — rejected: load-bearing vs constraint vs background classification slippery; D-only without B — rejected: relies on user catching every stale ref, breaks down on long grills; B-only without D — rejected: covers obvious staleness, misses semantic drift`
+
+  > Two-layer policy. Layer 1 (auto-flag): skill detects records pointing to missing files/skills/issues, treats them as "ignore + flag for /reflect", not "ask"; same for reversible decisions older than ~60 days. Layer 2 (show-and-continue): every Q-block names the memories it leans on with a one-line summary + UUID + age, so user can interject with stale flag in real time. Avoids confidence-tiered classification (rejected as too slippery for skill to judge); avoids trust-unless-contradicted (the failure mode we're fixing). Auto-questions every memory use was rejected — too high friction.
+- **Memories used:** `none`
+
+---
+
+### Non-memory context loading: Read CONTEXT.md + Glob docs/adr/* names at skill start; ADR full-Read only on topic-match. Per-skill depth varies.
+
+- **UUID:** `4215d98d-2e3a-4d82-9db4-f916f43dcc5e`
+- **When:** `2026-05-03T07:39:55.406745+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:2026-05-03-grill-me-memory-aware`
+- **Project:** `jarvis`
+- **Alternatives considered:** `B index-then-targeted — rejected: ADR-index not universal; C reference-memories — rejected: dual maintenance with file source-of-truth; D no explicit step — rejected: that's the current drift failure`
+
+  > CONTEXT.md is short by design (glossary + invariants) so full Read is cheap and bounded. ADR full content is heavy, but ADR filenames are descriptive — Glob+name-scan picks the relevant ones for targeted Read. /grill-me does the file-load once at start (it's long anyway). /to-issues and /to-prd do the same on entry since their output must reference glossary vocabulary. ADR-index file (option B) rejected as not universally present; reference-memories pointing to files (C) rejected as dual-maintenance trap; trust-via-CLAUDE.md (D) rejected as the current failure mode.
+- **Memories used:** `none`
+
+---
+
+### outcome_list integration: /grill-me only; /to-issues and /to-prd skip
+
+- **UUID:** `c62e23d9-38f5-4589-bfa7-339b02f7124e`
+- **When:** `2026-05-03T07:46:37.462178+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:2026-05-03-grill-me-memory-aware`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A outcomes on all 3 — rejected: overshoot for downstream skills; C outcomes only as audit trail — rejected: doesn't address input-side blindness; D trust UserPromptSubmit hook — rejected: hook doesn't query outcome_list`
+
+  > Design decisions happen in /grill-me; that's where past failures must influence the choice. /to-issues and /to-prd transmit decisions downstream — if they're invoked without an upstream grill (no decision_uuids[]), the existing gate already halts them. So outcome_list is one extra call on /grill-me, zero on the other two. Filter: area/topic, severity≥medium, since=90d. 2+ failures → surface explicitly before first Q ("X failed twice in this area due to Y, proceed or rethink?"). Putting outcomes on every skill rejected as overshoot; outcomes-as-audit-only (C) rejected as not closing the input-side blindness; trust-the-hook (D) rejected because hook doesn't touch outcome_list.
+- **Memories used:** `none`
+
+---
+
+### Skill protocol: after brief-mode memory_recall, parse UUIDs from `id=<uuid>` markers and pass UUIDs (not names) to memories_used in record_decision
+
+- **UUID:** `d663a715-b9e4-4e15-b9af-74a9b7651433`
+- **When:** `2026-05-03T07:48:39.301149+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:2026-05-03-grill-me-memory-aware`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Trust the principle in record_decision_always_pass_memories_used — rejected: didn't prevent recurrence today; Switch to non-brief recall by default — rejected: token cost too high`
+
+  > Recurring failure: this turn alone, I called record_decision with name strings and got "memory name(s) did not resolve to UUIDs" warning twice. The brief-mode recall output contains `id=<uuid>` per hit; skill must parse and maintain a local name→uuid map. Without this rule encoded in the SKILL.md, the warning will keep appearing — record_decision_always_pass_memories_used flagged the principle but didn't operationalize the parsing step. Q8 (editorial: parallel section in /grill-me, Step 0 in /to-issues+/to-prd) — recorded inline, not separate decision.
+- **Memories used:** `none`
+
+---
+
+### /analyze-comms → /reflect: rename, not wrapper. Single skill absorbs the pipeline.
+
+- **UUID:** `042deab5-df39-4725-8696-2ef57d578aa4`
+- **When:** `2026-05-03T08:13:36.350751+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:grill-510`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Wrapper alternative (/analyze-comms as low-level pipeline + /reflect as user-facing entrypoint) rejected because (1) /analyze-comms has no direct user callers — there's no second consumer to justify an abstraction; (2) deletion test passes — moving the 5 .py into /reflect/ does not redistribute complexity to N callers, it consolidates; (3) "two real implementations before abstraction" rule (SOUL.md) would be violated. Skill-proliferation antipattern explicitly favors fewer fuller skills. This also reverses an older decision (verify_skill_not_reflect, 292a0235) that rejected /reflect for /end overlap — that overlap is being resolved in #509 by stripping reflection from /end, so the reason for rejection no longer holds.</rationale>
+  > <parameter name="alternatives_considered">["Wrapper: /analyze-comms stays as low-level pipeline, /reflect is thin UX layer — rejected: only one caller, no abstraction warrant, breaks deletion test", "Keep both skills with overlapping scope — rejected: skill-proliferation antipattern", "Retire /analyze-comms entirely and rebuild /reflect from scratch — rejected: throws away working pipeline scripts"]
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117, 292a0235-4f61-4e5e-b0d4-08625deedfe0, 9697a109-dd91-4062-b5ac-86d6d12b27e4, df89ef11-4d0f-4fcf-956d-67860bcae599`
+
+---
+
+### Aggregates snapshot for /self-improve migration: structured extraction (per-aggregate) at docs/design/reflect-aggregates-pending-migration.md.
+
+- **UUID:** `9bbf9ca8-8224-4ba0-862f-8f01bcaf2407`
+- **When:** `2026-05-03T08:16:29.456241+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-510`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Snapshot serves as input artifact for the future /self-improve grill. As-is dump (option A) forces the next session to reverse-engineer intent from imperative prose, risking semantic drift between original aggregate behaviour and migrated implementation. Structured form per aggregate (what it did, output shape, data sources, known issues) preserves design intent and is what /grill-me actually consumes. Path lives in docs/design/ alongside other architectural artifacts — docs/skills-migration/ would be a one-shot directory with no long-term load (skill-proliferation logic applies to docs too).</rationale>
+  > <parameter name="alternatives_considered">["Whole old SKILL.md dump as-is — rejected: low signal density, forces reverse-engineering at /self-improve grill time", "docs/skills-migration/ dedicated directory — rejected: one-shot use, adds to doc taxonomy without long-term value"]
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117, df89ef11-4d0f-4fcf-956d-67860bcae599`
+
+---
+
+### #510 migration file: snapshot ALL 8 steps of old /reflect with per-step candidate destination annotation; final routing deferred to future /grill-me sessions on /self-improve and /verify.
+
+- **UUID:** `b6a0e343-5eb7-41a2-bbc4-d2f691249c28`
+- **When:** `2026-05-03T08:24:19.852086+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-510`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Old /reflect has 8 steps, not 5. Issue body lists only 5 aggregates (5.25 calibration, 5.5 FoK, 5.75 recall-audit, 7 hypothesis, 8 stale-memory). Steps 1-4 (decision/outcome verification) duplicate existing /verify. Step 5 (decision-basis loading from #252) is reflection-specific enrichment not in /verify. Step 6 (outcome-pattern detection) is aggregate-style and fits /self-improve. Resolving the destination for Step 5 (candidate /verify) and Step 6 (candidate /self-improve) requires its own grill on each target skill — packing that decision into #510 over-scopes a rename. Migration file annotates "candidate destination" per step; real routing happens after future grills validate the fit. Steps 1-4 marked drop (subsumed by /verify) — only mechanical confirmation needed.</rationale>
+  > <parameter name="alternatives_considered">["Migrate Step 5 → /verify and Step 6 → /self-improve inline in #510 — rejected: overscopes a rename PR, requires grill on both target skills before knowing fit", "Drop everything except the 5 listed aggregates — rejected: loses Step 5 #252 decision-basis logic that has no replacement", "Snapshot only 5 listed aggregates per issue body — rejected: hides the Step 1-6 question, future session has to re-derive scope from old SKILL.md"]
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117, ded9a608-ed2a-4cd2-aec1-62b9edaaea08, df89ef11-4d0f-4fcf-956d-67860bcae599`
+
+---
+
+### Cross-skill /reflect references stay AS-IS in #510; dangling refs documented in migration file; cleanup deferred to tracker-issue post /self-improve and /verify grills.
+
+- **UUID:** `6b2d3daf-5029-4a1f-9415-ca50a40d2e58`
+- **When:** `2026-05-03T08:33:34.891038+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-510`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > 5 other skills (implement, grill-me, to-issues, to-prd) and scripts/recall-audit.py reference /reflect with semantics that the new /reflect (cross-session comms audit) does not provide. Replacing now would either (a) reference /self-improve before its scope is grilled — protected claim risk — or (b) leave neutral TODO markers that read as broken. Per the deferred-Steps-5/6 decision (b6a0e343), final destination for these semantics is unknown until /self-improve and /verify get their own grills. Honest documentation of the dangle in the migration file + a tracker issue is the smallest reversible change consistent with HITL nature of #510.</rationale>
+  > <parameter name="alternatives_considered">["Find-replace /reflect → /self-improve|/verify in all 5 skills now — rejected: writes claims before target skills are grilled, creates protected-claim drift risk", "Replace with neutral TBD markers — rejected: technically references a non-existent skill, reads as broken to future readers", "Block #510 merge until tracker issues exist — rejected: overconservative for reversible work, adds gate without proportionate value"]
+- **Memories used:** `b6a0e343-5eb7-41a2-bbc4-d2f691249c28, df89ef11-4d0f-4fcf-956d-67860bcae599`
+
+---
+
+### /end Step 4 outcome_record is enrichment-only: for every decision_made episode emitted this session that lacks an outcome_record, create a pending one. /implement and /delegate keep emitting decisions in real time; /end fills gaps, doesn't duplicate.
+
+- **UUID:** `545c1636-878b-474c-8bc7-4a55f7a39c52`
+- **When:** `2026-05-03T09:14:11.174564+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:grill-509`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Three alternatives weighed. (A) /end-only: single pass risks missing mid-session deliverables. (B) /implement+/delegate-only: duplicates outcome_record code in two skills, fires on PR-open when status isn't yet knowable. (C) Hybrid: real-time decision_made emission stays where it is, /end does enrichment for any orphaned decision. Hybrid avoids duplication, captures everything that has a decision episode, and fits "small interface, large hidden implementation" deep-module principle. Issue body's WHY clause was stale (cited /reflect for outcome verification — that scope moved to /verify per #510 grill); rewrite WHY to point at /verify (outcome status) and /self-improve (aggregate attribution).</rationale>
+  > <parameter name="alternatives_considered">["/end-only outcome_record — rejected: single-pass, misses mid-session captures", "/implement+/delegate-only — rejected: duplicates code, fires before status is knowable", "Keep issue body WHY as-is referencing /reflect — rejected: stale post-#510-grill, /reflect no longer does outcome verification"]
+- **Memories used:** `f5b5f74a-3ee4-4574-b1a9-652ae87f7a10, 7de58f46-3795-4497-9104-f907a0737f9d, b6a0e343-5eb7-41a2-bbc4-d2f691249c28, 042deab5-df39-4725-8696-2ef57d578aa4`
+
+---
+
+### /end Step 4 outcome_record orphan detection v1: heuristic on decision rationale text (scan for #NNN, PR <num>, file path). Architectural-only decisions skipped. Post-hoc decisions get post_hoc=true marker. Explicit deliverable field on record_decision deferred to separate tracker issue.
+
+- **UUID:** `5caf47be-1272-4296-9a06-912a657065f8`
+- **When:** `2026-05-03T10:04:36.662589+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-509`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Three sub-rules. (1) Decisions with deliverable hint in rationale → create outcome_record(pending) using extracted ref as URL basis for /verify. (2) Architectural-only decisions (no deliverable hint) → skip — outcome of pure architectural calls is "applied downstream", attribution belongs to /self-improve, not /verify. (3) Post-hoc decisions saved by /end Step 2 reconciliation → also enrichment-eligible, plus carry post_hoc=true so /self-improve can detect record_decision_during_refactors regressions (memory 7de58f46). Tool/schema extension to add explicit deliverable field is real but cross-project (mcp-memory shared with redrobot) and warrants its own tracker issue — packing it into #509 would scope-creep a small skill-cleanup PR.</rationale>
+  > <parameter name="alternatives_considered">["Add explicit deliverable field to record_decision now — rejected: cross-project schema change, scope-creeps #509, requires migration of all call-sites", "outcome_record for ALL decision_made episodes regardless of deliverable — rejected: pollutes outcome_list with un-verifiable architectural decisions, drowns /verify signal", "Skip post-hoc decisions in enrichment — rejected: loses regression signal for /self-improve"]
+- **Memories used:** `7de58f46-3795-4497-9104-f907a0737f9d, f5b5f74a-3ee4-4574-b1a9-652ae87f7a10, 545c1636-878b-474c-8bc7-4a55f7a39c52`
+
+---
+
+### /end CONTEXT.md gap check uses heuristic trigger: scan this session's decision_made rationales + git-diff under docs/design and docs/adr; surface terms-not-in-glossary as a prompt only when signals fire. Skip silently otherwise.
+
+- **UUID:** `15850096-bb9b-4a88-969f-a0cc90ff3de4`
+- **When:** `2026-05-03T10:08:46.299275+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-509`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Always-ask (A) generates noise on short non-domain sessions. Grill-only trigger (B) double-fixes — /grill-me already updates CONTEXT.md inline per protocol 7ad9fbb2. Owner-driven hard requirement (D) leaves a dangle when Step 1 reflection is removed. Heuristic (C) — fires only when domain signal is present (new terms in rationale OR design-doc changes), reuses session journal data already loaded in Step 1, skips cleanly when irrelevant. Cost: a glossary-diff at /end time. Benefit: catches assumptions that escaped the grill loop.</rationale>
+  > <parameter name="alternatives_considered">["Always ask (A) — rejected: noise on non-domain sessions", "Grill-only trigger (B) — rejected: /grill-me already inlines CONTEXT.md updates, would double-fix", "Owner-driven via grill discipline (D) — rejected: leaves dangle when Step 1 reflection is removed"]
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 545c1636-878b-474c-8bc7-4a55f7a39c52`
+
+---
+
+### /end Step 4 outcome_record contract: pattern_tags = union of decision rationale topic tags + 'source:end-enrichment' + 'deliverable_kind:<pr|issue|file>'. Session-PR identification: session journal (Step 0 decisions) primary, `gh pr list --author @me --search created:>=today` fallback when journal is empty.
+
+- **UUID:** `373d888d-4103-45d6-a185-3cb07593dc47`
+- **When:** `2026-05-03T10:12:26.922158+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-509`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Tags: silent-drop incidents (f5b5f74a) require populated project + pattern_tags. Three-part union gives /verify and /self-improve filterable signal — origin (end-enrichment vs inline /implement), deliverable kind, and topic context inherited from the decision episode. PR identification: session journal is authoritative (it's already loaded in Step 0 and cannot be lost to context compaction). Shell `gh` fallback covers the edge case where journal is missing — robust without being primary, since shell results need filtering by author and time, while journal is pre-attributed.</rationale>
+  > <parameter name="alternatives_considered">["pattern_tags = empty array — rejected: silent-drop precedent (f5b5f74a)", "gh pr list as primary — rejected: requires post-filter for author/session-window, fragile vs journal which is pre-attributed", "Conversation scan as primary — rejected: lossy after compaction"]
+- **Memories used:** `f5b5f74a-3ee4-4574-b1a9-652ae87f7a10, 5caf47be-1272-4296-9a06-912a657065f8`
+
+---
+
+### Batch /delegate #509 #510 — #509 fully delegated to subagent; #510 hybrid (subagent for unprotected scope, main session for SOUL.md + CLAUDE.md edits which are T2-protected).
+
+- **UUID:** `de53be53-036f-4614-9e18-5eac844ee3ae`
+- **When:** `2026-05-04T10:49:04.798834+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > #509 touches only .claude-userlevel/skills/end/SKILL.md — not in the protected-files table — fully delegatable. #510 AC requires editing config/SOUL.md and CLAUDE.md (both repo-level T2-protected per docs/security/agent-boundaries.md), which subagent principal cannot edit (blocked by scripts/protected-files.py hook). Splitting #510 — bulk mechanical work (skill rename, migration-doc, install-manifest, evals/reflect.yaml, scripts/recall-audit.py docstring) goes to subagent on the canonical branch; main session pushes follow-up commit with SOUL.md + CLAUDE.md updates after reviewing subagent's diff. Parallelism = 2 (within safe band of 2-3 per skill).</rationale>
+  > <parameter name="alternatives_considered">["Both fully delegated — rejected: subagent blocked on SOUL.md / CLAUDE.md, would emit partial outcome", "Both inline via /implement — rejected: #509 is small and self-contained, no value in keeping inline", "Sequential dispatch — rejected: #509 and #510 are independent, parallelism within safe band"]
+- **Memories used:** `545c1636-878b-474c-8bc7-4a55f7a39c52, 5caf47be-1272-4296-9a06-912a657065f8, 15850096-bb9b-4a88-969f-a0cc90ff3de4, 373d888d-4103-45d6-a185-3cb07593dc47, 042deab5-df39-4725-8696-2ef57d578aa4, 9bbf9ca8-8224-4ba0-862f-8f01bcaf2407, b6a0e343-5eb7-41a2-bbc4-d2f691249c28, 6b2d3daf-5029-4a1f-9415-ca50a40d2e58`
+
+---
+
+### Implement issue #509: refactor /end skill to remove reflection steps, add CONTEXT.md gap check and outcome_record enrichment
+
+- **UUID:** `6e0ce01b-3ac7-4973-bd3c-00ba9e02558e`
+- **When:** `2026-05-04T10:52:36.807202+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `Keep reflection in /end (rejected per #510 scope); Implement full automated CONTEXT.md patching (deferred per issue scope); Make outcome_record enrichment real-time (rejected: belongs to /verify+/self-improve per 545c1636)`
+
+  > #509 required removing behavioral reflection (moved to /reflect per #510) and adding two new per-session enrichment steps: CONTEXT.md gap detection via heuristic trigger (rationale-term diff + design-doc git-diff), and outcome_record enrichment for decisions with deliverable hints. Post-hoc decision saves marked with post_hoc=true flag for /self-improve regression detection. Step renumbering from 0/0.5/1..7 to 0/1..8 with new steps at 2-3."
+- **Memories used:** `5caf47be-1272-4296-9a06-912a657065f8, 15850096-bb9b-4a88-969f-a0cc90ff3de4, 373d888d-4103-45d6-a185-3cb07593dc47, 545c1636-878b-474c-8bc7-4a55f7a39c52`
+
+---
+
+### Fix Windows python3 stub via shim in user-owned Python install dir, plus upstream PR to switch hookify hooks.json from python3 to python
+
+- **UUID:** `1eb4597c-9f3f-4fd7-a923-a0f9018e6ae9`
+- **When:** `2026-05-04T11:19:31.000596+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Edit plugin cache directly (resets on update); Disable hookify plugin; Add python3 shim to ~/bin (rejected — comes after WindowsApps in Windows PATH); Cross-platform launcher script in upstream`
+
+  > Two-layer fix: (1) Local shim `python3.bat` in `C:\Users\petrk\AppData\Local\Programs\Python\Python313\` (PATH position 26, ahead of WindowsApps stub at 29) — system-wide solution for any tool expecting python3, no admin needed, doesn't touch system PATH. (2) Upstream PR #1701 to anthropics/claude-plugins-official replacing python3→python in hookify hooks.json — minimal diff, blast-radius limited to 4 strings, works on Win/Mac/modern Linux. Considered cross-platform launcher script (rejected — adds files + complexity, mainainers' call) and PATH modification (rejected — system change requires user consent + intrusive).
+- **Memories used:** `none`
+
+---
+
+### Self-improvement skills reorganize into 3-layer Sense/Decide/Act architecture with /improve as the Sense+Decide orchestrator
+
+- **UUID:** `77b2dfaa-4878-4953-9d27-ff3b2e1b4816`
+- **When:** `2026-05-04T12:03:30.111567+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.75`
+- **Actor:** `session:grill-improve-skills`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Двухскильный split (/improve + /improve-new) без orchestrator — отвергнуто: autonomous-loop требует одной точки routing; Один скилл с двумя режимами (--new vs --analyse) — отвергнуто: разные pipeline'ы, не делят ничего кроме слова improve; /learn как имя для α — отвергнуто: не подразумевает написание кода; /verify оставить вне Sense — отвергнуто: outcome resolution естественная часть сбора сигналов`
+
+  > Скиллы /reflect-old, /verify, /self-improve, /improve-codebase-architecture перекрывались по сбору сигналов и не имели общего входа для autonomous-loop. Решение: один orchestrator /improve собирает сигналы (calibration, FoK, recall audit, outcome patterns, hypotheses, stale memories, health check), ранжирует и диспатчит к act-скиллам (/improve-new = бывший self-improve для нового, /improve-codebase-architecture для рефакторинга). /verify входит в Sense-слой (выполняет outcome-row resolution как часть сбора). Каждый act-скилл по-прежнему запускается standalone и умеет top-up недостающих сигналов. Имя /improve выбрано потому что семантически парное (improve + improve-new + improve-codebase-architecture), и на уровне UX user пишет "улучшись" → orchestrator. Альтернатива "две скилла без orchestrator" отвергнута: autonomous-loop требовал бы хардкода routing в SDK-уровне, и пользователь не имел бы единой точки входа для "что у меня сейчас болит".
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140, 5ba4a474-5e8d-445d-aa37-ce29e6845d0f, ded9a608-ed2a-4cd2-aec1-62b9edaaea08`
+
+---
+
+### Signal cache lives in new Supabase table signal_snapshots (jsonb payload + kind + computed_at + ttl)
+
+- **UUID:** `efb8d94e-7a03-4df8-bc36-e0a2a8573eeb`
+- **When:** `2026-05-04T12:03:36.918987+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-improve-skills`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A: один memory record analysis_snapshot — partial update неудобен; C: working_state — семантический конфликт с ephemeral назначением; D: per-detector memories + index — размножение и GC-сложность`
+
+  > Чтобы Sense-слой не пересчитывал детекторы на каждый autonomous-loop тик и каждый ручной /improve. Supabase table даёт строгий shape, partial updates per-detector kind, нативный TTL/staleness, кросс-девайс синхронизацию без файлов. Альтернативы: (A) memory record — частичный апдейт = переписать весь документ, (C) working state — семантически конфликтует (it's ephemeral handoff), (D) per-detector memories — размножение записей и сложная GC-политика. Стоимость: миграция + 2 MCP метода (signal_write, signal_read), потолок ~200 строк. Шарится с redrobot-friendly schema (как остальные таблицы memory server).
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### /improve dispatches autonomously — no HITL gate before launching selected act-skill; guardrails (risk classification, allowlist, confirm-on-destructive) handle safety
+
+- **UUID:** `3ff65281-a47e-4d0c-a003-136a120b742d`
+- **When:** `2026-05-04T12:03:43.932147+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-improve-skills`
+- **Project:** `jarvis`
+- **Alternatives considered:** `HITL перед dispatch — отвергнуто: убивает autonomous-loop value и противоречит guardrails-first философии; HITL только в autonomous-loop, не в ручном /improve — отвергнуто: симметрия выгоднее, ручной flow тоже хочет минимум friction`
+
+  > Guardrails были построены именно для того, чтобы убрать HITL из routine flow. Если /improve будет каждый раз спрашивать "запустить /improve-new или /improve-codebase-architecture?" — это превращает скилл в paperwork и убивает autonomous-loop value. Безопасность обеспечивается на уровне act-скиллов: existing self-improve risk classification (Low auto / Medium plan-show / High propose-only), плюс tiered safety gate model (Tier 0 auto / Tier 1 owner-queue / Tier 2 blocked). /improve выбирает act-скилл и зовёт; act-скилл сам решает что делать с результатом по своему risk policy.
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### Keep SandboxRobotExecutor as a thin holder (TrajectoryExecutor + tool_config + workspace + safety + robot) instead of inlining it into _execute_v3
+
+- **UUID:** `9f1e1d1a-e4d6-483c-885c-7b7761158960`
+- **When:** `2026-05-04T18:24:50.149059+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:redrobot-2026-05-04-evening`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Inline SandboxRobotExecutor into _execute_v3 — rejected: blast radius into ui/routers/sandbox.py with no functional gain; Delete the class entirely and inline TrajectoryExecutor construction — same as above, larger scope`
+
+  > After removing dead V1 methods (plan/execute_plan/plan_and_execute/_execute_single_pass/_switch_tool), the class has no methods left — only attributes. Two options: (a) keep as a 5-attribute bundle, or (b) inline into ui/routers/sandbox.py::_execute_v3. Picked (a) for scope discipline: option (b) requires touching the already-large sandbox router (~1000 LoC, V3 path under active scrutiny per PR #721 history), changing executor._executor / executor.tool_config call sites in 5+ places, with no functional gain. Bundling 5 related fields into one ctor call is a real (if minor) ergonomic win for the V3 callback. If the bundle fails the deletion test later (i.e. callers stop needing the grouping), inline in a follow-up PR.
+- **Memories used:** `none`
+
+---
+
+### Adopt Round-2 competitor code patterns in priority order: CuraEngine skin+overhang first, then RoboCook tool-registry, then PlasticineLab differentiable MPM as gradient teacher, then PASTA feasibility+DBSCAN, then Hanut reimplementation when sensor pipeline ready.
+
+- **UUID:** `6883f703-5cf3-4d3b-887e-8f89b51be1ec`
+- **When:** `2026-05-04T20:04:09.103918+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-05-04-competitor-code-research`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Adopt RoboCook first (rejected: largest port effort, blocks quick wins); Reimplement Hanut first (rejected: no code, sensor pipeline immature); Skip CuraEngine as too far-domain (rejected: skin+overhang transfer cleanly); Adopt PlasticineLab MPM as runtime physics (rejected: 15k-particle ceiling fails sand-realistic resolution)`
+
+  > Two-round audit of 11 competitor codebases found 5/11 Round-1 gaps have concrete file-anchored fixes. Order chosen by gap-impact / port-effort: CuraEngine fills Gaps #3 #5 #11 in days (quick win); RoboCook fills Gap #9 with bigger per-tool GNN data lift; PlasticineLab as TEACHER preserves UW-Madison surrogate pattern with higher-fidelity oracle (runtime ceiling 15k particles forces teacher/student split); PASTA DBSCAN partial Gap #10; Hanut deferred no-code ~1-week port. Top-down (Gap #1) and deficit-first (Gap #2) confirmed unique to redrobot across all 11 — publication differentiators not adoption candidates.
+- **Memories used:** `784d1f2f-83bf-432d-9b88-60cbfff977cb, 19bbe196-3a93-46dd-b87e-f1e00528d559, 9adef782-8e9c-4ec1-9326-83492b53f949, 92876de1-c24b-4d1e-ae9f-2884cc23a413, 9bf3a02c-9916-4d18-90a5-3e826b96e00e, 2249bb82-14ea-4d9e-a808-ccec002df383`
+
+---
+
+### Sandcastle integration uses strict orchestrator boundary (variant A): sandcastle opens PRs only, never merges; review and merge stay with the live orchestrator (/delegate §6 review path or /verify on next tick).
+
+- **UUID:** `436f9549-3acf-4ee0-85e5-c7259735d62e`
+- **When:** `2026-05-05T13:47:12.827727+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-me`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Container isolation closes the worktree-contamination class (5+ recent failures incl. #510 2026-05-04). It does NOT close the review-class failures — fabrication, AC-dodge, silent value changes (#648 IK seeds), interaction-effect blindness (#649v2 J6-pin clobber). Those are caught by memory-aware review in the live session. Variant A keeps that review intact while gaining true isolation. B (in-sandbox impl→review) lacks Jarvis memory context and cannot replicate the orchestrator-grade audit. C (autonomous LOW-risk merge) extends blast radius — autonomous merges by a headless cron night-loop into main are the failure mode the existing routine_medium_merge_is_autonomous rule was NOT scoped for (it assumed live session + memory + review). Reversibility hard: A→B/C is one orchestrator branch; B/C→A requires unwinding policy across skill+Dockerfile+prompt+cron.</rationale>
+  > <parameter name="alternatives_considered">["B: in-sandbox impl→review (Sonnet→Opus) — rejected, review without memory context ≈ Copilot+; ok later for whitelisted docs-only batches", "C: autonomous merge for LOW-risk — rejected, blast radius into main, no live review, conflicts with how routine_medium_merge_is_autonomous was scoped"]
+- **Memories used:** `5ba4a474-5e8d-445d-aa37-ce29e6845d0f, 737763bf-740f-4864-9860-7ad41149af50, 9a5a1ade-d3c0-4163-8559-dff5993094ea, 80e6497b-c5f8-4849-a9fd-23f0bf0a2587, f0f0334f-98af-4c88-a6bb-05d359eef3b7, b18bc36e-d2a9-4316-96ca-80fd4d4d8b93, 9757b985-cf68-4310-9d44-0571697d337f`
+
+---
+
+### Sandcastle protected-file enforcement: prompt hard-rules + orchestrator PR review only. No in-container pre-commit hook, no read-only mounts, no host-side pre-PR boundary check.
+
+- **UUID:** `6ce7902c-5697-4b89-b642-9a84c4b9c459`
+- **When:** `2026-05-05T13:59:59.110893+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-me`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Threat model under variant A is fundamentally different from current /delegate. Current /delegate worktree-isolation is advisory — protected-file edits leak directly to main repo working tree (incidents #344, #389, #410). With sandcastle + Docker, isolation is real: any edit lands on a feature branch in a temp worktree, never on host's main checkout. Orchestrator review before merge (locked in Q1, decision 436f9549) is the existing gate — gh pr diff --stat catches CLAUDE.md/.mcp.json hunks at PR-open time, exactly as it does for human reviewers. Adding boundaries.json + container pre-commit + host pre-PR check duplicates that gate while introducing maintenance burden (sync between host hooks, container pre-commit script, prompt rules). Owner's framing: "system under delegate and direct-with-user are different" — direct-with-user uses host PreToolUse hooks (immediate block); delegated/containerized uses orchestrator review (deferred block on isolated diff). Both are valid layered defences for their respective threat models. Revisit only if a real incident shows prompt+review missing protected-file changes that container-side enforcement would have caught.</rationale>
+  > <parameter name="alternatives_considered">["B2: container pre-commit hook on protected paths — rejected, duplicates orchestrator review gate, adds boundaries.json sync surface", "C2: read-only bind-mount of protected files — rejected, overkill, brittle git status interactions", "D2: host-side pre-PR boundary scan of result.commits[] — rejected, equivalent to existing gh pr diff review just earlier; no value over Q1 review gate"]
+- **Memories used:** `436f9549-3acf-4ee0-85e5-c7259735d62e, 80e6497b-c5f8-4849-a9fd-23f0bf0a2587, ace97204-32bb-4ae6-a3ca-b36302d35766`
+
+---
+
+### Sandcastle parallelism cap: 3 default for live dispatch, configurable up to 5 for trivial-review batches (docs, tests). AFK loop mode is single-container by design.
+
+- **UUID:** `b8f7de1d-1214-4e36-a566-516fe1dc26bc`
+- **When:** `2026-05-05T14:08:02.669774+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:grill-me`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > With docker isolation, worktree-contamination is no longer the bottleneck. Real bottleneck under variant A is orchestrator review throughput — review stays with one live Claude Code session whose smart-zone is ~100K tokens. 3 concurrent diffs fit in smart-zone; beyond that review quality degrades. Docker RAM (~600MB-1GB/container) and Anthropic Max rate limit (~50 req/min on 5×) tolerate higher concurrency, but they are not the binding constraint. 5 is the escalation cap for issues where review is rubber-stamp (docs, test-coverage). 10+ requires fresh-session review batching via /verify — separate mode, not needed for v1. Old /delegate cap of 2-3 was justified by contamination fear; new cap of 3-5 is justified by review smart-zone economics — different argument entirely.</rationale>
+  > <parameter name="alternatives_considered">["Cap=2 (more conservative) — rejected, no contamination justification anymore, leaves throughput on the table", "Cap=5 default — rejected, review smart-zone fills too quickly, quality drops on non-trivial issues", "No cap, defer to docker resources — rejected, ignores review-side throughput which is the real bottleneck"]
+- **Memories used:** `436f9549-3acf-4ee0-85e5-c7259735d62e, d828bd94-c9ab-4c06-bb9f-b5afa00ff1d9, b10e218f-0f7a-405b-825a-7d96b74a25fb`
+
+---
+
+### Зафиксировать первый полный аудит SculptureVision/facehugger как `docs/AUDIT.md` на ветке `dev/redrobot-integration`
+
+- **UUID:** `c5bcd6eb-bc9c-4b3a-8483-f893ca92a99b`
+- **When:** `2026-05-06T09:24:58.538668+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:audit-2026-05-06:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Только обновить память без статической доки — отклонено, нужен один большой артефакт для просмотра не-через-Jarvis; Расписать аудит как ADR — отклонено, это не одно решение а карта территории; Включить в README.md — отклонено, README уже 26KB и про деплой/setup`
+
+  > Owner впервые на офисном сервере с этим репо, до этого знал систему только поверхностно. Гит фиктивный (разреженная история, рабочее дерево опережает ветки на месяцы). До интеграции робота и любых архитектурных правок нужен был один артефакт-карта. Аудит сделан как docs/AUDIT.md — секции 1-10 фактуальные наблюдения с пруфами, секции 11-12 приоритезированный план (П1 структурная гигиена, П2 фундамент перед роботом, П3 nice-to-have). Контракт интеграции робота уже зафиксирован отдельно в memory `sv_redrobot_integration_contract` — секция 3 ссылается. Хук `no_state_in_static_storage` сработал дважды по ходу — статус-маркеры PR'ов и даты убраны и из доки и из памяти. Обсуждение П1+П2 отложено в новую сессию.
+- **Memories used:** `04c060fe-554b-443e-acfd-b1aa78cadac7, 7dd1f7aa-f63c-4291-b059-823315f43762, a3662372-fe17-4433-88de-1492d01d6deb`
+
+---
+
+### SV heightmap export uses prepare→Blender-writes-files→finalise pattern with optional CLI arg, not direct Django ORM in Blender
+
+- **UUID:** `93769177-1b77-4b3b-b6a6-effddc631ee5`
+- **When:** `2026-05-06T09:47:53.740345+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-05-06-sv-pr2b:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Blender bootstraps Django (django.setup()) and writes Heightmap row directly — rejected: fragile, slow startup, leaks DB credentials.; REST callback from Blender to Django after writing — rejected: extra surface area, auth handling.; Skip Heightmap row, compute .npz on-demand from a streaming endpoint — rejected: data only exists at comparison time, can't recompute offline.; Trimesh-only client-side rasterisation — rejected: trimesh.load can't read FBX without external SDK.`
+
+  > PR-2b on dev/redrobot-integration (commit cbc7ef0). Blender runs as subprocess from Celery worker — no Django ORM available. Three pieces: (1) prepare_heightmap_run creates pending Heightmap row + writes params.json; (2) Blender script reads params.json, rasterises signed_deviation via BVH downward raycast at cell centres, writes heights.npz + meta.json; (3) finalise_heightmap reads .npz back via FileField, flips row to completed/failed. Coordinate frame: Blender world == installation-local frame in metres, heights = (z_target − z_current) × 1000. Origin from min(markers_gcp), shape from cut_box, grid_step_mm from settings (1.0 default, no migration). prepare wrapped in try/except — if migration 0006 not applied or metadata incomplete, params_path stays None and Blender runs as before. Deploy-safe ahead of migration. Smoke-tested against installation1 FBXes (signed deviation range −28..+51mm).
+- **Memories used:** `7dd1f7aa-f63c-4291-b059-823315f43762, 04c060fe-554b-443e-acfd-b1aa78cadac7, 033de0ab-687e-4047-8b07-983dae2a32a8, a3662372-fe17-4433-88de-1492d01d6deb`
+
+---
+
+### SculptureVision dev environment: env-driven DB config + SQLite for local dev, prod-Postgres untouched
+
+- **UUID:** `78b9f61f-b716-4669-b22e-cdb151294da2`
+- **When:** `2026-05-06T10:55:17.903155+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:end-2026-05-06:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Apply migration to prod-Postgres directly (rejected: violates branching policy); Install local Postgres for dev (rejected: heavier, dev box has no Postgres service); Patch py3.12 incompat one-by-one (pkg_resources, numpy, cryptography) (rejected: drift from prod env, escalating fixes); Build Python 3.10.20 from source (rejected: needs Visual Studio + SDK on Windows)`
+
+  > Need to apply heightmap migration 0006 to develop on dev/redrobot-integration without touching prod-Postgres before alignment with Темир (sv_no_automerge_until_temir_alignment + sv_branching_policy). Approach: parametrize DATABASES via os.getenv with current hardcoded values as defaults (zero prod-behavior change), add sqlite3 branch when DB_ENGINE=sqlite. Dev uses db_dev.sqlite3 file in repo root (added to .gitignore). Side fixes: filled previously-empty .env.example with all keys, added python_version&lt;'3.11' marker to backports.asyncio.runner (no wheel for py3.12+), recreated venv on Python 3.10.11 installed via winget (user had downloaded 3.10.20 source tarball — not buildable on Windows without Visual Studio). Migration comparison.0006_heightmap applied to dev SQLite successfully. Commit 0020d01 pushed to dev/redrobot-integration. Files: config/settings/base.py, .env.example, requirements.txt, .gitignore.
+- **Memories used:** `7dd1f7aa-f63c-4291-b059-823315f43762`
+
+---
+
+### Drive-by drift fix #20 → PR #21 в той же сессии (вместо отдельной issue + delegate)
+
+- **UUID:** `a16b895c-2ca8-4a61-9c7c-b0a2c5867913`
+- **When:** `2026-05-06T11:18:00.599677+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `session:end-2026-05-06:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > CI на #6 поймал migration drift (RenameIndex Heightmap). Блокер для 4 PR. Subagent worktrees не запускали Django (Py 3.14). User поставил venv 3.10 → makemigrations comparison → 0007 single-line, locally verified. PR #21 merged per LOW skill policy.
+- **Memories used:** `none`
+
+---
+
+### PR #18 close + replace narrower #22 — не override owner's parallel 0020d01
+
+- **UUID:** `a5945988-2aa5-4d6a-9b28-6d7718080bef`
+- **When:** `2026-05-06T11:18:02.97583+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:end-2026-05-06:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > Race condition: owner смерджил 0020d01 «env-driven DB» пока subagent #18 работал. Подходы расходятся (fail-fast vs sane defaults; DATABASE_* vs DB_*). DB defaults — policy decision; manual rebase = override owner choice. Close #18 + новый #22 на non-conflicting часть (SECRET_KEY+DEBUG) + drive-by CI triggers/env.
+- **Memories used:** `none`
+
+---
+
+### SV audit P1+P2 issues structure: 10 issues with explicit dependencies
+
+- **UUID:** `cacd2140-5dd0-4f36-b8db-64ab14d988ed`
+- **When:** `2026-05-06T11:18:10.686873+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-05-06:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > AUDIT.md sections 11-12 split into 10 issues #7-16. P1 hygiene parallel; P2 with deps #10 to {14,15,16} and #13 to #16. CI as blocker for splits. Push-back on user proposal to split production_tasks.py without diagnosis.
+- **Memories used:** `none`
+
+---
+
+### Skill trigger model: three types (event/cron, user/orchestrator intent, mid-task self-trigger). Type 3 explicitly dropped.
+
+- **UUID:** `b1acebab-a1df-4c16-840e-225fad60c409`
+- **When:** `2026-05-06T11:19:59.400549+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-05-06:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep Type 3 (mid-task self-trigger) — rejected: empirically unreliable, eats smart-zone budget; Single trigger model (everything via skills, no hooks) — rejected: event-driven things become reliable only via hooks/cron`
+
+  > Сессия диагностировала: агент почти не self-invoke skills вне явных user-команд. Mid-task skill invocation эстирует smart-zone budget (~100K) и эмпирически не работает. Дешевле дать Jarvis-у доделать текущую задачу и оркестратору вызвать следующий скилл в свежей сессии. Закреплено в docs/adr/0001-skill-trigger-model.md. Headless под sandcastle = Type 2 на старте сессии. Документировано в CONTEXT.md глоссарий. Epic #522, child issues #523-#532.
+- **Memories used:** `1546ab9a-bbc6-46f3-ab0e-f11ec235d1f7`
+
+---
+
+### Shared memory + record_decision protocol moves out of skills into user-level CLAUDE.md (Tier 1), with hooks as Tier 2 backstop. Source of truth: .claude-userlevel/CLAUDE.md in jarvis repo; mirror: ~/.claude/CLAUDE.md via install.ps1.
+
+- **UUID:** `087433a9-6c45-4721-9633-df03d942b82d`
+- **When:** `2026-05-06T11:20:09.100745+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:2026-05-06:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep protocol in each skill — rejected: current state, source of the rewrite pressure; Tier 2 only (hooks for everything) — rejected: too brittle for soft rules; Move to SOUL.md instead of CLAUDE.md — rejected: SOUL is identity, CLAUDE is process; protocol is process; Direct edit ~/.claude/CLAUDE.md without mirror — rejected by user: source of truth must stay in jarvis repo`
+
+  > Memory protocol сейчас размазан по 5+ скиллам с лёгкими вариациями — главный источник дрейфа и cognitive load на чтении скиллов. Централизация в CLAUDE.md делает скиллы тонкими и различимыми. Tier 2 хуки как backstop для binary checks. Используется существующая install-manifest infra (тот же паттерн что для SOUL.md/settings.json) — нет нового механизма. Закреплено в docs/adr/0002-shared-protocol-in-global-claude-md.md. Tracked в #523. Verification через существующие recall-audit метрики (#532).
+- **Memories used:** `1546ab9a-bbc6-46f3-ab0e-f11ec235d1f7, ff994ca2-ac3a-49d4-86cb-360512df3619`
+
+---
+
+### Centralise memory + record_decision protocol in user-level CLAUDE.md (#523, PR #533)
+
+- **UUID:** `f1b70d56-1ba3-42c1-91fb-33e72e47e45a`
+- **When:** `2026-05-06T11:42:41.550686+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:end-2026-05-06:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep protocol in each skill (rejected — current state, source of rewrite pressure); Tier 2 hooks for everything (rejected — too brittle for soft rules); Move to SOUL.md instead of CLAUDE.md (rejected — SOUL=identity, CLAUDE=process)`
+
+  > [post-hoc] Implemented ADR-0002: extracted shared memory recall + record_decision contract from 5 skill files into a new .claude-userlevel/CLAUDE.md (mirrored to ~/.claude/CLAUDE.md via install-manifest claude_md group). Skills shrunk to workflow-specific content; Tier 3 skill-specific gates stayed in-skill. Risk: behavioural surface change across every session (auto-loaded user memory). Tracking via #532 recall-audit baseline. Sessions should now reference one canonical place rather than drift across 5+ copies.
+- **Memories used:** `7cbc4e3f-2d38-4f01-a6f1-f7cf2c06f1b4`
+
+---
+
+### Recall-audit baseline (#532) recorded as-is despite small N; AC adjusted to absolute counts
+
+- **UUID:** `45e809de-5013-4cf4-bd8a-3485599fd236`
+- **When:** `2026-05-06T11:42:48.276601+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:end-2026-05-06:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Wait for accumulation before #523 (rejected — blocks foundation work for days); Extend baseline by including redrobot sessions (rejected — different repo/rules, not comparable)`
+
+  > [post-hoc] Local D--GitHub-jarvis project dir had only 3 jsonl sessions (older rotated). Baseline shows 0 record_decision/store/recall calls — denominator empty, original >5pp absolute rule undefined. Posted baseline as-is to issue #532 with caveat; switched comparison metric to absolute counts (record_decision per session, store/decision-text-no-recall raw counts). Post-migration measurement still requires ≥20 fresh sessions. Alternative — wait for accumulation — would have blocked #523 for days.
+- **Memories used:** `none`
+
+---
+
+### Sandcastle agent runtime: Claude Code framework + Ollama local model inside the container, scheduled to safe hours on Main PC. Don't mount host ~/.claude. API/Sonnet path retained as fallback for hard issues, but default for AFK loop is Ollama. Cost target: ~$0 for AFK throughput.
+
+- **UUID:** `894ac658-67da-4f32-a0a2-5b5ebefac8ee`
+- **When:** `2026-05-06T16:31:31.353456+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `skill:grill-me`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Owner's framing: Claude Code is the free framework, models are the cost. Ollama swap is officially supported (claude_code_capabilities). This converts the cost-vs-sterility axis into a performance-vs-sterility axis with cost ≈ 0. AFK loop on workstation idle hours costs only electricity — turns idle compute into agent throughput, which is the DOWN-axis growth pattern in architecture_growth_two_dimensions. Trade-off accepted: Ollama-class models trail Sonnet-4-6 on hard reasoning, but the trigger checkbox (SOUL.md) already routes domain-logic / non-trivial tasks to /implement inline; what reaches /delegate AFK queue is mostly mechanical (docs, tests, refactors). For the rare hard-issue dispatch, /delegate keeps an API/Sonnet escape hatch via agent provider override. Sterility gain from B4 (no host ~/.claude mount) is preserved — Skills baked into Dockerfile, MCP via env-vars; identical setup on every device incl. redrobot rollout. Prerequisites before relying on this for nightly cron: (1) verify Ollama is installed + a coding-tuned model (e.g. qwen3-coder or qwen2.5-coder ≥30B) is pulled, (2) smoke-benchmark throughput on this hardware (token/s during a real /implement-style task) — if CPU-only and <10 tok/s, the AFK loop won't drain the queue; document threshold in CONTEXT.md, (3) define the safe-hours window (proposal: 22:00–08:00 weekdays + all weekend, configurable via Task Scheduler trigger), (4) cost-evidence loop: parseSessionUsage already returns tokens; outcome_record carries them; monthly review attributes Ollama vs API spend.</rationale>
+  > <parameter name="alternatives_considered">["B4 plain API (Sonnet) — rejected: $270/mo for the projected AFK volume violates 'frugal externals' budget and is unnecessary when Claude Code supports Ollama natively", "A4 mount ~/.claude (Max sub) — rejected: device-pinned mount paths (3 devices, redrobot) defeat reproducibility; OAuth token in container is non-zero risk", "Hybrid: Ollama for AFK + Max-mount for live dispatch — deferred. Possible later refinement once we know per-mode performance, but starting with one path simplifies"]
+- **Memories used:** `0c791012-d12b-445e-aada-8d6b6abea17f, d828bd94-c9ab-4c06-bb9f-b5afa00ff1d9, b10e218f-0f7a-405b-825a-7d96b74a25fb, 53cb337d-abc9-406a-8558-57d61e220b79, d6f00dc3-f1c4-4ccf-81b8-d47869459d53, 9757b985-cf68-4310-9d44-0571697d337f`
+
+---
+
+### Sandcastle failure-mode policy: fail-fast + outcome_record for everything; watchdog wrapper auto-starts Docker and Ollama with bounded poll; Ollama OOM gets one retry with a downgrade-model (e.g. 30B → 14B) before escalating via 'too-large-for-local' label; safe-hours window honored via soft-stop between iterations (no kill mid-iteration); Telegram push only on infra-down (Docker/Ollama failed to come up), all other outcomes silent.
+
+- **UUID:** `0c3017c6-01ec-4392-86a1-6a1522e4c5ef`
+- **When:** `2026-05-06T16:44:59.833163+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-me`
+- **Project:** `jarvis`
+- **Alternatives considered:** `No auto-start, manual daemon prep — rejected, the chain-of-trust concern was vague and AFK loop with manual prep is brittle; Multi-retry with backoff for any failure — rejected, hides root causes; orchestrator-tick level is the right recovery layer; Notifications on every failure — rejected, AFK partial-completion is normal noise, would erode signal value of Telegram channel`
+
+  > All recovery is at orchestrator/next-tick level, not inside sandcastle — keeps the agent loop simple and observable. Auto-start of Docker/Ollama is safe under cron-as-user during AFK window: no privilege escalation, no user collision (user is away by definition), poll-with-timeout prevents fake successes if daemons hang. Owner correctly challenged 'chain of trust' framing — there's no real escalation, just process start + readiness probe. OOM single-retry with smaller model is the cheap-then-escalate pattern: most OOMs come from one outlier issue with huge context; downgrade saves the iteration without burning the queue. Try-list lives in PowerShell wrapper, not sandcastle internals — keeps sandcastle config clean and the retry policy auditable in one file. Notifications scoped to actionable infra-down events; queue-level outcomes (partial/no-progress) are normal for AFK loops and would create morning spam.
+- **Memories used:** `894ac658-67da-4f32-a0a2-5b5ebefac8ee, b8f7de1d-1214-4e36-a566-516fe1dc26bc, 436f9549-3acf-4ee0-85e5-c7259735d62e`
+
+---
+
+### Sandcastle deployment shape: Workshop PC is the single AFK production target for both jarvis and redrobot loops. Main PC serves as dev/test bench only — sandcastle config changes are validated here on small smoke runs, then promoted to Workshop. No cross-owner phased rollout; workshop is effectively owner-controlled despite SergazyNarynov being nominal repo owner. redrobot rollout = drop the same .sandcastle/ scaffolding into the redrobot worktree on Workshop, with project-scoped paths and outcome project=redrobot. Safe-hours window applies per-repo (jarvis and redrobot loops scheduled non-overlapping to avoid Ollama VRAM contention). redrobot CI re-enable is a separate small decision — for now sandcastle gates on local pytest inside container for redrobot, gh check-status for jarvis.
+
+- **UUID:** `4890aa35-07ae-4e4c-8c4b-ec37e749d751`
+- **When:** `2026-05-06T16:58:32.324936+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-me`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A6 jarvis-only on Workshop, redrobot stays inline — rejected, redrobot benefits from same AFK throughput; no real friction blocking it; B6 Sergazy runs his own — rejected, he doesn't develop, only oversees; setup-friction is wasted; Run on Main PC, escalate to Workshop later — rejected, Main PC explicitly insufficient for real load per owner; would force a second migration`
+
+  > Owner clarified workshop machine is effectively his with full access; Sergazy is oversight-only. Cross-owner setup-friction (which drove the original phased rollout reasoning) does not exist. Workshop PC is also higher-spec than Main PC — Main PC was the wrong production target. This collapses A6/B6/C6 into the simpler dev-bench-to-prod-bench pattern matching the existing 3-device discipline (CONTEXT.md: anything device-pinned is a bug; sandcastle config must be portable, env-driven). Single ops point on Workshop also simplifies Telegram alerting, log collection, and outcome attribution. The redrobot-specific safety detector (planning/, driver/, mujoco/) and AFK-prohibited path list still apply at the prompt level inside the container — Q2 prompt+review boundary works identically on redrobot.
+- **Memories used:** `0c3017c6-01ec-4392-86a1-6a1522e4c5ef, 894ac658-67da-4f32-a0a2-5b5ebefac8ee`
+
+---
+
+### Sandcastle memory provenance: full memory MCP bridge inside the container. Vendor mcp-memory/server.py into Dockerfile, register in container .mcp.json same as host. Agent gets memory_recall, record_decision, outcome_record, memory_store from inside the container. Credentials: Supabase anon key + RLS, never service-role; reuses .sandcastle/.env. Provenance discipline: agent writes carry source_provenance='sandcastle:agent:<run_id>' and actor='sandcastle:agent'; outcome_record pattern_tags include 'sandcastle','afk'. Orchestrator review-tick audits agent-attributed decisions as part of merge policy. Skills baked into image (COPY .claude-userlevel/skills) so the agent works with the same skill context as an inline /implement session.
+
+- **UUID:** `228a2d9b-b57a-4d0f-8771-662482386b8a`
+- **When:** `2026-05-06T17:07:09.483195+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.82`
+- **Actor:** `skill:grill-me`
+- **Project:** `jarvis`
+- **Alternatives considered:** `B7 stateless agent + orchestrator-only memory — rejected, makes sandcastle agent equivalent to a generic subagent, defeats AFK Jarvis-quality goal; C7 host-side memory injection into prompt — rejected, pollutes orchestrator smart-zone per dispatch, undoes Q3 parallelism economics; A7 minus writes (read-only bridge) — rejected, lossy: per-task architectural sub-decisions would not land in queryable memory, regression vs inline /implement`
+
+  > Owner pushed back on B7/C7 with the architectural argument I missed: host-side memory injection forces orchestrator to absorb recall context per dispatch, doubling its smart-zone burn (recall at dispatch + injected snippet at review). Q3 cap=3 was sized against orchestrator smart-zone — host-side injection effectively shrinks cap to 1-2 in practice, undoing Q3. Bridge isolates the memory cost: each agent recalls in its own context, orchestrator smart-zone preserved for review. Without bridge, sandcastle agent equals a generic subagent — defeats the AFK Jarvis-quality goal. Credential/plumbing concerns were overstated: anon key + RLS handle scope; vendoring mcp-memory is ~30 min, not architectural. Memory-write pollution is solved by provenance discipline + orchestrator audit on review, not by disabling writes. Matches record_decision_during_session_not_at_end. The subagent-ignores-lessons pattern was about current /delegate where subagents have NO skills loaded; sandcastle bakes .claude-userlevel/skills into image, making symmetry with inline /implement real for the first time.
+- **Memories used:** `b8f7de1d-1214-4e36-a566-516fe1dc26bc, 894ac658-67da-4f32-a0a2-5b5ebefac8ee, 737763bf-740f-4864-9860-7ad41149af50`
+
+---
+
+### Sandcastle model escalation chain (refines Q5 0c3017c6): Tier 0 primary Ollama coding model → Tier 1 Ollama downgrade on OOM (one retry) → Tier 2 DeepSeek-class mid-tier API (cheaper than Claude, stronger than local Ollama) on persistent OOM/quality fail → label 'too-large-for-local' for owner. Claude API stays as explicit owner-only escalation, never auto-escalation from the AFK loop.
+
+- **UUID:** `f8e27d53-db5c-4aac-9dee-c3290a53c49a`
+- **When:** `2026-05-07T09:32:03.942192+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:to-issues`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Owner refinement on Q5 escalation policy: skipping straight from local-Ollama failure to Claude API overpays. DeepSeek-coder-class APIs are roughly 10× cheaper than Sonnet on input/output, while still meaningfully stronger than a 14B local model for the kind of issue that defeats Ollama. This produces a graceful cost-quality ramp instead of a binary local-vs-Claude choice. Watchdog implements the chain; sandcastle's agent provider parameter is swapped per-tier (claudeCode adapter pattern remains, just pointed at a different inference endpoint via env var). Claude API kept reachable but only on owner-explicit override (e.g. issue label 'use-claude-api'), preventing autonomous Claude spend from a cron loop.</rationale>
+  > <parameter name="alternatives_considered">["Two-tier Ollama → Claude API — rejected, overpays for issues DeepSeek would handle", "Add Claude API as auto-tier-3 — rejected, owner wants Claude spend gated to explicit override given AFK loop volume", "Single tier with bigger Ollama model — rejected, hardware ceiling on Workshop PC means OOM is real for some issue contexts"]
+- **Memories used:** `0c3017c6-01ec-4392-86a1-6a1522e4c5ef, 894ac658-67da-4f32-a0a2-5b5ebefac8ee`
+
+---
+
+### Bypass paperwork CI checks (PR Body Check, Project Sync) only for dependabot[bot]/renovate[bot] — keep pytest, gitleaks, meta-tests required.
+
+- **UUID:** `34f29b07-f30f-4497-a71f-4488a9dd6cda`
+- **When:** `2026-05-07T10:01:30.095196+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:end`
+- **Project:** `jarvis`
+- **Alternatives considered:** `skip-all-checks for dependabot — rejected (supply-chain risk); force linked-issue via auto-created bucket issue — rejected (paperwork churn)`
+
+  > Bots can't author linked issues and run with restricted secret scope. Bypassing only paperwork preserves real defenses. User proposed "skip all checks for dependabot"; I pushed back on supply-chain risk for shared mcp-memory deps and we converged on paperwork-only. Implemented in PR #536.
+- **Memories used:** `none`
+
+---
+
+### Hermes Agent изучен как референс, миграция Jarvis на Hermes отвергнута. Сохраняем Claude Code + собственный стек. Из Hermes — три кандидата на спайк: (a) Modal/Daytona terminal backend как потенциальная замена sandcastle epic #534, (b) auto-skill-creation hook на N tool calls, (c) Honcho dialectic user modeling.
+
+- **UUID:** `2c0b2d49-e101-4167-bde5-858f92e12c7e`
+- **When:** `2026-05-07T13:51:18.191467+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:hermes-eval-2026-05-07`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Полная миграция на Hermes как оркестратор + Claude Code + sandcastle — отвергнуто: self-improvement ограничен skills, своя память глубже, lock-in в молодой OSS; Использовать Hermes containerization вместо sandcastle прямо сейчас — отложено до спайка, нужна реальная проверка; Игнорировать Hermes полностью — отвергнуто: 3 фичи реально полезны как идеи`
+
+  > Hermes self-improvement ограничен skills+memory и не трогает архитектуру/промпты/MCP — то же, что у Jarvis уже есть. По памяти Jarvis инженерно строже: pgvector+HNSW+hybrid RRF против FTS5+LLM-summary, типизированные записи, обязательный source_provenance, decision log с reversibility/confidence, FK outcome→decision. Hermes выигрывает в agent-curated nudges (авто-сохранение) и Honcho user modeling — оба портируемы как идеи. 18 messaging gateways/subagents/hooks/MCP/scheduled tasks дублируют Claude Code. Lock-in риск: Hermes 3 месяца от роду, OSS-проект Nous, может пивотнуть. Опыт не теряется только при наличии плана миграции — его нет, форматы skills/SOUL/decisions не переносятся.
+- **Memories used:** `ab528091-6c86-43a0-b340-b1dfbbb047b6, 27c28a8e-2969-4550-9d4d-ffd25e36e5d8, 5fb66906-28ce-4bbe-9f64-0a8ce19630c3, 96aecc59-b1b7-4bb9-b578-907eead72cb9, 378b0a16-d3aa-4c0a-a9ea-82cab8d10a18`
+
+---
+
+### Honcho-style implicit memory derivation внедряем как Jarvis-native подсистему. Архитектура: (1) хуки + scheduled task делают деривацию, (2) скиллы — потом, как сценарии ревью; система проектируется отдельно от скиллов. Storage: расширяем `memories` тремя полями (`requires_review BOOL`, `confidence NUMERIC`, `derivation_run_id UUID`); отдельный тип не нужен — выводы идут в существующие `user`/`feedback` с `requires_review=true` и namespaced provenance (`hook:deriver:<run>`, `task:dreamer:<run>`). Routing деривации: Workshop PC + Ollama по умолчанию (как в sandcastle), DeepSeek API как fallback при недоступности Workshop. Stop hook = лёгкий аккумулятор, SessionEnd hook = headless дешёвой моделью пишет candidates. Scheduled weekly task = Dreamer-pass для merge/conflict/supersede. Review — RPC в memory MCP (`memory_review_list`, `memory_review_decide`), не привязан к конкретному скиллу. Recall по умолчанию фильтрует `requires_review=false`.
+
+- **UUID:** `d9592c05-722f-4682-b1fb-65c6ead0f5ec`
+- **When:** `2026-05-07T14:33:04.12249+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.78`
+- **Actor:** `session:hermes-eval-2026-05-07`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Интегрировать managed Honcho SaaS напрямую — отвергнуто: lock-in, $5–15/мес сверху, privacy, дублирование source-of-truth; Добавить новый тип памяти `observation` — отвергнуто: выводы по содержанию = `user`/`feedback`, отличие в lifecycle, флаги решают; Слить всю логику в `/end` скилл — отвергнуто: работает только при явном вызове юзером, теряем фоновый Dreamer и авто-деривацию на каждый конец сессии; Headless `claude -p` на Anthropic API для Deriver — отвергнуто как default: избыточно дорого для регулярной фоновой работы; остаётся как fallback бранч при недоступности Workshop+DeepSeek`
+
+  > Honcho решает реальный пробел Jarvis: имплицитная деривация инфы о юзере (поведенческие паттерны, выводы из переписки) — сейчас всё пишется только эксплицитно через skill/`memory_store`. SaaS Honcho прямо не интегрируем (lock-in, дублирование truth, privacy на чужом сервере). Реализуем сами: всё уже есть в стеке (Supabase, MCP, hooks, scheduled tasks, sandcastle/Ollama-runtime для дешёвого LLM). Новый тип не вводим — `user`/`feedback` концептуально уже это и есть, отличие в lifecycle (requires_review). Routing через Workshop PC + Ollama закрывает Q1 (стоимость) и Q3 (privacy) одновременно — фоновая деривация на $0 переменных и без отправки transcript наружу. Скиллы (`/learn`, `/end` slim, batch review) проектируем после системы — система не должна зависеть от выбора скиллов. Это разворот «скиллы определяют систему» → «система определяет скиллы».
+- **Memories used:** `0107c6bd-3419-4080-b3ec-7cbedcb123e3, bc8d1f6a-0b3f-48c0-946a-b4c4e9cb962a, ab528091-6c86-43a0-b340-b1dfbbb047b6, 27c28a8e-2969-4550-9d4d-ffd25e36e5d8, 37bb585c-d58c-4e9d-8c83-70a9b8e0da29`
+
+---
+
+### Slice 1 sandcastle: использовать нативный Anthropic-compatible endpoint Ollama (≥0.14, янв 2026) — без proxy. Контейнер тонкий: Claude Code CLI + git + gh + curl. Ollama живёт на хосте, контейнер ходит через host.docker.internal:11434.
+
+- **UUID:** `375449f9-5026-4471-a705-922c5baddf7f`
+- **When:** `2026-05-08T04:49:51.96888+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:implement-537`
+- **Project:** `jarvis`
+- **Alternatives considered:** `claude-code-router в контейнере (отвергнуто: лишний компонент в supply chain, не нужен пока единственный бэкенд — Ollama); LiteLLM прокси (тяжелее, Python — нарушает 'Only justified Python' правило); Сменить агента на opencode с нативным Ollama (отвергнуто: нарушает зафиксированный decision 894ac658, Claude Code остаётся стандартом); Ollama внутри контейнера (отвергнуто: дублирование весов на rebuild, медленный cold-start, конкуренция за GPU между container/host)`
+
+  > Память claude_code_capabilities (обновлена 2026-04-21) уже фиксировала этот путь, плюс подтверждено Ollama blog и docs.ollama.com/integrations/claude-code. Прокси (claude-code-router/free-claude-code) требуются только для OpenAI-совместимых бэкендов (DeepSeek, OpenRouter) — их добавит slice 5 как escalation. В slice 1 это лишний слой и ещё одна точка отказа. Веса Ollama не дублируются в образ → быстрый cold-start, persistent на хосте. Docker Desktop на Win/Mac (Main и Workshop оба Windows) резолвит host.docker.internal автоматически — extraHosts не нужны. Реализует grill-decision 894ac658 буквально как записано: Claude Code framework + local Ollama + sterile container.
+- **Memories used:** `894ac658-5697-4b89-b642-9a84c4b9c459`
+
+---
+
+### Deriver scope: candidates produce only `user` and `feedback` memory types; `project` excluded as state-not-knowledge. Caps: ≤5/session-end run, ≤20/Dreamer run. Confidence floor 0.5 for write.
+
+- **UUID:** `ccce2be6-12c9-4236-a267-f56786f8d647`
+- **When:** `2026-05-08T05:16:42.738124+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-with-docs:session:2026-05-08-549`
+- **Project:** `jarvis`
+- **Alternatives considered:** `include project type — rejected: state belongs in GitHub per CONTEXT invariant; no caps — rejected: derivation prompts produce long noisy lists; lower floor (0.3) — rejected: too much review burden; user-only — rejected: feedback is the high-value Honcho pattern (behavioural rules)`
+
+  > user is additive low-risk; feedback is high-blast-radius (always_load candidates) so demands review-gate downstream. project violates CONTEXT.md "no state in memory" invariant — Honcho-style passive derivation is structurally bad at state. Caps prevent run-away noise; 0.5 floor filters speculative inference. Owner accepted user+feedback explicitly; caps and floor accepted by tacit agreement.
+- **Memories used:** `af74264f-223e-409c-bb05-97c652554f7e`
+
+---
+
+### Auto-promote tier: always-gate v1 — every Deriver/Dreamer candidate lands `requires_review=true`, no exceptions. Future tiered auto-promote left as data-driven extension once ≥4 weeks of review-decision data exist.
+
+- **UUID:** `31ebba19-adb6-4ad0-ac33-ceac5bc5cea2`
+- **When:** `2026-05-08T05:22:49.167479+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:grill-with-docs:session:2026-05-08-549`
+- **Project:** `jarvis`
+- **Alternatives considered:** `tiered auto-promote at confidence >= 0.9 with explicit-correction signal — rejected: signal detection is itself the unreliable inference; auto-promote user type only — rejected: arbitrary split, complicates schema for marginal gain; always-gate forever — rejected: leaves no room for learned policy after data accumulates`
+
+  > feedback memories enter always_load and shape every future session — silent corruption only surfaces via /reflect months later. The "explicit-correction signal" that would condition auto-promote is the exact reasoning the Deriver hallucinates, so gating on it is circular. Honcho ships always-gate by default. Review burden is a UX problem solved in /learn, not a permissions problem solved in derivation. Owner accepted explicitly: "аргументы сильные, делаем always-gate с возможностью внедрения auto-promote в будущем".
+- **Memories used:** `af74264f-223e-409c-bb05-97c652554f7e, 8374f50e-1c24-4ff0-8ca0-d2495c3e7e45`
+
+---
+
+### Push-effect predictor in planner has a fixed swap-in interface predict(heightmap, push) -> updated_heightmap with 3-stage evolution: (1) geometric stub now (cells along path lose H, end-cell gains H, no mass conservation), (2) Warp DEM offline as training-data generator, (3) CNN surrogate trained on Warp data swapped in via the same interface. bulk_planner does not change between stages.
+
+- **UUID:** `cd234f5b-7b1e-4a45-9f67-21cb47bcc203`
+- **When:** `2026-05-08T05:31:05.261818+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-me:session:tier2-596`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Skip the abstraction, hardwire geometric update into bulk_planner — rejected: locks us out of CNN swap when it's ready, breaks design_for_extensibility.; Use Warp DEM directly as planner predictor with budget — rejected: owner said long sim cannot live in prod planner path.; Train CNN now from heightmap-physics ground truth — rejected: heightmap physics already lies on long-range transport, would train a wrong model.`
+
+  > Owner stated explicitly: 'push simulation нужно улучшать итеративно, warp simulation долгий, чисто его использовать в проде нельзя, но CNN без него не обучить, поэтому пока делаем геометрический stub, его хватит на первое время, но в скором будущем сделаем нормальную симуляцию и обучим CNN, тогда можно будет просто подменить старый вычислитель.' Locking the swap-in shape now means the geometric stub and the future CNN agree on signature so the rest of the planner is fidelity-agnostic. Warp DEM stays out of the inline planner path forever (latency forbids it) but earns its keep as the training oracle.
+- **Memories used:** `5e5ebd75-7efb-4b06-836d-acb622cf0b32`
+
+---
+
+### Tier 2 of #596 unified into one mechanism: scoring-based push selection on a dynamic cost-map (figure=hard, active-deficit=soft, buffer=zero) + greedy push picking with intra-Pass geometric self-update of the diff_map. Closes (a2) sequencing-via-residual-mask and (b) figure-damage-via-pathfinding with the SAME machinery; (c) full mass simulation deferred to CNN-surrogate swap-in.
+
+- **UUID:** `8c7c6749-2d4f-4b3e-b728-8115cbaf149f`
+- **When:** `2026-05-08T05:31:39.924703+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:grill-me:session:tier2-596`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Three separate issues per Tier 2 item — rejected: owner wanted unified mechanism, separate efforts duplicate cost-map plumbing.; Push simulation first as foundation — rejected: heightmap_sim_transport_limitation says cheap heightmap sim lies on long-range; geometric stub is honest about its limits.; Local beam search instead of greedy with self-update — deferred: greedy with memory is simpler, beam can be added if greedy underperforms.; Hard-block figure + ignore current-deficit (b only) — rejected: owner wants (a2) covered with one mechanism.; Continue using lookahead_planner beam search — rejected: 7+ min/pass made it off-by-default in #616, performance dead-end.`
+
+  > Owner needs (a2)+(b) addressed now under one mechanism, not three separate Tier-2 items. Path-cost via cost-map closes (b) directly. (a2) converts to (b)-shaped problem if each picked push immediately updates a per-Pass dynamic cost-map: subsequent candidates see the freshly-formed deficit as soft obstacle. Geometric self-update (cells along path lose H, end-cell gains H, no mass-conservation, no berm) is enough as stub — owner's plan is to upgrade to Warp-trained CNN surrogate that swaps into the same predictor slot. Zoning edge-residue concern is moot today (no sub-zones inside workspace) and pushes through to multi-fragment Workspace selection at Strategist level when 3D lands, not Tier 2 scope.
+- **Memories used:** `e9fb290e-340e-49e4-9887-4717d59b32c4, 5e5ebd75-7efb-4b06-836d-acb622cf0b32, c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7, 8c8c8d40-7d51-45d5-a5f0-1ec5ff9ab0fc, 19bbe196-3a93-46dd-b87e-f1e00528d559, 2249bb82-14ea-4d9e-a808-ccec002df383`
+
+---
+
+### Dreamer contradiction handling: writes "merge proposal" candidate (option b) — new row in `memories` with `requires_review=true` and new column `merge_targets UUID[]` listing conflicting source UUIDs. `memory_review_decide(action=merge_into)` atomically accepts new row + sets `superseded_by` on targets. Recall MUST skip rows with non-empty `merge_targets` even when `include_unreviewed=true` — they are meta-rows, not knowledge.
+
+- **UUID:** `d162cca4-25ba-4342-b6e2-c1c92bd2ba78`
+- **When:** `2026-05-08T05:56:46.506669+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-with-docs:session:2026-05-08-549`
+- **Project:** `jarvis`
+- **Alternatives considered:** `(a) write third candidate alongside — rejected: triplicates without resolving; (c) flag-only via events row — rejected: loses Dreamer proposal value; encode targets in source_provenance JSON — rejected: makes recall-skip rule fragile, not type-checked; auto-resolve on confidence — already excluded by Q4 always-gate`
+
+  > Option (a) duplicates without resolving (recall returns three rows weighted by recency); option (c) loses Dreamer's value-add (whole point is the proposed merge text). Option (b) preserves human-breaks-ties from Q4 always-gate while keeping the proposal queryable. New column over JSON-encoded targets because (i) UUID array is queryable for the recall-skip filter, (ii) JSON encoding hides the relationship from the schema, making the recall-skip rule a foot-gun. Owner accepted both shape and column.
+- **Memories used:** `31ebba19-adb6-4ad0-ac33-ceac5bc5cea2, ccce2be6-12c9-4236-a267-f56786f8d647`
+
+---
+
+### Tier 2 implementation choices: (1) A* on 8-connected cell grid for path search; (2) greedy push-picking with intra-Pass dynamic cost-map self-update as default, beam-1 lookahead behind feature flag (off, like #616); (3) two new modules sandbox/cost_map.py + sandbox/path_planner.py, geometric stub folded into existing sandbox/deposit_model.py via PushEffectPredictor Protocol; (4) integration via feature-flag in bulk_planner.plan_bulk_passes preserving back-compat.
+
+- **UUID:** `bfe90a55-dca5-4dcb-bb1a-b4c10fca204a`
+- **When:** `2026-05-08T06:07:58.901529+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-me:session:tier2-596`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Visibility graph instead of A* — rejected: needs polygonal model, A* on grid maps directly onto cost-map.; Beam search default — rejected: lookahead_planner already proved that direction expensive in #616.; Three new modules including push_predictor.py — rejected by deletion test: thin wrapper over existing deposit_model functions.; Inline integration without feature flag — rejected: prevents A/B mock comparison and rolls back hard if regressions surface.`
+
+  > A* on grid is milliseconds at this scale (40x60 cells, 30-cell push) and naturally yields curved paths around soft-cost obstacles, subsuming Tier 2 'curved push paths' item. Greedy with self-update first because it is simpler and the lookahead_planner beam search is already on-record as off-by-default for cost (#616). Folding the predictor into deposit_model rather than a new push_predictor module is the deletion test from SOUL: a thin wrapper around predict_deposit + along-path removal earns nothing as a separate file. Protocol gives CNN-surrogate the swap-in slot without an extra module. Feature-flag integration preserves the current bulk_planner contract — owner can A/B mock-runs.
+- **Memories used:** `8c8c8d40-7d51-45d5-a5f0-1ec5ff9ab0fc`
+
+---
+
+### Tier 2 sliced into three issues: alpha=cost_map.py + deposit_model PushEffectPredictor extension + unit tests; beta=path_planner.py A* + unit tests (depends on alpha interface); gamma=bulk_planner integration behind feature-flag + e2e mock convergence comparison vs baseline on dome and letter shapes (depends on alpha+beta).
+
+- **UUID:** `938d7af4-132d-45cc-90bb-5aee0af8515f`
+- **When:** `2026-05-08T06:08:09.243654+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-me:session:tier2-596`
+- **Project:** `redrobot`
+- **Alternatives considered:** `One mega-issue — rejected: too big for smart zone, no intermediate verification, repeats lookahead_planner mistake.; Alpha-then-beta-then-gamma fully serial — weaker: alpha and beta are independent given a stable interface, parallelising saves a session.`
+
+  > Vertical slice on alpha: cost-map alone is verifiable with synthetic diff_maps + figure_masks. Beta alone is verifiable with synthetic cost-maps. Gamma is the user-visible slice — convergence improvement on real shapes. Alpha and beta can run in parallel by an interface stub. Gamma serialises after both. This matches /to-issues tracer-bullet pattern and avoids the lookahead_planner trap of one giant change with no intermediate verification.
+- **Memories used:** `none`
+
+---
+
+### Dreamer cadence: volume-driven, triggers when pending-candidate count ≥30 OR ≥7d since last run (whichever first). Input window: pending candidates + accepted `feedback` from last 90d, capped at 200. Write authority: Dreamer may emit new `feedback` candidates AND merge proposals; both land `requires_review=true`; source UUIDs cited in `source_provenance` as `task:dreamer:<run>:from=<uuid>,...`.
+
+- **UUID:** `fa9bd40d-9d30-4c13-ad1d-98669d3b1e2a`
+- **When:** `2026-05-08T06:14:25.132495+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-with-docs:session:2026-05-08-549`
+- **Project:** `jarvis`
+- **Alternatives considered:** `weekly fixed cron — rejected by owner: less consistent than volume signal; every N session-ends — rejected: zero-candidate sessions waste compute; input = whole corpus — rejected: cost + dilution by stale memories; Dreamer merge-only — rejected: loses synthesis value; no source-UUID citation — rejected: owner can't audit candidate origin`
+
+  > Owner pushed back on weekly fixed cadence — volume-driven is more consistent (matches what's actually happening), and is cheaply implementable as a counter on requires_review=true candidates since last run. 7-day backstop guards low-volume weeks. N=30 ≈ 6 sessions at Q1 cap of 5/run, tunable. Input window 90d is corpus-level smart-zone analog. Dreamer write authority extended to new feedback because merge-only would kneecap the value (half the job is "I see a pattern across 5 entries"); flooding risk mitigated by Q1 cap of 20/run plus mandatory source-UUID citation in provenance.
+- **Memories used:** `ccce2be6-12c9-4236-a267-f56786f8d647, 31ebba19-adb6-4ad0-ac33-ceac5bc5cea2, d162cca4-25ba-4342-b6e2-c1c92bd2ba78`
+
+---
+
+### Quality safeguards: (7a) dedup at cosine ≥0.85 against production Voyage embedding via new RPC `memory_dedup_check`; (7b) on dedup hit, bump existing memory's `confidence` asymptotically capped 0.95 + append provenance — bump applies ONLY to accepted memories, not still-pending candidates; (7c) cap overflow truncates by confidence, drops logged to `events` row for `/learn`.
+
+- **UUID:** `6aa3c882-d955-4661-ab24-0ac2e190593c`
+- **When:** `2026-05-08T06:22:00.454812+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-with-docs:session:2026-05-08-549`
+- **Project:** `jarvis`
+- **Alternatives considered:** `dedup on local Ollama embedding — rejected: dedup space != recall space; silent drop on dedup — rejected: loses persistence-of-pattern signal; bump pending candidates too — rejected: Deriver could self-promote without owner gate; fail run on cap overflow — rejected: brittle on verbose sessions; 0.90 dedup threshold — not raised; 0.85 is the epic's preset`
+
+  > Whole memory stack runs on Voyage; dedup'ing in a different vector space (Ollama) would be fiction — recall at retrieval time uses Voyage, so write-time dedup must match. ~$0.0001 per call, ≤5/run, negligible. Bump-on-re-derive is signal (pattern persists across sessions) but only valid against already-validated memories — bumping pending candidates would let Deriver self-promote via repetition. Truncate-by-confidence keeps high-signal candidates and avoids brittle whole-run failures from one verbose session. Owner accepted full bundle.
+- **Memories used:** `e306cb81-81b5-4979-853b-04a2704deca7, ccce2be6-12c9-4236-a267-f56786f8d647, 31ebba19-adb6-4ad0-ac33-ceac5bc5cea2`
+
+---
+
+### redrobot abandons 1-week sprints. Slices reference parent issue (e.g. #596) instead of being bound to Sprint field. Project board Sprint column ignored going forward. Milestone usage unchanged (goals, not deadlines). Matches jarvis project policy.
+
+- **UUID:** `939adaa1-ec31-4b23-9141-358a09739706`
+- **When:** `2026-05-08T06:29:15.153447+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:to-issues:session:tier2-596`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Keep sprints — rejected by owner.; Hybrid: sprints for non-research work only — rejected: more rules, not fewer.`
+
+  > Owner statement 2026-05-08: 'мы разве не отказались от спринтов? Если тут ещё нет, то пора.' Sprint binding adds ceremony without value when work is owner-driven and parent-issue grouping covers the natural unit. Slices under one parent issue achieve the same coordination that a Sprint label tried to. Aligns redrobot process with jarvis (already sprint-free). CLAUDE.md sections about Sprint planning and 'максимум 3-5 issues на спринт' need updating but that is mechanical follow-up.
+- **Memories used:** `17b09d06-0ecb-4cf3-8b7b-360570591d99, 0298df61-aad3-4487-88f5-a0e01083bd52`
+
+---
+
+### Privacy: pre-Deriver regex scrubber mandatory, applied at TWO layers (Tier-1+Tier-2): (i) SessionEnd hook scrubs transcript chunk before headless `claude -p` invocation; (ii) memory MCP `memory_store` rejects payloads matching the same patterns. Patterns cover known secret formats (sk-*, ghp_*, xox*, JWT, AKIA*, `.env` KEY=VALUE blocks) plus device-path normalisation (`C:\Users\<name>\…` → `<USER_PATH>/…`). Scrubber-fire counter logged for `/learn` to spot eager patterns.
+
+- **UUID:** `eb62980e-0e95-442f-ba3c-3bb885d368d5`
+- **When:** `2026-05-08T06:31:53.140913+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:grill-with-docs:session:2026-05-08-549`
+- **Project:** `jarvis`
+- **Alternatives considered:** `trust the model only — rejected: Tier-1 alone insufficient for high-blast-radius write to memory; scrubber in hook only — rejected: leaves explicit memory_store callers unguarded; MCP guard only — rejected: Deriver still sees raw secrets, prompt could memorise/echo; no path normalisation — rejected: violates device-portability invariant`
+
+  > SOUL invariant: secrets never persist to memory. Memory is the exact write target — regex fence is the deterministic enforcement layer per `enforcement_layer_matches_threat_model`; prompt-only "don't leak" is Tier-1 instruction-following, insufficient. Local Ollama doesn't help — leak is to Supabase, not to a remote LLM. Two-layer mirrors the existing CLAUDE.md / ADR-0002 Tier-1/Tier-2 pattern: hook handles common case fast, MCP-side guard is universal backstop covering all writers (not just Deriver — explicit memory_store from any skill benefits). Cost trivial vs. remediation cost of leaked key. Owner accepted.
+- **Memories used:** `6aa3c882-d955-4661-ab24-0ac2e190593c, ccce2be6-12c9-4236-a267-f56786f8d647`
+
+---
+
+### Skill split: `/learn` is thin glue over `memory_review_list` / `memory_review_decide` RPCs — no business logic in the skill. No `accept_all` / bulk-accept RPC in infra. Three carve-outs stay skill-side: bulk-accept heuristics (loop of single decides), merge-proposal rendering, cross-skill UX flows like `/end` mini-review. Recall semantics (`include_unreviewed`, merge-target skip), promotion atomicity, SessionStart pending-count surfacing stay in infra. Constraint: candidate throughput must be bounded so review burden remains human-sized — solving overload via bulk-accept is rejected.
+
+- **UUID:** `81216bc3-5c32-4001-8ea3-0761bf4f42e2`
+- **When:** `2026-05-08T06:44:39.8236+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:grill-with-docs:session:2026-05-08-549`
+- **Project:** `jarvis`
+- **Alternatives considered:** `accept_all RPC with policy params — rejected by owner: normalises rubber-stamping, undercuts always-gate; thick `/learn` skill owning conflict-resolution logic — rejected: couples infra to skill, breaks `/learn`-replacement; bulk-accept lives in infra but skill drives policy — rejected: same rubber-stamp risk; no skill at all, RPCs only — rejected: review needs UX surface, /learn already scoped in #526`
+
+  > Thin-wrapper rule means RPCs alone must drive a fully functional review UX without `/learn` — if skill-specific knowledge leaks into an RPC, the abstraction is wrong. Owner explicitly rejects `accept_all` RPC: when reasoning beyond single-user, an accept-all primitive normalises rubber-stamping behaviour and undercuts the always-gate from Q4. The constraint flips downstream: tune Q1/Q2 caps so weekly review is feasible single-by-single, don't bandage with bulk-accept. Aligns with action_agent_safety_gate_model_v1 — owner-queue tier should stay reviewable, not auto-clear.
+- **Memories used:** `fa9bd40d-9d30-4c13-ad1d-98669d3b1e2a, 31ebba19-adb6-4ad0-ac33-ceac5bc5cea2`
+
+---
+
+### Cross-project shape: Deriver and Dreamer are owner-level infra, not jarvis-scoped. SessionEnd hook lives in user-level `~/.claude/settings.json` (mirrored from `.claude-userlevel/`), fires on every owner session regardless of project. Candidate `project` is content-determined by the Deriver: `user` type → `project=null` (global); `feedback` → scoped to where the rule applies (session's project or global). Recall default `include_unreviewed=false` applies uniformly across all projects — no per-project special-casing. Migration safeguards: (a) column-collision check via `information_schema` before writing migration, (b) RPCs require explicit `project` parameter (accepts `null` for global), (c) cross-project smoke test as migration-PR blocker — redrobot recall must return identical result set pre/post on a no-candidates baseline.
+
+- **UUID:** `b37fb780-96a6-459c-8c2a-b5632bc7592f`
+- **When:** `2026-05-08T06:53:03.959925+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-with-docs:session:2026-05-08-549`
+- **Project:** `jarvis`
+- **Alternatives considered:** `per-project recall default (3a) — rejected: leaks asymmetry into shared pipeline; jarvis-only Deriver (3b) — rejected by owner: artificially limits derivation, jarvis is personal-agent layer not project tool; Deriver scopes candidates to session project always — rejected: forces owner-universal facts (e.g. communication style) into one project's namespace; Dreamer per-project — rejected: duplicates compute, fragments cross-project pattern detection`
+
+  > Owner correction: jarvis is the personal-agent layer over the owner's sessions, not a project-scoped tool. Both redrobot and jarvis are owner's projects; the Deriver observes the owner, who is one human. Original (3a)/(3b) were both wrong shapes — (3a) leaked asymmetry into recall config, (3b) artificially limited derivation to one project. Correct model: derivation runs everywhere, candidates self-classify scope. Hook placement at user-level (mirror chain, not project-level) is consistent with `.claude-userlevel/` canonical-source invariant. Migration safeguards reframed: not "redrobot opt-out" but "no regressions on shared schema".
+- **Memories used:** `81216bc3-5c32-4001-8ea3-0761bf4f42e2, fa9bd40d-9d30-4c13-ad1d-98669d3b1e2a, ccce2be6-12c9-4236-a267-f56786f8d647`
+
+---
+
+### Drop /cycle skill from #522 redesign; split Type 1 into /status-record + /verify-pending; sandcastle orchestrator owns the goal-aware nightly loop that autonomous-loop used to run.
+
+- **UUID:** `bc6ba754-376f-4f2b-9e38-dba5dcad8173`
+- **When:** `2026-05-08T07:48:21.786241+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-with-docs:session-2026-05-08`
+- **Project:** `jarvis`
+- **Alternatives considered:** `One skill /cycle with autodetection — rejected: autodetect drift is silent failure, and after orchestrator lands the autonomous-loop branch has no caller anyway; One skill /cycle with --mode= flag — rejected: leaks scheduling knowledge to caller, exactly the duplication ADR-0002 is reducing; Keep /cycle, push autonomous-loop function into orchestrator only — rejected: still leaves autodetect logic for the remaining two rhythms with no benefit`
+
+  > Epic #522 collapsed three rhythms (autonomous-loop, status cron, verify event) into /cycle. With sandcastle orchestrator landing as the night-time decision/action loop, the autonomous-loop slot has no reader — function migrated, not duplicated. Remaining two rhythms (periodic state snapshot, post-delegation verify) have different triggers/inputs/outputs and are cheap to confuse if collapsed; explicit split reduces autodetect-drift risk. self-improve stays in /learn (analysis), execution becomes regular issues the orchestrator picks up. Total skill count 16→17 — extra surface offset by clearer triggers and removal of autodetect logic in Type-1 entry point.
+- **Memories used:** `none`
+
+---
+
+### /grill-me checkbox under no-Type-3 rule resolves via Resolution A: /implement and /delegate exit with grill_required status when checkbox triggers; orchestrator dispatches /grill in fresh session, then re-dispatches /implement/delegate.
+
+- **UUID:** `6b2cfcd5-7147-460a-be9c-c4a3bf8638a6`
+- **When:** `2026-05-08T07:48:26.707028+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-with-docs:session-2026-05-08`
+- **Project:** `jarvis`
+- **Alternatives considered:** `B Inline grill-then-implement — rejected: duplicates grill content into /implement body; C Drop checkbox enforcement — rejected: shifts gate to orchestrator which has no memory and no checkbox itself`
+
+  > Only resolution consistent with ADR-0001 (no mid-task self-trigger) and ADR-0002 (kill duplication). Inline-grill option recreates the duplication ADR-0002 is removing. Drop-checkbox option shifts cognitive load to a forgetful orchestrator and breaks SOUL.md's scope-shrinkage guarantee. Two extra sessions per gated implement is cheap relative to a missed assumption.
+- **Memories used:** `none`
+
+---
+
+### #528 "restore to upstream" = pinned-SHA diff with allowlist: forbidden additions (record_decision, memories_used, always_load, source_provenance, Tier-1/2/3, recall protocol) live only in global CLAUDE.md; allowed additions limited to local path references (CONTEXT.md, docs/adr/, /grill-with-docs entry point).
+
+- **UUID:** `4bc25125-0378-4ded-a618-bc79e632ff35`
+- **When:** `2026-05-08T07:52:22.504139+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-with-docs:session-2026-05-08`
+- **Project:** `jarvis`
+- **Alternatives considered:** `B byte-equal upstream — rejected: blocks reasonable project-local path references; C upstream-shaped not equal — rejected: no clear stop-rule against gradual re-inlining of protocol blocks`
+
+  > Resolution A from grill session. Byte-equal upstream (B) loses useful project path references; "upstream-shaped" (C) leaves recidivism gap for re-inlining protocol blocks. Pinned SHA + explicit allowlist gives reviewer a deterministic pass/fail on PR without brittle CI prose-diff gate.
+- **Memories used:** `none`
+
+---
+
+### /learn (#526) stays unified across reflect+self-improve+verify-pattern with mode parameter (`/learn comms|repo|outcomes` or no-arg = full pass); orchestrator does NOT absorb any /learn function. #532 escalation criteria: empty_memories_used_pct > 15% absolute over 20 post-migration sessions OR rise of >5pp vs baseline → file Tier-2 hook issue.
+
+- **UUID:** `12823855-91c7-4bff-b774-4e5cf76db7bb`
+- **When:** `2026-05-08T07:55:57.464949+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-with-docs:session-2026-05-08`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Split /learn into three Type-1 skills — rejected: same trigger, same output shape, false economy; Single delta-only threshold — rejected: misses pre-existing high empty rates; Single absolute-only threshold — rejected: misses regressions when baseline is good`
+
+  > Unlike /cycle (three semantically different actions, one absorbed by orchestrator), /learn is one action (analyse past corpus) over three different inputs. Mode parameter is fine here because callers always know which corpus they want. No orchestrator overlap — analysis stays Jarvis-side, only the resulting issues feed the orchestrator. Dual threshold (absolute + delta) catches both pre-existing pathology and post-migration regression.
+- **Memories used:** `none`
+
+---
+
+### Drop /status as Type-2 skill: owner reads state via inline memory_recall on the events written by /status-record (Type 1). Single skill, no read-side dashboard skill. Total target stays at 16. #524 hook gets a structural intentionally_empty=true flag in record_decision schema; hook blocks empty memories_used unless flag set.
+
+- **UUID:** `a685a14b-18d3-4b82-b3f2-6013c0e01cf4`
+- **When:** `2026-05-08T08:07:02.488117+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill-with-docs:session-2026-05-08`
+- **Project:** `jarvis`
+- **Alternatives considered:** `5a Rename Type-1 to /snapshot-state, keep /status — rejected: read-side skill is unnecessary indirection over memory_recall; 5a Single /status with --record flag — rejected: flag combinatorics, two readers in one skill; 5b Prose-grep for [no-recall-needed] marker — rejected: brittle, hook becomes non-deterministic; 5b Block all empty memories_used — rejected: legitimate policy/tag/config decisions have no memory basis`
+
+  > 5a: read-path is just memory_recall over status events — no skill needed. Removes naming collision with /status-record by removing the colliding skill entirely. 5b: only structural escape-hatch is honest in a deterministic hook; prose-grep is brittle, no-escape blocks legitimate policy/tag/config decisions with no memory basis.
+- **Memories used:** `none`
+
+---
+
+### implement sandcastle slice 2: memory MCP bridge inside container + skills baked in (#540)
+
+- **UUID:** `50018458-e618-4e0c-a11c-f82e866b2f57`
+- **When:** `2026-05-08T08:16:49.370356+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:implement-540`
+- **Project:** `jarvis`
+- **Alternatives considered:** `overwrite worktree's project .mcp.json via onSandboxReady hook — rejected: mutates host repo state during run, fragile if branchStrategy isn't fully isolated; bind-mount mcp-memory/ from host instead of vendoring — rejected: violates sterile-container decision 894ac658 and breaks portability across devices; use --mcp-config CLI flag — rejected: requires intercepting how @ai-hero/sandcastle invokes claude; user-scope ~/.claude.json achieves same with no framework hooks; delegate to subagent — rejected: infrastructure work crossing Dockerfile + sandcastle config + prompt + memory schema discipline benefits from full session context`
+
+  > Slice 2 adds full memory MCP + canonical skills to the sandcastle container so AFK iterations get the same recall/decision-log/outcome substrate as inline /implement. Approach: Dockerfile vendors mcp-memory/ (server.py + sibling modules + requirements.txt) into /opt/mcp-memory/, installs python3 + pip + requirements, copies .claude-userlevel/skills/ into /home/agent/.claude/skills/, writes a user-scope ~/.claude.json with the memory MCP entry using ${SUPABASE_URL}/${SUPABASE_KEY}/${VOYAGE_API_KEY} env-substitution (Claude Code expands these from container env at runtime). main.mts forwards SUPABASE_URL, SUPABASE_KEY (anon), VOYAGE_API_KEY from .sandcastle/.env. .env.example documents anon-only with explicit "service-role banned". Prompt.md adds mandatory memory_recall as step 0 + mandatory source_provenance='sandcastle:agent:<run_id>' + actor='sandcastle:agent' on every memory write. RLS enforcement of provenance is slice 3 (#542) — slice 2 is the wiring + prompt discipline. Chose user-scope ~/.claude.json over overwriting the bind-mounted worktree's project .mcp.json to avoid mutating the host repo state mid-run; user-scope works regardless of CWD. Vendored entire mcp-memory/ rather than just server.py because server.py imports from sibling modules (client.py, embeddings.py, recall.py, handlers/, etc.).
+- **Memories used:** `228a2d9b-b57a-4d0f-8771-662482386b8a, 894ac658-67da-4f32-a0a2-5b5ebefac8ee, 436f9549-3acf-4ee0-85e5-c7259735d62e, 37bb585c-d58c-4e9d-8c83-70a9b8e0da29`
+
+---
+
+### Implement #728 (slice 1 of #596) with new cost_map.py + path_planner.py modules and opt-in obstacle_aware_paths flag in plan_bulk_passes
+
+- **UUID:** `e4be014f-5f2a-4669-a0c8-00d9de1c9d20`
+- **When:** `2026-05-08T11:23:01.57003+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:redrobot-728-impl`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Reuse existing _astar_grid in bulk_planner — rejected: spec/decision bfe90a55 required new modules; Down-sample waypoints to cap count — rejected: corner-clipping under linear interpolation between cell centers; Drop pushes with endpoint-in-figure entirely — partially adopted (only when no free cell exists along start→end ray)`
+
+  > Spec mandated module split per parent decision bfe90a55 (A* 8-conn + new cost_map.py + path_planner.py). Existing bulk_planner already had embedded A* but driven by formed-areas heuristic and ignored figure_mask param. Slice 1 wires figure_mask directly via cost_map (figure=HARD, else=0), defaults flag OFF for back-compat. Two implementation gaps surfaced during testing: (1) pushes can be aimed AT figure cells when deficit center + max-distance clamp lands mid-figure — resolved by walking endpoint back to last non-figure cell along start→end before A*; (2) down-sampled waypoints can clip figure corners on linear interpolation between non-adjacent cells — resolved by keeping every interior cell on the A* path (slice 2 can swap in Douglas-Peucker simplification when needed). Aligns with three_state_workspace_model and deficit_first_bulk_planner architectural premises.
+- **Memories used:** `1d963b08-cbb0-44d5-af96-ca4c278f1bae, c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7, 3bd7ce53-ca58-486a-b12f-5af4f468495f, 8c8c8d40-7d51-45d5-a5f0-1ec5ff9ab0fc, 19bbe196-3a93-46dd-b87e-f1e00528d559`
+
+---
+
+### Epic = grouping of slices by theme/capability when ≥2 slices share the goal or have inter-dependencies. Single independent slice (no deps in, no deps out) ships without an epic. Epic body serves as PRD-or-equivalent (when no PRD exists). Closes when capability ships, not on a date.
+
+- **UUID:** `4271e2a5-c0cb-4a5e-954c-b4c11df83d06`
+- **When:** `2026-05-08T13:07:42.090242+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-548`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Sharper than capability-demo test alone: makes epic optional, not mandatory. Removes ceremony for one-off slices (drive-by fixes, isolated improvements). Aligns with grill→to-prd→to-issues chain — PRD becomes epic body. Empty optionality matters: forcing milestone-per-slice was the sprint-ceremony failure mode #548 wants to kill. Owner's framing: "epic просто удобно иметь, чтобы отслеживать прогресс одной цельной, многошаговой задачи".</rationale>
+  > <parameter name="alternatives_considered">["A: epic ≥2 PRs always (ignores semantic capability)", "B: epic = anything not fitting in 1 week (reintroduces date-boxing)", "C: epic = theme/direction (collapses into pillar)", "D: capability-demo test, always create epic (mandates ceremony for solo slices)"]
+- **Memories used:** `bdf9cfaa-c46f-4d8b-afef-a90c8aa91632, ecd6f6c9-8bb5-4be6-8526-fee314a885d0, 7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### No numerical WIP limit on active epics; self-throttle by owner-attention (HITL/grill/review) load, not by epic count. AFK epics cost ~0 attention.
+
+- **UUID:** `13fc7fb8-27db-4bcc-b005-ad4813eb4185`
+- **When:** `2026-05-08T13:14:03.30509+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-548`
+- **Project:** `jarvis`
+- **Alternatives considered:** `WIP=2 per project — ignores AFK vs HITL distinction; WIP=N global — same flaw + cross-project coupling; Hook blocking gh milestone create at threshold — preemptive automation, wrong primitive; Memory always_load N=2 rule — codifies wrong invariant`
+
+  > Original WIP=2 was cargo-culted from team contexts. Scarce resource for solo operator is owner attention. AFK epics (subagents/sandcastle) consume no attention until HITL surfaces. Hard numeric cap would block opening a 3rd unrelated epic when prior two are 100% AFK — wrong primitive. Continuous-flow Pocock posture aligns with attention-throttling, not count-throttling. SessionStart may surface phase breakdown (HITL-stage vs AFK-running counts) as passive signal.
+- **Memories used:** `bdf9cfaa-c46f-4d8b-afef-a90c8aa91632, ecd6f6c9-8bb5-4be6-8526-fee314a885d0`
+
+---
+
+### implement Slice 3 sandcastle RLS provenance gate (#542) — anon INSERT restricted to sandcastle:% provenance across memories/episodes/task_outcomes/events_canonical
+
+- **UUID:** `71eda7c8-901f-4d3b-9b16-a6a1c91496e5`
+- **When:** `2026-05-08T13:19:30.269099+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:slice3-2026-05-08`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Add source_provenance column to all 3 missing tables — rejected: redundant with existing actor field on episodes/events_canonical, breaks C17 substrate writers; Use actor for all 4 tables — rejected: memories has source_provenance NOT NULL since phase 2c, swapping would be a major migration; Skip task_outcomes entirely — rejected: in AC list; Defer slice and ask principal about schema asymmetry — rejected: auto mode, decision is reversible`
+
+  > Schema asymmetry forces per-table choice of provenance-equivalent column: memories has source_provenance (NOT NULL since phase 2c); task_outcomes lacks it — adding nullable column matches memories pattern; episodes and events_canonical already use `actor` as the provenance field per their column comments ('session:<id>', 'scheduled:<skill>', etc.) — using actor LIKE 'sandcastle:%' avoids redundant column addition and matches existing semantics. Slight deviation from AC literal text 'source_provenance' for episodes/events_canonical, documented in PR body and schema comment. Service-role bypasses RLS so host orchestrator unaffected per AC framing. Meta-test parses migration SQL (parallel-copy pattern from test_schema_drift_guard.py per #326) — does not require live DB at CI time.</rationale>
+  > <parameter name="memories_used">["99933db1-094a-417e-ac77-c64f9f2d900b", "f0865197-2b98-4383-a322-547c6daa30be", "dfe4a9de-1821-4229-ac68-a885318fd0c9", "1c8d279e-8461-41f1-b00b-7839f4a853ab"]
+- **Memories used:** `none`
+
+---
+
+### Drop term epic entirely. Use GitHub milestone as single grouping primitive for related slices. Milestone description carries the PRD. No separate epic-issue layer. Single independent slice ships without milestone. Hierarchy: pillar narrative, goal Type A, milestone capability plus description, slice PR.
+
+- **UUID:** `2a7ae10e-afc3-4523-b0bc-c4b90ddbe1a5`
+- **When:** `2026-05-08T13:25:32.698942+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-548`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep epic-issue plus milestone double layer; Use only epic-issues, no milestones; Keep epic issues but skip milestones for small ones`
+
+  > Owner clarified mid-grill that the goal is grouping smezhnyh slices under one umbrella with a shared description. Epic-issue plus milestone was double-bookkeeping: both had bodies, both had to be created, slices linked to both. Collapsing to milestone-only removes the redundancy. Milestone description equals stable PRD; lack of comment thread forces clean separation, where discussion lives on slices and intent lives on milestone. Existing epic issues 534, 549, 522 become redundant: bodies migrate to milestone description, issue closes as superseded.
+- **Memories used:** `bdf9cfaa-c46f-4d8b-afef-a90c8aa91632, 4271e2a5-c0cb-4a5e-954c-b4c11df83d06, 13fc7fb8-27db-4bcc-b005-ad4813eb4185`
+
+---
+
+### Migration of existing epic-issues 522, 534, 549 to milestone-only: bodies move to milestone description, issues close as superseded. Executed inline after grill closes, not tracked as a separate slice. M37 renamed from "Skill set redesign — 2026-05" to "Skill set redesign". Milestones created retroactively for 534 and 549. CI guard for Children heading dies with epic-issue concept.
+
+- **UUID:** `e04fcfb5-4011-481c-a367-a58c640f33be`
+- **When:** `2026-05-08T13:37:36.961332+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:grill-548`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Track migration as a slice under 548; Migrate only 534 and 549; Defer migration entirely`
+
+  > Owner says paperwork-free, do it now after grill. All three are owner-internal artifacts, no external contracts depend on issue numbers. Inline execution avoids tracking-slice ceremony for a one-off migration. CI workflow requiring Children heading retargets or deletes; no longer load-bearing once epic-issues are gone.
+- **Memories used:** `2a7ae10e-afc3-4523-b0bc-c4b90ddbe1a5`
+
+---
+
+### Delete sprint-report skill. No active users. Replace with last-work-report skill triggered on milestone close (PostToolUse hook on gh milestone close OR webhook). No Friday cron — that is sprint-cadence vestige. If hook proves brittle, downgrade to no replacement.
+
+- **UUID:** `f2197164-e12c-4bf0-b1c0-38ab29fbb1b2`
+- **When:** `2026-05-08T13:43:24.76087+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-548`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Friday 20:00 cron — sprint-cadence vestige; Keep sprint-report — unused skill drift; No replacement — lose the report value if it has any`
+
+  > Owner: skill unused, redrobot is owner-owned (memory just saved), no external contract to honor. Milestone-close hook fits new continuous-flow model: capability ships, report follows. Friday 20:00 cron would re-introduce the cadence rhythm that 548 is killing. Skip-entirely is fallback if hook turns out brittle.
+- **Memories used:** `2a7ae10e-afc3-4523-b0bc-c4b90ddbe1a5, e04fcfb5-4011-481c-a367-a58c640f33be`
+
+---
+
+### improve-codebase-architecture trigger flips from sprint close to milestone close, on next SessionStart, only if milestone has 3 or more closed slices. session-context.py reads closed milestones, filters by closed_issues at least 3, checks whether sweep ran after closed_at via memory tag sweep_run_milestone_N, surfaces a one-line recommendation if not.
+
+- **UUID:** `9858468b-70cc-4e66-8c22-4442fd85c7b8`
+- **When:** `2026-05-08T13:49:55.102418+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-548`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Trigger seven days after close; Trigger on every milestone close regardless of size; Pull-mode only with no SessionStart hint`
+
+  > Aligned with new continuous-flow model. Small milestones with one or two slices do not accumulate architectural drift worth a sweep. The three-slice threshold filters out drive-by groupings while catching real capability bets. Push-mode SessionStart visibility chosen over pull-mode because owner already accepted SessionStart as the orientation surface.
+- **Memories used:** `2a7ae10e-afc3-4523-b0bc-c4b90ddbe1a5`
+
+---
+
+### Memory cleanup precedes code/skill changes. New memory milestone_hierarchy_v3 created as always_load source of truth, then old entries superseded or updated, then CLAUDE.md/CONTEXT.md/skills/scripts realigned, then existing epic-issues migrated, then CI guards retargeted, then single PR.
+
+- **UUID:** `8bddf189-a00d-4d13-968c-10a183df9a77`
+- **When:** `2026-05-08T13:53:01.737504+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:grill-548`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Code first then memory — inversion risk: old memory contradicts new code; Memory and code in same PR step-by-step — no functional gain, harder to review`
+
+  > Memory is source of truth for CLAUDE.md and skill bodies. Updating code first leaves a window where prompt rules drift from memory and can re-inject the old hierarchy on next recall. Memory-first order eliminates that window.
+- **Memories used:** `2a7ae10e-afc3-4523-b0bc-c4b90ddbe1a5, 9858468b-70cc-4e66-8c22-4442fd85c7b8`
+
+---
+
+### Defer live-apply of sandcastle slice 3 RLS migration until host MCP service-role switch (#564) lands
+
+- **UUID:** `26b21b38-83bd-4878-b807-5cc3866831dd`
+- **When:** `2026-05-08T14:16:37.519237+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:2026-05-08-end:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Apply the migration immediately and accept host-write breakage — rejected, host record_decision/emit_event are silent fire-and-forget, errors would not surface; Add multi-prefix anon allow policies (skill:%, hook:%, session:%) — rejected, defeats the threat model since any compromised anon path can spoof those prefixes; Force-push fixes onto closed PR #563 — denied by harness rule, would also rewrite history that #562 already squashed; Open new clean PR with all polish + ceremonial no-op migration to satisfy schema-drift guard — rejected as gamey and adds churn`
+
+  > Claude code-review on PR #563 surfaced (with concrete grep of mcp-memory/client.py) that the host MCP uses anon key, and host writes use non-sandcastle provenance prefixes ('skill:implement', 'hook:user-prompt-submit', 'session:<id>', 'skill:consolidation'). After applying the slice 3 RLS migration to live Supabase, every host insert into episodes/events_canonical/task_outcomes via record_decision/emit_event/outcome_record would be silently rejected. PR body had flagged this as speculative; the review made it concrete. Therefore the migration code is on main but live apply is gated on #564 (priority:critical) shipping a service-role-preferring client.py first. #565 (priority:high — UPDATE/DELETE hardening) sequenced after #564 for the same reason. Polish from the review (LIKE case-sensitivity comments, rollback note, schema column-ordering doc fix) folded into the future #564 PR rather than chasing a no-op paired migration purely to satisfy the schema-drift guard.
+- **Memories used:** `none`
+
+---
+
+### implement #564 — host MCP prefer SUPABASE_SERVICE_KEY before #542 RLS lands
+
+- **UUID:** `18bf124d-34a4-4269-80dd-b2c9fd571fc8`
+- **When:** `2026-05-08T14:21:17.033601+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:implement-564`
+- **Project:** `jarvis`
+- **Alternatives considered:** `option 2 multi-prefix anon allow policies — defeats threat model; option 3 explicit provenance plumbing per callsite — brittle, high effort; skip-grill-me on this borderline case — accepted, lowering confidence; issue body itself is the grill output`
+
+  > Issue body's option 1 (key precedence in client.py) is the correct call: option 2 (multi-prefix anon allow policies) defeats the threat model that decision 228a2d9b set up — sandcastle should have anon + RLS, host should bypass. Option 3 (mandatory provenance plumbing per callsite) is high-effort and brittle. Pattern matches backfill-outcome-memories.py which already uses this precedence. Symmetric fix applied to consolidation-report.py and evolve-neighbors.py — they're standalone host scripts in the issue's break-list and don't share client.py. Stderr warning when only anon set keeps the gap visible without breaking unrotated devices. Live-Supabase smoke + apply_migration are AC items #3/#4 — explicit principal manual gates after this PR merges.
+- **Memories used:** `none`
+
+---
+
+### Reduce session-start context bloat: disable computer-use MCP entirely, disable unused marketplace plugins (design:*, engineering:*, product-management:*, anthropic-skills office, mcp-server-dev); keep Chrome MCP enabled but toggle via /mcp on-demand; ccd_* informed but not yet decided.
+
+- **UUID:** `ea52d79d-f9ad-4b14-acf7-894339948198`
+- **When:** `2026-05-08T14:26:41.299308+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-05-08:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Disable Chrome MCP entirely — rejected, occasional web automation needs; Trim CLAUDE.md or always_load rules — rejected as low-ROI per user 'don't lose nuance for 500 tokens'; Find/remove duplicate Supabase MCP (1dc56ff2 vs b494bd72) — deprioritized, both are deferred-only so cost is just names not schemas`
+
+  > Real /context measurement showed ~107k loaded with 50k being session messages, leaving ~57k baseline at fresh start. Biggest user-controllable consumers: computer-use 12k (request_access/request_teach_access embed installed-apps catalog twice), Claude-in-Chrome 8.6k, ccd_* 3k, marketplace plugin skills 2-3k. User strategy: focus on big rocks, skip micro-opt where information value exceeds 500-token cost. computer-use is unused for OS automation in dev sessions. Marketplace plugins duplicate existing /implement /diagnose /grill-me. Chrome retained as on-demand toggle because web automation occasionally needed.
+- **Memories used:** `ff994ca2-ac3a-49d4-86cb-360512df3619, 36ddd650-34b6-463f-be16-3d7177d06db6, 4d75a1ea-41e9-49b5-a91e-031dd1ff7e74`
+
+---
+
+### BUFFER_END_PENALTY = 5e3 in cost_map.py, sized between ACTIVE_COST_PER_MM*1mm (=100) and FIGURE_COST/2 (=5e5)
+
+- **UUID:** `f21440b4-0086-44fa-a2dc-4d6b563943dc`
+- **When:** `2026-05-08T14:38:19.265228+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:redrobot-2026-05-08-end:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Endpoint-only penalty in scoring layer (not cost_map) — rejected: A* operates on cell costs, not push-intent metadata; Apply penalty during update_after_push — rejected: structural cost belongs in build, not refresh`
+
+  > Buffer band needs to dominate a clean active cell (so A* avoids hugging figure on routine pushes per #696) but yield to genuine deficit-near-figure cases (active soft cost stacks on top). 5e3 sits 50× above clean-cell soft cost and 100× below the hard ceiling — clear ordering. Applied via 8-neighbour dilation of figure_mask in build_cost_map; opt-out via apply_buffer_penalty=False to preserve slice-1 binary semantics for callers that need it. Sweep harness in chunk 730c may revise the value.
+- **Memories used:** `none`
+
+---
+
+### For issue 730 use stacked PRs into long-lived integration branch, not a re-cut into separate issues
+
+- **UUID:** `fd4268ca-b4ed-4aae-8a9e-281998bdde6c`
+- **When:** `2026-05-08T14:39:29.681189+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:redrobot-2026-05-08-end:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Re-cut into separate issues; Single large PR`
+
+  > Issue 730 has 8 acceptance bullets across 3 coupled chunks (constants+buffer, beam-1 flag, sweep+benchmark). Re-cutting adds bookkeeping without separability gain since chunks target the same module surface. Stacked PRs into feat/730 keep each within smart zone. User confirmed.
+- **Memories used:** `4a62bdf8-c138-4479-bf12-9a9fdd5d64a8`
+
+---
+
+### Implement #730 slice 3 chunk B as `obstacle_aware_beam` flag with BEAM_TOP_K=3, scoring by simulated `predictor.update` residual sum
+
+- **UUID:** `204ec7b8-f19d-4745-89e2-d20a462a4846`
+- **When:** `2026-05-08T15:04:33.372032+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:end-730b:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > Issue #730 acceptance criteria specify "Top-K=3 candidates by greedy score, each evaluated with the predictor's projected post-update map, pick best." Chose to layer beam selection inside the existing dynamic_cost_map loop (#729) rather than parallel implementation: beam needs the residual_diff state anyway, and reusing the loop preserves byte-identical behavior for `dynamic_cost_map=True, beam=False`. Refactored existing for-loop into shared while-loop. Beam ON without dynamic_cost_map=True still drives the predictor (documented). Default OFF per prior decision bfe90a55. Scoring metric = sum(|residual|): simple, monotonic, matches the convergence target the sweep in chunk C will optimize. Alternatives rejected — see field. PR #734 stacked on #733 (730a). Tests: 3 new (default-OFF preserves dyn_cost_map output; ScriptedPredictor proves beam re-orders head; beam alone invokes predictor). Pre-existing master failures (test_tool_catalog_select_by_name + test_high_excess_gets_larger_tilt_in_rx) filed as #735.</rationale>
+  > <parameter name="alternatives_considered">["Separate parallel loop for beam — rejected: code duplication, both paths need residual_diff", "Make beam imply dynamic_cost_map=True silently — rejected: caller may want one without the other; explicit `or` in the gate is clearer", "Score by max(|residual|) instead of sum — rejected: noisier signal; sum aggregates across the whole map matching benchmark mean_dev metric", "Hardcode K=3 inline — rejected: BEAM_TOP_K module constant gives chunk C sweep a tunable handle", "Pass residual_diff.copy() to scoring updates — rejected: predictor contract is pure (returns new ndarray), copy is wasteful"]
+- **Memories used:** `c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7, 283efd25-7b2c-4fe6-a3c4-e4704893fbdc`
+
+---
+
+### Smoke 2/3: record_decision on Main PC works after SERVICE_KEY rotation
+
+- **UUID:** `ee2b07ed-7ae5-4f2c-87ef-0e4539b1dd29`
+- **When:** `2026-05-08T15:07:40.29537+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:smoke-564-mainpc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `skip smoke and apply migration directly — rejected, breaks AC of #564`
+
+  > Verifying the host MCP path that PR #563's RLS gate would block under anon — `actor='session:smoke'` is non-sandcastle prefix. Success here means client.py is reading SUPABASE_SERVICE_KEY (per #569).
+- **Memories used:** `none`
+
+---
+
+### Post-migration smoke: record_decision via SERVICE_KEY succeeded with non-sandcastle actor
+
+- **UUID:** `638eec02-5bf5-4fcb-a178-8c154a63c40d`
+- **When:** `2026-05-08T15:19:28.992228+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `session:smoke-564-post-migration`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > RLS gate from #542 migration is live. actor=session:smoke-post would be blocked under anon — success here is the proof that mcp-memory/client.py picks SUPABASE_SERVICE_KEY (per #569).
+- **Memories used:** `none`
+
+---
+
+### Implement #565 RLS slice 3.5 — gate anon UPDATE+DELETE with provenance predicate
+
+- **UUID:** `f3b85eeb-b883-4891-b349-f64c8c9dc28c`
+- **When:** `2026-05-08T15:22:33.035585+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `full /grill-me pass — rejected, design locked in issue body; delegate to subagent — rejected, security-adjacent + cross-cutting (migration + schema mirror + meta-test) needs context; include live apply_migration in PR — rejected, wait for principal explicit approval per safety rule`
+
+  > Issue body provides verified SQL pattern (DROP open policy → CREATE op-specific policy with USING+WITH CHECK on provenance LIKE 'sandcastle:%'). Same predicate as slice 3 INSERT gate, just extended to UPDATE/DELETE. Threat model: closes anon DELETE-everything hole and provenance-forging via UPDATE that survived slice 3. Sequencing safe — host MCP now uses SERVICE_KEY (per #569, smoke-verified earlier this session), so host UPDATE/DELETE on non-sandcastle rows isn't broken by the tighter anon policies. Skipping /grill-me — design is locked in issue body, only mechanical work remains: migration file, schema.sql mirror, meta-test extension, CONTEXT.md note. Will not auto-apply to live Supabase — flag for principal in PR body.
+- **Memories used:** `dfe4a9de-1821-4229-ac68-a885318fd0c9, 716fe238-b3ce-4d22-9ce7-11c1bb89d7c9`
+
+---
+
+### implement Sandcastle slice 4 PowerShell watchdog wrapper (#541)
+
+- **UUID:** `7b303003-67cf-4be0-a2ac-1448662c1a10`
+- **When:** `2026-05-09T10:37:21.317822+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:implement-541`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Add llm jsonb column to task_outcomes — rejected: bloats slice with migration + schema-drift meta-test ceremony; Parse sandcastle stdout for result — rejected: mixed with agent output, env-controlled JSON file is cleaner; Write outcome_record from Node post-hook in main.mts — rejected: keeps cost-tracking in two places (TS + PS), single owner is simpler`
+
+  > Single entry point Run-Sandcastle.ps1 wraps tsx main.mts with daemon autostart (Docker, Ollama), polls health, soft-stop at safe-hours boundary between iterations, and writes outcome_record to Supabase via PostgREST anon insert (source_provenance='sandcastle:watchdog:&lt;run_id&gt;' satisfies #565 RLS gate). main.mts gets a SANDCASTLE_RESULT_FILE env hook to dump RunResult JSON (commits, branch, iterations, usage) for the wrapper to parse. task_outcomes has no llm column, so token metrics ride in lessons as JSON for now — schema migration deferred to avoid bloating slice with meta-test ceremony. Pester 5 tests cover daemon-state matrix via mocked health probes. No Telegram (slice 6), no multi-tier fallback (slice 5).
+- **Memories used:** `none`
+
+---
+
+### implement Sandcastle slice 6 Telegram alerting (#544)
+
+- **UUID:** `b7359eb2-add1-4a5c-a635-47fadb77938e`
+- **When:** `2026-05-09T11:37:06.774582+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:implement-544`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Pipe alerts through Claude Code telegram plugin -- rejected: plugin lives in a Claude session, watchdog is a standalone PowerShell process with no MCP access; Fire Telegram on every Record 'failure' -- rejected: ACs explicitly ban routine-outcome spam; infra-only is the design intent (decision 0c3017c6); Add a generic 'class' field to Record() and dispatch by class -- rejected: introducing a new column-like field in lessons JSON for one slice; using reason string + a Test-IsInfraDown predicate is enough`
+
+  > Watchdog calls Telegram Bot API directly via Invoke-RestMethod with TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID from .sandcastle/.env -- the Claude Code telegram plugin runs only inside a Claude session and is unreachable from the standalone PowerShell wrapper. Alerts fire on a strict whitelist of infra-down reasons (docker-down, ollama-down, npm-not-found, no-result-file) so morning chat carries signal not noise; routine partial:window-expired, exit-code agent failures, and success outcomes stay silent. Reasons get classified at Record-time so the Telegram fan-out is a single boolean check (Test-IsInfraDown). Messages capped at 200 chars and never embed secrets -- run id, repo, daemon name, and run.log path only.
+- **Memories used:** `none`
+
+---
+
+### Slice 730c ships as harness-only — keep cost_map.py defaults at slice-1 baseline, do not commit autonomously-selected weights this slice
+
+- **UUID:** `b6f8ebf6-86ab-4b98-9296-785a156bce0c`
+- **When:** `2026-05-09T13:54:00.271827+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:27bdd30c:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Fix figure_mask conflation inline in this slice — rejected: invasive PipelineV3 surgery, doubles slice scope, and #730c was already the largest of the three; Commit baseline defaults explicitly with a comment 'sweep ran, baseline won' — rejected: misleading, gives the impression a real selection happened; Wait to open PR until full sweep produces a non-baseline pick — rejected: harness work is independently valuable; the dome regression is a real bug worth surfacing immediately`
+
+  > Smoke run of the sweep harness on the dome fixture revealed that PipelineV3 builds figure_mask from target_heightmap (pipeline_v3.py:336), so obstacle_aware_paths=True drops every push as 'aimed into figure' and the regression gate rejects every non-baseline candidate. Running the full 3×3×3 sweep would deterministically pick baseline. Better to ship the wiring + harness + tests + 3-mode benchmark + selection rule, file the figure_mask conflation as follow-up #737, and re-run the sweep once formed-vs-target masks are separated. Acceptance criterion 'committed defaults' is technically open but blocked by data, not by missing code.
+- **Memories used:** `none`
+
+---
+
+### File figure_mask=target conflation as follow-up issue #737 instead of fixing in slice 730c
+
+- **UUID:** `e81803ae-1b2a-4ce2-a90f-bd6ccdd98cc0`
+- **When:** `2026-05-09T13:54:07.032665+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:27bdd30c:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Inline patch: pass current_heightmap-derived mask to plan_bulk_passes from pass_planner — rejected: hides the conflation behind a one-shot fix instead of fixing the source; Disable obstacle_aware_paths when figure_mask covers >X% of active zone — rejected: heuristic band-aid that masks the design issue`
+
+  > The bug — PipelineV3.figure_mask is derived from target_heightmap, so tier2 obstacle_aware_paths treats the entire target shape as an obstacle on synthetic fixtures — is a #728 design legacy, not a slice 730c regression. Fixing it requires splitting figure_mask into target_figure_mask (current behaviour, used by metrics/viz) and formed_figure_mask (new, recomputed per pass from current_heightmap deviation). That's its own architectural slice with cross-cutting impact on Strategist + planner + diagnostic outputs. Filing #737 keeps slice 730c's scope honest and gives the figure_mask redesign its own grill-me/PRD path.
+- **Memories used:** `none`
+
+---
+
+### Implement sandcastle slice 5 (#543): multi-tier model escalation chain in PowerShell watchdog
+
+- **UUID:** `73b393f8-026f-451a-aa75-eb69b6d2c4ac`
+- **When:** `2026-05-09T13:57:51.029535+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:543-implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Orchestrate escalation inside main.mts — rejected: tsx/node iteration loop and result-file writing make tier retries awkward; sandcastle's run() is a single shot per call.; Skip 'same issue' targeting (let agent re-pick) — rejected: violates AC #3 and makes 'too-large-for-local' labeling impossible to attribute correctly.; Use a separate orchestrator script (Python) — rejected: project rule is 'only justified Python is mcp-memory/server.py'; PowerShell watchdog is already the integration surface.; Add full event/outcome schema for tier_used — rejected: #541 deferred schema, ride lessons-as-JSON until Slice 7 benchmark gives a stable shape.`
+
+  > Per #543 AC (decisions f8e27d53, 0c3017c6): escalation chain Ollama-tier0 → Ollama-small-tier1 → DeepSeek-class-tier2 → owner. Architecture choice: orchestration lives in Run-Sandcastle.ps1 (the watchdog), not in main.mts. The watchdog already owns iteration control, daemon health, outcome recording, and failure classification — adding tier state machine here keeps main.mts a pure config shim and reuses the existing reason/log infrastructure for OOM detection. main.mts gets minor parameterization (SANDCASTLE_AGENT_MODEL/BASE_URL/AUTH_TOKEN env overrides + SANDCASTLE_TARGET_ISSUE forwarding) and prompt.md gets a small "forced target" block honoring the env var, so escalation retries land on the same issue per AC #3 rather than re-picking from the queue. OOM detection is heuristic on log content (memory-related substrings) plus known exit codes — perfect detection isn't required because false positives just trigger a (cheap) retry. Telegram stays infra-down only; tier escalations are routine and silent (already covered by existing slice-6 test). No schema migration — tier metadata rides in lessons JSON like slice 4. Pester tests mock Invoke-Sandcastle to script the tier matrix per AC.
+- **Memories used:** `27c28a8e-2969-4550-9d4d-ffd25e36e5d8, ab528091-6c86-43a0-b340-b1dfbbb047b6`
+
+---
+
+### formed_figure_mask defined as asymmetric structural: (current >= target - tolerance_mm) AND figure_mask
+
+- **UUID:** `248ee694-82ce-487f-8591-280c16f91dfa`
+- **When:** `2026-05-09T16:43:05.861298+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:slice737-grill`
+- **Project:** `redrobot`
+- **Alternatives considered:** `symmetric |current-target|<=tolerance_mm: rejected — too strict in bulk phase, mask stays empty when reroutes matter most; phase-aware k*current_max_dev: rejected — non-stationary mask across passes, oscillation risk; configurable forming_tolerance_mm: rejected — new tuning knob without a driver`
+
+  > The hazard obstacle_aware_paths protects against is burying already-finished structure with new pushes. That hazard exists exactly when a cell has reached or exceeded target height. Cells still in deficit are not 'formed' — pushes ending there are desired, not avoided. Asymmetric definition (not |current-target|<=tol) avoids treating overshoots as protected, which would block the very shaving passes needed to fix them. Adds no new config knob and aligns with the formed-cell definition already used internally at bulk_planner.py:903-925, so it lifts one existing rule to module scope rather than introducing a second. Rejected: (a) symmetric tolerance_mm — stays nearly empty in bulk phase, defeats reroutes when they matter most; (b) phase-aware k*max_dev — introduces non-stationary obstacle map for reasons unrelated to forming progress, oscillation risk; (c) new forming_tolerance_mm config — extra tuning dim with no driver.</rationale>
+  > <parameter name="memories_used">["c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7", "8c8c8d40-7d51-45d5-a5f0-1ec5ff9ab0fc"]
+- **Memories used:** `none`
+
+---
+
+### formed_figure_mask is a pipeline-owned per-tick derived field on WorkspaceState; PassPlanner forwards ws.formed_figure_mask to plan_bulk_passes
+
+- **UUID:** `a039e06a-71c7-49a3-a0e7-c0ac54128f10`
+- **When:** `2026-05-09T16:44:31.889392+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:slice737-grill`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Strategist computes inside next(): rejected — outside its 'produce Decision' contract, state.py reserves mask derivation for pipeline; bulk_planner computes internally from current+target+tolerance: rejected — leaf module with too many responsibilities, duplicates rule if reused`
+
+  > WorkspaceState docstring already names "Heightmaps / masks / diff: refreshed by pipeline before each Strategist tick" as pipeline's responsibility. formed_figure_mask is structurally another per-tick derived mask alongside figure_mask, reachable_mask, diff_map. Putting it on state gives a single source of truth that Strategist can later read for stagnation/escalation logic without re-deriving. PassPlanner becomes a one-line change: pass ws.formed_figure_mask instead of ws.figure_mask to plan_bulk_passes. Rejected: Strategist-computes — outside its "produce Decision" contract; bulk_planner-computes — pushes derivation into a leaf module with too many responsibilities and would duplicate the rule if anyone else needs the mask.</rationale>
+  > <parameter name="memories_used">["c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7"]
+- **Memories used:** `none`
+
+---
+
+### Rename figure_mask param to obstacle_mask at the bulk_planner / cost_map seam (plan_bulk_passes, build_cost_map, _walk_back_to_free_cell)
+
+- **UUID:** `7dff96bd-e3d1-4154-95ad-da4e67407d95`
+- **When:** `2026-05-09T16:49:34.325096+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:slice737-grill`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Keep figure_mask param name, only change call site: rejected — perpetuates the naming lie that is the root cause of #737; Rename to formed_figure_mask: rejected — misnomer in standalone bulk_planner tests that pass synthetic obstacle grids unrelated to forming`
+
+  > The conflation between "target shape" and "obstacle to avoid" was the root cause of #737. Honest naming at the leaf module decouples planning vocabulary (figure = target shape) from planner-internal vocabulary (obstacle = where pushes shouldn't end). cost_map.py:72 already documents the contract as "figure cells -> FIGURE_COST" — the parameter is conceptually an obstacle map; whether it's sourced from target-shape or formed-shape is the caller's policy. The change touches sandbox/ not the safety-critical planning/ tree, so minimum-touch virtue is preserved for planning/. Mechanical rename caught by ruff/grep.</rationale>
+  > <parameter name="memories_used">["c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7"]
+- **Memories used:** `none`
+
+---
+
+### formed_figure_mask refresh granularity = per-pass only; mid-chain refresh deferred. Code comment notes option (b) for cheap revisit.
+
+- **UUID:** `5f674570-cb49-483b-af0e-e6c294534b95`
+- **When:** `2026-05-09T16:56:34.016794+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:slice737-grill`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Mid-chain refresh after each predicted push: rejected for now — stacks dynamic_cost_map and formed-mask predictors, compounds prediction error; revisit if paths-aware coverage proves insufficient`
+
+  > Issue #737 scope explicitly says "recomputed each pass" — out of band to expand. Pass boundary aligns with scan/confidence boundary, the natural granularity for re-deriving obstacle topology. Mid-chain refresh would stack two predictors (dynamic_cost_map already feeds predicted heightmap into next push within chain; layering predicted-formed on top compounds error and risks the chain operating against its own simulated reality). Per design_for_extensibility feedback + quality_over_speed: leave an inline comment at the formed_figure_mask compute site naming option (b) and what would trigger it (paths-aware under-coverage in benchmarks), so a future revisit is a 5-minute read instead of re-deriving the design tree.</rationale>
+  > <parameter name="memories_used">["c1a6bd2f-56ae-4eed-9c13-9c72592ce3a7", "ffcf8b3b-8aa9-4265-a761-7b49370608b0"]
+- **Memories used:** `none`
+
+---
+
+### #737 acceptance criteria sharpened: dome+SAND, paths/paths+beam total_passes>0 AND mean_dev_final <= 1.05 x baseline; benchmark JSON path in PR body
+
+- **UUID:** `534f9d11-74a0-44ce-a932-081435e582d2`
+- **When:** `2026-05-09T16:59:46.860677+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:slice737-grill`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Keep loose 'actual passes, not 0' AC: rejected — not falsifiable, can't gate merge; Hard equality with baseline mean_dev: rejected — paths approach legitimately differs from baseline pass-by-pass; 5% slack matches the sweep harness production gate`
+
+  > Original AC2 ("paths run gets actual passes, not 0") was not falsifiable. Tying to the 5% mean_dev non-regression gate already enforced by the 730c sweep harness reuses a production criterion #737 is supposed to unblock — same bar, same metric, no second standard. Adding letter fixture (SAND) prevents regressing the original #728 use case (reroute around already-formed strokes) while fixing the dome conflation. Including the benchmark JSON path in the PR makes the gate spot-checkable by reviewers without re-running.</rationale>
+  > <parameter name="memories_used">["7318a198-6269-4985-bcde-2a196cbb0e87"]
+- **Memories used:** `none`
+
+---
+
+### implement #737 — split target_figure_mask vs formed_figure_mask, rename obstacle_mask, sharpen AC gates
+
+- **UUID:** `fcd16259-6bd6-4f65-9395-6477fe199eec`
+- **When:** `2026-05-09T17:02:39.611279+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:slice737-impl`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Defer until tier2 weight sweep produces other selections: rejected — no candidate can clear the 5% gate while dome regresses to 0 passes, blocking #596; Delegate to subagent: rejected — safety-critical planning/ touch + cross-cutting design needs full session context`
+
+  > Issue #737 unblocks the 730c sweep harness from selecting non-baseline cost weights for tier2 obstacle_aware_paths. Grill-me resolved 5 architectural Qs (stored in issue body + working_state_redrobot_slice737). Plan: (1) add compute_formed_figure_mask helper using asymmetric structural definition (current >= target - tolerance) AND figure_mask, (2) add WorkspaceState.formed_figure_mask pipeline-owned field refreshed per Strategist tick, (3) rename figure_mask -> obstacle_mask in bulk_planner/cost_map seam to honestly name what it is, (4) pass_planner forwards formed_figure_mask as obstacle_mask, (5) E2E smoke benchmark dome+SAND with paths total_passes>0 AND mean_dev<=1.05x baseline. Inline comment near compute site names the deferred mid-chain refresh option (b) for cheap revisit. Touches planning/state.py (safety-critical) and planning/pass_planner.py (one-line kwarg) — principal approval implicit through grill-me ok + auto-mode.</rationale>
+  > <parameter name="memories_used">["7318a198-6269-4985-bcde-2a196cbb0e87", "248ee694-82ce-487f-8591-280c16f91dfa", "a039e06a-71c7-49a3-a0e7-c0ac54128f10", "7dff96bd-e3d1-4154-95ad-da4e67407d95", "5f674570-cb49-483b-af0e-e6c294534b95", "534f9d11-74a0-44ce-a932-081435e582d2"]
+- **Memories used:** `none`
+
+---
+
+### SUPERSEDE 248ee694: formed_figure_mask uses SYMMETRIC tolerance |current - target| <= tolerance_mm (was asymmetric current >= target - tolerance_mm)
+
+- **UUID:** `9e969c34-0dcd-44ef-843e-fd47129a945a`
+- **When:** `2026-05-09T17:35:35.988515+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:slice737-impl:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Keep asymmetric, gate on direction of sculpting (raise vs cut): rejected — caller-side complexity, two definitions for one concept; Asymmetric clipped to [target-tol, initial]: rejected — baseline-direction-specific, breaks for mixed targets where some cells raise and others cut`
+
+  > Asymmetric definition flagged pristine SAND letter cells as 'formed' because target < initial there (cut letters), so current = initial > target trivially satisfied current >= target - tol. SAND benchmark reproduced: paths/paths+beam dropped to 0 passes again. Symmetric definition (originally rejected as option (a) for being too strict on overshoots) is the only one that handles both directions of sculpting (raise vs cut) on pristine state. Overshoot-during-sculpting concern was overstated: dynamic_cost_map block already handles 'this cell was just filled' via predictor; formed-mask is for protecting already-converged cells across multiple passes, not for guarding mid-stroke overshoot. Sculpted-cell intersection (|target - initial| > tol) is retained from the earlier fix to keep margin cells out. Verified against both dome (PASS, 28.70 mean_dev vs 29.14 baseline) and SAND (regression — 0 passes, this fix targets it).</rationale>
+  > <parameter name="memories_used">["248ee694-82ce-487f-8591-280c16f91dfa"]
+- **Memories used:** `none`
+
+---
+
+### Merge /end-quick into /end via --quick flag — single skill with mode gate (Steps 0-4/6/8 full only, Steps 5+7 always)
+
+- **UUID:** `0aa17584-ff0d-410a-872b-5e535b5805a2`
+- **When:** `2026-05-09T17:40:32.610693+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:loop-skill-redesign-2026-05-09`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep two skills as-is — rejected: explicit AC requires merge; Subcommand syntax /end quick instead of --quick — rejected: AC specifies --quick flag literally; Auto-detect mode from session length — rejected: AC explicit + autodetection rejected pattern from /cycle decision (525 body)`
+
+  > Implementation of issue #527 (Skill set redesign milestone). Two near-identical skills with different verbosity violate skill_proliferation_antipattern; collapsing to one skill with --quick flag is the explicit AC of #527, grilled in #522 session 2026-05-08. Frontmatter description retains both phrasings ("end", "end quick", "быстро закончим") so trigger matching works for either. Steps 5 (working state) and 7 (commit) are kept in --quick mode because both old skills had them; Steps 0–4 (journal scan, decision reconcile, CONTEXT gap, outcome enrichment, goal log), 6 (branch cleanup), 8 (verbose output) are full-mode-only. Issue already grilled — not re-grilled in this iteration per loop queue protocol.
+- **Memories used:** `1056eab5-5b32-4d0c-8720-a09a84aa9ff0, d955dccc-ce58-44a9-a97c-2ae619fec117, 48f0a121-1d29-4d42-b387-8b39f5262c79, 8ce8fd4e-ec7f-47b5-8a65-576494e90201`
+
+---
+
+### Implement #524 Tier 2 hook with structural escape (intentionally_empty bool flag) and emit flag into episode payload
+
+- **UUID:** `107f873b-3e8e-4b27-928b-aae24b0a2f82`
+- **When:** `2026-05-09T20:21:19.805527+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-05-10:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `prose-grep on rationale text — rejected pre-issue: brittle, false positives; block without escape hatch — rejected: forces dishonest dummy UUIDs when no memory genuinely informed; single test file mixing pure + subprocess + handler — rejected: failure noise`
+
+  > Followed pre-resolved AC from issue body (grill session 2026-05-08 settled "structural escape over prose-grep"). Tactical calls during implementation: (1) register gate hook BEFORE existing recall hook on the same mcp__memory__record_decision matcher so deny fires before unrelated work; (2) emit intentionally_empty into payload only when true to keep episodes lean; (3) split test coverage into pure evaluator (9 cases) + subprocess (6 cases) + handler payload (2 cases) to keep failure messages targeted. Closes #524 via PR #577 (squash-merged, all checks green, Copilot errored without substantive review).
+- **Memories used:** `none`
+
+---
+
+### implement #576 — installer orphan-skill cleanup
+
+- **UUID:** `f5121b71-18f8-4700-acc8-2a7745cabfb5`
+- **When:** `2026-05-09T20:29:48.837172+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:jarvis-implement-576`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Skill-only special-case (rejected: future whitelisted dirs would need duplicate logic); Delete orphans without quarantine (rejected: irrecoverable; issue requires backup); Defer to #531 (rejected: #576 must land first to clean state for #531 deletions)`
+
+  > Approach: extend build_plan to scan target skill dirs (and any directories entry with `include`) and emit `prune_orphan` actions for children not in the whitelist; apply_plan renames each orphan into a quarantine path consistent with existing `_quarantine_dest` (parametrize the backup label). Generalise to any `directories` entry with `include`, not just skills, so future whitelisted dirs benefit. Lands before #531 (deprecated-skills cleanup) so migration produces clean device state. Tests cover: orphan detected, all-whitelisted no-op, fresh state no-op, dirs without `include` skip pruning, apply quarantines orphan recoverably. Issue body already grilled approach + AC; decision episode 0aa17584 captured the architecture, this call records the implementation choice.</rationale>
+  > <parameter name="memories_used">["6b098fcf-42bf-488f-95c7-b08651af1f4a", "9a54a5ac-537f-4cf3-806c-74a196ebd310", "5ba4a474-5e8d-445d-aa37-ce29e6845d0f"]
+- **Memories used:** `none`
+
+---
+
+### /status-record cron cadence: daily at 07:00 local; snapshot shape: YAML front-matter + markdown body, name `status_snapshot_<YYYY-MM-DD>`, type=reference, tag `status-snapshot`.
+
+- **UUID:** `bdc3a8ed-614e-4654-893f-f722a208cfe7`
+- **When:** `2026-05-09T20:52:18.585014+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:525-status-record`
+- **Project:** `jarvis`
+- **Alternatives considered:** `3×/day cadence — rejected, daily is enough for milestone-scale change and triples memory rows; JSON content instead of YAML+markdown — rejected, memory_recall surfaces content as text; YAML+markdown gives both parseability and readability; events_canonical episode instead of reference memory — rejected, issue body explicitly specified type=reference + tag, and reference memories are easier to recall by tag; store one snapshot per repo — rejected, single combined snapshot keeps cross-repo correlation in one place`
+
+  > Issue #525 left cadence "TBD at PR time, default 1×/day". Daily is sufficient resolution for milestone burndown / stale-issue trends since milestone work spans days. 07:00 picked to land before the 07:17 nightly-research and 09:03 autonomous-loop slots, so downstream readers (orchestrator, owner) see today's snapshot when they wake. Shape uses YAML front-matter (machine-parseable for trend analysis: e.g. last 7 snapshots → milestone burndown) plus a human-readable markdown body (so memory_recall consumers get usable text). One-snapshot-per-UTC-date upsert prevents memory bloat from re-runs. Pure recording — no analysis, no proposals — matches the deficit between recording (cron job) and acting (sandcastle orchestrator, #531 blocker).
+- **Memories used:** `1778e466-01b1-4327-9bfa-c5179db46c5e, 51f12452-be90-4dda-a435-74ba7fc043a0, 26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### /learn comms reads from a new Supabase comm_patterns table populated by a per-device extraction script; transcript scraping moves out of the skill entirely.
+
+- **UUID:** `bf9ad8f6-28e5-4bba-8c15-e0040d08eafa`
+- **When:** `2026-05-09T20:59:55.96184+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.75`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > The issue's "Supabase only, headless-visible" promise can only be honoured for the comms corpus if the data path itself moves to Supabase. Keeping transcript scraping inside the skill (option b) preserves two divergent data paths in one skill — the exact smear the redesign attacks. Dropping comms in v1 (option a) loses real cross-device behavioral analysis already in production. Option (c) extracts on each device into a structured Supabase table; the AUP base64 risk does not recur because the script writes server-side rows rather than feeding base64 blobs into the model context. Sandcastle/headless runs become first-class corpus contributors via the same path.</rationale>
+  > <parameter name="alternatives_considered">["a) Drop comms in v1 — loses already-working cross-device behavioral pipeline.", "b) Keep transcript path under mode=comms only — re-introduces the smear the redesign exists to remove.", "d) Have skill itself read transcripts directly inline — same AUP exposure as today, plus adds per-device file shuttling back into the skill body."]
+- **Memories used:** `77f341de-4cb0-49e3-9dcc-9402bc45c474, d955dccc-ce58-44a9-a97c-2ae619fec117`
+
+---
+
+### Comm-pattern extractor ships c-rich: replace regex+heuristic categorisation with a small local-Ollama classifier in the same shipping unit. No parity comparison with the old /reflect output.
+
+- **UUID:** `67c8d212-2906-4ac0-8d00-7d6c07cc0239`
+- **When:** `2026-05-09T21:07:49.642335+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.7`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > The classifier is cheap to author (local Ollama, Deriver-shaped), and the existing regex's FN rate + heuristic category bucket are already a known-bad baseline (per current /reflect skill notes). Running 20 sessions of post-migration data through the broken regex purely to keep parity wastes the post-migration window — the lessons would all reduce to "the regex was bad". User explicitly overrode phase_split_pattern_memory_overhaul (ship deterministic first) for this reason: parity vs. a known-broken baseline is not worth a phase split here.</rationale>
+  > <parameter name="alternatives_considered">["c-minimal: lift-and-shift existing regex pipeline into Supabase write path, defer regex fix — preserves parity but baseline is known-bad, wastes the post-migration sample window.", "Middle cut (lift-and-shift + targeted regex hole): doubles surface area without delivering either pure parity or a clean rebuild."]
+- **Memories used:** `2d6a383f-99d3-430c-9120-5d6d778c58cc, 77f341de-4cb0-49e3-9dcc-9402bc45c474`
+
+---
+
+### comm_patterns table: one row per detected pattern instance (α), embedding column from day 1, no retention rollup. Extractor fires from a Stop hook on each device (i) with a per-device watermark for idempotency.
+
+- **UUID:** `32825852-776b-4f87-a1d8-fbcdb02f3436`
+- **When:** `2026-05-09T21:13:05.775623+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > α (per-instance rows) is the only shape that lets /learn comms run SQL slicing by label/date/device/confidence without unpacking JSON — β (per-run jsonb blob) just relocates ~/.cache files into Postgres without making them queryable, which defeats the move. Day-1 embeddings are cheap (Voyage Tier-1 paid, no per-task cost concern under Claude Max for the extractor itself), and adding them later forces a backfill. Stop-hook trigger (i) pins extraction to the source-of-truth moment instead of accepting up-to-24h cron staleness; idempotency comes from a per-device last-watermark row. Sandcastle/headless runs naturally skip writes here (no user correctives), preserving "Supabase = headless-visible" semantics for outcomes/decisions while comms remains an interactive-only signal.</rationale>
+  > <parameter name="alternatives_considered">["β: one row per device per run with jsonb payload — recreates ~/.cache in Postgres, not queryable.", "Add embedding column later — forces a backfill once classifier output stabilises.", "(ii) cron sweep of jsonl deltas — adds staleness, duplicate-write risk if Stop hook ever co-exists.", "Roll up >90d to aggregate-only from day 1 — premature; raw volume is kilobytes per session."]
+- **Memories used:** `5a343cea-c712-4ffe-a512-e088309ba9c3, d828bd94-c9ab-4c06-bb9f-b5afa00ff1d9, 77f341de-4cb0-49e3-9dcc-9402bc45c474`
+
+---
+
+### /learn outcomes ships with two upgrades over /verify Step 4: feedback memories from pattern detection write as candidates (requires_review=true) under the always-gate; a fourth SQL pass adds decision-outcome attribution (failed-decision cluster, overconfidence cluster, intentionally_empty rate).
+
+- **UUID:** `eb257c5a-185e-4c69-a48d-a32ae5fe64ab`
+- **When:** `2026-05-10T09:23:20.996384+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > User framing: the skill-set redesign is the explicit moment to fold pending improvements in — same logic as Q3 c-rich. Lift-and-shift would re-import /verify's direct feedback memory_store, which already drifts from the always-gate principle baked into Deriver/Dreamer; under weekly-cron cadence the drift compounds. Switching to candidate-writes preserves the same trigger thresholds (success<60%, pattern_tag in 2+ failures, lesson 3×) but routes through the review gate. The fourth SQL pass adds the genuinely new capability the issue lists ("review resolved decisions, attribute outcomes") and operationalises the #524 intentionally_empty>10% trigger by surfacing the rate in every /learn run.</rationale>
+  > <parameter name="alternatives_considered">["Lift-and-shift /verify Step 4 verbatim — re-imports always-gate violation, drifts further under weekly cron.", "Keep direct feedback memory writes but add review flag retroactively in a follow-up — same pattern this redesign exists to break.", "Drop legacy three queries, replace with attribution-only — loses operationally-useful task_type/pattern_tag/lesson signals already proven in /verify."]
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117, 2d6a383f-99d3-430c-9120-5d6d778c58cc`
+
+---
+
+### /learn repo: (C) caller-parameterised scope (default cwd, --repos=all opens cross-repo), (I-gated) auto-issues only on manual invocation; weekly-cron /learn all stays propose-only and writes a reference event to memory.
+
+- **UUID:** `f3cc27be-93c1-4f93-9ec6-ae15bb710c19`
+- **When:** `2026-05-10T09:30:46.421553+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Caller-parameterisation matches the existing /status-record shape and respects "Jarvis decides what's subagent/multi-repo-suitable" — default ergonomic, capability available when needed. I-gated resolves the tension between owner's PM-autonomy expectation (which favours auto-creation) and the always-gate principle just locked in for /learn outcomes (which forbids unattended writes): manual invocation has owner-in-loop so auto-issue is fine; weekly-cron is unattended and stays read-only. The cron's reference-event report still surfaces candidates for cheap manual triage, so latency cost is bounded.</rationale>
+  > <parameter name="alternatives_considered">["(A) Jarvis-only — loses the multi-repo capability without saving meaningful complexity.", "(B) All repos always — overreaches into redrobot from a jarvis-internal weekly cron.", "(P) Propose-only globally — loses owner's PM-autonomy ergonomics on manual runs.", "(I) Auto-issue globally — drifts from always-gate under unattended cron, repeats the pattern this redesign exists to break."]
+- **Memories used:** `b1216b17-3175-4ec5-9174-498a6b2e0e72, d955dccc-ce58-44a9-a97c-2ae619fec117`
+
+---
+
+### /learn all fans out sequentially: cron fires one entry that spawns three fresh sessions (/learn comms, /learn repo, /learn outcomes) and a fourth lightweight assembly pass that stitches the three resulting memory events into the weekly summary.
+
+- **UUID:** `c65710ee-fcb1-4e92-863f-aca4c58b6a6a`
+- **When:** `2026-05-10T09:48:42.470406+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Smart-zone discipline (Plan/Execute/Clear, ~100K budget) breaks if one session runs three corpora's classifier+SQL+ideation+proposal output before fresh-eyes review — exactly the AI Hero anti-pattern personal_workflow_aihero_adoption locks in. Fan-out preserves per-mode smart-zone and fresh-eyes review while still honouring the issue's mode=all contract. Sequential over parallel: weekly cron has zero latency pressure, parallel adds orchestration failure modes for a Sunday-night batch with no upside. Each sub-session writes a memory event; the assembly pass reads three small events and produces cross-corpus correlations (e.g. overconfidence cluster + corrective pattern) that justify the unified /learn skill existing rather than three independent crons.</rationale>
+  > <parameter name="alternatives_considered">["(X) Single-session sequential run of three modes — violates smart-zone/P-E-C, kills fresh-eyes review on own output mid-session.", "(Y-parallel) Fan out in parallel — adds orchestration failure modes, no latency upside on weekly cron.", "(Z) Drop /learn all, three independent staggered crons — loses the cross-corpus juxtaposition that justifies a unified skill."]
+- **Memories used:** `13de847b-30ff-42b2-a831-0dcf6377a8c3, d955dccc-ce58-44a9-a97c-2ae619fec117`
+
+---
+
+### Split #526 into three child issues: (A) comm_patterns schema migration + ADR, (B) extractor script + Stop hook + backfill, (C) /learn skill landing. Drop the "parity with /reflect" smoke-run AC since c-rich + Supabase migration explicitly abandon parity; rewrite ACs per child.
+
+- **UUID:** `2723af58-1d12-40de-884d-98a95307ce2c`
+- **When:** `2026-05-10T09:54:31.344106+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Three deliverables now live under #526 after this grill; each is a clean vertical slice with different review surfaces. (A) touches shared mcp-memory/schema.sql (cross-project with redrobot) and demands paired apply_migration plus its own ADR — folding it into a skill PR loses review focus. (B) depends on (A), bundles classifier+hook+backfill — its own testable unit. (C) lands /learn but its repo/outcomes modes are independent of comms infra and can ship as soon as #523 is closed (which it is); comms mode is gated on B. The parity AC is unsound after Q3 c-rich (no parity baseline) and Q2 (corpus moves to Supabase). Splitting also makes failure attribution clean: a regression in comms-extractor doesn't co-mingle with a regression in outcome attribution.</rationale>
+  > <parameter name="alternatives_considered">["(Q) Keep #526 monolithic, rewrite ACs — bundles a shared-schema migration with a skill rewrite, defeats vertical-slice principle and slows /learn repo+outcomes which are unblocked.", "Split into two (schema+extractor as one, skill as two) — leaves the LLM-dependent classifier work bundled with the deterministic schema change, violates phase_split_pattern_memory_overhaul."]
+- **Memories used:** `99933db1-094a-417e-ac77-c64f9f2d900b, 2d6a383f-99d3-430c-9120-5d6d778c58cc`
+
+---
+
+### comm_patterns table uses L3 dual-column taxonomy: primary_label enum (stable, queryable) + subtype free-text (descriptive). The primary_label enum is re-derived afresh in child issue (A)'s ADR from a current sample of session transcripts, NOT lifted from /reflect's heuristic categories which predate the recent skill+memory refactors and may be stale.
+
+- **UUID:** `9e9ab041-276d-4ef2-ab60-b066c1e05a76`
+- **When:** `2026-05-10T10:04:30.847962+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > L3 gives Phase B a stable groupable column AND preserves descriptive nuance the qualitative report uses today. (L1) freezes the broken "other bucket" /reflect already complains about; (L2) defeats the queryability that justifies the Supabase move at all. Specifying labels in (A)'s ADR rather than at classifier-author-time prevents the post-hoc-guessing pattern that produced /reflect's wide other-bucket. Crucially: labels are NOT lifted forward from /reflect — they were authored before the skill-set redesign, the memory overhaul, and the always-gate Deriver/Dreamer arrival, so the working categories may have shifted. Re-derivation from a current transcript sample is part of (A)'s scope. Future label additions go through a Dreamer-shaped review gate, same pattern as memory candidates.</rationale>
+  > <parameter name="alternatives_considered">["(L1) Fixed enum frozen at schema — entrenches /reflect's known-bad other-bucket, brittle to new patterns.", "(L2) Free-text labels — defeats Postgres-queryability move, recreates fuzzy-match aggregation problem.", "L3 with labels lifted from /reflect — fast but ships stale taxonomy without verifying it matches current session data.", "Defer label spec to classifier author — repeats the post-hoc heuristic-bucket pattern."]
+- **Memories used:** `13de847b-30ff-42b2-a831-0dcf6377a8c3, 2d6a383f-99d3-430c-9120-5d6d778c58cc`
+
+---
+
+### comm_patterns rows: anchor_quote stored raw + redacted boolean, gated by an extractor-side scrubber that runs before write (regex pass for likely secrets/PII, replaces quote with placeholder + sets redacted=true). Project scope is global (no project='jarvis' pinning); read-side filters by project where useful.
+
+- **UUID:** `3d8d99ef-0158-433a-8642-3f7b46c17cdf`
+- **When:** `2026-05-10T10:18:09.304488+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-526`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > /reflect's "raw quotes in ~/.cache" footprint moves to "raw quotes in shared cloud DB" — failure mode shifts and warrants a write-time scrubber. (R2) hash-only kills the qualitative-report capability that justified the migration; (R1) raw-only ports an acceptable-on-disk policy into a multi-project cloud surface where one accidental session-pasted secret bites permanently. (R3) preserves the actionable-report signal while putting the redaction gate at the right point: before data exists in the DB. The scrubber reuses the secret-scanner shape from Pillar-9 Sprint-1 rather than rebuilding. Global project scope: corrective/affirmative patterns observed during redrobot-context sessions are still owner-Jarvis interaction patterns and should aggregate cross-project; partitioning at write would lose signal that /learn comms needs to see across the whole interaction surface.</rationale>
+  > <parameter name="alternatives_considered">["(R1) Raw quote, no scrubber — ports a device-local policy into shared cloud DB, one pasted secret bites permanently.", "(R2) Hash + length only — kills qualitative report (the migration's whole point).", "Pin comm_patterns to project='jarvis' — partitions at write, loses cross-project pattern signal."]
+- **Memories used:** `716fe238-b3ce-4d22-9ce7-11c1bb89d7c9, 77f341de-4cb0-49e3-9dcc-9402bc45c474`
+
+---
+
+### like_spotify_mobile_app: pivot from solo-utility to open-source framework with pluggable extension points. Default flavor = Petr's setup (Spotify + headset/hotkey + Supabase + archive/best-of/follow). Other flavors = contributor PRs.
+
+- **UUID:** `85e9f306-6b79-4df6-a1ee-36374b91a4e8`
+- **When:** `2026-05-10T10:37:08.858903+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.7`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `Keep solo-utility scope, only port features into tools/ — rejected: doesn't address the friends-with-same-problem use case owner cares about; Extend desktop only, Android stays solo-flavor (my Q2 recommendation) — rejected by owner: same project, same logic, no architectural reason to split`
+
+  > Owner explicitly reframed the project's mission during /grill-me. The 2026-04-08 YAGNI-decision (`like_spotify_cross_device_simplified`) is being deliberately revisited — it argued against custom backend, not against extension abstractions. The new bet rests on open-source ergonomics: friends and outside contributors have similar problems but want different triggers (volume button, custom hotkeys) and different providers (YouTube Music). Owner's stance: «сейчас сделаем одну реализацию под себя, а если кто-то захочет другую пусть делится в PR». Per SOUL calibration "abstractions need two real implementations" we will validate every interface with ≥1 alternative impl before declaring it stable.
+- **Memories used:** `2c09236b-8ac1-4fe6-9ce1-de9ffbd7143d, fb73c6d6-7c40-4cee-bbad-31aa44120d8c, 268617e8-82fa-44dc-b21c-06120a61baf7, b922386c-812e-4d01-a0a0-f93fe08050d1`
+
+---
+
+### like_spotify_mobile_app: phase Phase 1 = desktop tools/ as framework + reference impl + sample-extension; Phase 2 = Android port as separate epic after Phase 1 abstractions are validated.
+
+- **UUID:** `3ae9ed5a-f84c-49aa-83ec-83d9e43c7546`
+- **When:** `2026-05-10T10:37:20.154563+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `Both platforms simultaneously — owner's first instinct; rejected as risk of over-designing under one impl per interface; Desktop-only, never port — rejected earlier in same grill`
+
+  > SOUL calibration "abstractions need two real implementations — otherwise it's indirection, not abstraction". Designing 5 interfaces (Trigger, PreLikeAction, MusicProvider, PostLikeAction, Storage) with only Spotify+headset+Supabase as the single set of impls would lock in shapes that contributors then have to fight. Python desktop has fast iter loop (Python > Flutter+Gradle+device); shaping interfaces there first reduces redesign cost. Android port is a non-trivial rewrite (154 tests, Riverpod state, Kotlin worker, Clean Architecture all Spotify-typed) — owner accepted it's days-to-weeks, not hours. Owner accepted phasing as proposed.
+- **Memories used:** `268617e8-82fa-44dc-b21c-06120a61baf7, 20741136-3036-4093-9bc4-5e8fcca38b60, fb73c6d6-7c40-4cee-bbad-31aa44120d8c`
+
+---
+
+### like_spotify_mobile_app Phase 1 extension points (5): Trigger, PreLikeAction, MusicProvider, PostLikeAction, Storage. Each as a thin abstract base class with one default impl + at least one sample/alt impl in repo to validate the shape.
+
+- **UUID:** `99dffb2c-369b-436d-80aa-99395fab92c5`
+- **When:** `2026-05-10T10:37:26.111994+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.7`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `Only 4 interfaces (drop PreLikeAction) — owner overrode: thin file is worth the contributor signal; Single MonolithicHandler — defeats the open-source framework pivot`
+
+  > Trigger covers «как пользователь говорит "лайкни сейчас"» (headset/hotkey/volume button). MusicProvider covers «откуда трек и куда лайк» (Spotify default; YouTube Music as plausible future fork). Storage covers «где хранится счётчик и состояние» (Supabase default; Google Sheets / local file as alternatives owner explicitly named). PostLikeAction covers «что после лайка» — archive remove, best-of, follow are *owner's надстройки*, не должны быть зашиты в core. PreLikeAction added per owner request — even though default flavor doesn't use it, having the abstract base class is a hint to future contributors (small file, big affordance signal).
+- **Memories used:** `fb73c6d6-7c40-4cee-bbad-31aa44120d8c, 268617e8-82fa-44dc-b21c-06120a61baf7`
+
+---
+
+### like_spotify backfill: pre-like GET /me/tracks/contains; Storage.increment(user, track, was_already_liked) returns count starting from 2 when was_already_liked=true on first row insert; backfilled BOOL column ensures one-time bump; existing accumulated counters not touched retroactively.
+
+- **UUID:** `bf9dc758-95d9-44c4-b937-07e2b40b56e9`
+- **When:** `2026-05-10T10:56:30.466132+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `Full retroactive backfill of all existing rows — not requested, scope creep; Backfill as PreLikeAction — wrong layer, leaks counter semantics into hooks; Use Spotify's saved-tracks count as initial value — wildly wrong (counts ALL liked tracks ever, not per-track)`
+
+  > Owner has many pre-existing Spotify likes that the new counter would treat as fresh. Setting first-encounter count to 2 when Spotify already had the like preserves the "3 likes → best-of" semantic without forcing him to re-like everything. Implementation belongs in Storage adapter (not pre/post actions) because it's counter semantics, not a user-visible side effect. Idempotency via `backfilled` BOOL — without it, reinstall + re-trigger could double-bump. Existing accumulated rows aren't backfilled because owner didn't ask, and there's no way to know retroactively which were "already liked when row was created".
+- **Memories used:** `fb73c6d6-7c40-4cee-bbad-31aa44120d8c, 268617e8-82fa-44dc-b21c-06120a61baf7`
+
+---
+
+### like_spotify Storage Phase 1: SupabaseStorage = default; GoogleSheetsStorage = second reference impl validating the interface. LocalJsonStorage deferred as good-first-PR.
+
+- **UUID:** `24cadb15-877a-4331-bb70-5ed6c23220da`
+- **When:** `2026-05-10T10:56:38.171668+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `LocalJsonStorage as second impl — owner overrode: less value than Sheets for typical user; Supabase only — violates two-impls rule, locks interface to RPC shape; All three impls in Phase 1 — over-engineering on day one`
+
+  > Owner's read of contributor population: most users won't run Supabase (DB ops, RLS) but most have a Google account. Google Sheets is the genuine middle ground — multi-device sync without ops. Two real impls satisfy the "abstractions need two implementations" rule and force the interface to be honest about constraints (Supabase: typed columns + RPC; Sheets: append-only rows + lookup latency). LocalJson would be a third impl validating "no remote at all" but adds little design tension over Supabase/Sheets — owner traded its triviality for Sheets' user value.
+- **Memories used:** `2c09236b-8ac1-4fe6-9ce1-de9ffbd7143d, fb73c6d6-7c40-4cee-bbad-31aa44120d8c`
+
+---
+
+### like_spotify Trigger Phase 1: TrayHotkeyTrigger default (resident tray icon + global hotkey, current tools/ behavior); OneShotCliTrigger as second impl (each invocation = one like, for users who prefer OS-level shortcut binding). VolumeButtonTrigger documented in CONTRIBUTING with skeleton, not implemented.
+
+- **UUID:** `1fca627b-4894-4170-945c-dc9e6d8b7f4b`
+- **When:** `2026-05-10T10:56:53.917953+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `TrayHotkey only — single impl, can't validate interface; Tray + OneShot + VolumeButton all in Phase 1 — owner explicitly said don't do volume button ourselves`
+
+  > Owner explicitly preferred the resident tray flavor as canonical ("вариант с билдом, это будет каноничный"). OneShotCli is the second impl that exists today in `desktop/like_spotify.py` — refactoring it to fit the Trigger interface validates that the interface accommodates both resident and per-invocation lifetimes without leaking lifetime concerns into MusicProvider/Storage. Volume button is the explicit "user might want this" example owner gave but disclaimed personally — fits the open-source-PR model perfectly: skeleton + docs, leave to a contributor with the platform need.
+- **Memories used:** `fb73c6d6-7c40-4cee-bbad-31aa44120d8c`
+
+---
+
+### like_spotify desktop layered as core (pure Python, cross-platform) + hosts/{windows,_stub}.py. Windows host has full features (tray, autostart via registry, mutex, winsound). Stub host = CLI-only fallback for macOS/Linux. Real macOS/Linux hosts are good-first-PR.
+
+- **UUID:** `fb8771fd-70b7-4f40-bd09-ace05c6fe81b`
+- **When:** `2026-05-10T10:57:02.066984+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.7`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `Windows-only — too narrow for OSS framing; Full mac/linux hosts in Phase 1 — weeks of work for hypothetical users, violates two-impls-with-real-users principle`
+
+  > Open-source framing makes Windows-only narrow; layering at the host boundary lets non-Windows users still install and use OneShotCli flavor without writing C extensions. Owner accepted cross-platform as a target. We don't pretend to *fully* support mac/linux on day one — that would mean writing macOS launchd integration, Linux notifier daemons, etc., for which there are no real users yet. Stub host = honest minimum that proves the seam is real, not theatrical.
+- **Memories used:** `fb73c6d6-7c40-4cee-bbad-31aa44120d8c, 59b90c47-5410-475a-bb31-60c9e3543d73`
+
+---
+
+### like_spotify install: install.ps1 (Win) / install.sh (mac/linux) one-liner does Python check + pipx install + interactive --setup (Client ID, Supabase URL/key, OAuth in browser) + autostart hookup (Win registry; mac/linux = print instructions). PyInstaller .exe path retained as second route for users who don't want Python.
+
+- **UUID:** `f81b2e78-675e-46b1-89e7-82f07106a78e`
+- **When:** `2026-05-10T10:57:08.89227+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `pip install instead of pipx — leaks deps into user site-packages, less clean for non-dev users; PyInstaller .exe as the *only* install path — forces the build burden onto every install, breaks plugin-developer flow; Auto-configure mac/linux autostart — platform fragmentation explosion`
+
+  > "Один запуск ставит всё" mapped to bootstrap script that handles all three concerns (runtime + package + first-run config). pipx (not pip) chosen because it isolates the venv per-tool and adds the entry point to PATH automatically — exactly what one-shot install demands. PyInstaller .exe kept because the friend-onboarding scenario in `tools/` already produces it; that's a different audience (no-Python users) and shouldn't be regressed. macOS/Linux autostart not auto-configured because launchd/systemd glue is non-trivial and varies per distro/shell — print + document is the honest minimum.
+- **Memories used:** `fb73c6d6-7c40-4cee-bbad-31aa44120d8c, 59b90c47-5410-475a-bb31-60c9e3543d73`
+
+---
+
+### like_spotify_mobile_app Phase 1 includes search-discoverability deliverable: GitHub repo topics targeting the same queries we just ran (spotify, spotify-automation, hotkey, media-keys, headset, like-track, scrobbler-alternative, plugin-framework, music-automation, python, tray, cross-device); README with keyword-rich problem statement in first paragraph + explicit comparison table positioning vs Pano Scrobbler, SpotifyHotKeys.ahk, Music Assistant, n8n; repo description and homepage field set via `gh repo edit`; consider opening a non-spam issue/discussion in adjacent projects only if there's a real user request there pointing to a missing feature we provide.
+
+- **UUID:** `6fb2e3db-9fed-401e-a4f5-08c8cc8ff69f`
+- **When:** `2026-05-10T11:05:42.827856+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill-me`
+- **Project:** `like_spotify_mobile_app`
+- **Alternatives considered:** `Skip discoverability — violates D1's open-source rationale, project becomes invisible word-of-mouth-only; Aggressive cross-posting in adjacent repos (PRs/issues advertising us) — spammy, hurts reputation more than it helps; SEO via blog post / dev.to article — valid, but Phase 2 territory; readme + topics is the minimum-viable discoverability`
+
+  > Owner's reasoning: «если такой же человек попробует найти наш проект так же, как мы только что искали, он сможет нас найти». The prior-art search returned zero direct matches — meaning duplicate-effort is the current state of the world for this niche. If our open-source pivot is to pay off (D1), the project must be findable by the same friends-with-same-problem we built it for. Comparison table is the highest-leverage move because it converts search visitors into informed users (or correctly redirects them to better fits like Pano Scrobbler if their need is actually scrobbling).
+- **Memories used:** `fb73c6d6-7c40-4cee-bbad-31aa44120d8c`
+
+---
+
+### comm_patterns.primary_label is a 6-value enum: correction_wrong_direction, correction_incomplete, affirmation, affirmation_with_redirect, preference_directive, meta_protocol — with subtype (free text) carrying particulars (e.g. repeat_mistake, terminology, cross_device_miss, hallucination).
+
+- **UUID:** `a80445d9-58ba-45ac-acad-c549b4922668`
+- **When:** `2026-05-10T11:10:41.263725+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:580-hitl:skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Re-derived from a fresh sample (n=69 interactive sessions over 14 days, 176 NEG + 17 POS regex candidates, stratified manual inspection of 40+15) per issue #580 acceptance criterion. The old /reflect taxonomy (permission_seeking, tunnel_vision, hallucination_attribution, repeat_mistake, cross_device_miss) almost never matched cleanly in the fresh corpus — most regex hits were false positives from skill-body echoes and task-notification blocks. Owner confirmed enum as proposed, no resizing. Compact 6-value surface keeps the CHECK constraint stable; particulars decompose into the free-text `subtype` and numeric `confidence` rather than enum-bloat or an `ambiguous` bucket. `repeat_mistake` is treated as a modifier (subtype) on whichever substantive label fits, not a label of its own. Aligned with already-locked decisions: dual-column taxonomy (9e9ab041), per-instance row shape α (32825852), anchor_quote+redacted+global-scope (3d8d99ef).</rationale>
+  > <parameter name="alternatives_considered">["Carry over old /reflect 5-corrective regex categories — rejected: did not match cleanly in fresh corpus, post-refactor concerns (protocol misses) absent.", "Add 'ambiguous' label for low-confidence cases — rejected: confidence numeric column already encodes uncertainty without polluting enum.", "Make repeat_mistake its own label — rejected: it is a modifier on substantive labels, belongs in subtype.", "Larger 8–10 value enum (split affirmation_with_redirect into scope_shrink/scope_expand, separate terminology and process_directive) — rejected: such fine grain belongs to subtype to keep enum stable across re-derivations.", "Keep label as plain text without CHECK constraint — rejected: no shared vocabulary, no aggregation across devices."]
+- **Memories used:** `77f341de-4cb0-49e3-9dcc-9402bc45c474`
+
+---
+
+### implement #581 — comm_patterns extractor + Stop hook + backfill
+
+- **UUID:** `1d686f4a-97b6-405d-8fca-ad438c7d4e2b`
+- **When:** `2026-05-10T11:35:31.350719+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:impl-581:afk`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Carry old /reflect regex taxonomy unchanged — rejected per ADR 0004 (corpus does not speak that vocabulary); Block in scrubber instead of substitute — rejected; extractor must succeed write with [REDACTED:label] tokens, not abort the whole row; Run grill-me before implement — declined; user explicit AFK directive + issue body type=AFK + 4 linked architectural decisions + ADR 0004 cover the open questions`
+
+  > Per ADR 0004 the comm_patterns table is locked (α per-instance row, write-time scrubber, global scope, six-value primary_label enum). Implementation slice fills it from interactive sessions via Stop-hook-driven extractor. Architecture: thin Python package scripts/comm_patterns/ (scrubber, classifier, transcript, store) + scripts/comm-patterns-extract.py CLI entry + scripts/comm-patterns/classifier.md prompt + scripts/comm-patterns-backfill.py for one-time pass over ~/.cache/jarvis-comms-analysis/*. Reuse Pillar-9 secret-scanner.py regex patterns (substitute mode, not block mode) plus add PII regexes (email, paths-with-username, .env-shaped, API-key shapes). Local Ollama qwen3:4b (only model fitting Main-PC RTX 3050 6GB VRAM at 27 tok/s, per main_pc_ollama_benchmark_2026_05_10) with think:false (per qwen3_think_false_required). Watermark in comm_patterns_watermark table (per-(device, session_id) row with last_message_idx). Sandcastle/headless skip via cwd/path containment of '.sandcastle' or 'worktrees'. AFK directive from user; issue is pre-grilled with 4 linked architectural decisions and explicit AC.</rationale>
+  > <parameter name="memories_used">["19ab3f79-aea3-4468-a09d-d8f47dd7a58b", "56932f78-09be-486b-babd-0ee59ff9d870", "77f341de-4cb0-49e3-9dcc-9402bc45c474", "9bb3332f-9b9f-4444-8723-77e37501de5f", "f5b5f74a-3ee4-4574-b1a9-652ae87f7a10", "1853a304-9a4f-4c8c-8e76-10b842118d7a"]
+- **Memories used:** `none`
+
+---
+
+### Five base-class signatures async-first (Trigger/PreLikeAction/MusicProvider/PostLikeAction/Storage). Sync impls wrap I/O in asyncio.to_thread. Errors via typed exceptions (AuthError/RateLimited/TransientError), not Result<T>. PostLikeAction chain runs sequentially with mutable LikeContext (not pub/sub) because count→promote-gate ordering matters.
+
+- **UUID:** `568826ee-e84d-4741-85ce-d587003c9e98`
+- **When:** `2026-05-10T11:37:32.852713+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.7`
+- **Actor:** `session:like-spotify-issue-20`
+- **Project:** `like-spotify`
+- **Alternatives considered:** `sync-first with optional async: rejected — async retrofit later is harder than to_thread now; Result<T> return type: rejected — Python idiom is exceptions, Result becomes noise; pub/sub PostLikeActions like MA event bus: rejected — explicit ordering needed for count→promote gate; fat MusicProvider with read-stats methods: rejected — Pano-style 10-method interface is the cited anti-pattern; ProviderFeature capability flag set: rejected as premature at 5 extension points`
+
+  > Mixed sync+async chains are the worst of both — pick async upfront, wrap legacy sync in to_thread. Pano's Result<T> is noise in Python (idiom is exceptions); typed exceptions cover the cases the host actually branches on. Chain over pub/sub: best-of promote gates on like_count populated by Storage one step earlier — explicit ordering required, MA's event-bus model would force shared mutable state via subscribers anyway. MusicProvider deliberately narrow (3 methods: get_currently_playing/like/user_id) reacting to Pano's 10-method fat Scrobblable that mixes scrobble with charts/friends/recents.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Plugin discovery for like-spotify framework: filesystem convention (Music Assistant style) — extensions/<domain>/{__init__.py,manifest.json}, loaded via importlib.import_module. Defer setuptools entry_points until third-party package demand appears.
+
+- **UUID:** `69634a12-3233-4969-b62c-4d149e4912c4`
+- **When:** `2026-05-10T11:38:03.405665+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:like-spotify-issue-20`
+- **Project:** `like-spotify`
+- **Alternatives considered:** `setuptools entry_points: forces pyproject for every contributor, manifest metadata homeless — defer as bridge-on-top later; single config-file (plugins.toml): explicit but high friction, doesn't address dependency install; closed enum + factory dispatch (Pano-style): simplest code but every new provider edits core, kills OSS contributions`
+
+  > MA proves filesystem convention scales (~60 providers). Zero ceremony for contributors: fork → drop folder → pip install -e → works. Manifest carries metadata (codeowners, requirements, docs URL, icon) that has no natural home in entry_points. Pano's closed-enum dispatch is the anti-pattern we are escaping — every new provider edits core. Rejected entry_points (forces pyproject ceremony, no manifest home), config-file (user friction), closed enum (not OSS). Each extension dir exports one of TRIGGER/PRE_LIKE_ACTION/MUSIC_PROVIDER/POST_LIKE_ACTION/STORAGE module-level async factory; manifest.json carries pip requirements installed at first enable (#28 wires installer). Decision emitted in real time per design_session_realtime_record_decision rule.
+- **Memories used:** `44962daf-1f97-4c3d-b8dc-6be9284a3a5b`
+
+---
+
+### implement #528: restore Pocock to-prd / to-issues / grill to upstream form (pinned SHA 733d3128); rename grill-with-docs → grill; delete grill-me dir
+
+- **UUID:** `32b59786-1f0d-4cc6-bce1-b86705984bcc`
+- **When:** `2026-05-10T18:30:16.756924+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:m37-528`
+- **Project:** `jarvis`
+- **Alternatives considered:** `keep grill-with-docs name — rejected: milestone PRD target list says /grill, ADR 0001 uses /grill; strict-revert removing setup-matt-pocock-skills adaptation — rejected: predates #528, would break in our env; defer cross-ref updates to separate PR — rejected: SOUL.md/CLAUDE.md loaded every session, stale refs mislead; keep disable-model-invocation: true — rejected: not in whitelist, not in upstream`
+
+  > M37 cleanup slice closing the loop on ADR 0002 (shared protocol moved to global CLAUDE.md). With Tier 1 protocol centralized, the bolted-on Jarvis layers in the three Pocock skills (memory recall preambles, decision_uuids sections, record_decision callouts, Tier framing) are redundant and re-introduce the smear ADR 0002 fights. Approach: pinned-SHA diff with explicit forbidden-term list + whitelist (per #522 grill 2026-05-08). Rename grill-with-docs → grill matches milestone PRD target list (Type 2 (12) /grill) and ADR 0001 canonical name. Lighter Pocock productivity/grill-me variant dropped — every Jarvis project has CONTEXT.md / docs/adr/. Pre-existing AIHERO-CREDIT-documented adaptation (`/setup-matt-pocock-skills` ref → "see project CLAUDE.md") preserved — predates #528 and not removing would break in our env. Cross-refs in SOUL.md, project CLAUDE.md, userlevel CLAUDE.md, AIHERO_CREDIT, and skills not touched by #529 updated. Refs in /implement /delegate LEFT — #529 rewrites those bodies.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 615e9029-f2c5-4f73-b5b1-f28835269b29, 13de847b-30ff-42b2-a831-0dcf6377a8c3, d955dccc-ce58-44a9-a97c-2ae619fec117, 9697a109-dd91-4062-b5ac-86d6d12b27e4`
+
+---
+
+### Implemented #21 tracer-bullet per docs/design/interfaces.md — like_spotify/{core,hosts,extensions,samples}/, two ABCs, default flavor
+
+- **UUID:** `332907e7-3214-478d-8e65-75221921163e`
+- **When:** `2026-05-11T10:38:54.800893+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:like-spotify-21`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Run asyncio loop on main thread, pystray on worker — rejected: pystray on Windows is fine off-main but stdlib examples put it on main; less risk; Sync-only port (no asyncio) — rejected per design doc anti-pattern #9 (mixed sync+async chains worst-of-both); Skip pyinstaller launcher.py and pass `-m like_spotify` to build.bat directly — partially adopted (build.bat uses -m, .spec uses launcher); keeps both workflows working; Filesystem loader in core (importlib.import_module by domain) — deferred: tracer bullet imports the two extensions directly; loader lands when third extension justifies it`
+
+  > Issue #21 acceptance criteria met: new package layout carved; Trigger + MusicProvider ABCs ported verbatim from #20 design doc; SpotifyMusicProvider ports tools/spotify_liker.py PKCE+API (sync requests wrapped in asyncio.to_thread); TrayHotkeyTrigger schedules emit() via run_coroutine_threadsafe; hosts/tray.py wires tray icon + feedback + --setup + autostart + single-instance; pyproject.toml ships `like-spotify` console script; tools/build.bat + LikeSpotify.spec rewired with like_spotify_launcher.py as PyInstaller entry; pytest smoke 3/3 passed (happy path, nothing-playing, like-failure); desktop/like_spotify.py and desktop/README.md deleted. Tactical choices: config at ~/.like_spotify/, asyncio loop on worker thread + pystray on main (Windows-compatible), launcher script bridges spec workflow vs python -m, single record_decision per session vs per-file. Stateless by design — Storage/PostActions land in #22/#23/#26. PR #33 opened, awaiting manual run-through of `pipx install -e . && like-spotify --setup` (no automated tray test possible). Decision basis: 85e9f306-6b79-4df6-a1ee-36374b91a4e8 (OSS pivot), 99dffb2c-369b-436d-80aa-99395fab92c5 (five extension points), fb8771fd-70b7-4f40-bd09-ace05c6fe81b (core/hosts split).
+- **Memories used:** `2c09236b-8ac1-4fe6-9ce1-de9ffbd7143d`
+
+---
+
+### #530 trivial-half: extract analyze-comms Python scripts from skills/reflect/ to scripts/analyze-comms/; /reflect SKILL.md keeps as descriptive-trigger skill but invokes scripts from JARVIS_HOME/scripts/analyze-comms/
+
+- **UUID:** `aebdf45b-0a72-46d5-90b6-cd3faf1a4517`
+- **When:** `2026-05-11T10:48:56.011555+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:530-trivial-half`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A: leave scripts inside /reflect skill — rejected because AC literal not met and re-surfaces; Delete /reflect entirely and make scripts purely CLI — rejected because /reflect still has agent-side Phase B qualitative analysis step + memory write decisions; descriptive trigger still earns the skill shape`
+
+  > User chose option B (literal AC compliance) over option A (leave scripts inside /reflect). #510 had folded analyze-comms scripts into /reflect skill ("rename, not wrapper"). #530 AC demands scripts under scripts/ — keeping scripts inside another skill leaves #530 formally un-closed and re-surfaces in next sprint. /reflect remains a real skill (descriptive trigger "weekly behavioral audit", "что я делаю не так") — only the implementation moves out. Skill becomes a thin orchestrator over scripts/ binaries, which is the correct skill shape per ADR-0001.
+- **Memories used:** `5ba4a474-5e8d-445d-aa37-ce29e6845d0f, 1546ab9a-bbc6-46f3-ab0e-f11ec235d1f7`
+
+---
+
+### Slim /implement and /delegate to skill-specific gates only; replace inline grill-me with structured grill_required exit; collapse /research mode sections; delete /status skill (#529)
+
+- **UUID:** `41a9255e-7da8-4049-9f3f-4801b331ee07`
+- **When:** `2026-05-11T11:05:21.557095+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:529-slim-skills`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep grill_me inline as in v1 of /implement — rejected by ADR-0001 (Type 3 not designed for, smart-zone budget); Slim /status to Type 2 read-wrapper — rejected by decision episode a685a14b (one less skill, one less naming collision; inline memory_recall is sufficient); Keep Mode: headers in /research — rejected as redundant ceremony when arg shape conveys the same`
+
+  > Per ADR-0001 (Type 1/2 only, no Type 3) and ADR-0002 (shared protocol in global CLAUDE.md), /implement and /delegate no longer restate memory recall or record_decision protocol blocks — those load from user-level CLAUDE.md every session. The Grill trigger checkbox stays, but skills now emit a structured grill_required exit line instead of running /grill inline (mid-task self-trigger is rejected). Orchestrator runs /grill in a fresh session and re-dispatches. /research no longer needs explicit Mode: Interactive / Mode: Discovery sections — behavior branches on whether a topic argument is supplied. /status is removed (not slimmed) per decision episode a685a14b — state-reads happen inline via memory_recall over /status-record events.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 5ba4a474-5e8d-445d-aa37-ce29e6845d0f, dcd2e999-13c5-4efb-a46a-aa8211535f12`
+
+---
+
+### TDD wired into /implement and /delegate via C'1+ adjacent-files pattern; /tdd standalone skill removed; shared docs live in .claude-userlevel/skills/_shared/tdd/.
+
+- **UUID:** `f92ede34-93e9-422b-adc8-a5952c8f2c48`
+- **When:** `2026-05-11T13:09:16.640986+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-tdd-loop-2026-05-11`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A: /tdd as alternative entry point with orchestrator-side classifier — rejected: duplicates checkbox logic outside /implement, breaks DRY on load-bearing rule.; B: tdd_required exit status mirroring grill_required, orchestrator re-dispatches to /tdd — rejected after C' emerged: still keeps /tdd as separate skill with no ad-hoc value, adds round-trip through orchestrator that C' avoids by entering TDD-mode in-place on re-entry.; C internal mode inside /implement SKILL.md body — rejected: violates ADR-0002 'skills shrink' direction, swells SKILL.md, #529 in active phase doing the opposite.; C'1 plain: TDD docs only in /implement/ — rejected: leaves /delegate unprotected, and subagents are the worst offenders for test-coverage overclaim.; C'2: /tdd survives ultra-thin with docs inside, /implement uses relative path ../tdd/ — rejected: cross-skill relative paths are fragile; one rename breaks silently.; D: leave standalone, user-invoked only — rejected: SOUL.md says TDD is the base loop, doctrinal contradiction with /implement writing code-first.`
+
+  > SOUL.md declares TDD as the base feedback loop, but /implement and /delegate never invoke /tdd — agents write impl first, then write tests that match impl rather than tests that match AC. Preventive doctrinal alignment + AC-integrity anti-cheating. ADR-0001 forbids Type 3 (mid-task self-trigger), so /implement cannot call /tdd inline. C' (adjacent files, Pocock pattern) gives skills a thin SKILL.md plus reference docs loaded on-demand — same pattern /grill-with-docs and current /tdd already use. C'1+ places TDD docs in a shared location so both /implement and /delegate point at one copy without cross-skill relative paths. Trigger = the existing SOUL.md grill-me checkbox: ≥1 yes also triggers TDD-mode (β-i). Re-entry detection is stateless re-derivation — /implement re-runs the checkbox; if positive AND working_state_jarvis has decision_uuids[] from a completed grill, enter TDD-mode; if positive AND no UUIDs, exit grill_required. /tdd standalone dies — 16→15 skill target, no #528 upstream-SHA constraint on /tdd, ad-hoc TDD without an issue is rare in jarvis.
+- **Memories used:** `13de847b-30ff-42b2-a831-0dcf6377a8c3, 615e9029-f2c5-4f73-b5b1-f28835269b29, 3be1ecb2-2eb4-44b0-a0fa-32b4f43412f9, bfcf55c0-6105-4200-91bb-0eee01bd29a4, d955dccc-ce58-44a9-a97c-2ae619fec117, 7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### TDD-mode operational semantics: one-AC-at-a-time red→green→refactor loop; AC-completeness gate in /delegate prompt; refactor permission extends to code freshly covered by a passing test in the same session.
+
+- **UUID:** `26e6250a-cbe7-4d8f-bdc1-391eb8f2090d`
+- **When:** `2026-05-11T13:09:31.430659+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `session:grill-tdd-loop-2026-05-11`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Test-first only in /implement, /delegate stays mechanical — rejected: subagents are the dominant overclaim vector.; Horizontal slicing (all tests, then all impl) — explicitly rejected by /tdd Pocock content, produces crap tests insensitive to real changes.; Don't extend refactor permission — rejected: TDD legitimately grows the test-covered surface mid-task, refusing to refactor it is artificial and discourages deep-module work that AI Hero principles already endorse.; Make AC-completeness a global hook rather than /delegate-specific — rejected: /implement runs inline with full context and doesn't need the reminder; hook would add noise to inline runs.`
+
+  > TDD-mode is not cosmetic — it forks the executive pattern of /implement and /delegate. Mechanical-mode writes impl, then tests (cheatable). TDD-mode picks one AC, writes failing test, confirms red, writes minimal impl, confirms green, optionally refactors, loops to next AC. Anti-horizontal-slicing rule from /tdd Pocock content is preserved in _shared/tdd/tdd-loop.md. /delegate needs an additional explicit gate because subagent_test_coverage_overclaim and subagent_acceptance_criteria_dodged_as_out_of_scope memories show that subagents drop AC items as 'out of scope' and write zero positive tests for new symbols — TDD alone does not patch this; the gate in /delegate's subagent prompt says: every AC item MUST have at least one corresponding test, dropping an AC is a delivery defect not a scope decision, escalate to orchestrator instead of skipping. Refactor permission: SOUL.md allows refactor 'when tests cover the touched behavior'; in TDD-mode tests are written before impl, so test-covered code expands as the session progresses — permission expands with it. This is encoded in _shared/tdd/tdd-loop.md as 'code is in your refactor scope once you have written and greened a test for it; not before'.
+- **Memories used:** `bfcf55c0-6105-4200-91bb-0eee01bd29a4, e9acc59d-0860-4bed-90e2-befc02c78dd8, 7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, abc0a54d-0806-4349-8863-45ae542071eb, 3be1ecb2-2eb4-44b0-a0fa-32b4f43412f9`
+
+---
+
+### Reconsidering /implement + /delegate merge into a single skill is deferred to a separate grill session (issue #591), blocked by #590 landing first; current TDD-wiring grill assumes the current split stands and produces merge-friendly artifacts (docs in _shared/tdd/, not inside either skill).
+
+- **UUID:** `ef6ec272-ed0b-436e-9dbc-29f40c580652`
+- **When:** `2026-05-11T13:09:46.309207+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:grill-tdd-loop-2026-05-11`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Decide merge now in this grill — rejected: doubles scope, violates vertical-slice principle, comparing against pre-#590 skill bodies.; Refuse to reconsider, treat 2026-04-21 split as settled — rejected: dishonest, the four arguments fail under the new context and silence creates the exact failure mode CLAUDE.md warns about ('Decisions belong in memory, not in chat').; Decide merge now, defer TDD-wiring — rejected: TDD-wiring is unblocked and addresses an active preventive concern; merge is architectural cleanup that can wait.`
+
+  > Mid-grill the user pushed back on the four arguments justifying the 2026-04-21 split (decision 5ba4a474). Under the C'1+ adjacent-files pattern just adopted and the /research mode-collapse precedent in #529, all four arguments stress-test poorly: naming-self-describes fails because /implement#X vs /implement#X#Y#Z routes by argument cardinality just as cleanly; different-judgement fails because the routing call can live in a merged body; different-merge-authority is per-PR not per-skill; different-runtime-mechanics is exactly what adjacent files exist for. Honest position: the 2026-04-21 split was correct for that time (no adjacent-files canon, no /research precedent), but the case for keeping it split is now weaker than the case for merging. Reopening the merge inside the current grill would (a) double scope and break vertical-slice discipline (AI Hero principle), (b) require a stress-test against #590 changes that aren't merged yet — comparing apples to oranges. Deferring to its own grill after #590 preserves the merge option without coupling it to TDD-wiring. TDD docs in _shared/tdd/ are merge-friendly by construction: if the merge happens, _shared/tdd/ stays put; both old skill bodies collapse into one but the reference material doesn't move.
+- **Memories used:** `5ba4a474-5e8d-445d-aa37-ce29e6845d0f, 13de847b-30ff-42b2-a831-0dcf6377a8c3, d955dccc-ce58-44a9-a97c-2ae619fec117`
+
+---
+
+### Personal proxy panel architecture: Tailscale Funnel for subscription endpoint only; pin 3X-UI Inbound External Proxy to public IP for vless data path
+
+- **UUID:** `5974f1be-8d08-4c79-9062-6ae64e88dd8d`
+- **When:** `2026-05-11T19:21:22.351831+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:proxy-debug-2026-05-12:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Buy domain + Let's Encrypt directly on 3X-UI panel — rejected: requires domain purchase + DNS A-record + cert provisioning, more moving parts than Funnel which is built into existing Tailscale stack; Migrate from 3X-UI to Hiddify-Manager — rejected: Hiddify-Manager has built-in routing-rules-in-subscription and explicit External Sub Domain config, but migration cost (recreate users, panel reinstall) not worth it for 2-3 friend users; Self-hosted GitHub Gist with hand-crafted sing-box JSON — rejected: loses auto-rotation propagation, would need manual gist edit on every key change; Server-side xray routing rules for RU bypass — rejected: server-side outbound=direct still egresses from NL IP, doesn't help Russian-IP-required services (gosuslugi, banks). Split-tunnel must be client-side`
+
+  > Hiddify mobile clients refuse HTTP and can't reach Tailscale CGNAT addresses (100.x). Funnel solves both for the panel — public HTTPS with valid LE cert, no domain purchase. But Funnel is L7 HTTPS reverse proxy, and Reality TLS handshake breaks through it (Reality is layer-4 fake-TLS, not real HTTPS). Caught a 3X-UI host-rewrite bug: panel auto-fills vless host from request Host header, so when sub fetched via Funnel domain it embedded that domain in vless URLs → all clients timed out including own PC. Fix: 3X-UI Inbound → External Proxy → pin Dest=103.106.1.92:443. Now sub fetched over Funnel HTTPS publicly, vless connections go direct to public IP bypassing Funnel. Verified externally: TLS 1.3 handshake on 103.106.1.92:443 with SNI=www.microsoft.com returns real Microsoft cert (Reality steal-from-server working).
+- **Memories used:** `bd4f80e0-3c24-4cec-b21e-d18ebbd2fb09, 6bec4c71-184f-4e58-b1e5-b1f8ea28f4ef`
+
+---
+
+### implement #593: scaffold .claude-userlevel/skills/_shared/tdd/ with migrated TDD reference docs
+
+- **UUID:** `fdc27f9b-fde3-4791-8e56-b32223def131`
+- **When:** `2026-05-12T08:11:26.659694+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:implement-593`
+- **Project:** `jarvis`
+- **Alternatives considered:** `delegate to subagent — rejected: cross-cuts manifest + CONTEXT.md + skills tree, subagents tend to relabel manifest changes as out-of-scope (cf. memory 9a5a1ade); include /tdd cleanup in same PR — rejected: explicitly out of scope per issue, #596 owns it; skip install.ps1 smoke — rejected: AC item, propagation is easy to miss without manifest whitelist update`
+
+  > Issue spec is fully concrete and atomic: create _shared/tdd/ as the canonical home for TDD reference material (tdd-loop.md, tests.md, mocking.md, refactoring.md), migrated from /tdd/ with Pocock attribution headers; add TDD-mode glossary entry to CONTEXT.md; add _shared to install-manifest.yaml whitelist; smoke-test propagation. Two prior architectural decisions (f92ede34 — TDD-mode wired adjacent via C'1+, _shared/tdd/ placement, /tdd standalone dies; 26e6250a — one-AC-at-a-time, refactor-permission extension) already resolved placement and content shape, so this is execution, not design. Scope explicitly excludes /tdd cleanup (covered by #596) and deep-modules.md / interface-design.md disposition.
+- **Memories used:** `f92ede34-93e9-422b-adc8-a5952c8f2c48, 26e6250a-cbe7-4d8f-bdc1-391eb8f2090d`
+
+---
+
+### Merged PR #740 (GET /api/config aggregated endpoint, #304) to master via squash.
+
+- **UUID:** `f1cfeac6-228c-4b60-b2f6-0437aeee7cd1`
+- **When:** `2026-05-12T08:44:15.282713+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `session:redrobot-2026-05-12:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Wait for explicit review — rejected: no reviewers required, advisory-only policy; Merge to dev branch — rejected: redrobot uses master as trunk, not dev`
+
+  > LOW risk routine merge: software-only read-only endpoint, no driver/planning/mujoco touches, MERGEABLE+CLEAN, both CI checks green (PR Checks, Project Sync). Per routine_medium_merge_is_autonomous and copilot_review_advisory_only — green tests + LOW risk = merge without asking.
+- **Memories used:** `48f0a121-1d29-4d42-b387-8b39f5262c79, 4a62bdf8-c138-4479-bf12-9a9fdd5d64a8, b1216b17-3175-4ec5-9174-498a6b2e0e72`
+
+---
+
+### Implement #304 GET /api/config as aggregator over existing sources of truth (ROBOT spec, app_state.workspace, system_config.yaml), no new schema/validation layer.
+
+- **UUID:** `37fd47be-08d8-4b81-a6da-186915f9828b`
+- **When:** `2026-05-12T08:44:22.352319+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:redrobot-2026-05-10:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `New Pydantic ConfigResponse schema with validators — rejected: YAGNI, duplicates YAML/ROBOT validation; Split into per-section endpoints (/api/config/robot, /tray, /tools) — rejected: frontend needs atomic snapshot to avoid mid-init races, #305 wants one fetch; Extend existing /api/status/robot_params — rejected: would conflate runtime status with static config, breaks SRP of status router`
+
+  > Endpoint is a thin read-only projection for frontend dynamic config (#305). Adding a Pydantic schema layer or duplicating validation would mean two sources of truth diverging over time — the YAML and ROBOT spec already validate at load time. Reuse keeps single source of truth invariant from CLAUDE.md ("Единые источники правды"). 8 endpoint tests assert payload shape; full schema enforcement is YAGNI until a second consumer needs it.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Wire TDD-mode into /implement as three-branch dispatch driven by SOUL.md grill-me checkbox + working_state_jarvis decision_uuids[] inspection; load _shared/tdd/tdd-loop.md as the procedural reference (no duplication in SKILL.md)
+
+- **UUID:** `1e4e275a-9a38-441e-b58b-b3aec4b205c4`
+- **When:** `2026-05-12T08:47:22.913308+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:impl-594`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Self-trigger /tdd mid-task — rejected by ADR-0001 (no Type 3); Add an explicit tdd_mode argument from the orchestrator — rejected: stateless re-derivation per #594 keeps the contract uniform across human and orchestrator entry; Duplicate tdd-loop procedure inline in SKILL.md — rejected: AC requires _shared reference only; avoids drift between the two host skills`
+
+  > Issue #594 spells out the dispatch logic literally; architectural Qs were resolved in two prior grills captured as decisions f92ede34 (C'1+ adjacent-files pattern, grill-me trigger, stateless re-entry) and 26e6250a (one-AC-at-a-time loop semantics + refactor permission extension). The grill artifact for THIS issue is the issue body itself plus those two UUIDs cited verbatim — no fresh grill needed. Re-entry stays stateless: every /implement entry re-runs the checkbox and re-reads working_state, so post-grill re-dispatch from the orchestrator works without a tdd_mode flag.
+- **Memories used:** `f92ede34-93e9-422b-adc8-a5952c8f2c48, 26e6250a-cbe7-4d8f-bdc1-391eb8f2090d, 3be6f593-48bc-4ba3-a53d-664382e2b38f`
+
+---
+
+### For #305 frontend dynamic config, use module-level cache + subscriber set + useAppConfig hook (rather than React Context provider).
+
+- **UUID:** `efb94e73-ac99-4bfb-8073-4a9e8e75a0a8`
+- **When:** `2026-05-12T08:55:47.324012+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:redrobot-2026-05-12:implement-305`
+- **Project:** `redrobot`
+- **Alternatives considered:** `React Context + Provider — rejected: requires App-level wrapper, can't be read synchronously outside React (ws.ts module-init use case), more boilerplate for a static singleton; Per-endpoint hooks (status quo) — rejected: duplicates fetch logic across robotParams/trayConfig/etc, no shared cache, the horizontal-slice pattern #305 was created to eliminate; SWR/React-Query — rejected: adds a heavy dep for one static endpoint, no revalidation needed (page reload is the refresh contract)`
+
+  > Backend /api/config payload is singleton-static-for-session and consumed by hooks already in the codebase (useRobotParams, useTrayConfig). A module-level cache with inflight Promise dedup + a Set<Setter> for fan-out matches the existing hook-only pattern, gives synchronous access from non-React modules (ws.ts EMPTY_STATUS init at load time via getCachedAppConfig), and keeps test isolation simple with one __resetAppConfigForTests export. Adds reloadAppConfig() for calibration refresh path (calibrationVersion bump). All hardcoded values in components/viewer3d/robotParams.ts retained as offline fallback.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Merged PR #741 (#305 frontend dynamic config loading) to master via squash.
+
+- **UUID:** `1a96a78f-71ef-4223-b9d2-900040562798`
+- **When:** `2026-05-12T08:56:52.450022+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.95`
+- **Actor:** `session:redrobot-2026-05-12`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Wait for review — rejected: advisory-only review policy, no reviewers required; Merge with --merge instead of --squash — rejected: project convention is squash (see fd77943 PR #740 history)`
+
+  > LOW risk routine merge: frontend-only refactor with hardcoded fallbacks preserved, no driver/planning/mujoco touches, MERGEABLE+CLEAN, both CI checks green. Per routine_medium_merge_is_autonomous and copilot_review_advisory_only.
+- **Memories used:** `48f0a121-1d29-4d42-b387-8b39f5262c79, 4a62bdf8-c138-4479-bf12-9a9fdd5d64a8, b1216b17-3175-4ec5-9174-498a6b2e0e72`
+
+---
+
+### Storage interface keyed on (user_id, CurrentTrack) — impls own track-identity
+
+- **UUID:** `e33caa1e-212f-42f9-912b-49fc92f728a5`
+- **When:** `2026-05-12T09:22:33.904559+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-05-12:post-hoc`
+- **Project:** `like_spotify`
+- **Alternatives considered:** `Pass raw provider_track_id string — rejected: leaks Spotify shape into the abstract base; Per-impl key adapter — rejected as YAGNI before second impl exists`
+
+  > Track identity is delegated to each impl rather than baked into the Storage signature: Supabase keys on provider_track_id while a future sheet-style impl may key on title/artist for human-readable rows. The ABC takes a CurrentTrack value object so the impl can pick what to store. This sets the pattern for any future Storage impl (e.g. flat-file, SQLite) — the contract test suite enforces semantics, not key shape.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### was_already_liked flag is INSERT-only — pipeline may pass True repeatedly, impl honours on first INSERT and ignores on UPDATE
+
+- **UUID:** `ba60d9f3-0e2e-4ecb-ba1f-1fafe84188ea`
+- **When:** `2026-05-12T09:22:41.262242+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.9`
+- **Actor:** `session:end-2026-05-12:post-hoc`
+- **Project:** `like_spotify`
+- **Alternatives considered:** `Pipeline tracks first-encounter state — rejected: stateful pipeline breaks the cache-friendly single-press model; Storage.set_backfilled separate call — rejected: two RPCs per like, race-prone`
+
+  > Backfill idempotency is owned by the storage impl, not by callers. Pipeline re-probes is_liked on every press (cheaper than tracking session-local state) and passes the flag to Storage.increment every time. Both Supabase RPC and Sheets impl set backfilled+count=2 only on INSERT; UPDATE path is plain +1 regardless. This frees callers from tracking first-encounter state. Contract test suite has dedicated invariants for this (test_subsequent_was_already_liked_still_plus_one, test_flag_ignored_after_first_encounter_without_it).
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Playlist + follow APIs live on concrete SpotifyMusicProvider, NOT on the MusicProvider ABC
+
+- **UUID:** `f1ede672-2038-493e-ab45-8c2231c5245f`
+- **When:** `2026-05-12T09:22:47.908914+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-05-12:post-hoc`
+- **Project:** `like_spotify`
+- **Alternatives considered:** `Add playlist methods to MusicProvider ABC — rejected: breaks 'stays narrow' invariant, forces non-Spotify impls to stub them; Separate SpotifyPlaylistClient class — rejected: extra indirection, token sharing complicates ownership`
+
+  > MusicProvider's docstring promises "stays narrow on purpose — charts, history, social out of scope". Playlist read/modify and artist-follow are Spotify-specific feature surface that don't belong on the abstract base. Solution: keep them as concrete methods on SpotifyMusicProvider; flavor-specific actions (ArchiveRemove, PromoteToBestOf, FollowArtist) reach in via isinstance(). Non-Spotify providers silently no-op. Sets the precedent for any future provider-specific action extension: add the API to the concrete class, not the ABC.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### GoogleSheetsStorage takes a token_provider callable, not pre-acquired tokens — defers OAuth/refresh to host
+
+- **UUID:** `dccb1939-a888-4caa-9e6d-926e3bd3a770`
+- **When:** `2026-05-12T09:22:55.946193+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:end-2026-05-12:post-hoc`
+- **Project:** `like_spotify`
+- **Alternatives considered:** `Bundle OAuth into Storage constructor — rejected: forces full OAuth design in this slice, blocks merging; Pass pre-acquired token string — rejected: no refresh, brittle in practice`
+
+  > Sheets OAuth is its own beast (separate from Spotify, needs Google Cloud client id, may use PKCE or installed-app flow). Bundling OAuth into the Storage impl bloats the slice and forces design choices before the wider --setup UX is designed (#28). Instead: GoogleSheetsStorage constructor takes token_provider: () -> str, host wires that to whatever refresh strategy fits. This let #25 ship as a clean technical slice while OAuth integration folds into the #28 install bootstrap where Spotify reauth + Google OAuth can be designed together.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Storage gains record_artist_track(user, artist, track) returning distinct-track count for (user, artist)
+
+- **UUID:** `3b57864e-a394-44cb-a596-29e78e8b62ad`
+- **When:** `2026-05-12T09:23:06.113765+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:end-2026-05-12:post-hoc`
+- **Project:** `like_spotify`
+- **Alternatives considered:** `Synthetic key like 'artist:<id>' in track_likes — rejected: mixes semantics in one table; Action-owned persistence layer — rejected: bypasses Storage, gives action two backends to wire; New abstraction (ArtistCounter) — rejected: scope creep, no second impl in sight`
+
+  > FollowArtistAction needs "distinct tracks per artist" counts and the existing increment/get_count keys on (user, track), not on artist. Three options: extend Storage with a new method, abuse the existing schema with synthetic keys, or have the action maintain its own persistence layer. Picked extension — keeps the abstraction honest (artist tracking is a Storage concern), the contract suite parametrizes invariants across both impls (3 new tests: distinct count, idempotency on triple repeat, artist independence), and the Supabase + Sheets impls both got cleanly addable schema (new table + new RPC vs new sheet tab). Sets the precedent for further Storage method additions if needed.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Mirror /implement's three-branch dispatch (mechanical/TDD-mode/grill_required) into /delegate per-issue, with TDD-mode-only AC-completeness clause in subagent prompt template.
+
+- **UUID:** `56ff5817-9f45-4d15-820a-f94a6511838d`
+- **When:** `2026-05-12T09:27:12.288711+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:impl-595`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Apply AC clause to all subagent prompts including mechanical-mode: rejected — adds noise to trivial issues and dilutes signal.; Make TDD-mode a batch-level flag: rejected — /delegate's existing model is per-issue grill_required, batch-level would conflict.; Shared AC clause in _shared/tdd/: rejected — decision 26e6250a explicitly marks it as /delegate-specific (subagent-context-only).`
+
+  > Issue #595 mandates parity with /implement #594. Subagents are the dominant AC-overclaim vector (memory subagent_acceptance_criteria_dodged_as_out_of_scope, subagent_test_coverage_overclaim) — TDD alone fixes test-ordering but not AC coverage, so an explicit /delegate-specific clause is required (per recorded decision 26e6250a). Per-issue dispatch is the natural fit because /delegate already enforces per-issue grill_required exits. Mechanical-mode prompt stays untouched to avoid noise on trivial issues. Stateless re-entry: same as /implement — checkbox + artifact re-evaluated each invocation, no flag carried in.
+- **Memories used:** `f92ede34-93e9-422b-adc8-a5952c8f2c48, 26e6250a-cbe7-4d8f-bdc1-391eb8f2090d, 9a5a1ade-d3c0-4163-8559-dff5993094ea, bfcf55c0-6105-4200-91bb-0eee01bd29a4`
+
+---
+
+### Use slice-issue pattern for partial PRs to satisfy "Require linked issue" CI gate without auto-closing parent.
+
+- **UUID:** `0a6e95b4-7854-4884-8f37-22fac6d0477f`
+- **When:** `2026-05-12T15:49:11.513138+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:redrobot-2026-05-12-pm:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Put Closes #parent in body and reopen issue post-merge — ugly auto-close/reopen toggle and races with /reflect; Modify CI workflow to accept Refs — widens gate semantics, weakens enforcement; Skip CI gate via admin merge — bypasses signal, regression-prone`
+
+  > redrobot CI workflow "Require linked issue" enforces regex `(closes|fixes|resolves)\s+#N` in PR body; `Refs #N` fails. Parent umbrellas like #727, #624 have acceptance criteria that need live-SV or on-site work, so auto-closing them on a skeleton-only PR is wrong. Slice-issue pattern (per CLAUDE.md "Parent issue + Task flat") creates a small issue that the PR DOES fully close — body links `Closes #<slice>` + `## Parent #<umbrella>` — satisfies CI, keeps parent open, and the slice acts as durable scope record. Applied to PR #743→#745 and PR #744→#746 this session; should be the default whenever a PR partially advances a parent.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Merge #743 (SV heightmap client skeleton) with schema divergence flagged via PR comment, defer reconciliation to live-integration follow-up.
+
+- **UUID:** `e72b37f3-3a9c-4616-abd1-8d17c5eaf054`
+- **When:** `2026-05-12T15:49:19.115799+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:redrobot-2026-05-12-pm:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Block merge until contract aligned — idles 0-day-old skeleton against an unbuilt server; net negative; Rewrite client to match contract before merging — speculative; SV server format isn't final either; rewrite likely needed anyway; Open separate issue for reconciliation — covered by parent #727 acceptance criteria, extra ticket is bookkeeping noise`
+
+  > Agent's npz layout embeds JSON metadata as a third array; integration contract (memory id=7dd1f7aa-f63c-4291-b059-823315f43762) specifies metadata served separately (JSON body or HTTP headers). This is mock-only code — no live SV consumer exists yet — so both layouts roundtrip cleanly for the test path landing here. Blocking the slice on reconciliation would idle the merge for days while Темир's server PR (Timaa22/Sculpture_vision_test#5 + PR-2b) ships. Better: merge skeleton + leave visible PR comment + track on parent #727's live-integration acceptance bullet. When Темир's PR lands, either client gains a second-call/header-parse path or SV emits embedded variant — small targeted follow-up.
+- **Memories used:** `7dd1f7aa-f63c-4291-b059-823315f43762`
+
+---
+
+### Fix SV issue #23 (heightmap CI green) as three-layer infra fix: drop conftest django_db_setup override, idempotent ADD COLUMN IF NOT EXISTS for migration 0008, fill missing required WorkCycle fixture fields.
+
+- **UUID:** `d197014f-9166-4a67-8e07-59bda89093db`
+- **When:** `2026-05-12T16:04:54.085643+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:sv-ci-23-fix:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > CI failure on dev/redrobot-integration was masked as "no DB setup" but unwrapped into three independent root causes: (1) conftest fixture overrode pytest-django's default django_db_setup without running migrate; (2) migration 0008 had been written with database_operations=[] because the prod DB had the column added by hand — fresh CI DB never got it; (3) the heightmap test fixture omitted threshold/cycle_timer/blender_script/contour_color, all NOT NULL with no DB defaults. All three are reversible, low-risk infra fixes. Idempotent RunSQL keeps prod safe while making fresh DBs work. Acceptance criterion "решение в conftest, не переписывание тестов" was honoured in spirit — only fixture data filled in. PR #25 merged to dev/redrobot-integration per SV automerge policy (LOW/MEDIUM auto-allowed against integration base). Side finding: heightmap tests in PR #5 were never validated against the live schema because CI was bootstrapped later in PR #6 — pattern matches sv_branching_policy / migration drift seen in #21. Worth a separate pass over other NOT NULL fields without DB defaults but not blocker.</rationale>
+  > <parameter name="alternatives_considered">["Rewrite migration 0008 with plain AddField — rejected: would fail on prod where column exists", "Add migrate call inside the django_db_setup override instead of removing it — rejected: the override duplicates settings_test.py with no added value, removal is cleaner", "Refactor WorkCycle model to add field defaults — rejected: out of scope, would touch prod model semantics for a test fixture problem", "Build a WorkCycleFactory in conftest — rejected: new test infra for one test file, the inline fixture fix is smaller surface"]
+- **Memories used:** `(intentionally empty)`
+- **Memories used (unresolved):** `c8a8011-not-a-memory-but-no-recall-hit-on-this-topic`
+
+---
+
+### Reject adopting Pocock's /handoff skill; keep working_state + session_snapshot + record_decision as the durable handoff stack.
+
+- **UUID:** `5d31b307-32e4-4fae-8e3e-4700cb7ba80a`
+- **When:** `2026-05-12T16:07:26.556989+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-handoff-eval:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Pocock's /handoff writes a fresh mktemp tempfile per session. Three problems vs. our setup: (1) random path breaks autonomous chaining — next cron-launched session can't discover the file without a manifest pointer, defeating the simplicity; (2) /tmp is device-local, our 3-machine setup needs cross-device durability which Supabase memory provides; (3) it's a single-shot summary file, we already have three durable layers (real-time record_decision, automatic session_snapshot via PreCompact hook, canonical working_state_jarvis). The only useful idea — "suggest next skills" — was extracted as a one-line addition to working_state schema (see PR #601), without forking storage. Architectural direction picked between named alternatives → recording.</rationale>
+  > <parameter name="alternatives_considered">["Adopt Pocock's /handoff as new skill — rejected: random tempfile path, device-local, duplicates existing durable layers", "Adopt /handoff alongside working_state — rejected: two handoff systems = drift, autonomous loop needs single canonical source", "Do nothing — rejected: missed the one useful idea (suggested next skills field)"]
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### Add "Suggested next skills" line to working_state_jarvis content schema in /end Step 5.
+
+- **UUID:** `5950ddc0-e150-4770-95b5-052ead850437`
+- **When:** `2026-05-12T16:07:33.210222+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:end-handoff-eval:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Extract the one useful pattern from Pocock's /handoff skill ("suggest skills for next session") and place it in the canonical handoff location we already use. Format: one ordered chain like `/status → /implement #N → /verify`. Lets manual resume and future autonomous chain skip the "what should I run first" decision. Zero new infrastructure — just a schema bullet in /end Step 5. PR #601 on jarvis. Policy/skill config change → recording per trigger #4.</rationale>
+  > <parameter name="alternatives_considered">["Add to Step 8 output instead of working state — rejected: output is ephemeral, working state persists and is what next session reads", "Add as separate memory key — rejected: more keys to discover, working_state already known by name", "Skip — rejected: missing the one good idea from Pocock's skill"]
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### Host split layout: hosts/windows.py (resident tray+hotkey+autostart) / hosts/_stub.py (mac/linux CLI fallback) / hosts/_common.py (shared wiring), with sys.platform dispatch in hosts/__init__.py::select_host(). OneShotCliTrigger as second Trigger impl validating per-invocation lifetime.
+
+- **UUID:** `c428f022-fca1-408a-bc3c-8119ddeca753`
+- **When:** `2026-05-13T04:25:19.153879+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:like_spotify_2026-05-13:post-hoc`
+- **Project:** `like_spotify`
+- **Alternatives considered:** `Single hosts/tray.py with sys.platform branches inside — rejected: imports fail on non-win; Keep tray.py + add hosts/cli.py — rejected: doesn't isolate _common helpers, duplicate code`
+
+  > Issue #27 required isolating winreg/winsound/ctypes.windll outside core. Three-file split keeps Windows-bound side effects in one module, lets _stub support like-once on every OS without dragging in pystray/keyboard, and shared helpers (config, storage, post-actions, setup) stay platform-pure. OneShotCliTrigger's start()-awaits-emit shape validates the Trigger ABC accommodates per-invocation lifetime alongside the resident TrayHotkeyTrigger — satisfies abstractions-need-two-implementations for Trigger. Closed via PR #40.
+- **Memories used:** `3a3dc48c-4bff-4a62-8b98-3e07c5713b7c`
+
+---
+
+### Google Sheets OAuth in --setup uses installed-app PKCE flow with client_id+client_secret persisted next to refresh_token. Storage choice exposed as wizard step (supabase/sheets/none); --reauth flag re-runs OAuth without losing other config.
+
+- **UUID:** `dfa0987c-b256-41b5-a968-623f8cb39a1c`
+- **When:** `2026-05-13T04:25:25.601536+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:like_spotify_2026-05-13:post-hoc`
+- **Project:** `like_spotify`
+- **Alternatives considered:** `Service account JSON file path — rejected: worse UX (GCP IAM + sheet sharing); Defer Sheets OAuth to follow-up — rejected: #25 AC required it in --setup; Skip persisting client_secret, re-prompt on refresh — rejected: long-lived host can't prompt`
+
+  > Issue #28 AC required browser OAuth for Sheets. Mirroring Spotify's PKCE flow (loopback 127.0.0.1:8794, /auth → token-exchange) keeps the auth pattern symmetric. client_secret persisted because Google requires it on refresh even for Desktop-app clients, and for desktop clients it's not a real secret. Service-account JSON path rejected: GCP IAM setup + sheet sharing is much worse UX than a one-time browser auth. Storage choice as a wizard step (not separate flag) preserves re-runnability — user can flip backends without redoing Spotify OAuth. Closed via PR #41 (also finished deferred #25 wiring).
+- **Memories used:** `3a3dc48c-4bff-4a62-8b98-3e07c5713b7c`
+
+---
+
+### README comparison table uses "use ours when X / use theirs when Y" framing vs Pano Scrobbler / SpotifyHotKeys.ahk / Music Assistant / n8n. VolumeButtonTrigger ships as a skeleton (matcher implemented + tested, _listen as NotImplementedError stub) to make the plugin-author guide credible.
+
+- **UUID:** `f4131532-16f2-4602-bcb6-e9008c059c13`
+- **When:** `2026-05-13T04:25:41.099464+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:like_spotify_2026-05-13:post-hoc`
+- **Project:** `like_spotify`
+- **Alternatives considered:** `Feature-only comparison table — rejected: misleading, dunks on adjacent projects; Prose-only CONTRIBUTING, no skeleton — rejected: less credible for plugin authors; Full VolumeButtonTrigger impl — rejected: scope creep for a discoverability slice`
+
+  > Issue #29 AC required "use ours when / use theirs when" framing — honest positioning since none of the adjacent projects are direct competitors (Pano = scrobbling history, MA = HA orchestration, AHK = single-file script, n8n = generic workflows). Feature-checkmark tables would mislead. The VolumeButtonTrigger skeleton turns CONTRIBUTING from prose-only into something a contributor can grep — matcher fully implemented + unit-tested (mirrors Android's MediaEventPatternDetector), only HID read loop is TODO. NotImplementedError guard test prevents silent no-op if someone deletes the stub. Closed via PR #42.
+- **Memories used:** `3a3dc48c-4bff-4a62-8b98-3e07c5713b7c`
+
+---
+
+### Robot network config: BORUNTE @ 192.168.1.68:9760 on Starlink workshop LAN (was 192.168.4.4 dedicated subnet)
+
+- **UUID:** `fcba07c7-6d32-4889-98e9-78cffb41fcd2`
+- **When:** `2026-05-13T07:19:55.142172+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:end-2026-05-13:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > Workshop network rewired 2026-05-13: BORUNTE moved off the dedicated 192.168.4.x link onto the shared Starlink + switches LAN. Owner reconfigured pendant from .4.4 → .1.68 (intermediate .1.69 collided with an EShare wireless-display device on the same subnet). PR #748 propagates the new IP to system_config.yaml plus all user-facing references (CLAUDE.md, README, PROJECT_PLAN, App.tsx, collect_dh, simulation docstring). Verified live: BorunteRobot('192.168.1.68', 9760).connect() returns firmware HC-QC-RX-7.8.07-master-F5.2.3, get_position() reads real joints. Pendant itself is a Chinese OEM tablet bundling EShare on :8000 alongside the BORUNTE control software — no "host mode" toggle, TCP host listener binds automatically once the pendant network is up.</rationale>
+  > <parameter name="alternatives_considered">["Keep dedicated 192.168.4.x link — rejected, owner wanted single shared LAN for SV + monoblocks + robot via switches", "Use .1.69 as initially attempted — rejected after live discovery of EShare collision"]
+- **Memories used:** `2403f131-68c2-4be3-b1f4-31fbec9fc2b2`
+
+---
+
+### Workshop PC4 sandcastle deploy (#545) blocked on two pre-existing host bugs (#607 Windows+worktree, #608 PS5.1 watchdog); pause slice #538/#545/#546 until either is fixed.
+
+- **UUID:** `be3c0aa4-223f-40d7-a3a7-d6711bcf9ca4`
+- **When:** `2026-05-13T08:03:19.490972+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:workshop-sandcastle-2026-05-13`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > 2026-05-13 Workshop PC4 deploy session: installed Docker Desktop 29.4.3, pulled qwen2.5-coder 14b+32b, built sandcastle:jarvis image, set OLLAMA_CONTEXT_LENGTH=65536. Two blockers surfaced on first real invocation: (1) sandcastle 0.5.7 uses git-worktree branchStrategy whose .git pointer is a Windows-absolute path unresolvable in Linux container — agent dies in init writing .git/info/exclude before reaching Ollama; (2) Run-Sandcastle.ps1 watchdog uses `2>&1` + `$ErrorActionPreference=Stop` which crashes on first stderr line under PS 5.1 (workshop default, no pwsh installed). Neither is fixable in this session without significant code change. Filed as #607 and #608. Slice #545's AC explicitly anticipated this Sprint 3 pattern ("every manual step encountered during deploy goes into setup script or runbook") — these are the manual fixes that need to land before deploy is honest. Bench against #538 also blocked: can't measure /implement-style work without working sandcastle.</rationale>
+  > <paramref name="alternatives_considered">["Hack pre-create .git/info/exclude — brittle, doesn't fix container resolution of Windows path", "Install pwsh 7 just to bypass #608 — fixes watchdog but #607 still kills the actual run", "Measure raw Ollama tok/s outside sandcastle — gives partial data but not /implement-style as #538 requires", "Switch sandcastle to clone-based strategy in main.mts — substantial change, deserves PR review not in-session"]</paramref>
+  > <parameter name="alternatives_considered">["Hack pre-create .git/info/exclude — brittle, doesn't fix container resolution of Windows path", "Install pwsh 7 just to bypass #608 — fixes watchdog but #607 still kills the actual run", "Measure raw Ollama tok/s outside sandcastle — gives partial data but not /implement-style as #538 requires", "Switch sandcastle to clone-based strategy in main.mts — substantial change, deserves PR review not in-session"]
+- **Memories used:** `ee699256-40c0-49d8-92e2-42deebfed5d7, 92fd14ad-febc-47cb-859a-faab280f0a5e, 32754e7a-25f0-4706-b4b1-116282ad8437, d24a1041-e755-476a-a15e-3b279f26fe0d, 2403f131-68c2-4be3-b1f4-31fbec9fc2b2`
+
+---
+
+### Fix SV API drift in two layers (path prefix + new required POST fields + detail_id bump) and defer queue-based cycle creation to follow-up #752 rather than reverse-engineer it blind.
+
+- **UUID:** `2feb29d6-eb61-4dcc-83f4-862a2ff292b9`
+- **When:** `2026-05-13T08:54:39.222647+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:redrobot-sv-drift-2026-05-13`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Reverse-engineer cycle creation endpoint by trial — rejected, OPTIONS schema for process_next looked wrong (Installation fields, not action params) and SV cyrillic descriptions were mangled in OpenAPI dump; Hold all fixes until Темир answers — rejected, read paths already broken on master, unblocking them is cheap and independent; Update only the client and skip config/memory detail_id bump — rejected, detail_id=69 is dead on SV and would silently fail at cycle creation regardless`
+
+  > Live smoke against SV (Tailscale 100.80.158.59:8000) surfaced three independent drifts: /cycles/→/workflows/cycles/, new required POST fields (status/threshold/cycle_timer/blender_script/contour_color), and direct POST forbidden with 'Циклы должны создаваться через CycleManager'. Read paths (list/get/comparison/heightmap) are fixable with the path+field updates alone and unblock #727 (SV-delivered heightmap consumer reads from existing cycles). Write side requires understanding SV's new queue model (/installations/queue/, /installations/{id}/process_next/, /toggle_auto_cycle/) — probing OPTIONS schemas returned ambiguous read_only flags and mangled Russian descriptions. Reverse-engineering without owner-of-SV (Темир) input risks wrong assumption baked into client. Splitting unblocks 80% of consumers immediately, isolates the open question into a single issue (#752) with concrete candidates + question for Темир.
+- **Memories used:** `none`
+- **Memories used (unresolved):** `89db1c4d-0000-0000-0000-sculpture_vision_connection_params`
+
+---
+
+### Use selective ln-63X worker invocation, not full /ln-630 coordinator, for routine test audit at scale
+
+- **UUID:** `3b8e5a0d-a7dc-4433-9e7d-76a37d3165c3`
+- **When:** `2026-05-13T09:26:43.214999+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:test-audit-pilot`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Full /ln-630 coordinator on every scope — rejected: 8 workers × references × research = expensive overhead, most workers contribute little on small scopes; Skip the skill, manual checklist review — rejected: pilot showed structural scoring (Impact × Probability) caught findings I would have skimmed past; Fork ln-631 with Python patterns (FastAPI, SQLAlchemy, pytest-mock) — deferred: revisit if selective workers prove insufficient signal on Python codebases`
+
+  > Pilot run of ln-633-test-value-auditor on tests/planning/ (11 tests, 357 LOC, redrobot) produced 5 actionable findings including one canonical 'high-value scenario, weak assertion' antipattern (test_tier2_flags_reach_bulk_planner using monkeypatch spy on private wiring) — exactly the behavior-vs-implementation question that motivated installing the skill. Single worker delivered ~80% of the value the user actually asked for. Full ln-630 coordinator delegates 8 workers + research phase + reference loading; for narrow scope (per-subdirectory) most workers (ln-634 coverage, ln-636 manual, ln-637 structure) have insufficient signal. Recommended pattern when scaling to hundreds of tests across projects: invoke ln-633 + ln-635 (isolation) + ln-638 (oracle-effectiveness) selectively per subdirectory; reserve full /ln-630 for whole-project final pass. Also: ln-631 (business-logic) detection patterns are JS/TS-hardcoded, weak signal on Python stack — Layer-2 LLM judgment compensates partially but not for missed Layer-1 candidates.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### /delegate batch (#611 #572 #539): dispatch #572 + #539 mechanical-mode in parallel subagents; exit #611 grill_required.
+
+- **UUID:** `fae17d68-199e-478d-9d0b-8974b94a3c3b`
+- **When:** `2026-05-13T09:37:52.530418+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Inline all three via /implement — rejected: #539 and #572 are self-contained, no session-context lean, ideal subagent fit; Skip grill for #611 and ask subagent to pick a fix path — rejected: explicit contract prohibits batch-level grill skip; silently picking would risk wrong fix (e.g. local workaround for what should be upstream PR); Single subagent doing all three sequentially — rejected: defeats parallelism, slower wall-clock, less isolation`
+
+  > Per-issue grill-checkbox routing: #539 is docs (0/4 yes) → mechanical. #572 is internal test additions + cleanup sweep with explicit AC enumerating exact assertions — "tests non-trivial" box doesn't fire when correctness is pre-pinned by AC, so 0/4 → mechanical. #611 has three competing fix candidates (upstream regex / local prompt.md workaround / fenced syntax switch); domain logic + non-trivial tests boxes fire ≥1/4, and no decision UUIDs in working_state_jarvis or `## Decisions` heading in body → grill_required exit. Parallel dispatch of two independent slices in one batch is the canonical sandcastle-release path; #611 returns after a /grill session.
+- **Memories used:** `6b9a3537-c5e0-46f2-b6e4-5e6dc7c3c1a5`
+
+---
+
+### Fix #611 locally in .sandcastle/prompt.md (replace `` `!` `` with `"!"`) instead of upstream sandcastle change; ship co-located CI guard + meta-test on the file
+
+- **UUID:** `a3d35fd2-8fed-4aab-8f22-941dcec3511d`
+- **When:** `2026-05-13T09:51:20.003276+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:grill:session:2026-05-13`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Re-diagnosed root cause: sandcastle 0.5.7 SHELL_BLOCK_PATTERN /!`([^`]+)`/g matches `!` immediately followed by backtick anywhere in raw template. Marker mechanism (\x01) only defends against arg-injected backticks via promptArgs, not the template author. Convention is that raw `!`...`` ALWAYS means shell-block (Claude Code), so writing `` `!` `` (inline-code containing literal !) is user error, not a sandcastle bug — upstream regex tightening would break legitimate cases. Local fix: line 23 `The "!" shell blocks...` (A1 — minimum change, readable, no escape weirdness). Regression guard: pre-commit + CI check forbidding `[^!\n]`!`` pattern in .sandcastle/prompt.md, with co-located meta-test per CLAUDE.md path-filtered-CI-guard rule. We're on the 4th workaround in the #607→608→610→611 chain; soft "don't do this again" is insufficient.</rationale>
+  > <parameter name="alternatives_considered">["Upstream sandcastle regex tightening — rejected: would break legitimate `!`...`` blocks and design is consistent (marker mechanism only covers args, by design)", "A2/A3 (verbose description / HTML-escape `&#33;`) — rejected: overkill vs A1's quote swap", "B (warning comment in prompt.md) — rejected: insufficient defense given 4-workaround chain", "C (no guard) — rejected: regression cost > guard cost"]
+- **Memories used:** `f0865197-2b98-4383-a322-547c6daa30be`
+
+---
+
+### 3-phase test-audit pipeline (audit slices → generate fix-issues → implement fixes), per-repo milestones, run-id audit-2026-q2 stable across slices
+
+- **UUID:** `9913776a-449c-4194-a8b2-3d0a2b7734ae`
+- **When:** `2026-05-13T09:56:52.210249+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:test-audit-pilot`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > Cross-project test quality audit on redrobot+jarvis. Phase 1 = 22 audit slices (one per subdirectory × 3 useful workers ln-633/635/638) + 2 ln-637 whole-project structure audits, parallelizable via /delegate. Phase 2 = single per-repo issue (#766 redrobot, #625 jarvis) that reads all reports under .hex-skills/runtime-artifacts/runs/audit-2026-q2/audit-report/, deduplicates findings (cross-worker convergence = single fix-issue marked [2-worker]), opens fix-issues into a separate "Test Audit 2026-Q2 — Fixes" milestone with label test-audit-fix. Phase 3 = N fix-issues opened by Phase 2, implemented via /implement or /delegate. Stable run-id (not date-stamped) chosen so Phase 2 can dedupe across slice reports written by different agents on different days. No GH Project board (owner won't review board — issues are sole persistence).</rationale>
+  > <parameter name="alternatives_considered">["Auto-open fix-issues directly from audit reports — rejected: ln-633-style false-positive risk on Python+JS-biased patterns, owner wants triage gate", "Single central repo for all findings (sandcastle/jarvis hub) — rejected: sandcastle is containerization for agents not a repo; per-repo milestone keeps PR/CI locality", "Date-stamped run-id (audit-2026-05-13) — rejected: blocks Phase 2 dedupe across multi-day slice completion", "Slice = 1 worker on whole project — rejected: doesn't fit smart zone, blocks parallelization"]
+- **Memories used:** `3b8e5a0d-a7dc-4433-9e7d-76a37d3165c3`
+
+---
+
+### Workshop sandcastle Ollama model tier: Tier 0 = qwen2.5-coder:14b, Tier 1 downgrade = qwen2.5-coder:7b. AFK viability threshold ≥30 tok/s sustained.
+
+- **UUID:** `58670ea5-0b34-491d-8f94-fa51786bc664`
+- **When:** `2026-05-13T10:14:16.192629+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:slice-538`
+- **Project:** `jarvis`
+- **Alternatives considered:** `qwen2.5-coder:32b as primary — disqualified at 5 tok/s due to VRAM spill; qwen3-coder:30b (MoE) as primary — same 30B-class VRAM ceiling, pull pending but will not change decision; qwen3.5:9b as Tier 1 — not coding-tuned, family-mismatch with 14b prompts; rejected vs 7b; Set defaults in Run-Sandcastle.ps1 itself — rejected to keep watchdog hardware-agnostic; defaults belong in /setup-tasks task config`
+
+  > Workshop PC RTX 5080 has only 16 GB VRAM. Measured 2026-05-13: qwen2.5-coder:14b Q4_K_M fits cleanly (14.2/16.3 GB used) and runs at 94.6 tok/s warm — 3× the AFK viability threshold. qwen2.5-coder:7b Q4_K_M sits at 7.5 GB VRAM and 227 tok/s warm, same family (prompt-format compatible) → ideal Tier-1 downgrade per #543's escalation chain. qwen2.5-coder:32b Q4 at 19 GB exceeds VRAM, spills to CPU, runs at 5.2 tok/s — 18× slower than 14b, unusable for AFK. 30B-class models hit the same VRAM ceiling regardless of MoE (active-params reduce latency-per-token but not weight residency). Threshold of ~30 tok/s sustained chosen by working back from a typical 5k-token iteration needing ≤5 min generation to drain ~10 issues per 4h safe-hours window with retry budget. Watchdog stays model-agnostic — defaults will be passed via /setup-tasks Task Scheduler entries in #545/#546 so future hardware changes are a config edit, not a code edit. Reversibility: trivial (param flip on Run-Sandcastle.ps1 invocation). Cost-of-being-wrong is bounded by HITL review cadence — a bad model picks up no merges, the queue stalls visibly within one review cycle.
+- **Memories used:** `19ab3f79-aea3-4468-a09d-d8f47dd7a58b, 27c28a8e-2969-4550-9d4d-ffd25e36e5d8, 1853a304-9a4f-4c8c-8e76-10b842118d7a, 2403f131-68c2-4be3-b1f4-31fbec9fc2b2, ee699256-40c0-49d8-92e2-42deebfed5d7`
+
+---
+
+### Sandcastle scheduling on Workshop PC uses Windows Task Scheduler (not the create_scheduled_task MCP), with one idempotent registration script servicing both jarvis and redrobot via -Repo param. Jarvis = 22:00 to 02:00; Redrobot = 02:00 to 08:00 (non-overlapping). Defaults baked: Tier 0=qwen2.5-coder:14b, Tier 1=qwen2.5-coder:7b.
+
+- **UUID:** `4bfb4c6b-5fc2-4bda-907c-2aa9a9cb688b`
+- **When:** `2026-05-13T10:25:43.985331+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:slice-545`
+- **Project:** `jarvis`
+- **Alternatives considered:** `NSSM/Windows Service running Run-Sandcastle continuously -- rejected: previous workshop deployment via NSSM hit SeServiceLogonRight failures (memory d24a1041); Task Scheduler with Interactive logon avoids that class of failure entirely; create_scheduled_task MCP -- rejected: fires remote agents, no host access to Docker/Ollama/worktrees; Bake schedule into Run-Sandcastle.ps1 via in-process loop -- rejected: PowerShell loop crashes lose the schedule; Task Scheduler is the right abstraction for fire-at-HH-mm-even-if-previous-died; Separate registration scripts for jarvis and redrobot -- rejected: duplicate code; one script -Repo param keeps #545/#546 a label-flip per epic architectural commitment; Bake model defaults into Run-Sandcastle.ps1 -- rejected in #538 deliberately to keep watchdog hardware-agnostic; defaults belong in the scheduler call site, which is this script`
+
+  > Sandcastle is local Docker infra (host Ollama, host Docker daemon, host filesystem worktree) so it must run on the Workshop machine specifically. The create_scheduled_task MCP fires remote Claude agents in Anthropic's environment and has no path to that host. So scheduling lives in Windows Task Scheduler. One registrar script (Register-SandcastleTask.ps1) parameterised by -Repo serves both loops, keeping #545 and #546 a label-flip rather than a re-architecture (matches the config-identical-between-jarvis-and-redrobot architectural commitment from epic #534). Non-overlapping schedule avoids VRAM contention on the 16 GB card -- at 14b residency the card has ~2 GB free, no headroom for a second concurrent model. Setup runbook (docs/agents/sandcastle-setup.md) explicitly justifies each remaining manual step (Docker Desktop install, Ollama install + OLLAMA_CONTEXT_LENGTH machine env var, .env, image build) so the Sprint-3 six-unaccounted-manual-fixes pattern (memory ee699256) cannot silently repeat. Principal=Interactive logon with Limited run-level -- does not require SeServiceLogonRight grant (the cause of the 2026-04-25 jarvis-scheduler failure, memory d24a1041). Reversibility: trivial -- Unregister-ScheduledTask reverses everything; the script is idempotent so re-running fixes drift. Confidence is high on the deploy primitive; lower on whether the agent overnight output is mergeable -- that is the next-morning AC.
+- **Memories used:** `ee699256-40c0-49d8-92e2-42deebfed5d7, d24a1041-e755-476a-a15e-3b279f26fe0d, 2403f131-68c2-4be3-b1f4-31fbec9fc2b2, 58670ea5-0b34-491d-8f94-fa51786bc664`
+
+---
+
+### Redrobot sandcastle uses shared sandcastle:jarvis image + shared jarvis-side watchdog (only .sandcastle/{prompt, main.mts, env} differs per repo). Schedule: daily 02:00 to 08:00 on Workshop PC, non-overlapping with the jarvis loop 22:00 to 02:00. Pytest in-container gate deferred to follow-up issue #630; interim enforcement is prompt-level discipline in redrobot prompt.md.
+
+- **UUID:** `ee25a844-5721-4c89-b8b3-5d8935506bad`
+- **When:** `2026-05-13T10:44:54.089056+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:slice-546`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Build a separate sandcastle:redrobot image -- rejected: duplicates Dockerfile, drifts; image is repo-agnostic by design; Copy Run-Sandcastle.ps1 watchdog into redrobot/scripts/sandcastle -- rejected: two copies to keep in sync, contradicts epic architectural commitment; Implement pytest gate inside this slice -- rejected per HITL alignment: nontrivial design (test surface discovery), would expand scope; prompt-level + next-morning orchestrator review is sufficient interim; Skip pytest gate entirely (rely only on orchestrator review) -- rejected: prompt-level discipline is a step beyond nothing, and the follow-up issue keeps the gate on the roadmap; Overlap jarvis/redrobot schedules and parallelise -- rejected: 14b at ~14 GB VRAM + a second model would OOM the 16 GB card; #538 hardware ceiling forces sequential`
+
+  > The sandcastle Docker image bakes mcp-memory and the canonical skill set -- both repo-agnostic infrastructure. Repo content lands via bind-mount at runtime. Building a separate sandcastle:redrobot image would duplicate the Dockerfile without adding value and would drift over time. Same logic applies to the PowerShell watchdog: it already supports -Repo redrobot internally (via REDROBOT_REPO_ROOT discovery) and locating it inside redrobot would mean two copies to keep in sync. Per-repo divergence is confined to .sandcastle/{prompt.md, main.mts, .env, README.md} -- the runtime config and agent prompt where repo identity actually matters (protected paths, repo slug, runId prefix). This matches the epic #534 architectural commitment that 'config is identical between jarvis and redrobot'. Schedule chosen 02:00-08:00 so jarvis (22:00-02:00) and redrobot do not contend for Ollama VRAM -- with 14b residency at ~14 GB on a 16 GB card there is no headroom for a second concurrent model. Pytest gate deferred per HITL alignment 2026-05-13: scope discipline (slice #546 ships scheduling + scaffolding; the gate has nontrivial design questions like touched-file test surface discovery vs full-suite vs `pytest --lf`), and the prompt-level discipline (agent instructed to run pytest itself before opening the PR) is a defensible interim because the orchestrator reviews every redrobot PR next morning anyway. The gate becomes load-bearing only when redrobot PRs are auto-merged, which is not on the near roadmap. Reversibility: trivial -- delete the Sandcastle-Redrobot task to roll back. The redrobot scaffolding remains in the repo but inert.
+- **Memories used:** `ee699256-40c0-49d8-92e2-42deebfed5d7, d24a1041-e755-476a-a15e-3b279f26fe0d, 2403f131-68c2-4be3-b1f4-31fbec9fc2b2, 58670ea5-0b34-491d-8f94-fa51786bc664, 4bfb4c6b-5fc2-4bda-907c-2aa9a9cb688b`
+
+---
+
+### Nightly sandcastle runs (Sandcastle-Jarvis 22:00 + Sandcastle-Redrobot 02:00) disabled 2026-05-13 pending tier-0 model replacement; current qwen2.5-coder:14b cannot drive Claude Code tool_use protocol through Ollama Anthropic shim.
+
+- **UUID:** `4f449739-5738-42a4-84d2-b9ac2bfe414e`
+- **When:** `2026-05-13T12:32:41.916521+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:2026-05-13-sandcastle-smoke`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep nightly runs as baseline metric — rejected: pollutes Supabase with false-success rows; Switch Tier-0 to other local model (deepseek-coder-v2, llama3.1, qwen3) immediately — rejected: needs fidelity bench, user busy; Switch Tier-0 to DeepSeek API now — deferred: card needs reissue before funding; Switch Tier-0 to Claude Haiku via Anthropic API — not chosen this turn, user prefers DeepSeek route; Patch Run-Sandcastle.ps1 success criterion (commits>0) + raise inner MaxIterations — rejected by user: more iterations do not fix tool_use protocol bug; orchestrator (not yet built) is the right place for success validation`
+
+  > Smoke test 2026-05-13 17:05–17:11 (Workshop PC, MaxIterations=1 then 5) executed end-to-end watchdog→Docker→Ollama→npm sandcastle→Claude Code agent in container. Infrastructure verified correct: skills mounted in container (/home/agent/.claude/skills/ has all 23 incl. implement/SKILL.md per `docker run sandcastle:jarvis`), prompt.md correct, main.mts correct, MCP memory bridge correct, outcome_record writes to Supabase correct. Root failure point: qwen2.5-coder:14b through Ollama's Anthropic-compatible /v1/messages shim emits skill dispatch as markdown-fenced JSON text ({"name":"/implement","arguments":{"issue_number":"558"}}) instead of structured tool_use block. Claude Code parses this as a regular text turn, agent stops, sandcastle reports "Run complete: reached 1 iteration(s) without completion signal." Verified zero real work: worktree HEAD detached on sandcastle/* branch (no feat/558-* checkout), only .mcp.json modified (onSandboxReady hook), 0 commits, issue #558 still status:ready (no claim, no comments). 5 outer attempts × ~16s each = 5 false-success outcome_records in Supabase, 0 PR. Bench #538 picked 14b on tokens/sec without measuring tool_use protocol fidelity — same gap as main_pc_ollama_benchmark_2026_05_10 (throughput-only). qwen3_think_false_required is precedent for Ollama protocol quirks per model. Nightly runs would produce 0 PRs and 5 false success records per night × 2 repos = Supabase metric pollution. User decision: disable nightly runs, plan switch to DeepSeek API (Tier-0 = Tier-2) once card reissued / funded. Later revisit local model with fidelity-aware bench. Orchestrator layer (autonomous_loop_v1_architecture) that catches GH events and dispatches to agents is also still not built — sandcastle is only the execution worker, not the routing/monitoring brain.
+- **Memories used:** `19ab3f79-aea3-4468-a09d-d8f47dd7a58b, 56932f78-09be-486b-babd-0ee59ff9d870, 27c28a8e-2969-4550-9d4d-ffd25e36e5d8, 26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### Revive Osasuwu/OOP as music-intel-mcp: Python rewrite, anti-bubble track-level recommender, 3 pillars (Understand/Discover/Act), MCP-wrap in Phase 2 for Jarvis integration.
+
+- **UUID:** `b7b97ef9-2793-4ada-83c9-8b5fb45bb8fc`
+- **When:** `2026-05-13T17:03:35.991639+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.78`
+- **Actor:** `session:2026-05-13-music-intel-brainstorm`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Stay in jarvis .scratch/ as one-off — rejected: scope outgrew scratch, needs versioning and stable API; Java rewrite preserving OOP code — rejected: uni-grade scaffolding, Python ecosystem stronger for music data; Artist-level recs (simpler) — rejected by user: artists have filler tracks, can dump on dud; Fork Beerspitnight/spotify-mcp-enhanced-music-overload — rejected: their scope is playlist-curation-via-Claude-Desktop, structure ties us; read as reference instead; Self-hosted ListenBrainz/Navidrome stack (Explo pattern) — rejected: user is on Spotify, not self-hosted; MCP-from-day-1 — deferred to Phase 2: MVP needs pipeline+viewer working before MCP-wrap is meaningful; Algorithmic-only ranking (no LLM) — rejected: without explanation we don't differentiate from Spotify; LLM-curator IS the product`
+
+  > User wants serious project not scratch one-off. OOP repo has existing Spotify+Last.fm scaffolding (Java, uni-grade) — revive name, drop code. Brainstorm + GitHub research established: (a) Spotify deprecated audio-features/recommendations/related-artists Nov 2024, our app NOT grandfathered; (b) ISRC → MusicBrainz → AcousticBrainz chain restores audio features at 70-90% coverage (Ortham/Beerspitnight technique); (c) Last.fm track.getSimilar still works for similarity graph; (d) prior art (SmartDiscover, Promptify, taste-mender) confirms multi-source enrich + LLM-curator pattern. User explicitly corrected burst-mode framing — product thesis is ANTI-bubble (Spotify's flaw is conservatism, our differentiation is surfacing things that may disappoint with high upside), so all scoring penalizes recent-30d tag overlap. Burst is a symptom not a feature.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Sandcastle Tier 0 primary model: qwen2.5-coder:14b → qwen3-coder:30b (2026-05-14).
+
+- **UUID:** `075ea33a-9a1d-4672-b62b-9fe4b266ffdc`
+- **When:** `2026-05-13T19:40:50.941191+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:sandcastle-30b-flip`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Stay on qwen2.5-coder:14b — rejected, root cause of 0-commit watchdog runs; Switch sandcastle workload to Claude API — viable fallback, but deferred since 30b passes fidelity probe and local-first is the design intent (Max sub covers it but exhausting Claude Code quotas on a Workshop background loop competes with foreground sessions); qwen2.5-coder:32b — disqualified by Workshop bench (5 tok/s, spills VRAM); Disable sandcastle scheduled tasks until model picked — partially in effect (no tasks registered on Workshop right now per Get-ScheduledTask) but unnecessary once 30b promoted`
+
+  > 14b failed live sandcastle runs (watchdog outcomes 2026-05-13 showed iterations=1, output_tokens=62–83, 0 commits) because qwen2.5-coder:14b emits skill dispatch as markdown-fenced JSON text instead of structured Anthropic tool_use blocks through Ollama's /v1/messages shim. Direct fidelity probe on qwen3-coder:30b (curl POST /v1/messages with tools=[get_weather], "Use the get_weather tool") returned a proper structured response: content=[{type:tool_use, name:get_weather, input:{city:Almaty}}], stop_reason:tool_use, 24 output tokens. Throughput cost is 94→43 tok/s warm (Workshop bench #538), still above the ≥30 tok/s threshold. User directed "попробуем coder 30b" after diagnosis. Config flipped: .sandcastle/main.mts default, .sandcastle/.env.example, scripts/sandcastle/Register-SandcastleTask.ps1 default, live .sandcastle/.env on Workshop. Already-registered scheduled tasks (if any) need re-register to pick up the new default.
+- **Memories used:** `e1830d75-c120-4ebf-8afc-01f7113e9a61`
+
+---
+
+### Sandcastle scheduled tasks switch to remote Anthropic-compat endpoint as primary (DeepSeek default); local Ollama Tier 0/1 disabled for AFK runs via new -Tier2AsPrimary switch on Run-Sandcastle.ps1.
+
+- **UUID:** `6a6ac586-a089-4925-a406-eba40d67a604`
+- **When:** `2026-05-13T20:36:07.750085+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:sandcastle-deepseek-pivot`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Stay on local Ollama with different model — rejected: no Ollama-served model has passed integration-level fidelity yet, throughput-only bench (#538) and naive curl probe both proved insufficient; Claude Sonnet via Max subscription — rejected: requires breaking sterile-container decision (894ac658) to mount user Claude credentials; AFK loop would compete with foreground sessions for the same rate-limit pool; Anthropic API direct — deferred: ANTHROPIC_API_KEY historically zero-balance (memory anthropic_api_credit_empty_2026_04_21); architecturally fine via existing -Tier2Provider claude path if credits funded; Disable sandcastle entirely — rejected: capability is needed for AFK throughput, problem is model selection not architecture; Full rewrite dropping Tier 0/1 code — rejected (per owner): minimal-scope preferred, gated switch keeps OOM-escalation path live for non-AFK manual runs`
+
+  > Two consecutive Ollama models failed real-Claude-Code tool_use fidelity in sandcastle smoke runs: qwen2.5-coder:14b (markdown JSON fence, 2026-05-13) and qwen3-coder:30b (Hermes-XML native template, 2026-05-14). Both produced 0-commit runs despite the watchdog reporting success. 30b passed a naive curl /v1/messages probe with explicit tool instruction — fooling the original fidelity gate — but in a real Claude Code container session emitted untranslated Hermes-XML. Root cause is Ollama's Anthropic-compat shim only translating a narrow subset of native tool emission templates. Owner direction: keep local Ollama for orchestrator/perception/recall workloads (no tool_use pressure), pivot sandcastle to DeepSeek API (cost-competitive, full Anthropic-tool fidelity via DeepSeek's native /anthropic endpoint). Sterile-container design (decision 894ac658) preserved — no ~/.claude mount, container uses ANTHROPIC_BASE_URL+key. Sonnet via Max subscription rejected for now: would require breaking sterile-container to mount Claude credentials, plus AFK loop would consume same rate-limit pool as foreground sessions. Implementation: added [switch]$Tier2AsPrimary to Run-Sandcastle.ps1; when set, watchdog resolves Tier 2 config once, skips Ollama autostart, skips Tier 0/1 dispatch entirely, runs only the Tier 2 invocation. Register-SandcastleTask.ps1 default Tier2Provider flipped to 'deepseek' and auto-includes the switch in scheduled-task args. Pester 65/65 green — switch is opt-in so OOM-escalation tests are unaffected. DEEPSEEK_API_KEY present in .sandcastle/.env on Workshop but balance is zero (402 confirmed 2026-05-14); owner tops up next day, then smoke + re-register scheduled tasks.
+- **Memories used:** `e1830d75-c120-4ebf-8afc-01f7113e9a61, 5b1a0d6a-18f3-47a9-919a-8fef5d5d59bd, d828bd94-c9ab-4c06-bb9f-b5afa00ff1d9, 53cb337d-abc9-406a-8558-57d61e220b79`
+
+---
+
+### Revive Osasuwu/OOP as Osasuwu/music-intel-mcp — Fresh Python design (not Java port). Archive Java as legacy/java branch + v0-uni tag, wipe main to orphan, delete stale uni branches, adopt jarvis-style conventions. /grill required before any product code.
+
+- **UUID:** `d94c44fb-03eb-4867-8440-9910f905a903`
+- **When:** `2026-05-14T07:58:44.828143+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:music-intel-mcp-revival-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `Mechanical Java->Python port — rejected: Java uni-grade, no fidelity value; Functional rewrite of Java's product scope — rejected: product framing changed; Keep OOP name — rejected: rename signals new direction, GitHub auto-redirects; Bulk-close 57 legacy issues — rejected: some still apply (e.g. hardcoded credentials); Tag-only Java preservation — rejected: branch easier to browse from UI; Skip /grill since setup is small — rejected: setup ok, product code must stop on grill`
+
+  > User clarified via AskUserQuestion: Fresh design (not mechanical port). Java is uni-grade; product framing changed to anti-bubble track-level recommender + 3 pillars (Understand/Discover/Act). Setup phase is pure infra (rename, workflows, labels, skeleton CLAUDE.md/SOUL.md/CONTEXT.md) — no domain decisions, safe before /grill. Product code (similarity strategies, anti-bubble logic, MCP surface) gated behind /grill stop-point per SOUL.md trigger-checkbox. Java preserved as branch+tag for ISRC-waterfall reference and Spotify creds lookup. 5 stale uni branches deleted as noise.
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22`
+
+---
+
+### DeepSeek-coder via Anthropic-compat endpoint validated end-to-end as sandcastle primary — passes integration probe.
+
+- **UUID:** `15dd3351-d0cd-4505-9a47-c454c0353027`
+- **When:** `2026-05-14T07:59:39.750857+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:deepseek-smoke-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Smoke run 2026-05-14 (run_id smoke-deepseek-20260514-124244) with SANDCASTLE_AGENT_{MODEL=deepseek-coder, BASE_URL=https://api.deepseek.com/anthropic, AUTH_TOKEN=$DEEPSEEK_API_KEY} produced two real PRs end-to-end (#631 memory-deriver Slice 1 +614 LOC, #632 Slice 3 +432 LOC) — claimed issues, made commits on feat/ branches, pushed, opened PRs with full AC/test-plan bodies, ran pytest 19/19 green, resolved GitHub secret-scanner collision in test fixtures, removed status:ready labels, and triaged unsafe-for-AFK issues (#554/#555 touching protected mcp-memory/server.py). Per the integration-probe gate (e1830d75) this is the gold-standard validation — synthetic curl probes and throughput benches are explicitly insufficient. <promise>COMPLETE</promise> was emitted at end-of-work, not as the silent-bail failure signature small Ollama models hit. Cache_read=128128 in usage looks dishonest (DeepSeek-shim may fake Anthropic cache metrics) but does not affect the fidelity verdict — real tool dispatches happened and produced verifiable side-effects (PRs visible via gh API).</rationale>
+  > <parameter name="alternatives_considered">["Continue with local Ollama (qwen2.5-coder:14b / qwen3-coder:30b): rejected — both failed real Claude Code integration probe (markdown JSON fence / Hermes-XML emission, 0 commits)", "Skip validation and assume DeepSeek works because watchdog wired it as Tier 2: rejected — that exact assumption pattern is what the integration-probe lesson (e1830d75) warns against", "Use Anthropic Haiku for Tier 2 instead of DeepSeek: deferred — DeepSeek is now validated and orders of magnitude cheaper; Haiku stays as escalation path via use-claude-api label"]
+- **Memories used:** `e1830d75-c120-4ebf-8afc-01f7113e9a61, 27c28a8e-2969-4550-9d4d-ffd25e36e5d8, 6a6ac586-a089-4925-a406-eba40d67a604`
+
+---
+
+### music-intel-mcp pivots framing from "anti-bubble recommender" (mechanism) to "causal-root retrospective" (purpose). Understand is primary, Discover is derived from root model, Act (playlist push, MCP) is byproduct.
+
+- **UUID:** `14595ec7-6049-4be9-8b16-c966be7fcb31`
+- **When:** `2026-05-14T09:15:01.22474+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `none`
+
+  > Owner clarified in /grill that the brainstorm's framing (anti-bubble vs. 30d cosine) was a mechanism, not the job. Real job: streaming services don't tell users *why* they listen to what they do — they exploit symptoms to retain users. This project, being non-commercial, can afford to surface causal roots with full evidence chains and accept the risk of "disappointing" recommendations. Once a user knows their root, recommendations become principled (root-driven) and the user gains agency to amplify/dampen. Playlist generation is explicitly a side-effect; the analysis is the product. Adds two new invariants: Transparency (every output carries derivation) and Causality (model roots, not symptoms). Reorders pillars from parallel to causal-dependent (Understand → Discover → Act). All downstream choices (scoring, MVP scope, storage schema, LLM-curator role, MCP surface) re-grill against this.</rationale>
+  > <parameter name="alternatives_considered">["Anti-bubble vs. 30d recent + per-track explanation (my initial recommendation) — rejected: still a mechanism description, treats Discover as primary, doesn't address user's stated need for introspection","Multi-job product with Understand/Discover/Act in parallel (brainstorm framing) — rejected: owner explicitly said playlist is a byproduct and Discover must derive from understood root, not run alongside","Playlist-curator-with-explanations as primary (Beerspitnight-style) — rejected: doesn't address the introspection job, makes the tool just a different recommender"]
+- **Memories used:** `b922386c-812e-4d01-a0a0-f93fe08050d1, 05e849cb-aa4f-4e5c-bee2-716806dceb22, 1778e466-01b1-4327-9bfa-c5179db46c5e, 7e79666d-f9fa-479c-859f-cc17d92fc009`
+
+---
+
+### Root taxonomy fixed at 8 categories with per-user weights. V0 root model uses 3 categories derivable from existing data: acoustic (AcousticBrainz dump), temporal (timestamps), scene (Last.fm tags). V1 adds 5 more requiring new infrastructure: timbre (audio analysis), career_phase, lyrics, structural, context_chain. Audio analysis is a deliberate killer feature, accepted compute cost is hours-to-days per batch. V0 outputs are labelled as proxy.
+
+- **UUID:** `cd51fa38-a741-44a1-989a-08c92bad3355`
+- **When:** `2026-05-14T09:30:14.840768+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `none`
+
+  > Owner accepted the 3-category V0 subset but explicitly required (a) weighted-per-user categories — different users have wildly different drivers (his lyric weight ≈ 0, others would weight it high); (b) all 8 needed for a "real" root, V0 is acknowledged as proxy with required labelling; (c) audio analysis is explicit V1 scope because "nobody else does it, that's why everyone gets symptom-level results — we can afford the time." This commits the project to batch-first compute (hours-to-days per pass is fine), introduces a category_weight vector as a first-class part of the root model, and licenses adding heavy dependencies (Essentia, librosa, lyrics APIs) when they buy precision. V0 acts as a working skeleton; V1 is the precision target. The proxy-labelling extends the transparency invariant to model maturity.</rationale>
+  > <parameter name="alternatives_considered">["Fixed taxonomy without per-user weights — rejected: owner pointed out that category importance varies per listener (lyric-driven vs instrumental-driven users)","V0 with all 8 categories from day 1 — rejected: 5 of 8 need infrastructure we don't have (audio pipeline, lyrics API, career-phase model); would block MVP indefinitely","V0 with only acoustic (single category) — rejected: would miss temporal-context (cheap, high-actionability) and scene (semantic anchor); acoustic alone gives BPM-buckets, not roots","Skip audio analysis entirely (cost-prohibitive) — rejected: owner explicitly called it the killer feature and accepted compute cost","Real-time / interactive analysis — rejected by implication: owner accepts hours-to-days batch time as a feature, not a bug"]
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22, 14595ec7-6049-4be9-8b16-c966be7fcb31, 67dbbb10-dcb7-4a1d-9295-6662da3318e8, b922386c-812e-4d01-a0a0-f93fe08050d1`
+
+---
+
+### AFK PR-rework detection: orchestrator reads events_canonical for review_negative events; event-dispatch.yml extended to emit them with payload.reviewer_kind in {human, copilot, claude_bot} at severity=medium. Claude-bot verdict string-match quarantined inside event-dispatch.yml; orchestrator never parses comment bodies.
+
+- **UUID:** `2c87e895-2d3a-4b0b-a727-18935d81a4cd`
+- **When:** `2026-05-14T10:38:47.271567+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-afk-q2:resumed-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `(a) pull_request_review.state==request_changes alone — broken: blind to Claude code-review bot which writes issue-comments not reviews; (b) Claude bot issue-comment string-match in orchestrator alone — fragile: bot verdict format change breaks autonomy hot path; (c) CI red alone — incomplete: green CI does not imply reviewer approval; (d) without extending event-dispatch.yml — aspirational: no review_negative rows exist today; Three distinct event_types per reviewer — rejected: orchestrator filter would fan out as more reviewers are added; single event_type + reviewer_kind discriminator stays stable`
+
+  > Composition over single-signal: pure pull_request_review API misses Claude code-review bot (writes issue-comments not reviews); pure string-match in orchestrator hard-codes a non-API contract into the autonomy hot path; pure CI-red is incomplete (green tests do not imply approved). Single event_type=review_negative with a reviewer_kind discriminator keeps orchestrator filter as one stable predicate as more bots are added. Severity=medium clears the orchestrator existing >=medium gate but stays below telegram-notify-hook >=high drain — rework is the normal AFK path; only escalation rungs (max-attempts, scope-creep, CI-red on rework) escalate to high. Quarantining the fragile string-match inside event-dispatch.yml (not orchestrator) localises the failure mode to a one-line workflow fix. Precondition working_state did not make explicit: events_canonical today has no review_negative rows; option (d) is aspirational without the emitter extension.
+- **Memories used:** `4d2bff13-d7d4-442f-b0fd-44f54aa90cb6, e1a23e31-3d25-4af8-83db-a7d4846ce555, 15dd3351-d0cd-4505-9a47-c454c0353027`
+
+---
+
+### Rasterization of per-vertex Blender deviations to a regular grid happens inside SV's production_script.py (PR-2b), not on the robot side. Output to the wire is grid (heights array), per-vertex form stays internal to SV.
+
+- **UUID:** `00c2018e-16a8-4d11-855f-35d4c96cd9db`
+- **When:** `2026-05-14T11:23:14.154621+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:sv-rasterization-clarification-2026-05-14`
+- **Project:** `redrobot`
+- **Alternatives considered:** `per-vertex on the wire + robot-side rasterization — rejected: blurs domain across repos, robot needs grid for trajectories regardless; ship both per-vertex AND grid — rejected: redundant payload, no consumer for per-vertex on robot side`
+
+  > Темир confirmed (2026-05-14) that current Blender pipeline already raycasts per-vertex (12 rays/vertex) and computes signed deviation per vertex on the existing `production_script.py` path. Original contract specified grid output. Two ways to bridge: (1) SV rasterizes per-vertex → grid before writing .npz, (2) ship per-vertex + positions, robot rasterizes. Picked (1) because robot wants grid for trajectory generation anyway, Blender already has the mesh in memory so rasterization is cheap and local, and splitting representation across two repos blurs the domain boundary the contract was set up to keep clean. Темир already confirmed feasibility — no engineering risk. Reversible if needed (could ship per-vertex later as second wire variant), but no reason to.
+- **Memories used:** `7dd1f7aa-f63c-4291-b059-823315f43762, 04c060fe-554b-443e-acfd-b1aa78cadac7, 60a47231-6859-424f-94ea-364935d99a88`
+
+---
+
+### AFK orchestrator architecture: programmatic watcher (lightweight Python/PowerShell daemon) на Workshop PC polls events_canonical каждые 30-60s; при unprocessed event с подходящим event_type запускает on-demand `claude -p "/dispatch-rework <pr>"` session, которая обрабатывает batch и выходит. Cron baseline `/autonomous-loop` каждые 6h как catch-up. Никакой persistent Claude session — экономия токенов и Max-подписки.
+
+- **UUID:** `e6441d77-457b-451a-ac48-06830c1d9a8a`
+- **When:** `2026-05-14T11:35:09.56464+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-afk-q2:resumed-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A. Cron-only orchestrator (текущий autonomous_loop_v1) — отвергнуто: hourly tick теряет ~7 итераций за 8 часов AFK ночи, занижает throughput AFK система задач; B. Event-reactive через Supabase Realtime WebSocket — отвергнуто: лишняя dependency и точка отказа, polling дешевле и достаточно; C-orig. Persistent Claude session с polling в инструкции скилла — отвергнуто пользователем: каждый poll жжёт контекст и Max-квоту даже на пустых проверках; D. GitHub Actions orchestrator (event-dispatch.yml triggers orchestrator.yml) — отвергнуто: Claude Code Action использует API биллинг, не Max-подписку; cloud_vs_local_scheduled_tasks_routing уже разделил routing; E. Cloud Managed Agents (Anthropic) как orchestrator — отвергнуто: managed_agents_wait_and_see позиция стоит, idle billing clarified но интеграция сырая`
+
+  > Persistent Claude session (вариант "polling в инструкции скилла") сжигает контекст-окно на каждый poll (tool call + empty result + reasoning), даже когда events нет — за 8 часов AFK ночи это сотни poll-циклов и десятки тысяч токенов на пустые проверки. Programmatic watcher решает только бинарный вопрос "есть ли работа?", и только при положительном ответе будит дорогой Claude-процесс с конкретной задачей. Это chean-scheduler + expensive-worker pattern, уже отработан в nightly_research_setup. Workshop PC 24/7 (новая info — robot-connection теперь сетевой, комп больше не пинуется к роботу) — естественный хост для watcher-демона. Cron baseline переживает рестарт watcher-процесса (если poller упал, через 6h /autonomous-loop догонит). Polling без Supabase Realtime — WebSocket dependency не нужна, простой SELECT каждую минуту латентность <60s даёт, что более чем достаточно для AFK loop где iteration сама занимает 10-30 мин. GitHub Actions как orchestrator (option D) отвергнут из-за биллинга — Claude Code Action использует API-токены, не Max-подписку. Cloud Managed Agents — wait-and-see per managed_agents_wait_and_see.
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140, e1a23e31-3d25-4af8-83db-a7d4846ce555, 4d2bff13-d7d4-442f-b0fd-44f54aa90cb6, 5fb66906-28ce-4bbe-9f64-0a8ce19630c3, 2c87e895-2d3a-4b0b-a727-18935d81a4cd`
+
+---
+
+### Sandcastle dispatch primitive (rework mode): single env var `SANDCASTLE_TARGET_PR=<N>` discriminates rework from fresh path. Watchdog passes thin handle only — sandcastle re-fetches review body / diff / CI state via gh inside the container. Branch resolution via `gh pr view <N> --json headRefName` inside sandcastle, не orchestrator-side. Per-PR concurrency lock через `outcome_records` query (pattern_tags @> '["pr-<N>"]' AND outcome_status IS NULL AND created_at > now()-2h) до dispatch. PR-label `status:rework-in-progress` добавляется/снимается для morning visibility.
+
+- **UUID:** `69b7eddb-fa74-4ea3-a1bd-c03580e3023c`
+- **When:** `2026-05-14T11:44:43.650131+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-afk-q2:resumed-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Two-flag mode (SANDCASTLE_MODE=rework + SANDCASTLE_TARGET_PR) — отвергнуто: дублирует один бит; Pre-fetched bundle в env (review body, head_ref, diff) — отвергнуто: env-size + shell-escape + stale-snapshot если reviewer пушит между fetch и launch; Orchestrator pre-resolves head_ref — отвергнуто: тот же staleness аргумент (force-push window); Per-PR lock через отдельную locks table — отвергнуто: outcome_records уже хранит in-flight state, дублировать не надо; Lock через events_mark_processed только (per-event, не per-PR) — отвергнуто: два разных события на одной PR оба marked processed по отдельности, концурренции на branch не предотвращает; Status-label на issue, не на PR — отвергнуто: rework это состояние PR, не issue`
+
+  > Single env-var presence-as-discriminator избегает дублирования информации (DRY: SANDCASTLE_MODE flag и SANDCASTLE_TARGET_PR кодировали бы один бит). Thin handle вместо pre-fetched bundle: env-size limits + shell-escape pain на Windows host, и stale-snapshot risk если reviewer пушит addendum между orchestrator fetch (T0) и sandcastle launch (T0+90s). Branch resolution внутри контейнера — та же staleness защита (PR может быть force-pushed). Per-PR lock load-bearing под параллельной моделью (cloud DeepSeek позволяет N контейнеров): два review_negative события на одной PR в течение rework window — норма (Claude bot fires, потом Copilot), без lock они спавнят два контейнера на одной branch и коллизятся в git. Lock через outcome_records (а не отдельную locks table) переиспользует существующий persistence слой; 2-часовой staleness cap защищает от orphan locks при container crash. Status-label на PR — visibility для утра, дополняет durable outcome_record. Labels это GH-resident, consistent с no-state-in-static-storage.
+- **Memories used:** `e6441d77-457b-451a-ac48-06830c1d9a8a, 2c87e895-2d3a-4b0b-a727-18935d81a4cd, 15dd3351-d0cd-4505-9a47-c454c0353027`
+
+---
+
+### AFK budget gate: probe-session `claude -p "/usage"` каждые 30 мин на Workshop парсит weekly% Max-subscription, кэширует ~/.jarvis/orchestrator/usage.json (TTL 35 min). Watcher gate-ит новые dispatches (orchestrator session И sandcastle containers) при weekly >= 90%; in-flight задачи не убиваем — 10% reserve достаточно на завершение. GH Actions code-review.yml gate-ится через repo variable `CLAUDE_QUOTA_PRESSURE` (`gh variable set` с Workshop, `if: vars.CLAUDE_QUOTA_PRESSURE != 'true'` в workflow). Reactive backstop на 429. Эскалация в Telegram при первом hit 90% weekly. DeepSeek API (sandcastle) — provider responsibility, watcher не tracks.
+
+- **UUID:** `d5b3fdd3-7452-4d41-ad7c-84d692d442fa`
+- **When:** `2026-05-14T11:57:41.441968+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-afk-q2:resumed-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Counter-based (tail ~/.claude/projects/*.jsonl, count session-starts) — отвергнуто: estimate, не видит GH Actions runs, miscalibrates через время; Reactive only (ждём 429, back-off) — отвергнуто: один dispatch уже сжёг tokens к моменту детекции; Anthropic Console web scraping — отвергнуто: нет официального API, fragile к UI changes; Threshold 80% weekly — отвергнуто: слишком консервативно, обрезает throughput без нужды; Threshold 95% weekly — отвергнуто: 5% reserve может не хватить если in-flight лоопится; Killing in-flight at 90% — отвергнуто: получим polluted state (открытые PR без закрытия, outcome_records null status); API-key billing для code-review (~$30/month) для изоляции бюджетов — отложено как fallback если (a) на практике не справится`
+
+  > Claude Code не отдаёт quota через headless CLI (verified: /usage только interactive, issues #40395/#20775 unresolved upstream). Probe-session даёт real number вместо empirical counter — точнее на edge cases (миграция с device на device, GH Actions runs которые watcher не видит). Cost ~500 tokens × 48/day = 24K/day, negligible. Threshold 90% weekly, не 5h block: weekly жёстче (reset раз в неделю), 10% reserve гарантирует завершение любой in-flight без обрыва. 5h block если ловит первым — temporary throttle, watcher просто back-off retry, не нужен явный gate. In-flight не убиваем потому что прерванные orchestrator/sandcastle оставляют polluted state (open PRs без закрытия, outcome_records без статуса, потенциально побитые branches). Gate на sandcastle dispatch тоже обязателен — push триггерит code-review.yml, без этого gate sandcastle косвенно жжёт quota за orchestrator-ом. GH Actions broadcast через repo variable дёшево и атомарно; alternatives типа Anthropic Console scraping out-of-tree to Claude Code и unstable. Sandcastle (DeepSeek) изолирован — provider tracks себя, никакого shared budget с Max.
+- **Memories used:** `e6441d77-457b-451a-ac48-06830c1d9a8a, 69b7eddb-fa74-4ea3-a1bd-c03580e3023c, 5fb66906-28ce-4bbe-9f64-0a8ce19630c3`
+
+---
+
+### V0 and V1 ship the analysis engine + storage + enricher + RootProfile artifact only — no UI, no MCP server, no Discover/recommender, no playlist push until V2+. Storage architecture is split: shared metadata store (additive, multi-user-ready, ~90-day per-entry TTL) holds track/artist enrichment facts; per-user store holds raw history + a time-series of RootProfile snapshots (data persists indefinitely across yearly returns). Enricher writes only to shared store.
+
+- **UUID:** `870623f7-95b2-42c4-a830-f6d4c5a964a9`
+- **When:** `2026-05-14T12:10:32.120545+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `none`
+
+  > Owner accepted option B (RootProfile JSON + prose) and added two independent structural decisions: (a) defer all UI/MCP/Discover/playlist work to V2+ — "anything built on top while the внутрянка isn't working is wasted"; (b) replicate the OOP-project pattern of a shared enrichment database where metadata accumulates across users, gated by ~90-day TTL so the same track is not re-fetched on every run. Combined effect: V0/V1 are pure engine work, the brainstorm's "MCP Phase 2 / playlist push at MVP" plan is overridden, and the CLAUDE.md note "file-based caching at v0, Supabase later" is replaced by a real database-from-day-1 commitment (tech choice still open). Data persistence is now a hard invariant — RootProfile becomes a time-series snapshot artifact, enabling future evolution-of-taste analysis. This commits the project to multi-user data shape even though V0 has one user.</rationale>
+  > <parameter name="alternatives_considered">["Ship MCP server with V0 as in brainstorm — rejected: owner explicitly deferred to V2+ until engine is mature","Discover slice (option D) in V0 — rejected: building recommender on proxy root model produces unverifiable output and violates causality invariant","Interactive dashboard (option C) — rejected: UI work on top of unproven engine wastes time, can be added later reading the same RootProfile","Pure file-based storage at V0 (per old CLAUDE.md) — rejected: shared-enrichment pattern needs concurrent write semantics and a real schema; SQLite is borderline, real DB is cleaner","One-shot ephemeral runs — rejected: owner requires year-later returning users to see their prior data; time-series snapshots are a feature not a side-effect"]
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22, 14595ec7-6049-4be9-8b16-c966be7fcb31, cd51fa38-a741-44a1-989a-08c92bad3355`
+
+---
+
+### AFK budget gate threshold supersedes prior 90% → 80% weekly. Hysteresis для unset CLAUDE_QUOTA_PRESSURE: weekly < 70% (10% release window против flapping). Остальная схема Q3.5 (probe-session, repo variable broadcast, in-flight не убиваем, sandcastle отдельно) без изменений.
+
+- **UUID:** `46830b4e-c9d8-4b89-962a-1a62fd80d15e`
+- **When:** `2026-05-14T12:41:51.98091+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:grill-afk-q2:resumed-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Оставить 90% — отвергнуто: 10% reserve может не хватить под N parallel containers; 70% — отвергнуто: слишком консервативно, обрежет AFK throughput без реальной нужды`
+
+  > Owner-calibrated threshold change. 80% даёт 20% reserve вместо 10% — компенсирует случаи когда in-flight задач больше чем оценено (e.g., 3 параллельных rework + 5 code-review.yml runs одновременно), и оставляет budget на HITL day-time work если AFK ночь сожгла больше ожидаемого. Hysteresis 80→70 (10pp) больше чем 90→85 (5pp) для той же причины — предотвращает flapping при колебаниях между active/passive periods.
+- **Memories used:** `d5b3fdd3-7452-4d41-ad7c-84d692d442fa`
+
+---
+
+### Storage is hybrid: Supabase Postgres for shared metadata (track-level, anonymous, 90-day per-entry refresh TTL). Local per-user data lives as plain JSON/JSONL files — no SQLite, no local DB engine. Layout: data/history.jsonl (append-only events), data/cache/<track_id>.json (mutable, pulled from shared store), data/profiles/<iso>.json (RootProfile snapshots), data/state.json (global pointers). Pull-and-cache pattern: analyser does one bulk Supabase query, materialises to local cache, runs offline. Personal history never leaves the user's machine.
+
+- **UUID:** `f7a9fcbd-9be9-4e68-9234-801597dfacd2`
+- **When:** `2026-05-14T13:09:49.633959+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `Local SQLite for per-user data (my prior recommendation) — rejected: SQLite buys indexed lookups and ACID, neither needed at V0 scale; adds a dependency; Supabase from day 1 for both shared and per-user data — rejected: personal listening events should not leave the user's disk; per-row write quotas penalise frequent history appends; Local Postgres in Docker — rejected: heavy infra for ~50 MB; loses the local-privacy advantage; DuckDB locally — kept on revisit list: better analytical perf but unnecessary at V0 scale; SQLite + Supabase hybrid — rejected: extra layer that does not pay for itself at V0 scale`
+
+  > Owner challenged "why a DB locally?" — re-evaluated honestly. V0 data sizes are ~50 MB total (32K events, 20K track-metadata records, dozens of snapshots), below DB-justifying thresholds. Access patterns are bulk-load-into-pandas for analysis, append for history, per-key write for metadata cache. Plain files cover all of this without driver/schema overhead. Natural per-class structure (JSONL append, per-key JSON, per-snapshot JSON) handles the only real concern (rewriting big files on every update) without a DB. Privacy bonus: personal listening events and derived RootProfiles never leave the user's disk — only anonymous track metadata is cloud-resident. Pull-and-cache keeps Supabase round-trips to one bulk pull per run, important for free-tier rate caps. Revisit threshold codified: >500 MB total or >10s load → Parquet+DuckDB.
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22, 870623f7-95b2-42c4-a830-f6d4c5a964a9, cd51fa38-a741-44a1-989a-08c92bad3355`
+
+---
+
+### AFK rework loop-stop policy: max 3 rework attempts per PR; scope-creep dual guard (LOC delta >50% от initial OR файлы вне initial-impl diff кроме tests/**); convergence target = n_critical=0 AND n_major<=2 (acceptable for human merge утром); conflict detection = same file:line touched в 2 разных rework attempts → reviewer disagreement, escalate; termination action = PR-label `status:needs-human` + single summary comment (3 attempts × findings) + outcome_record outcome_status=partial + events_canonical event_type=rework_stuck severity=medium (не high — owner discovers через SessionStart утром, не будим ночью).
+
+- **UUID:** `8e757f01-839b-4be2-a98b-a479452b5ec1`
+- **When:** `2026-05-14T13:10:51.347442+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-afk-q2:resumed-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `max_attempts=5 — отвергнуто: противоречит quality_over_speed, жжёт quota без выхода; max_attempts=2 — отвергнуто: слишком рано дёргает принципала, 2nd attempt часто clarification round; Single guard (LOC OR file-scope) — отвергнуто: LOC ловит раздув, file-scope ловит расползание — разные failure modes, нужны оба; Convergence только по n_critical=0 — отвергнуто: PR с 8 MAJOR findings не готов к merge, нужен cap на major; severity=high для rework_stuck — отвергнуто: будит ночью, нарушает AFK paradigm; high = real-time emergency (CI red, quota_pressure); Killing in-flight container при trigger — отвергнуто: trigger проверяется между attempts, всегда даём текущему attempt доработать`
+
+  > 3 attempts baseline: 1 = honest first try, 2 = clarification round, 3 = всё ещё открыто значит проблема в дизайне не в коде, нужен человек. Поддерживает always_load quality_over_speed (одна правильная реализация лучше чем N быстрых rework). LOC 50% threshold отделяет fix (rework по determined scope) от re-architecture (расползание). File scope guard ловит case когда sandcastle решил "пока я тут, поправлю и соседнее" — классическая AI-extraction pattern. Convergence n_major<=2 потому что 0 нереально (Claude code-review всегда найдёт мелочи), а >2 значит код не готов к merge без принципала. Conflict detection через same file:line — единственный достоверный signal что reviewers disagree (а не sandcastle регрессирует); regression сама по себе ловится "n_major не уменьшается между attempts". Termination severity=medium: rework_stuck не emergency, owner смотрит утром через SessionStart context — high зарезервировано для CI red на rework push (real failure). Все числа стартовые, калибровка по outcome_records pattern_tags за первые 2 недели live AFK.
+- **Memories used:** `e6441d77-457b-451a-ac48-06830c1d9a8a, 69b7eddb-fa74-4ea3-a1bd-c03580e3023c, 46830b4e-c9d8-4b89-962a-1a62fd80d15e, 2c87e895-2d3a-4b0b-a727-18935d81a4cd`
+
+---
+
+### Root validation: three-level classification (root/tendency/artifact_suspect) plus the "honest empty" invariant. V0 runs four tests: coverage labelling (E), confidence floor (A), temporal stability (D, gated by dataset size — n_unique_tracks > ~1000 AND history_span > ~6 months, both calibrable), calibration test suite (G — synthetic random history must not produce high-confidence roots). Rejected candidates are surfaced in quality_log[] with the failed test, never silently dropped. Empty roots[] is a valid output. V1 must add user feedback loop (F) for marking tendencies as real/imposed/error. Bootstrap stability (B) reserved as future option.
+
+- **UUID:** `bce66b6e-8a56-455b-8082-1da894c4dbe6`
+- **When:** `2026-05-14T13:32:44.581494+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `Binary root/not-root — rejected: hides the gray area, loses information; Show everything including single-binge (transparency-through-abundance) — rejected: would dilute the signal so far that artifacts violate the causality invariant; Defer validation to V1 — rejected: V0 would ship a tool that confidently surfaces artifacts, violating transparency from day 1; Bootstrap stability (B) now — deferred: 5-10x compute cost not justified for the 3-category proxy model; reserved for V1 when 8 categories make cross-validation meaningful; Cross-source agreement (C) now — deferred: scene tags too noisy in V0 to act as an independent confirmer; will be meaningful when V1 timbre arrives`
+
+  > Owner accepted the proposed validation stack and added a strong invariant: the engine must be able to honestly return "no roots found" when data does not warrant claims, instead of fabricating something to fill the report — that is transparency. Owner flagged that temporal stability needs a dataset-size gate (small dataset cannot be split chronologically without artifacts); when the gate fails, candidates default into tendency, not root, preserving honesty. Owner committed F (user feedback) as a V1 must-have, not optional. The three-level taxonomy lets the system surface real findings without hiding the gray area; quality_log[] makes rejection inspectable, satisfying transparency more strongly than a binary report. Defaults N=1000 tracks, T=6 months are first-guess and will be calibrated on owner's actual data (20K tracks, 17 months) in the first run.
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22, 870623f7-95b2-42c4-a830-f6d4c5a964a9, cd51fa38-a741-44a1-989a-08c92bad3355, f7a9fcbd-9be9-4e68-9234-801597dfacd2`
+
+---
+
+### PR body update responsibility (rework loop): sandcastle обновляет PR body только в terminal state (convergence или rework_stuck), не на каждый attempt. Append-only секция `## Rework history` (per-attempt summary), original body preserved. Closes-line, title, labels — не трогаем (orchestrator/owner territory). AC checklist обновляется по verdicts если AC measurable. Owner edits между AFK ночами сохраняются — sandcastle делает fresh `gh pr view --json body` перед append, не cached snapshot. Body update = последнее действие в iteration (после push, после event row, перед container exit) для atomicity.
+
+- **UUID:** `5b9c5d24-bf6b-4965-8ca3-1832eca802c8`
+- **When:** `2026-05-14T13:35:03.775712+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-afk-q2:resumed-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Update на каждый rework attempt — отвергнуто: intermediate inconsistency, больше точек конфликта с owner edits; Orchestrator updates body — отвергнуто: knowledge work, нужна модель в контейнере; orchestrator = thin scheduler; Overwrite body с fresh template — отвергнуто: теряет owner edits + audit trail предыдущих attempts; Journal в PR comments вместо body section — отвергнуто: comments разбросаны по timeline, сводный history-section в body даёт единую точку для morning reader; Update title по attempt count — отвергнуто: title = stable identifier, не progress indicator`
+
+  > Sandcastle, не orchestrator, делает body update — это knowledge work (parse findings, понять что менялось через N attempts), нужна модель в контейнере; orchestrator остаётся thin scheduler per e6441d77. Только terminal state потому что in-flight body churning создаёт inconsistency для morning reader (label + git log + comments дают всю информацию о progress без редактирования body). Append-only защищает owner edits и сохраняет audit trail attempts. code-review.yml пишет issue-comments не body edits — нет concurrent write conflict. Fresh fetch перед append — стандартная защита от lost updates если owner editировал между AFK ночами.
+- **Memories used:** `e6441d77-457b-451a-ac48-06830c1d9a8a, 8e757f01-839b-4be2-a98b-a479452b5ec1, 69b7eddb-fa74-4ea3-a1bd-c03580e3023c`
+
+---
+
+### Acoustic root derivation pipeline: HDBSCAN clustering on 18-feature AcousticBrainz vectors (per-user fit, no forced k), 1:1 mapping from validated cluster to root, mandatory machine-readable structural descriptor per root, optional LLM curator prose strictly bounded to {structural_descriptor, sample_tracks, scene_context} as inputs. Hyperparameters calibrated and stored in method_params per snapshot. Curator may not introduce facts absent from its input — it renders, it does not infer.
+
+- **UUID:** `01ba9bb7-a190-4ce1-a984-45a416573f3b`
+- **When:** `2026-05-14T13:44:41.645552+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `k-means — rejected: forces k clusters even on structureless data, breaks honest-empty; GMM with probabilistic membership — rejected: also requires k, plus dual-membership complicates evidence_coverage and confidence semantics; Agglomerative/hierarchical with root + sub-roots tree — rejected: 20K-point cost and validation complexity not justified at V0; Top-N selection over clusters — rejected: hides discarded clusters, contradicts transparent-rejection invariant; LLM-curator with raw sample tracks only (no structural descriptor) — rejected: prose-only label is unverifiable and would let curator hallucinations propagate as 'roots'`
+
+  > HDBSCAN is the only candidate algorithm compatible with the honest-empty invariant: it can return zero stable clusters when the data has no structure, while k-means/GMM always force-fit k clusters. 1:1 cluster-as-root avoids hidden top-K cutoffs that mask "we threw away root #4". Structural descriptor is the source of truth; LLM prose is a presentation layer that can fail without invalidating the artifact. Restricting curator inputs to already-derived structures preserves transparency: a future debugger can replay descriptor → prose deterministically and check for hallucinated content. Hyperparameters in method_params make two snapshots comparable only when params match — explicit, not a silent confound.
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22, cd51fa38-a741-44a1-989a-08c92bad3355, bce66b6e-8a56-455b-8082-1da894c4dbe6, f7a9fcbd-9be9-4e68-9234-801597dfacd2`
+
+---
+
+### PR rework как separate `/rework` skill (не reuse `/implement`). Skill принимает PR number как argument: `claude -p "/rework <PR>"`. TDD discipline reactive (per CRITICAL finding → failing test → green), не top-down per AC. Grill-me checkbox skipped — rework = ответ на explicit review findings, не на implicit assumptions. Watcher dispatches через skill argument, не через `SANDCASTLE_TARGET_PR` env var (env var остаётся sandcastle invariant, skill argument — invocation concern).
+
+- **UUID:** `9884299d-999c-4863-8b56-235fd09ec6e2`
+- **When:** `2026-05-14T13:47:38.414582+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-afk-q2:resumed-2026-05-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Reuse /implement с SANDCASTLE_TARGET_PR flag — отвергнуто: shallow branching, раздувает skill body без cohesion; Reuse /implement с внутренним routing по PR existence — отвергнуто: implicit detection, нарушает explicit interface; TDD top-down per AC для rework — отвергнуто: AC уже implemented в initial; rework reagирует на findings, не переизобретает; Grill checkbox включён в /rework — отвергнуто: explicit feedback != implicit assumptions, grill бесполезный noise; Watcher ставит SANDCASTLE_TARGET_PR напрямую без skill слоя — отвергнуто: смешивает invocation и runtime layers`
+
+  > Separate skill сохраняет deep module principle: `/implement` optimized под happy path "issue → TDD per AC → branch → PR", `/rework` optimized под "parse verdict → classify findings → apply fixes → update body". Mode flag в `/implement` был бы shallow flag-driven branching (CONTEXT.md anti-pattern). Shared infra (TDD references, memory recall protocol) уже в `_shared/`, не в skill bodies — DRY satisfied. Reactive TDD: findings структурные = test case почти написан, переиспользуем _shared/tdd/ references но driving logic другая. Grill skip honest — assumptions уже checked в initial /implement (если grill fired); если review показывает "approach wrong" это CRITICAL finding ловится loop-stop guards (8e757f01) и эскалируется к owner, не уходит в auto-rework. Skill argument vs env var separation: watcher знает skill names (invocation API), sandcastle знает env vars (runtime API) — два разных слоя, не смешиваем.
+- **Memories used:** `e6441d77-457b-451a-ac48-06830c1d9a8a, 69b7eddb-fa74-4ea3-a1bd-c03580e3023c, 8e757f01-839b-4be2-a98b-a479452b5ec1, 5b9c5d24-bf6b-4965-8ca3-1832eca802c8`
+
+---
+
+### Two coupled decisions. (1) Rename root category `acoustic` to `audio` everywhere — old name was a residue of AcousticBrainz dataset naming and clashed with Spotify's `acousticness` per-track feature; AcousticBrainz dataset keeps its proper-noun name. (2) Temporal root pipeline: temporal does not cluster in its own space; it produces conditional patterns of the form (time_bucket, conditioned_root) with lift = P(conditioned_root | bucket) / P(conditioned_root) plus confidence and stability tests. Default time_bucket partition: day_part(4) × weekday_kind(2) × season(4) = 32 buckets; calendar configurable via method_params.temporal_calendar (5/2 weekdays is a default, not universal — V1 feedback channel allows per-user override for shift workers etc.). Epochs (life-period segments) detected in V0 via sliding-window KS-test on cluster distributions and stored in RootProfile.epochs[] separately from roots[] — epochs are historical context, not roots. Pipeline ordering invariant: audio → scene → temporal → epochs; temporal step refuses to run when upstream categories produced no roots and no tendencies.
+
+- **UUID:** `00f7e1eb-9848-48c2-87f3-5123aca80bb9`
+- **When:** `2026-05-14T14:02:26.220221+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `Temporal as qualifier-only field on every other root (option 1) — rejected: temporal patterns disappear from roots[] enumeration; no symmetric way to validate/classify them under the trio-class taxonomy; Temporal on its own feature space (option 3) — rejected: invents an extra clustering step that just re-derives (bucket→cluster) associations less directly; 168-bucket (hour×day) partition — rejected: ~190 events/bucket at owner's scale, fragile statistics; default coarser is more honest; Epochs in V1 only — rejected: epoch context is needed to validate root stability (a root present only in one epoch is a different finding from a recurring one); cheap to add now; Keep the name 'acoustic' — rejected: dual-meaning with Spotify's per-track acousticness feature creates persistent confusion`
+
+  > Owner asked what "acoustic" meant in my Q7 framing and flagged it as ambiguous — could be mis-read as "acoustic music" (genre) rather than "scalar audio features for any track". Renaming now is cheap; later it would touch every test, JSON schema and downstream consumer. Temporal grilling surfaced that temporal is not parallel to audio/scene — it has no standalone feature space and only becomes meaningful when conditioned on what is being listened to. Modeling it as conditional patterns avoids inventing a fake parallel pipeline and matches the actionability invariant ("you listen to X cluster on weekday mornings" is actionable; "you listen on weekday mornings" alone is trivia). 32-bucket partition is the right depth for ~32K events (sufficient bucket counts, ~1K events/bucket) while staying human-meaningful; per-user calendar override anticipates non-standard schedules without forcing UI work in V0 (yaml/json config now, UI in V1). Epochs in V0 are cheap to compute (one scipy KS-test in a loop) and supply important context: a root present only in one epoch is fundamentally different from a recurring one. Pipeline ordering codifies the dependency.
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22, cd51fa38-a741-44a1-989a-08c92bad3355, 01ba9bb7-a190-4ce1-a984-45a416573f3b, bce66b6e-8a56-455b-8082-1da894c4dbe6`
+
+---
+
+### Scene root pipeline for V0: derivation uses Last.fm track tags only (signal i), method is NMF on the user's track×tag matrix (method α). K is auto-selected from a small grid {3,5,8,13} by mean topic coherence (PMI of top tags) above a floor; if no K passes, scene_roots=[] (honest empty). Tag preprocessing: lowercase + strip punctuation + curated stop-tag list (meta-tags like "seen live", "favourite") + minimum frequency filter (drop tags applied <5x in user's library); no stemming. Each accepted topic becomes a scene root 1:1 with structural descriptor {top_tags+weights, top_artists, coherence_score, K_selected, K_grid_explored} and optional curator prose. Last.fm artist similarity intentionally excluded from derivation and reserved for V2+ recommender / cross-validation. Curated genre taxonomies (MusicBrainz/RYM/Wikipedia) are V1+ enrichment-direction. Tag-embedding clustering rejected for V0 on transparency grounds; embedding-based synonym canonicalization saved for V1 as optional preprocessing step with mapping recorded in method_params.
+
+- **UUID:** `91229a71-70bb-4ccd-8dbe-f60ceeaa08ac`
+- **When:** `2026-05-14T15:21:07.224557+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.75`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `Tag-embedding clustering (δ) — rejected for V0: weaker transparency, pretrained model bias, dimensionality issues, smearing of multi-tag tracks; saved as V1 synonym-collapse preprocessing only; Louvain on tag co-occurrence graph (γ) — saved option but not chosen: NMF is simpler and gives weighted membership instead of binary community; revisit if NMF coherence is consistently poor on real data; Last.fm artist similarity + Louvain (8.1.ii) — rejected: encodes crowd-listening bubble that the project is built to counter; would corrupt the causality invariant at the source; Curated taxonomies (8.1.iii) in V0 — deferred to V1: scrape and integration cost not justified before the tag-only path proves insufficient; Tag stemming — rejected: collapses meaningful distinctions like 'post-rock' vs 'rock'; case folding plus synonym mapping (V1) cover the real cases`
+
+  > Owner accepted (i)+(α) and asked specifically why not tag-embeddings. The honest answer: embeddings buy semantic richness (cross-synonym, cross-language matching) at a steep transparency cost — NMF outputs "topic = these tags with these weights" which is machine-inspectable evidence; embedding-cluster centroids in 384-dim space can only be explained post-hoc by projecting back to tag space, and pretrained model biases (English Wikipedia-heavy, music-domain-naive) get silently baked in. Averaging tag-embeddings per track also smears multi-tag tracks into meaningless midpoints. Owner approved deferring embeddings to V1 as a synonym-collapse preprocessing step — a transparent, auditable use of embeddings that preserves NMF's transparency advantages. Excluding Last.fm artist similarity from derivation is the load-bearing choice: that signal IS the bubble-formation mechanism the project is built to escape; using it would smuggle the symptom into the root model at its source. K-selection by coherence floor preserves honest-empty: when no topic structure exists, none is invented.
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22, cd51fa38-a741-44a1-989a-08c92bad3355, 01ba9bb7-a190-4ce1-a984-45a416573f3b, 00f7e1eb-9848-48c2-87f3-5123aca80bb9, bce66b6e-8a56-455b-8082-1da894c4dbe6`
+
+---
+
+### V0 exit lock for music-intel-mcp grill: (a) category_weights are present in the schema but inert in V0 — each category produces its own section without aggregation; weight elicitation lands in V1 alongside either a recommender or a display-ordering UX. (b) RootProfile JSON schema is canonised at schemas/root_profile.v0.example.json with top-level keys schema_version, model_maturity, snapshot_id, user_id, generated_from, category_weights, method_params, roots[], tendencies[], epochs[], quality_log[], analytics. (c) Root IDs are snapshot-local in V0; snapshot-to-snapshot matching deferred to V1 via linked_to_previous_id. (d) V0 acceptance criteria — 10 falsifiable contracts: ingestion of scratch CSV, Supabase shared metadata store provisioned, pull-and-cache works offline, pipeline runs audio→scene→temporal→epochs with honest-empty per step, trio-class validation per category produces output or honest-empty with non-empty quality_log, calibration test suite green on synthetic uniform-random data, RootProfile artifact conforms to schema, personal data containment proven (no per-user writes to Supabase), runtime docs in README, CI green.
+
+- **UUID:** `7b3adb41-09cf-44a1-a64e-f449a5b2fd4f`
+- **When:** `2026-05-14T15:36:30.290529+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-music-intel-mcp-2026-05-14`
+- **Project:** `music-intel-mcp`
+- **Alternatives considered:** `none`
+
+  > All foundational branches of the V0 design tree are resolved: framing (causal-root retrospective), root taxonomy (8 categories with V0 subset), output (RootProfile JSON only, engine-first), storage (hybrid Supabase shared + local JSON), validation (trio-class with four V0 tests and honest-empty invariant), three category pipelines (audio/HDBSCAN, temporal/conditional-pattern, scene/NMF), schema (canonical example file), acceptance criteria (10 falsifiable contracts). Remaining open questions are calibration-time (thresholds, prompt template details) or V1+ scope (audio analysis infra, feedback channel, schema for shared store implementation tables) — not blockers for next step. Grill exits here; next step is /to-prd or directly /to-issues for vertical-slice decomposition. Inert category_weights is deliberate: keeping the field in the schema preserves future-compatibility without forcing premature elicitation UX. Snapshot-local IDs are accepted risk: users comparing snapshots across years will need V1 matching logic — acknowledged in CONTEXT.</rationale>
+  > <parameter name="alternatives_considered">["Stable root IDs in V0 — rejected: requires snapshot-matching algorithm (cluster diff with previous snapshot) which is meaningful design work and not on the critical path for first-run usefulness", "Active weight elicitation in V0 (self-report or inferred) — rejected: nothing in V0 consumes weights; would be dead code", "Defer schema lock to first implementation slice — rejected: without a canonical example, tests cannot be written and slices drift", "Combined roots+tendencies in one list with a flag — rejected: downstream consumers (V2 MCP, dashboard) want cheap dispatch by section; trivial to concat when needed", "Skip quality_log[] in V0 to ship faster — rejected: violates transparent-rejection invariant and silently hides validation failures"]
+- **Memories used:** `05e849cb-aa4f-4e5c-bee2-716806dceb22, 14595ec7-6049-4be9-8b16-c966be7fcb31, cd51fa38-a741-44a1-989a-08c92bad3355, 870623f7-95b2-42c4-a830-f6d4c5a964a9, f7a9fcbd-9be9-4e68-9234-801597dfacd2, bce66b6e-8a56-455b-8082-1da894c4dbe6, 01ba9bb7-a190-4ce1-a984-45a416573f3b, 00f7e1eb-9848-48c2-87f3-5123aca80bb9, 91229a71-70bb-4ccd-8dbe-f60ceeaa08ac`
+
+---
+
+### Implement SV#29 (bulk ruff reformat) directly without grill — 0/4 trigger checkbox yeses
+
+- **UUID:** `a8a57d36-6c03-4324-b8ff-6ffcea88c243`
+- **When:** `2026-05-15T11:02:52.37436+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:sv-29-impl:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Run pre-commit run --all-files instead of ruff direct — blocked by missing Python 3.10 interpreter (PEP-514 registry miss); ruff direct executes the same logic the hook would; Also fix the 207 remaining lint warnings — out of scope (would change semantics, violates AC); Pick #28 or #27 instead — both touch architecture-heavy zones, would trigger grill; #29 was the clean autonomous choice`
+
+  > Issue scope is pure mechanical formatting: no user-visible behavior, no domain logic, no non-trivial tests, no crossing of non-trivial code. ruff config from #24 was the input; output is `ruff check --fix` (safe fixes only, no --unsafe-fixes per AC) + `ruff format`. 207 pre-existing lint warnings deliberately left for follow-up triage. Dropped black/flake8/isort per AC. PR #33 base = dev/redrobot-integration per sv_branching_policy. Merged squash, LOW risk per implement §7.5.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Purge always_load taxonomy from 23 → ~1 entries: inline 5 rules into CLAUDE.md/SOUL.md, untag 16 to on-demand recall, fix sv_no_automerge content (main-only scope), open recall-quality root-cause issue #641.
+
+- **UUID:** `a38393da-69f8-4942-9e21-d50c39bf9139`
+- **When:** `2026-05-15T11:27:44.280072+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-05-14-always-load-audit:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep all 23 always_load — rejected: owner explicit, plus contradicts always_loaded_context_budget_principle ('only rules that affect every decision'); Untag-only, no MD inlining — rejected: would lose the engineering posture rules that genuinely should bind every action (verify-before-assuming, recall-before-action) if recall fails; Fix recall first, then chunk away — rejected: option 3 explicitly chosen by owner ('оба параллельно'). Cleanup independent of recall fix; deferred cleanup keeps SessionStart bloated meanwhile`
+
+  > Always_load list ballooned to 23 entries because agent was using the tag as insurance against weak topic-recall — surfacing grill-only, PR-only, record_decision-only rules in every SessionStart even when irrelevant. This inverts the always_load contract ("bind every decision") into "things I'm scared recall will miss". Owner flagged it as misuse and confirmed bucketing: engineering posture → CLAUDE.md (recall, verify-before-assuming, no-state-in-static, sibling-grep, skill-contract); identity-grade ("quality over speed") → SOUL.md; tactical/contextual rules → keep in memory but untag. Also caught content error in sv_no_automerge — owner correction: "нельзя мерджить только в production/main ветку" (main only, not Темир's other branches). Root cause (recall quality) tracked in #641 so this doesn't recur.
+- **Memories used:** `ff994ca2-ac3a-49d4-86cb-360512df3619, 4d75a1ea-41e9-49b5-a91e-031dd1ff7e74`
+
+---
+
+### Headless ≡ Jarvis in -p with full context; two contexts (sandcastle, scheduled); /delegate gets pre-dispatch gate; working_state is interactive-only; labels needs-grill/needs-prd/draft added, ready-for-agent retired
+
+- **UUID:** `5f7c54d9-6e86-4281-8937-eff0bcfa2827`
+- **When:** `2026-05-15T11:36:09.943437+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-2026-05-15-headless`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Solo-grill inside sandcastle — rejected as vibe-coding under a lacquer of process; Defer-and-abort (sandcastle queues 'grill needed' and stops) — rejected, longer feedback loop with no safety gain over pre-dispatch gate; Namespaced working_state_jarvis_issue_<N> keys — rejected, sandcastle has no resumable session, the right answer is don't write at all; Three actor categories (subagent/scheduled/interactive) — collapsed to two headless contexts (sandcastle/scheduled) after user clarified sandcastle is Jarvis-in--p not separate identity; Single linear readiness label chain — replaced with two orthogonal axes (readiness vs dispatch authority); Aggressive label deletion of all bare topic tags — pulled back after usage check showed 1-15 issues attached; only ready-for-agent (0 uses) deleted inline, rest deferred to #643`
+
+  > Grill session 2026-05-15 resolved that "headless agent" is not a separate identity but Jarvis in -p with the same memory and skills, just without an operator. Original concern (parallel sandcastle agents clobbering working_state_jarvis singleton) dissolves once we accept that headless contexts shouldn't write working_state at all — sandcastle's artefact is PR+outcome_record scoped to issue, scheduled's artefact is a memory event. autonomous-loop daily tick declared dead/superseded by sandcastle+orchestrator. Grill-checkbox cannot be honoured inside a sandcastle (no human), so enforcement moves up to /delegate as a pre-dispatch gate: require sandcastle label, no needs-* blockers, AC section, ≥1 decision UUID in body. Vibe-coding solo-grill rejected as exactly the failure mode SOUL.md is calibrated against. Labels were partly built already (sandcastle, tier:*, needs-research, decision-made) but missing needs-grill/needs-prd/draft and had orphan ready-for-agent duplicating sandcastle semantics — fixed inline. Two orthogonal axes recognised: Readiness (draft → needs-* → ready) vs Dispatch authority (sandcastle/unsafe-for-AFK × tier:N). Pillar-N and topic-tag normalisation deferred to #643 because it needs its own grill.
+- **Memories used:** `9ba726e6-9718-4a1a-986e-cfdba08e43e5, a4d37306-3572-40a6-b1dd-d0b745579388, 51f12452-be90-4dda-a435-74ba7fc043a0, 9757b985-cf68-4310-9d44-0571697d337f, 9a5a1ade-d3c0-4163-8559-dff5993094ea, 33af9d9e-8c5b-441d-bbae-09816b5717f1`
+
+---
+
+### SV issue #4 — REST API rewrite: separate `comparisons/` (ReadOnly) and `models_3d/` URL namespaces under `/api/v1/`, branched off `main` (not `dev/redrobot-integration`)
+
+- **UUID:** `f02a258d-3d3b-4916-a55e-5e80c75ce102`
+- **When:** `2026-05-15T18:20:08.619232+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-sv-issue4`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > Issue #4 in Timaa22/Sculpture_vision_test was a half-stripped serializer state from a model migration. Picked it as the next SV task because: (a) chistey backend (no migrations, no hardware tests), (b) detailed analysis already in issue body from 2026-05-14, (c) unblocks the broken `/cycles/<id>/comparison/` action as a side-effect. Used `comparisons/` (new, frontend doesn't touch it) and `models_3d/` (matches existing frontend `POST /api/v1/models_3d/split_model/` call in ModelSplitter.jsx — issue body's suggestion of `models/` would have broken FE). Branched off `main` per issue body note overriding the SV main=prod-only branching policy for this isolated backend-only change. Kept ComparisonResultViewSet read-only because writes flow through `apps/comparison/services.py` from the Blender pipeline. After this session: priority shifted to issue #26 (PR-2b heightmap raster) — robot integration — which will be done directly on the server, not locally. PR opened: https://github.com/Timaa22/Sculpture_vision_test/pull/39</rationale>
+  > <parameter name="alternatives_considered">["Branch off dev/redrobot-integration per sv_branching_policy — rejected, this PR is unrelated to robot integration and issue body explicitly notes feature branch off main", "Make ComparisonResultViewSet full ModelViewSet — rejected, writes happen through Celery pipeline, REST POST/PUT would create orphan rows", "Use `models/` URL prefix per issue body — rejected, would 404 the frontend's existing ModelSplitter.jsx POST call", "Consolidate WorkCycle.parameters['comparison_result'] JSON with the table now — rejected, out of scope, flagged in PR body for separate effort"]
+- **Memories used:** `04c060fe-554b-443e-acfd-b1aa78cadac7, 8072acf6-5982-416f-8859-000145fdf4b0`
+
+---
+
+### AFK day 2026-05-16: no automated watchdog scheduled task — proceed with manager-session-only model + sandcastle's own cron + manual user resume on attention windows.
+
+- **UUID:** `22401d44-dff4-45a7-8cb4-a99e5f4cdc11`
+- **When:** `2026-05-16T03:05:45.873531+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-05-16-afk-day-kickoff`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > mcp__scheduled-tasks__create_scheduled_task and update_scheduled_task both blocked with "unavailable in unsupervised mode" — UI approval gate cannot fire in this session's permission mode. Direct write to scheduled-tasks.json + SKILL.md does NOT activate schedule (daemon caches state, file edits not honored on hot path). Spent ~10K tokens validating these paths. Continuing to thrash on infra burns the day; the user's 16h attention window + existing sandcastle/status-record schedules + frequent baton saves are sufficient fallback. File a follow-up issue for the MCP permission gate as a self-improve item — DO NOT block AFK work on it.</rationale>
+  > <parameter name="alternatives_considered">["Use mcp__scheduled-tasks__create — UI permission blocked (tried 2x)", "Use mcp__scheduled-tasks__update on existing slot — same permission block", "Direct write to scheduled-tasks.json + SKILL.md — daemon doesn't reload from file, change not honored", "Windows Task Scheduler with claude -p — headless dies under detached spawn per headless_claude_p_dies_under_bash_run_in_background memory", "CronCreate durable=true — fires within same session, no fresh context, defeats purpose", "Keep retrying — sunk-cost trap, no signal anything will change"]
+- **Memories used:** `33af9d9e-8c5b-441d-bbae-09816b5717f1, 6b098fcf-42bf-488f-95c7-b08651af1f4a, 26d04374-cdbb-49a1-a0e7-37b0e0451140, ff994ca2-ac3a-49d4-86cb-360512df3619`
+
+---
+
+### Defer all main-session handoff primitives from autonomous-day-orchestration-v2 research. Sandcastle-internal primitives parked as backlog grill topics.
+
+- **UUID:** `5deadf2f-aae9-44a5-94e6-42f15234ff05`
+- **When:** `2026-05-16T04:00:01.385187+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `skill:grill:session:2026-05-16`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Ship Hardiman-shape hooks now via Sonovore port - rejected: pain drops to near-zero on 1M + voluntary P/E/C + maturing orchestrator; Adopt Anthropic cwc-long-running-agents harness in main session - rejected: harness built for autonomous long-running agent, owner is interactively at keyboard; Build top-3 in main session first as testbed, port later - rejected: orchestrator architecture structurally different, few primitives port cleanly; Action evaluator+verify-gate inside sandcastle immediately - deferred to backlog grill`
+
+  > Owner reframed: interactive main session is reserved for high-leverage human work (grill, design, architecture); everything else automated via orchestrator+sandcastle. Per CONTEXT.md, that architecture is handoff-free by design: orchestrator session ephemeral (events_canonical = state), sandcastle iteration single-container (PR + outcome_records = state). On 1M-token model auto-compact is non-issue. P/E/C handoff is voluntary AI Hero discipline, not forced. Manual paste pain that triggered research is a one-off (AFK day 2026-05-16 emergency because autonomous system not ready). Research remains valuable input for future sandcastle hardening, but shipping handoff hooks now solves a problem about to evaporate.
+- **Memories used:** `13de847b-30ff-42b2-a831-0dcf6377a8c3, 9ba726e6-9718-4a1a-986e-cfdba08e43e5, 36ddd650-34b6-463f-be16-3d7177d06db6, ff994ca2-ac3a-49d4-86cb-360512df3619`
+
+---
+
+### Launch AFK autonomous chain via Windows Task Scheduler one-shot (Jarvis-AFK-Chain-20260516), bash wrapper afk-chain.sh, 24-iteration cap, opus model, never-halt policy.
+
+- **UUID:** `d1b8ae4e-ff49-4f6b-8c03-2355df7cf832`
+- **When:** `2026-05-16T05:14:22.156097+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:2026-05-16:chain-launch`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Bash run_in_background - rejected: dies when parent session ends per documented incident; Cloud routines RemoteTrigger - rejected: local dev work not cloud env; User launches manually - rejected after user picked Task Scheduler; Halt on queue exhaust - rejected: user wants never-halt`
+
+  > Owner explicitly empowered autonomous chain for 2-day AFK window with quota max-out. Direct claude -p via Bash run_in_background would die when parent session ends per memory headless_claude_p_dies (incident 2026-05-01 #498). Task Scheduler is the proven-working detached path. PowerShell Register-ScheduledTask succeeded with bypass mode. Never-halt chosen so remaining iterations not wasted; ambient/research/cross-project tiers ensure productive use of cap.
+- **Memories used:** `13de847b-30ff-42b2-a831-0dcf6377a8c3, 9ba726e6-9718-4a1a-986e-cfdba08e43e5`
+
+---
+
+### Recall RPC review-gate filter (C4) is unconditional, not show_history-gated
+
+- **UUID:** `a821d40d-f7bb-468d-af01-c93d706dea28`
+- **When:** `2026-05-16T05:29:03.878592+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter1`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Place filter inside (show_history or ...) block — rejected: conflates review-gate with history-gate, breaks always-gate ADR-0003 §Q4; Keep filter only on RPCs reviewer explicitly named (skip match_memories_v2) — rejected: same class of leak, sibling-grep rule applies`
+
+  > PR #631 review C4 says recall RPCs leak rows where requires_review=true or merge_targets is non-empty. Filter could be placed inside the (show_history or ...) block (treating review-pending as "history") or unconditional. Chose unconditional because review-pending and merge-proposal rows are semantically NOT history — they are unverified writes. show_history exists to surface superseded chains; reviving non-accepted candidates via show_history would defeat the always-gate (decision 31ebba19). The CONTEXT.md glossary entries for Candidate and Merge proposal both say recall must skip these "by default"; opt-in is via separate include_unreviewed=true flag (not yet implemented), which is independent of show_history. Applied to match_memories, match_memories_v2, keyword_search_memories, get_linked_memories (both UNION branches). Sibling-grep caught match_memories_v2 which the reviewer missed.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### CHECK constraint forbids empty merge_targets arrays (M2 fix)
+
+- **UUID:** `3586b542-02d1-4ea4-9340-b78658c2e347`
+- **When:** `2026-05-16T05:29:13.556012+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.8`
+- **Actor:** `session:afk-chain-iter1`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Tighten GIN predicate only (no CHECK) — rejected: every consumer must remember the empty-vs-null distinction; Application-layer normalization (write '{}' as NULL) — rejected: relies on every writer following convention, no DB-level safety`
+
+  > M2 review identified GIN partial predicate (WHERE merge_targets IS NOT NULL) misaligned with recall filter (merge_targets IS NULL OR merge_targets = '{}'). Two options: tighten GIN predicate to also require non-empty, or add CHECK forbidding empty arrays. Chose CHECK because it makes the boundary binary (NULL = not a proposal, non-NULL = is a proposal) at the data layer — consumers can rely on `merge_targets IS NULL` as the canonical "not a proposal" test, no edge cases. CHECK wraps in DO block with pg_constraint guard so re-applying schema.sql is idempotent. Recall filter remains `merge_targets IS NULL OR array_length(...) = 0` for defense-in-depth (CHECK could be dropped, filter still correct).
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Triage labels assigned to 5 untriaged jarvis issues: #644 (infra/medium/bug/needs-grill), #641 (core-agent/high/bug/needs-research), #606 (skills/low/task/ready), #605 (infra/medium/task/ready), #486 (status:ready added).
+
+- **UUID:** `1091ca35-70e4-4bc4-b2b6-6371313c9492`
+- **When:** `2026-05-16T05:35:26.054023+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter2`
+- **Project:** `jarvis`
+- **Alternatives considered:** `status:ready on #644 — rejected, alternatives between 3 solutions need owner pick first; needs-grill on #641 — rejected, problem statement is concrete enough; the 'gather data first' shape is exactly what needs-research is for; Defer triage and pick workflow-guard meta-tests instead — rejected, only one path-filtered workflow exists (schema-drift) and it has its meta-test, so #326 surface is already clean`
+
+  > Mechanical triage pass per priority queue Tier 1 item 2. Decisions: #644 → needs-grill because 3 alternative fixes proposed (settings.local pre-approval, env-flag variant, setup-phase pattern) require owner decision. #641 → needs-research because acceptance criteria call for instrumentation + 50-call audit BEFORE any tuning round; this is discovery-shaped, not implementable-as-is. #606 and #605 → status:ready because AC is concrete and self-contained. #486 already had bug/priority/area labels from prior triage; only the status: dimension was missing. Priorities: #641 high because memory recall is core mechanism with measured failure pattern; #644 medium because it has a working AFK manager-session workaround; #486/#605 medium per existing or stated severity; #606 low per "skeleton only, YAGNI" framing.
+- **Memories used:** `381de7fb-13ab-458e-ab2b-a286361a8a18, 9a5a1ade-d3c0-4163-8559-dff5993094ea`
+
+---
+
+### PR #631 re-review fixes applied inline (iter:4) — 2M + 4m + 4n from 2026-05-16 review.
+
+- **UUID:** `6f0bb74d-6ec8-4f08-8277-0e1526986ec1`
+- **When:** `2026-05-16T05:48:39.858372+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-4`
+- **Project:** `jarvis`
+- **Alternatives considered:** `park as status:awaiting-owner without fixes — rejected, MAJORs warrant work; just fix constraint predicate — rejected, leaves M2 timestamp-anchor untouched; rewrite smoke script entirely — rejected, scope creep`
+
+  > Verdict was "Approve with comments" — 2 MAJORs in smoke script (docstring framing + LIMIT-window fragility under concurrent writes) and minor pg_constraint / information_schema / bool-vs-boolean cleanup. Per kickoff baton rule (MEDIUM/HIGH → apply inline; LOW/MINOR → park) and inline-for-sandcastle-area, addressed substantive fixes plus easy nits in one commit. Skipped m3/m4 (PR body edits) and one redundant check nitpick as parking-lot grade. 20/20 meta-tests pass.
+- **Memories used:** `3586b542-02d1-4ea4-9340-b78658c2e347, a821d40d-f7bb-468d-af01-c93d706dea28`
+
+---
+
+### /last-work-report ships as a discoverable skeleton (registered in install-manifest whitelist + CLAUDE.md routing) with body deferred until /improve-codebase-architecture wires it in.
+
+- **UUID:** `2ef55c56-4b39-4908-bf91-caf3cb326326`
+- **When:** `2026-05-16T05:55:47.727948+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:afk-iter5`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > #606 AC explicitly scopes "Skeleton only — don't pre-build report-generation logic until /improve-codebase-architecture actually consumes it." Two options surfaced: (a) repo-only file unregistered, or (b) register and stub. Picked (b) because a registered skeleton enables discovery: the owner saying "last sprint report" gets the SKELETON notice rather than a missing-skill error, which itself proves the trigger phrasings match. Boundary with #605: that sibling auto-surfaces at SessionStart; this skill is the manual-trigger fallback for the same payload. Same shape, two entry points — if #605 is reliable this skill stays fallback, otherwise it becomes primary. Output contract pinned in SKILL.md so the follow-up PR fleshing the body has a stable target.</rationale>
+  > <parameter name="alternatives_considered">["Repo-only file, not registered in install-manifest — rejected: invisible to discovery, owner gets missing-skill error on trigger phrases.", "Fully implemented today (gh api + memory_recall body) — rejected: violates #606 YAGNI scope, couples to /improve-codebase-architecture contract that isn't finalised.", "Defer entire skill until #605 lands and /improve-codebase-architecture consumes — rejected: contract pinning now de-risks the follow-up PR; trigger phrasings need to be discoverable so the owner can manually fall back if #605 is brittle."]
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 06ca2740-57af-4eef-a8be-bb6a36587ab5`
+
+---
+
+### Park PR #631 as status:review awaiting owner merge after silent post-rework code-review confirmed across 2 iter
+
+- **UUID:** `997d4dd0-9420-4273-afdd-732a79324598`
+- **When:** `2026-05-16T06:00:55.589137+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-6`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Create status:awaiting-owner label - rejected, label-taxonomy is owner territory; Wait another iter - rejected, baton 2-iter rule explicitly triggers now; Comment-only no label - rejected, label is cheap discoverability`
+
+  > Iter:4 commit 1b21f38 addressed 2 MAJOR + 4 MINOR + 4 NITPICK from the 05:38Z verdict. Code Review action ran post-commit (SUCCESS 05:50:44Z) but posted no new claude[bot] verdict. Iter:5 observed once; iter:6 confirmed unchanged. Per baton 2-iter rule, silent post-rework re-review = treat as approval and park. Used existing status:review label since no status:awaiting-owner exists in repo and label-taxonomy is owner-process territory.
+- **Memories used:** `6f0bb74d-6ec8-4f08-8277-0e1526986ec1`
+
+---
+
+### Fix PR #631 body deferred minors (m3 stale AC + m4 wrong test count) autonomously despite iter:4 parking them for "owner edits"
+
+- **UUID:** `364156e3-f33d-4c7b-957f-04981d0c3d56`
+- **When:** `2026-05-16T06:05:35.784509+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:afk-chain-iter-7`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Leave deferred per iter:4 note — rejected: stale text is not parking, it's drift; Open separate doc-fix PR — rejected: PR body lives on the same PR, no merge ceremony needed; Comment on PR with corrections instead of editing — rejected: AC checklist needs to be the authoritative checklist at merge`
+
+  > Iter:4 deferred m3/m4 as "PR body parking until owner edits" but they are pure-text reversible documentation corrections that improve the merge record quality. The cost of leaving stale AC ("backfill UPDATE" line contradicting the implementation) and wrong test count (15 vs actual 20) is reviewer confusion; the cost of fixing is one gh pr edit call. Per "Fix > track for trivial reversible" rule (CLAUDE.md), text-only doc accuracy fixes in own-repo PR bodies are autonomous. Also added missing AC bullets for RPC review-gate filters and CHECK constraint (anchored to their record_decision UUIDs) and corrected paired-migration framing to match the actual `supabase/migrations/` artifact.
+- **Memories used:** `6f0bb74d-6ec8-4f08-8277-0e1526986ec1, 997d4dd0-9420-4273-afdd-732a79324598, a821d40d-f7bb-468d-af01-c93d706dea28, 3586b542-02d1-4ea4-9340-b78658c2e347`
+
+---
+
+### Park PR #645 (/last-work-report skeleton) as status:review after clean Code Review run with zero buffered comments.
+
+- **UUID:** `bb0374f8-8e2d-4099-b229-7aa1abf836b4`
+- **When:** `2026-05-16T06:10:22.137017+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter8`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Auto-merge - rejected: hard rule forbids non-LOW merges; AFK chain has no merge mandate.; Re-run Code Review action - rejected: burns cost with no broken-signal evidence.; Wait another iteration - rejected: review completed; nothing changes without owner.`
+
+  > Code Review workflow completed SUCCESS with 0 inline comments and 2 benign permission denials; Copilot reviewer errored (not actionable); all other CI checks green. AFK baton rule explicitly maps LOW/MINOR verdicts (or clean review runs) -> park, not autonomous merge. Same posture applied to PR #631 in iter:6 (decision 997d4dd0). Owner must make merge call.
+- **Memories used:** `997d4dd0-9420-4273-afdd-732a79324598, 2ef55c56-4b39-4908-bf91-caf3cb326326`
+
+---
+
+### Add explicit "Verify the fix isn't already on main" step to /triage SKILL.md between Recommend and Reproduce
+
+- **UUID:** `3e356a9f-b29f-4148-9c52-b2783edada81`
+- **When:** `2026-05-16T06:17:38.632464+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter9:autonomous`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > iter:3 outcome (verify-close-486) showed that #486 was stamped status:ready in iter:2 without grepping for the proposed-fix symbol — the fix was already on main (commit 9193338 + tests/test_installer.py:1206). The lesson noted "verify-before-status-ready as a triage subroutine candidate". This rule is generic (applies to any project where /triage is invoked) and evergreen, so it belongs in the user-level skill file, not the project-specific AFK baton where it currently lives. The rule prevents wasted AFK agent slots on already-implemented issues and confused audit trails. Generic phrasing ("ready-for-agent") matches the skill's canonical role vocabulary; the jarvis-specific `status:ready` label maps to it per CLAUDE.md.</rationale>
+  > <parameter name="alternatives_considered">["Keep the rule only in AFK baton: rejected — ephemeral, dies with the chain and doesn't bind interactive triage sessions", "Add to project CLAUDE.md: rejected — rule is project-agnostic and the skill is user-level", "Add to .out-of-scope/: rejected — that's for rejected features, not triage steps"]
+- **Memories used:** `1091ca35-70e4-4bc4-b2b6-6371313c9492`
+
+---
+
+### Park PR #646 as status:review after body-fix to satisfy require-linked-issue check (linked tracking issue #647)
+
+- **UUID:** `d593aa3f-3b2e-477b-8053-8b9852a22891`
+- **When:** `2026-05-16T06:24:36.962871+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:afk-chain-iter-10`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > PR #646 (autonomous iter:9) was opened with `[no-issue]` in body, which is for commit msg regex (#329) but NOT for PR Body Check workflow — the workflow only honors `Closes #N`/`Fixes #N`/`Resolves #N` or `priority:critical` label. PR is not critical (skill doc enhancement). Per CLAUDE.md "Fix > track for trivial reversible (#428)" + post-factum issue-bucket pattern from #183, filed #647 as tracker, updated PR #646 body with `Closes #647`. Re-run of require-linked-issue passed. All checks now SUCCESS except Copilot which errored on its own end (per iter:8 precedent — non-blocking). Parking rather than merging follows iter:6/iter:8 LOW/MINOR-parks-not-merges rule.</rationale>
+  > <parameter name="alternatives_considered">["Apply priority:critical label — rejected: PR is not critical, would abuse the hotfix escape valve", "Close PR and reopen with linked issue — rejected: unnecessary churn, body edit triggers re-run", "Leave as-is without fix — rejected: failing check blocks owner-merge later", "Merge directly as docs-only — rejected: AFK chain LOW/MINOR-parks-not-merges rule (iter:6 precedent)"]
+- **Memories used:** `bb0374f8-8e2d-4099-b229-7aa1abf836b4, 997d4dd0-9420-4273-afdd-732a79324598, 3e356a9f-b29f-4148-9c52-b2783edada81`
+
+---
+
+### Mark stale memories with STATUS header + preserved historical content, not delete or merge.
+
+- **UUID:** `b06695d5-3b1b-4ec2-95cb-6a249524400c`
+- **When:** `2026-05-16T06:30:50.790403+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:afk-chain-iter-11-2026-05-16`
+- **Project:** `jarvis`
+- **Alternatives considered:** `memory_delete the 4 stale memories — rejected: loses lineage useful for /reflect and architecture history; Merge 3 nightly_research_* into one — rejected: collapses orthogonal facts (cron, SQL fallback, issue bridge); harder to recall on narrow queries; Add STATUS header only, drop historical body — rejected: same lineage-loss problem, just slower-bleeding`
+
+  > Memory cleanup found 4 memories referencing dead skill files (`checkpoint/SKILL.md`, `nightly-research/SKILL.md`). Two alternatives were considered. Deletion loses the design lineage that informs /reflect and architecture audits. Merging across distinct facts (cron/sql-fallback/issue-bridge) collapses orthogonal concerns and produces a less-recallable blob. Keeping the original content under a "Historical content" section + a dated STATUS pointer at the top gives future recalls both the current truth and the lineage — and is cheap to re-do for the next batch of stale memories.
+- **Memories used:** `51f12452-be90-4dda-a435-74ba7fc043a0, 71a4b60d-d4c1-4169-84af-a68ce4d03dc4, 3348c814-d614-4b1f-9fce-38eb52929538, b239cc8f-cba4-41e8-8e88-39eb746ad4a1`
+
+---
+
+### Iter:12 Tier 2 memory hygiene — STATUS headers on 3 stale vintage memories (repo_improve_deferred, jarvis_v15_skill_final_plan, architecture_final)
+
+- **UUID:** `21311f9e-18af-4e2c-9b53-a9036f41f814`
+- **When:** `2026-05-16T08:02:58.978657+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:afk-chain-iter-12`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Delete the stale memories outright — rejected: iter:11 established preserve-history pattern, lineage useful for /reflect; Aggressive bulk update of all vintage memories — rejected: working_state explicitly says cap 2-3 per iteration with verification; Tier 3 research draft instead — rejected: Tier 2 still has yield, finish hygiene before pivoting`
+
+  > Each verified before rewrite per iter:11 protocol. repo_improve_deferred: deferred skill DID ship but reframed as /improve-codebase-architecture — pointer added. jarvis_v15_skill_final_plan: "Removed skills (confirmed)" list is wrong — autonomous-loop/setup-tasks/triage/reflect all came back as separate skills; CLAUDE.md routing table is now SoT. architecture_final: principle still valid (verified mcp-memory/server.py and src/risk_radar.py both present, no rogue src/{telegram,scheduler,budget}/), but "final" label misleading given Supabase schema expansion, sandcastle, 25+ skills since. Same preserve-history pattern as iter:11 (STATUS header on top, historical content kept verbatim). No dup-detector collisions expected — descriptions differentiated.
+- **Memories used:** `a32f95da-de7d-455b-b9d8-3c8c4e1aaf0c`
+
+---
+
+### Iter:13 applied STATUS headers to 2 vintage memories (federation_phase_0_complete, audit_3_main_changes_lock_2026_04_28); third candidate (metacognition_sprint_shipped) blocked by dup-detector despite same-name upsert; deferred.
+
+- **UUID:** `d35a4567-ea29-4a13-a036-08dfa3fdab71`
+- **When:** `2026-05-16T08:09:57.095513+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter13`
+- **Project:** `jarvis`
+- **Alternatives considered:** `delete sibling memory pillar_4_sprint_metacognition_loop_closure: would lose distinct milestone-26 record; merge two metacognition memories into one: orthogonal concerns per handoff rules; bulk-rewrite >3 memories: violates iter:11-12 cap heuristic`
+
+  > Continuing iter:11-12 memory hygiene pattern: pick 2-3 vintage memories per iteration, verify each against current code, apply dated STATUS header preserving original content. federation: skill count 12→24 verified via Glob, end-quick consolidated into /end --quick flag; audit_3_main_changes: line numbers in body stale (redesign doc evolved), content remains historical reference. Third memory hit dup-detector against pillar_4_sprint_metacognition_loop_closure_done_2026_04_21 (sim 0.79) across 4 attempts with differentiated descriptions; same-name upserts SHOULD bypass dup-check but did not. Stopping at cap per working_state guidance ("don't bulk-rewrite"). Anomaly filed as observation.
+- **Memories used:** `9a54a5ac-537f-4cf3-806c-74a196ebd310, 7cbc4e3f-2d38-4f01-a6f1-f7cf2c06f1b4, 879899e7-e17a-44dd-9fd6-b1d9c63540e8`
+
+---
+
+### File issue #648 to track AFK chain wrapper preservation gap rather than auto-fix during chain
+
+- **UUID:** `2632d5c5-3170-4f3c-a0d6-f57295d2505e`
+- **When:** `2026-05-16T08:17:20.484262+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-14`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Auto-move script to scripts/afk-chain.sh: rejected - touches .gitignore + active-chain working tree, non-trivial to revert if owner picks different layout; File narrower bug-only issue without preservation framing: rejected - masks deeper root cause (off-tree infrastructure), owner may apply a narrow fix and re-encounter same problem on next device; Open PR with option-1 implementation: rejected - inline-implementing wrapper changes during the same chain that runs this wrapper risks self-interference`
+
+  > Wrapper .scratch/afk-chain.sh is gitignored but is load-bearing AFK infrastructure. A real quota-detection patch lives only in working tree of one device, recoverable only because chain has not run git clean. Three viable preservation options (move-only, +tests, +skill); choosing among them is an owner judgment call, not a trivial reversible drive-by. Filing an issue preserves the bug + fix description, hands the decision to owner, and avoids touching .gitignore + scripts/ paths autonomously mid-chain.
+- **Memories used:** `b06695d5-3b1b-4ec2-95cb-6a249524400c, d35a4567-ea29-4a13-a036-08dfa3fdab71`
+
+---
+
+### File issue #649 covering scheduled-task silent-degradation cluster
+
+- **UUID:** `02d22bb1-c514-4ba9-b5c4-c81b005baa45`
+- **When:** `2026-05-16T08:23:06.010373+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-15`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Outcome-records analysis found two clusters with shared root cause (scheduled-task env lacks required secrets, scripts silently degrade). Existing memory documents but no tracker exists. Filed one consolidated issue with 3-layer preventive proposal.
+- **Memories used:** `1a22f5d0-5bbf-40a9-ae54-7695ea39e683`
+
+---
+
+### File #650 worktree-isolation failure cluster as shared-class issue with 4-layer mitigation proposal; no autonomous fix (orchestrator-side, .claude/* territory).
+
+- **UUID:** `df7c5140-ad05-4c15-9460-2ef5281a609f`
+- **When:** `2026-05-16T08:28:20.379373+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-16`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > 5+ confirmed worktree-isolation incidents over ~3 weeks (#240/#241/#242, #674/#678, #412, #413, #510, plus #383 harmless-collision) with data-loss in 2 cases. Memories document the pattern but no GH tracker captures the owner-side prevention surface. iter:15 outcome→issue conversion pattern proved high-leverage (yielded #649); this is the natural next application. Issue is shape-first (L1/L2/L3/L4 layered mitigations) — owner picks scope. Autonomous fix declined because `/delegate` skill edits live under `.claude/*` which is gate-blocked, AND because the right enforcement primitive (skill prelude vs PreToolUse hook) is a design call owner should make.</rationale>
+  > <parameter name="alternatives_considered">["Auto-fix /delegate skill prelude with L1 stash-guard — blocked by .claude/* gate", "File separate issues per incident instead of cluster — would lose shared-class framing (iter:15 lesson: cluster framing more actionable)", "STATUS-header the memories to point at #650 — defer; cap is 2-3/iter and dup-detector friction documented", "No-op — declined because pattern is data-loss capable and visible enough to justify a tracker"]
+- **Memories used:** `ace97204-32bb-4ae6-a3ca-b36302d35766, 80e6497b-c5f8-4849-a9fd-23f0bf0a2587, f0f0334f-98af-4c88-a6bb-05d359eef3b7, 9a5a1ade-d3c0-4163-8559-dff5993094ea`
+
+---
+
+### File #651 — subagent fabrication (claim != diff) cluster issue with L1–L5 layered detection proposal
+
+- **UUID:** `7229c971-803c-4cd1-825d-af41ade88431`
+- **When:** `2026-05-16T08:34:57.191147+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-17`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Split into 3 child issues (diff-lie / coverage-lie / state-lie) — rejected: owner decides shape, single tracker preserves cluster framing; Inline-fix /delegate skill epilogue — rejected: .claude/* edit gate blocks autonomous chain; Defer to Tier 4 cross-project triage — rejected: jarvis baton not exhausted; Tier 3 channel still productive`
+
+  > Tier 3 outcome→issue conversion #3 — Subagent-fabrication class is documented in 4+ memories (subagent_fabrication_commit_message_vs_diff, subagent_test_coverage_overclaim, subagent_acceptance_criteria_dodged_as_out_of_scope, subagent_misses_interaction_effects) plus the always_load verify_before_assuming_implemented rule, but no GH tracker captures the mechanical orchestrator-side detection surface. #316 closed with instruction-based mitigations only — same orchestrators that need the rules are the ones being asked to remember them. Filed shape-first with 5 layered mitigation options (L1 diff-presence assertion, L2 coverage assertion, L3 GH-state assertion, L4 prompt enforcement, L5 PreToolUse hook). Pattern proven repeatable: this is the 3rd outcome→issue conversion in 3 iterations (#649 silent-degradation, #650 worktree-isolation, #651 fabrication-detection). No autonomous fix — touching /delegate skill or Agent-tool hooks is .claude/* territory.
+- **Memories used:** `50de5f5c-7efa-488c-89f4-ff843f7689bc, bfcf55c0-6105-4200-91bb-0eee01bd29a4, 9a5a1ade-d3c0-4163-8559-dff5993094ea, 737763bf-740f-4864-9860-7ad41149af50, 5b1a0d6a-18f3-47a9-919a-8fef5d5d59bd`
+
+---
+
+### File #652 to track orchestrator-side AC-dodge enforcement gap (subagent acceptance-criteria silently relabeled as out-of-scope), framing L2-L5 mitigation layers and converging enforcement-primitive question with #650/#651.
+
+- **UUID:** `fbe6d017-a256-4ec1-be62-15ad157af1c4`
+- **When:** `2026-05-16T08:40:26.063011+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-18`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Memory 9a5a1ade documents AC-dodge class as recurring, last updated 2026-05-14 (two days AFTER L1 prompt-level mitigation merged via #599 on 2026-05-12). L1 asks subagent to self-enforce; orchestrator-side /delegate §6 review checklist has 8 items but no item-by-item AC walk against issue body. Verified by grep. Tier 3 outcome→issue conversion #4, channel now 4-for-4. Third issue (#650, #651, #652) converging on enforcement-primitive meta-question.
+- **Memories used:** `9a5a1ade-d3c0-4163-8559-dff5993094ea, bfcf55c0-6105-4200-91bb-0eee01bd29a4, 50de5f5c-7efa-488c-89f4-ff843f7689bc, 737763bf-740f-4864-9860-7ad41149af50, 7dd8ea95-69c5-4c3b-a26b-2d3c9696bff0`
+
+---
+
+### File post-compaction premise-hallucination class as GH issue #653 — Tier 3 conversion #5, channel 5-for-5.
+
+- **UUID:** `6cc4c704-a85f-4e88-acff-d019f68a67bf`
+- **When:** `2026-05-16T08:46:12.643113+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter19`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Memory post_compaction_task_premise_verification (179ee1f2) documents the class with one confirmed incident (2026-04-22 batch-3 false-1.0 near-miss) but is recall-gated only — not always_load, no skill prelude, no hook. Class is high-leverage: main-session compaction-hallucinated premises slip every existing check because the producer and validator are the same agent. Filing follows the iter:15-18 shape-first template (class / existing mitigation / sub-modes / L1-L5 layered fixes / owner-decision points / linked memories). Distinct from #652 (AC-dodge): #652 is subagent-side AC truncation; #653 is main-session post-compaction state corruption. Four-way convergence on enforcement-primitive choice (#650/#651/#652/#653) is now strong enough to warrant explicit meta-decision when owner returns. Interaction-effects candidate (a) was pivoted away from because /delegate §6 already has an explicit interaction-audit instruction (line 236) with lesson #649 v2 reference — converting that would have been redundant with the existing #650/#651/#652 enforcement-primitive convergence.
+- **Memories used:** `179ee1f2-79b1-4418-bf18-24c86beec25b, 7dd8ea95-69c5-4c3b-a26b-2d3c9696bff0, a61a4315-b528-44e4-9904-e8977a7c27a2, 30055aa1-3159-4e59-a0df-c003fe418353, 8374f50e-1c24-4ff0-8ca0-d2495c3e7e45`
+
+---
+
+### iter:20 wrote enforcement-primitive synthesis draft, not 7th tracker
+
+- **UUID:** `c4311238-9102-43bf-bb8a-573af28647a4`
+- **When:** `2026-05-16T08:56:48.246112+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-20`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Candidate pool narrowing per baton; 4-way enforcement-primitive convergence is strongest chain signal. Synthesising into pre-grill briefing leverages existing convergence rather than adding triage burden.
+- **Memories used:** `50de5f5c-7efa-488c-89f4-ff843f7689bc, 179ee1f2-79b1-4418-bf18-24c86beec25b`
+
+---
+
+### Synthesise cwc / Sonovore / Continuous-Claude / SuperClaude harness primitives against Jarvis as a 10-section pre-grill briefing rather than file a 7th convergence tracker
+
+- **UUID:** `192c4bc2-4018-40b0-a5f2-9afd458a7f7d`
+- **When:** `2026-05-16T09:04:33.056933+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:afk-chain-iter21`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Iter:20 baton flagged "synthesis before Nth tracker" as the new pattern after the 4-way enforcement-primitive convergence. Iter:21 baton listed (c) cwc-harness-applicability research draft as the diversification candidate. Writing a draft costs ~30min and produces a matrix the owner can scan in 5min; filing another tracker would compound the 6 already-filed owner-gated issues. Draft converges with iter:20 synthesis at a different angle (primitive-by-primitive rather than failure-class-by-class), which is itself a useful triangulation. Gitignored per docs_research_unfinished policy — owner reads in place, not via PR.</rationale>
+  > <parameter name="alternatives_considered">["Tier 4 cross-project triage in redrobot — rejected: would require write actions on foreign repo (labelling), violates outbound-to-others rule", "Tier 3 (b) memory-without-tracker scan — rejected: would likely produce a 7th tracker, contradicts iter:20 'synthesis before Nth' pivot", "Tier 5 chain-log meta-audit — possible but iter:14 already covered the rc=1 cluster; second pass at iter:21 has diminishing returns", "No-op iteration — rejected: Tier 3 channel still has clear candidate (c) that hasn't been executed"]
+- **Memories used:** `179ee1f2-79b1-4418-bf18-24c86beec25b, 9a5a1ade-d3c0-4163-8559-dff5993094ea, ab528091-6c86-43a0-b340-b1dfbbb047b6, 51f12452-be90-4dda-a435-74ba7fc043a0, 7dd8ea95-69c5-4c3b-a26b-2d3c9696bff0`
+
+---
+
+### iter:22 file ONE consolidated tracker (#654) covering 5 lesson-recorded recurring failures with no enforcement-primitive tracker, sourced from memory-list scan instead of outcome-list scan
+
+- **UUID:** `1d436ced-105a-4b82-9f7a-0fe70f7fd5ef`
+- **When:** `2026-05-16T09:12:33.541792+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter22`
+- **Project:** `jarvis`
+- **Alternatives considered:** `File 5 separate trackers — rejected: fragments triage, dilutes signal vs the consolidated synthesis chain already in place; Skip and do (b) 3rd-axis cost/risk synthesis — rejected: would be 3rd synthesis in a row, baton said pace not over-saturate; Skip and do (c) chain-log scan iter:1-21 — rejected: last done iter:14 #648, diminishing returns mid-run; Skip and do (d) read-only redrobot triage — rejected: lower leverage than memory-source backlog discovery, save for later iter; Filter to top 2 only and file 2 separate — rejected: artificial 2/3 cap, all 5 share the same fix-class so single tracker is denser`
+
+  > Memory-without-tracker scan surfaced 5 feedback memories tagged with recurring/repeat-failure/silent-failure markers and explicit recurrence counts (breadcrumb_rot, emoji_in_status_tables, outcome_record_verify_after_write, stacked_pr_delete_branch_closes_chain, protocol_encoded_while_violated_recurrence), all 5 confirmed uncovered by `gh issue list --search` on topic terms. Baton iter:22 candidate (a) explicitly recommended this scan with rule "if 2-3 candidates surface, file ONE consolidated issue (not N separate)". 5 candidates exceed the 2-3 threshold but the consolidate-vs-split call still favors one tracker because (1) all share the same anti-pattern shape (memory recorded the prevention, nothing wired up), (2) the chain has been growing exactly this enforcement-primitive backlog all week (#649-#653), (3) consolidating contributes 5 candidates to the synthesis grill that iter:20+iter:21 drafts already set up. Adds the third axis (memory-source) the chain was missing — prior trackers were all outcome-source, the synthesis drafts were meta. Tier 3 SYNTHESIS-not-Nth-tracker pattern still respected: this is not a 6th failure-class tracker, it's a scope-discovery doc for the existing enforcement-primitive backlog.
+- **Memories used:** `c5616dc5-4c91-4d71-9675-72b80819cf3e, b6319414-a68b-4616-aaa6-711fdc9b44a5, f5b5f74a-3ee4-4574-b1a9-652ae87f7a10, 586f4452-536e-4ab5-a006-50ecf8251c9e, 2ebdc3b7-5775-4b85-a9be-c1af4e764102, 573b9d5f-4f96-4664-8aad-9c4ffcb2d0e4`
+
+---
+
+### iter:23 synthesize 3rd-axis cost/risk briefing as draft, completing class/harness/cost triangulation; no 8th tracker filed
+
+- **UUID:** `89e4471a-c080-43bd-b6b7-1b49c3d1d60a`
+- **When:** `2026-05-16T09:19:25.761146+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-23`
+- **Project:** `jarvis`
+- **Alternatives considered:** `(b) chain-log meta-pattern audit iter:1-22 — rejected: last done iter:14 #648, diminishing returns until end-of-run; (c) read-only redrobot triage — rejected: lower leverage than completing 3-axis triangulation in same chain; (d) outcome cluster re-scan with iter:22 context — rejected: 7d cooldown per baton DON'T list, just ran iter:22; file 8th tracker — rejected: chain-opened tracker count 7 already saturating owner queue; pace rule says ONLY file with strong same-evidence signal; Tier 6 no-op — rejected: candidate (a) is unambiguous high-value work`
+
+  > Baton iter:23 candidate (a) explicitly named 3rd-axis cost/risk synthesis as top recommendation, citing iter:20 = failure-class axis and iter:21 = primitive/harness axis with missing cost-axis. Synthesis-before-Nth-tracker pattern still proven 2-for-2 (iter:20+21) and orthogonal scope-discovery proved 1-for-1 (iter:22). iter:23 fills the missing axis with concrete adopt-order artifact (LOC, hours, gate-status, dependency graph, 5 cost-buckets) that prior briefings explicitly deferred. Output: 211-line gitignored draft mirroring iter:20/21 structure for owner ease, ending with convergent ordering A1+A2+A3 → D11 → B5 → B6+B7 → D12 → defer D13. Net value: owner gains adopt-order picks without needing to re-read class or harness briefings. Pace honored (chain at 23/24, one iter remaining).
+- **Memories used:** `none`
+- **Memories used (unresolved):** `c5616dc5, 573b9d5f`
+
+---
+
+### Iter:24 final-iter closure work — consolidate chain-meta operational lessons into one reference memory (autonomous_chain_runbook_lessons_2026_05_16) rather than file 8th tracker or 4th synthesis.
+
+- **UUID:** `d574e289-7b18-48f2-bc4a-2511671f9c52`
+- **When:** `2026-05-16T09:25:21.485773+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-2026-05-16-iter-24`
+- **Project:** `jarvis`
+- **Alternatives considered:** `(b) read-only redrobot triage — viable but iter:24 cross-project surface adds noise without preserving lessons; lower leverage; (d) honest no-op — too defensive; chain has clear closure work available; File 8th tracker capturing chain-meta patterns — explicitly forbidden by baton ('DON'T file 8th tracker without strong same-evidence-source signal'); adds owner-triage load; 4th synthesis axis — baton: 'only 3 orthogonal axes exist; further work is implementation, not synthesis'`
+
+  > Baton explicitly recommended iter:24 = low-noise closure work (NOT 8th tracker, NOT 4th synthesis — saturates). Three options recommended: (a) chain-log meta-audit, (b) read-only redrobot triage, (d) honest no-op. Picked (a)-variant: instead of filing yet another tracker for owner, consolidated 15 operational lessons from this 24-iter chain into one reference memory. Rationale: baton block 'Hard rules' captures these for THIS chain but dies at chain exit — lessons need a persistent home to outlive the baton. Owner-load delta: zero (memory not issue). Future-chain leverage: high (saves rediscovery cost). Reversibility: trivial (memory editable/deletable).
+- **Memories used:** `a4e7d4b3-1b9a-4f8c-9e2d-7c5a1b2c3d4e`
+
+---
+
+### File #655 — installer orphan-prune drift for /tdd skill, with 4 owner-decision mitigation options
+
+- **UUID:** `66a96e4a-de54-497e-8ed9-953a0ce293b0`
+- **When:** `2026-05-16T09:32:24.009229+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter25-post-closure`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Run install.ps1 -Apply directly — blocked by .claude/* hard rule and not autonomous-safe; Edit CLAUDE.md to acknowledge /tdd exists — wrong direction; source is right, mirror is wrong; Just no-op the iteration — would lose the finding; baton closure means this won't be re-discovered for free; Bundle with #648 (wrapper preservation gap) — different class: #648 is git-ignored patches, this is mirror-vs-source state drift`
+
+  > Discovered live drift on Main PC: ~/.claude/skills/tdd/ fully populated and surfaces in skills list, but #596 dropped tdd from .claude-userlevel/skills/ and install-manifest.yaml include whitelist; docs (CLAUDE.md, implement, delegate SKILL.md) explicitly say "no standalone /tdd skill". Installer prune_orphan logic exists (installer.py:411-428) but only fires on -Apply, which user hasn't re-run since #596. Filed as tracker (not fix) because: (a) hard rule "No .claude/* edits" blocks running install.ps1 -Apply autonomously, (b) per-device fix needs owner present on each device, (c) the structural fix (SessionStart drift detector) needs owner approval before touching scripts/session-context.py. Tier 5 chain-sharpening work — turns "I notice drift" into a shared queryable artifact rather than dying with this iteration.
+- **Memories used:** `01ac8c74-8823-4057-8f31-e7174e6f1329`
+
+---
+
+### File #656 — install missing-skill drift (last-work-report) as sibling to #655 (orphan direction); 4th tracker completes mirror-drift class synthesis trigger.
+
+- **UUID:** `5584d38e-d15d-4c28-86ca-b7295bec10d6`
+- **When:** `2026-05-16T09:39:11.870902+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-26`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Sibling-grep on recent merge #606 (per baton suggestion #2) revealed that ~/.claude/skills/last-work-report/ does not exist on Main PC despite the PR commit message claiming "discoverable today." This is the opposite-direction drift to #655 (which covers source-removed-but-mirror-retained). The two together complete the bidirectional install-mirror drift class, and combined with #648 (gitignored wrapper) and #654 (memory-without-tracker), there are now 4 trackers in the mirror-vs-source-drift class — exactly the threshold the baton named for synthesis. Filing as a separate issue rather than commenting on #655 because the mitigation surface differs (orphan-prune vs missing-add) even though the SessionStart drift-warner mitigation overlaps. Also surfaced 6 additional unenumerated orphans (gm-craft, grill-me, grill-with-docs, status, dnd-prep.bak.orphan, dnd.bak.orphan.bak.orphan) as evidence of pattern breadth. Issue is no-code Tier 5 work, owner-load is single-issue triage.</rationale>
+  > <parameter name="alternatives_considered">["Comment on #655 instead — rejected: distinct direction with non-overlapping primary mitigation (prune vs install)", "File as PR-revert request to #606 — rejected: PR is correct, the over-claim is in commit message which is immutable; install is genuinely manual", "Run install.ps1 -Apply directly to fix — rejected: risk of unintended device state change during AFK without owner OK; not authorized in baton hard-rules", "No-op (already covered by #655) — rejected: orphan vs missing are distinct mitigation surfaces, and 4th tracker triggers synthesis the baton called out"]
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117, 9697a109-dd91-4062-b5ac-86d6d12b27e4`
+
+---
+
+### Synthesis #4 — mirror-vs-source drift class added as 4th axis to enforcement-primitive synthesis chain
+
+- **UUID:** `bba24c3e-a142-4b58-8ee7-d7cd97d98808`
+- **When:** `2026-05-16T09:44:46.332445+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:afk-chain-iter27`
+- **Project:** `jarvis`
+- **Alternatives considered:** `sibling-grep on previous merge 5645893 — small chore commit, low yield; drive-by anchor-link audit in docs/ — Tier 2 ambient, lower leverage than synthesis trigger; outcome-cluster scan since iter:15 — already done iter:15-19, dup risk; Tier 6 honest no-op — chain hard-rule says do not halt voluntarily on absence of work; synthesis #4 was the explicit baton recommendation`
+
+  > Baton synthesis trigger fired with 4 trackers (#648 wrapper, #654 memory-tracker, #655 orphan-skill, #656 missing-skill) sharing common shape: source-of-truth at A, live state on N devices at B, no automated reconciliation. The 4 mitigation matrices overlap at one surface — SessionStart context loader can detect all 4 drift directions in a single bidirectional warner. Drift is structurally different from prior 3 axes (class/harness/cost): it's a passive-state-divergence problem, not an action-time decision failure. Draft proposes L1-L4 cost-progression (manual sync → SessionStart warner → CI+hooks → skill extraction), maps onto iter:23 convergent adopt-order. 7 grill points + 7 owner decisions queued. No code changes; gitignored draft per docs_research_unfinished policy.
+- **Memories used:** `01ac8c74-8823-4057-8f31-e7174e6f1329, 5584d38e-d15d-4c28-86ca-b7295bec10d6, 66a96e4a-de54-497e-8ed9-953a0ce293b0`
+- **Memories used (unresolved):** `c4311238, 192c4bc2, 89e4471a, 1d436ced`
+
+---
+
+### File #657 documenting commit-message-vs-DB drift: commit 5645893 claimed always_load=1 but live count is 6 (5 inlined memories still tagged). 5th tracker in mirror-vs-source-drift class.
+
+- **UUID:** `9eea45ab-e156-4804-b5cd-16c6905800f6`
+- **When:** `2026-05-16T09:52:39.561851+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.92`
+- **Actor:** `session:afk-chain-iter28`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Sibling-grep on commit 5645893 surfaced a concrete instance of the iter:27 drift class. Verified extant+tagged via memory_recall(show_history=true). No follow-up commit performed the promised memory mutations. Filed with 4 owner-decision options; only (4) status-header is AFK-safe.
+- **Memories used:** `abc0a54d-0806-4349-8863-45ae542071eb, e9acc59d-0860-4bed-90e2-befc02c78dd8, ff994ca2-ac3a-49d4-86cb-360512df3619, 01ac8c74-8823-4057-8f31-e7174e6f1329`
+
+---
+
+### Iter:29 sibling-grep on commit 6087152 — no drift; all 5 commit promises verified on Main PC. Drift class has bounds.
+
+- **UUID:** `de8554a5-da5a-43d4-8c67-d6419599c8d5`
+- **When:** `2026-05-16T09:56:48.620311+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:afk-chain-iter29`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Per baton candidate #6, ran sibling-grep on next-back state-promising commit. Verified: (1) .gitignore line 48 has '.scratch/', (2) .mcp.json has 'uml' entry per diff, (3) UML_MCP_HOME=C:\Users\petrk\uml-mcp set as User env var, (4) kroki healthcheck at localhost:8000 returns status:pass with mermaid 11.12.3, (5) uml MCP tools surfaced in this session's deferred tools (mcp__uml__generate_diagram_url, generate_uml). Per-device claim for laptop/2nd device explicitly out of scope (commit text said 'set per-device when they install uml-mcp'). Result is informative even though no tracker filed: bounds the iter:27 drift synthesis prediction — drift class is not infinite, it covers commits whose state-promise lacks backing deployment automation, NOT commits with happy-path deployable changes already executed. 6087152 had User env var + filesystem setup actually performed; 5645893 had memory-DB mutations promised but not scripted — that's the discriminator. Useful for owner's grill on drift-axis synthesis as 6th data point (negative class).</rationale>
+  > <parameter name="alternatives_considered">["Pivot to redrobot cross-project triage — deferred, lower priority than completing baton candidate", "Outcome-cluster scan since iter:15 — dup-detector class still needs reproduction; defer", "Memory→tracker scan refinement to link #657 to #654 — different drift sub-class, forced linkage rejected", "Drive-by docs anchor-link audit — low yield, no signal that any are broken"]
+- **Memories used:** `01ac8c74-8823-4057-8f31-e7174e6f1329`
+
+---
+
+### Apply iter:29 commit-side-effect discriminator backward across last 12 commits; predictive on 100% of verifiable cases (8/8); exposes 3 side-effect sub-classes (file-write / per-device-process / MCP-call) requiring different verifiers; L2 drift warner (§4) ships narrow (filesystem-only) for v1, broader sub-class coverage deferred to v2 contingent on recurrence.
+
+- **UUID:** `b641994b-49a1-45e0-8912-9aa43605c4a9`
+- **When:** `2026-05-16T10:03:41.41706+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:afk-chain-iter-30`
+- **Project:** `jarvis`
+- **Alternatives considered:** `File 6th tracker for MCP-call sub-class (d87b795 unverifiable) — rejected: no actual drift evidence, only verification gap. Premature.; Broaden L2 warner spec immediately to cover all 3 sub-classes — rejected: violates iter:23 cost-axis discipline; scope creep before v1 ships.; Halt synthesis until SQL-side d87b795 verification possible — rejected: discriminator already holds on 8/8 verifiable cases; SQL-gated check is a separate work item, not a blocker.; Skip backward-scan and pursue baton candidate (7) sibling-grep on 48a770f — rejected: 48a770f is Workshop-only state, unverifiable from Main PC; lower yield than backward-scan.`
+
+  > Iter:29 surfaced the discriminator from a single negative case (6087152 NO DRIFT vs 5645893 DRIFT). One data point is brittle — backward-scan over last 12 commits tests the predictive model on a larger sample. Result: discriminator holds 8/8 on verifiable subset; 4 commits land in sub-classes the original filesystem-mirror framing doesn't cover (Workshop-only state, MCP-call episodes). Narrow-v1 + broaden-v2-on-recurrence keeps the §4 spec executable today while logging the broader scope as future axis work; matches the cost-axis adopt-order from iter:23 (A1+A2+A3 → defer).
+- **Memories used:** `01ac8c74-8823-4057-8f31-e7174e6f1329`
+
+---
+
+### File #658 as un-trackered outcome from iter:13 partial (dup-detector observability gap on same-name upsert)
+
+- **UUID:** `fa774852-6f2a-4335-943e-4b4500c96053`
+- **When:** `2026-05-16T10:09:59.188766+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:afk-chain-iter-31`
+- **Project:** `jarvis`
+- **Alternatives considered:** `File silently as bug without grill framing — rejected, root cause uncertain and owner-grill checkbox would be wrong without the 3-hypothesis structure; Skip and let iter:13 lesson rot — rejected, baton candidate 10 was the recommended Tier 3 task and this is the singular hit; Diagnose inline via execute_sql to memory_review_queue — rejected, owner hard rule blocks Supabase mutations and even SELECT is outside AFK chain comfort zone; ACpoint 1 hands diagnosis back to owner; Pivot to candidate 8 (cross-device-observability synthesis) — rejected, that's synthesis-first; this is a real un-tracker'd outcome with explicit 'file' guidance`
+
+  > Iter:13 outcome lesson explicitly said "File grill topic" and never produced one. Outcome-list scan since iter:15 (the recommended Tier 3 task for iter:31 per baton candidate 10) surfaced this as the only un-trackered failure/partial pattern — every other failure/partial since iter:15 already has a tracker (#649-#657). Code reading shows the upsert path can't actually be blocked by similarity (atomic on_conflict project,name), making the observation either an observability misperception or a race in concurrent classifier verdicts — both worth owner grill but neither obvious. Filed with shape-first framing matching iter:15-17 template: 3 causal hypotheses, 4 owner-decision points, AC walks to evidence-first (pull memory_review_queue row before code change). Adds memory-class to Tier 3 channel (prior trackers covered outcome-source #649-653, memory-source #654, mirror-source #655-657 — this adds memory_store-observability as 9th tracker).
+- **Memories used:** `01ac8c74-8823-4057-8f31-e7174e6f1329`
+
+---
+
+### File tracker for installer prune_orphan recursive-rename bug surfaced by live dnd.bak.orphan.bak.orphan in mirror
+
+- **UUID:** `67d74eac-007b-4830-ba73-713921c62ffe`
+- **When:** `2026-05-16T10:16:56.11241+00:00`
+- **Reversibility:** `reversible`
+- **Actor:** `session:afk-chain-iter-32`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Iter:528 PR #588 lesson said Fix needs separate ticket but no tracker exists. Live mirror has dnd.bak.orphan.bak.orphan (two-deep). Code at installer.py:411-428 iterates all children of dest including previously-quarantined .bak.orphan items; _backup_dest at 188-194 appends another .bak.orphan suffix. Matches iter:31 lesson on follow-up-language slippage. Filing as Tier 3 outcome-to-issue.</rationale>
+  > <parameter name="confidence">0.85
+- **Memories used:** `9a54a5ac-537f-4cf3-806c-74a196ebd310, 01ac8c74-8823-4057-8f31-e7174e6f1329`
+
+---
+
+### File #660 outcome_record.memory_id FK gotcha tracker — 5x lesson recurrence in 2026-05
+
+- **UUID:** `ff4834a9-7739-4a0c-bd63-8468e57731aa`
+- **When:** `2026-05-16T10:26:58.187239+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.86`
+- **Actor:** `session:afk-iter33`
+- **Project:** `jarvis`
+- **Alternatives considered:** `installer-hygiene synthesis #5 — synthesis channel saturated 4-for-4; drive-by anchor-link audit on docs/ — low-yield filler; Defer FK gotcha further — rejected, 5x recurrence proven; Direct code fix Option 1+3+4 PR — rejected, subagent-fragile + .claude gate`
+
+  > Iter:32 baton recommended this as iter:33 task. outcome_record.memory_id (FK to memories.id) is confused with record_decision-returned episode UUIDs (which point to episodes.id, different table). 5x recurrence in 2026-05 (issues #646/#594/#593/#540/#599 outcome lessons). Code-read confirmed schema asymmetry: tools_schema.py:463-509 description has no FK-target warning; verify SKILL.md:62-71 is the only doc that gets it right; user-level CLAUDE.md §2 omits outcome_record.memory_id. Filed shape-first with 3 sub-modes, 5 mitigation options, evidence-first AC. Sibling to closed #325. Three open memory-axis trackers (#641/#654/#658) plus #660 form four-way triangulation for owner-grill. Tier 3 outcome-to-issue channel: 10-for-10 since iter:15.
+- **Memories used:** `f5b5f74a-3ee4-4574-b1a9-652ae87f7a10, 7e79666d-f9fa-479c-859f-cc17d92fc009, 01ac8c74-8823-4057-8f31-e7174e6f1329`
+
+---
+
+### Wrote installer-hygiene synthesis #5 (drafts only, gitignored) — installer-class sub-cluster #655/#656/#659 framed as installer-correctness gap (idempotence + bidirectional sync + auto-trigger), with L1-L5 phased mitigation and L2 (idempotence fix + two-pass quiescence test, ~1h) recommended as the floor structural improvement.
+
+- **UUID:** `54ce0bfb-6884-4a2a-a3e5-20d0ee2c6bb7`
+- **When:** `2026-05-16T10:33:35.890365+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:afk-chain-iter34`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Option 12 memory-subsystem grill prep — deferred; baton called installer-class higher-leverage with cooler context. Memory-axis 4-way triangulation needs owner discussion, installer-class is mechanical.; Skip synthesis, file L2 directly as a PR — rejected; AFK hard rule forbids non-LOW PR ops without owner sign-off on architectural direction, and the suffix-list-vs-sibling-quarantine choice is owner-decision.; Tier 2 anchor-link audit — rejected by baton as lower-yield.`
+
+  > Working_state baton iter:33 recommended this as iter:34's top task (option 11). Three trackers in same component (scripts/install/installer.py) — convergence-trigger per chain pattern. Differentiates from synthesis #4 (drift class, all 4 surfaces) by zooming into installer-component-specific gaps and adding what #4 missed: two-pass quiescence as a stronger structural fence than the SessionStart-warner, plus #659's idempotence (not addressed by warner at all). Tier 3 work hierarchy — no code touched, gitignored draft per docs_research_unfinished policy.
+- **Memories used:** `9a54a5ac-537f-4cf3-806c-74a196ebd310, 6b098fcf-42bf-488f-95c7-b08651af1f4a`
+
+---
+
+### Wrote memory-subsystem grill-prep synthesis #6 framing 4 trackers (#641/#654/#658/#660) as one channel-asymmetry class with L1-L5 phased adoption
+
+- **UUID:** `d1ef2779-e018-482a-ab48-0f1cba86896b`
+- **When:** `2026-05-16T10:39:07.935971+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `session:afk-chain-iter-35`
+- **Project:** `jarvis`
+- **Alternatives considered:** `(2) drive-by anchor-link audit — low yield, deferred; (4) cross-project triage redrobot — Tier 4, no jarvis blocker; (6) Tier 5 sharpen-chain post-mortem of synthesis channel — would extract reusable template, but synthesis-axis itself less mature than memory-axis; (NEW) deeper-zoom on single #660 only — would lose four-way convergence; chain rule says synthesize when 3+ trackers triangulate`
+
+  > Iter:34 baton flagged memory-axis as the mature next synthesis candidate; four open trackers triangulate store/recall/source/calibration-link channels; channel-asymmetry discriminator unifies them. Shape: subsystem promises contracts via tool schema/skill text but provides no structured failure signal when contracts violate; mirrors drift-class discriminator (synthesis #4). L1 floor = P1+S2 for #660 (5x highest-recurrence, ~2h, zero risk); L2 recommended = L1 + S1 structured store response + S5 lesson scan = closes 3/4 trackers under 6h. Disagreement with synthesis #4: memory subsystem has no single leverage point (4 distinct channels); needs 4 distinct mitigations OR an L5 architectural refactor. Novel primitive surfaced: S5 lesson scan generalises beyond memory-subsystem to all recurring failure classes with lesson trail. Synthesis channel 6-for-6 per chain pattern.
+- **Memories used:** `c5616dc5-4c91-4d71-9675-72b80819cf3e, f5b5f74a-3ee4-4574-b1a9-652ae87f7a10, 586f4452-536e-4ab5-a006-50ecf8251c9e, 01ac8c74-8823-4057-8f31-e7174e6f1329`
+
+---
+
+### Fix 5 broken anchor links in docs/design/c17 + c18 inline (PR #661) rather than file a tracker; ship audit script as gitignored .scratch/ tool not committed CI guard.
+
+- **UUID:** `aa981969-ddb5-463d-957a-0e3f77f87736`
+- **When:** `2026-05-16T11:29:24.232612+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter36`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Per CLAUDE.md "Fix > track for trivial reversible (#428)": broken link sweep across docs/ is trivial, reversible, sibling-grepped via mechanical audit script — exactly the inline-fix profile, not the issue-track profile. Audit script kept gitignored: shipping it as CI guard would be scope-creep within an iter:36 ambient drive-by, and the path-filter meta-test pattern (#326) is a different shape. Note in PR body invites owner to escalate the script to CI follow-up if they want it. Branch from origin/main not from current feat/606 to keep diff clean; CONTEXT.md WIP carried but not committed.</rationale>
+  > <parameter name="alternatives_considered">["File issue + close in 5min: rejected as exactly the paperwork #428 warns against.", "Ship audit script as CI guard inside this PR: rejected — out of scope for ambient iter:36, escalation belongs to owner judgement.", "Commit to current feat/606 branch: rejected — would conflict with that PR's scope and pollute its diff.", "Skip and file tracker only: rejected — fixes are 5 lines, already verified mechanically."]
+- **Memories used:** `67c4495f-38d6-47d9-8ff4-aa833b890ee2, 319d10ae-fe43-4b08-b0c6-50a9b9478553`
+
+---
+
+### MCP-call sub-class verifier protocol: query `episodes` table by UUID-prefix LIKE-match (not events_canonical) — d87b795's 8 decision UUIDs all resolve as kind=decision_made, NO DRIFT.
+
+- **UUID:** `e9637c35-f0c5-4017-8b95-577d0a2cc779`
+- **When:** `2026-05-16T11:34:59.598489+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter37`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Query events_canonical only — what record_decision docstring implies; rejected as 0/8 UUIDs resolved there, confirms routing asymmetry; Skip verification, classify as UNKNOWN permanently — rejected, leaves 1 sub-class of drift unverifiable forever; Add MCP tool decision_get_by_id — rejected as scope, that's a tracker for owner not a chain iter task; tracker candidate noted in baton; Treat episode UUIDs as opaque (no verification possible without admin) — rejected, Supabase MCP execute_sql is available and was the obvious path`
+
+  > Iter:30 drift discriminator backward-scan classified 1 MCP-call commit (d87b795) as UNKNOWN because the verification path was unclear. Iter:37 resolved it: record_decision returns episode UUIDs that live in the `episodes` table (kind=decision_made, payload->decision carries text), NOT in events_canonical (which only gets OTel GenAI fields when llm metadata is passed). Verifier protocol: SELECT id, kind, payload->>'decision' FROM episodes WHERE id::text LIKE 'prefix%'. Applied to d87b795: all 8 claimed UUIDs (Q2/Q3/Q3.5×2/Q4/Q5/Q6) resolve with matching actor=session:grill-afk-q2:resumed-2026-05-14 and created_at on the commit date. Negative drift finding — commit performed the side-effect, claim holds. Cross-axis confirmation of synthesis #6 channel-asymmetry framing: the same `decision_uuid` vs `memory_id` routing confusion that produced tracker #660 explains why iter:30 hit UNKNOWN — the obvious table name (events_canonical, named in record_decision docstring) is wrong target; correct target is `episodes`. Now drift discriminator covers all 3 sub-classes with explicit verifier code: file-write=fs.stat, per-device=cross-device read, MCP-call=episodes UUID-prefix SQL.
+- **Memories used:** `d1ef2779-e018-482a-ab48-0f1cba86896b, bba24c3e-a142-4b58-8ee7-d7cd97d98808`
+
+---
+
+### Synthesis #7 — cross-device observability axis: per-device-process sub-class is opaque by physical topology; L3 (device_status table + device_probe MCP tool + /device-checkin skill + /verify clause, ~3h) is recommended floor, L4 (automated emitters, ~6h) is ceiling; no tracker filed yet (class is gap in observability, not recorded failure).
+
+- **UUID:** `4bc90d1d-2662-4331-aed4-c0699cb5e76e`
+- **When:** `2026-05-16T11:42:24.400568+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:afk-chain-iter38`
+- **Project:** `jarvis`
+- **Alternatives considered:** `File tracker now without grill — rejected: class is observability gap, not failure; no recurrence evidence to anchor the tracker; Edit mirror-vs-source-drift draft to inline the cross-device axis — rejected: drafts are gitignored; cross-ref via memory pointer per existing chain pattern; Skip synthesis #7 and do Tier 4 redrobot triage — rejected: baton recommends synthesis #7 as last narrow gap; redrobot cross-project drive-by lacks loaded conventions; Use memory_store to track device state instead of new table — analyzed at §6 point 1; rejected because retention semantics conflict; Extract synthesis-channel template into runbook memory instead — deferred to Tier 5 future iter; baton recommends synthesis #7 first`
+
+  > Iter:30 backward-scan tagged 3 of 12 commits UNKNOWN due to per-device-opaque side-effects (48a770f scheduler registration, 0a1f686 task registration, c6a1fb8 hardware bench). The drift discriminator from iter:29 cannot classify them because no cross-device read surface exists. Channel map shows shared-cloud (Supabase) + shared-git (GitHub) cover intent but not per-device-local state (Task Scheduler, env vars, mirror sync). Discriminator: cross-device-observable iff verifiable from any device with git+gh+Supabase+repo-filesystem; cross-device-opaque iff requires reading state only the device-that-ran-the-commit can see. Closure requires device to EMIT to a shared row — non-soft-prompt fix. L3 establishes the read surface; L4 adds autonomous write-path. Cross-axis confirmation: same discriminator as synthesis #6 (promised contract without structured signal) — two-substrate confirmation of the meta-class. Substrate count predicts leverage shape: uniform substrate → single leverage point (drift); multi-substrate → coordinated multi-mitigation (memory + device topology). Synthesis channel 7-for-7. Closes the last narrow gap in major-axis chain.
+- **Memories used:** `1853a304-9a4f-4c8c-8e76-10b842118d7a, 9e542dcf-fc59-4481-b708-5a76eb6071b1, 8388d4f3-855b-48a7-9009-6f9c87371a9d`
+
+---
+
+### Extract AFK-chain synthesis-channel template into reusable runbook reference memory autonomous_chain_synthesis_template (skeleton + axis types + cross-axis protocol + tracker-vs-defer heuristic).
+
+- **UUID:** `6b773b5a-31b9-4b75-ae8f-b5e4fe71d75d`
+- **When:** `2026-05-16T11:47:11.359323+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:afk-chain-2026-05-16:iter-39`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Defer template extraction — rejected, pattern is mature and chain may continue, value of capture is highest now; Inline template into autonomous_chain_runbook_lessons_2026_05_16 — rejected, lessons memory is dated-snapshot and full; reference memory cleaner separation of operational lessons (one-shot) vs template (reusable skeleton); File a tracker issue with the template instead — rejected, runbook memories are the canonical location per CLAUDE.md no-state-in-static-storage; issues are for state changes, this is reusable design; Cross-project triage on redrobot (Tier 4) — viable but lower leverage given chain just completed major axis and template capture has decay risk if iter chain continues past smart zone`
+
+  > 7-for-7 major-axis synthesis chain (iter:20-38) reached completion 2026-05-16. Pattern is mature: convergent §-skeleton across 7 drafts, substrate-count-predicts-leverage-shape insight (iter:38) is the missing runbook field, file-vs-defer heuristic crystallised in iter:38. Template extraction is the right Tier 5 trigger now per next-action-for-successor in working_state_jarvis. Future chains can apply this skeleton from iter:1 instead of rediscovering it. Memory type=reference (operational guide), scoped to jarvis project, linked to existing runbook-lessons memory for layered recall.
+- **Memories used:** `6a8b639c-7bf5-42d6-9169-121ec2047608, 599fd623-fabd-42db-881a-56756dabb3b9, 26d04374-cdbb-49a1-a0e7-37b0e0451140, 8388d4f3-855b-48a7-9009-6f9c87371a9d`
+
+---
+
+### Rework PR #661 inline (5 edits across c17+c18 docs) + file tracker #662 + park as status:review
+
+- **UUID:** `810db31b-657f-41ba-97e8-cb8ca3153eb5`
+- **When:** `2026-05-16T11:58:26.400207+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter-40`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Park PR as-is without rework — rejected, MEDIUM verdict requires fix-before-merge per Code Review guidance and existing chain pattern (iter:1, iter:4); Fix only reviewer-flagged instances — rejected, CLAUDE.md sibling-grep rule explicitly says partial fix triggers 2nd-round review with same class finding; File anchor-link rot tracker WITHOUT inline fix — rejected, fixes are trivial reversible scope-obvious per #428; Tier 4 redrobot triage as originally baton-recommended — deferred, PR #661 fresh Code Review verdict is higher-priority`
+
+  > Code Review on PR #661 surfaced MEDIUM finding (stale line numbers misleading readers to credential-security content) plus 2 pre-existing c18 broken anchors (out-of-scope, but sibling-grep brought them in). Per CLAUDE.md sibling-grep rule, audited full c17/c18 scope — found 4 additional stale line-ranges (C17 starts at 439 not 408, C18 at 673 not 657, L3 leans at 1890/1801 not 1728/1763). Class fix > instance fix. Reviewer 8 systemic finding (CI guard for anchor links) + Reviewer 2 suffixed-anchor drift class = 2nd sibling threshold met (iter:36 = 1st) per baton's "anchor-link rot wait for 2nd sibling" heuristic — promoted to tracker #662. Anchor-audit.py validates clean. No CI changes introduced (require-linked-issue red predates this rework).
+- **Memories used:** `e8f0d65a-2c5a-4abc-be7d-d6e8a4e5e6a7`
+
+---
+
+### Anchor-link drift class bounded: iter:36 + iter:40 fixes were complete; 12 remaining suffixed-N anchors verified correct via slug-counter math; no additional drift found across docs/design/. L2 sanity algorithm (enumerate `#slug-N` N≥1 for manual review) added to .scratch/anchor-audit.py — empirical evidence supports #662 L2 design.
+
+- **UUID:** `8d3c13c0-1e30-4837-857f-64bc105e50cd`
+- **When:** `2026-05-16T12:03:17.13829+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter41`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Stronger heuristic L2 (e.g., section-locality check) — rejected as brittle and prone to false-positive; manual-review punch list is honest about intent-detection limit.; Promote audit script to scripts/ + CI workflow — out of scope (needs .github/workflows/ + meta-test per #326, owner decision territory per #662).; Skip extension, do redrobot Tier 4 triage instead — rejected; foreign-repo outbound interpretation ambiguous, jarvis Tier 2 ambient maintenance is safer and equally useful.`
+
+  > Iter:40 surfaced a blind spot in string-not-found anchor auditing: suffixed-N anchors that exist as slugs but point to wrong heading. The fix scope expanded 2→6 via sibling-grep. Question for iter:41: are there more such cases hiding elsewhere? Implemented L2 algorithm (gitignored script, safe), ran across all docs/design/. Result: 12 suffixed-N anchors, all verified correct via heading-occurrence counting (2 C17/C18 base slugs, 11 each Rejected/How-measured, indices align with intended C18-section targets). Negative finding bounds the class — no further fix-inline needed. L2 algorithm validated as enumerate-for-manual-review (cannot detect intent automatically; punch list is the strongest mechanical signal).
+- **Memories used:** `c5616dc5-4c91-4d71-9675-72b80819cf3e`
+
+---
+
+### Drop 13 stale line-number citations across c17/c18/memory-fok design docs; keep section anchors. Sibling-grep extension of iter:40 PR #661 partial fix.
+
+- **UUID:** `3573f1c2-7e16-47f0-816d-6bc76d86d781`
+- **When:** `2026-05-16T12:10:58.943863+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter42`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Update line numbers to current correct values — rejected: numbers will re-drift on next insertion, this is the failure iter:40 already documented; Skip and file a tracker — rejected: fix-inline per CLAUDE.md #428 (reversible, <30 min, scope-obvious), same class as iter:40 commit which was also fix-inline; Defer all of memory-fok.md including the substance-drift cases (L38, L147 reference removed code paths) — accepted partial: handle only pure stale-line-number cases, file separate tracker for substance drift if confirmed`
+
+  > Iter:40 commit 2e628f6 narrowed sibling-grep to `(line N)` / `(lines N-M)` patterns only, missing `:NNN` line refs embedded in markdown link text and `L3 lean NNN` / `L3 line NNN` inline references. Iter:42 audit found 13 more stale citations: c17 (8), c18 (3), memory-fok.md (2). Each verified by reading the cited line in the target file — most point at unrelated content (e.g. `v2-redesign.md:1733` is C5 judge calibrator row but cited for C17 OTel; `schema.sql:151` is goals RLS but cited for events table; `memory.py:588` for `_emit_recall_event` defined at L426). Apply same strategy as iter:40 commit: drop line numbers (fragile under heading rename + insertion), keep section anchors (`#c17--observability--audit-1`, `#c18--proactive-challenger-1`, `#self-detection`, etc.) verified valid by anchor-audit.py iter:41 clean pass. Section anchors are the durable navigation primitive; line numbers are not. Same low-risk profile as iter:40 (docs-only, no executable change). Surfaces lesson: when fixing a regex-bounded class, expand the regex to peer patterns before declaring class bounded.
+- **Memories used:** `506002be-541c-435b-8b2c-f04ca8c32da2, c5616dc5-4c91-4d71-9675-72b80819cf3e, 8ee95001-2f08-4c4f-9fb0-6126a2f808e7`
+
+---
+
+### File issue #664 as substance-drift tracker for memory-fok.md (4 owner-pick mitigation options A/B/C/D); no doc inline edit
+
+- **UUID:** `981e8a43-c79c-4238-bdcc-5c63c8758792`
+- **When:** `2026-05-16T12:21:14.00428+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter43`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Option A (in-place annotation) — inline edit ourselves: rejected because doc is gap-analysis PRD; owner needs to decide canonical-form policy across all Phase 5.3 design docs; Option C (full retrofit) — autonomous rewrite of Section 2: rejected because erases gap-analysis framing the doc opens with; high-risk substance change; Defer to next chain iteration: rejected because findings have decay; better to file evidence now while context fresh; Bundle with existing PR #663: rejected because #663 is parked status:review and bundling would force re-review for substance change orthogonal to line-ref drops`
+
+  > Iter:42 PR #663 explicitly flagged memory-fok.md L38/L147 as substance drift (different sub-class from line-number drift) and deferred to a separate audit. Iter:43 verified: commit 9a0e0dd (PR #473 merging #444) on 2026-04-29 removed the inline `_upsert_known_unknown` calls from `_hybrid_recall` per #439 D5. Doc was not updated — three drift sites remain (L38 status-table claim, L48 gap row, L147 D5 instruction). Per baton "if confirmed drift, file shape-first tracker — don't try to fix doc inline since spec-vs-shipped reconciliation is owner judgment." The doc opens by declaring itself a gap-analysis PRD (not a clean-slate design), which makes mechanical retrofitting risky — D5 prose argues FOR a change that's already shipped, so wholesale rewrite erases the historical framing. 4 mitigation options proposed (A: in-line shipped annotation, B: implementation-status header, C: full retrofit, D: top-of-doc note + defer). 7th tracker in mirror-vs-source-drift class.
+- **Memories used:** `23400103-7356-407f-930b-d242538ca465, 8374f50e-1c24-4ff0-8ca0-d2495c3e7e45`
+
+---
+
+### File #665 as shape-first substance-drift tracker for docs/design/memory-overhaul.md; no inline doc edit attempted; recommended mitigation = A+B combo (inline annotations + top-of-doc status header).
+
+- **UUID:** `6061be5d-8316-4b4a-a6a2-853ad041fce1`
+- **When:** `2026-05-16T13:30:59.048954+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter44`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Inline-edit Section 1 + Section 5 to mark shipped rows — rejected per #664 shape-first precedent; Bundle audits for all 3 remaining Phase 5.3 docs in one tracker — rejected; per-doc trackers are more grep-friendly; No tracker, just memory note — rejected; owner-grill bundle needs queryable trackers per #648-664 precedent`
+
+  > memory-overhaul.md opens declaring "Status: research complete, design pending principal review" but Phase 0 schema (PR #189, 11 columns), Phase 1 recall filters (schema L269-272), Phase 2 classifier (classifier.py + handlers/memory.py:543), Phase 5.1d-α + 5.2-α/β/γ have all shipped. Section 1 audit table has at least 6 of 10 rows now stale (gaps #1/#4/#6/#7/#8/#9/#10). Same discriminator as iter:43 #664. Shape-first because doc declares itself a PRD; mechanical "now fixed" edits would erase historical framing.
+- **Memories used:** `23400103-7356-407f-930b-d242538ca465, 2d6a383f-99d3-430c-9120-5d6d778c58cc`
+
+---
+
+### File shape-first tracker for compression-resilience.md substance-drift — header reads "Sprint 1 in flight (milestone #25, epic #277)" while all 3 phases shipped and milestone #25 closed 2026-04-21; also uses forbidden term "epic" per CLAUDE.md.
+
+- **UUID:** `0e4e9d40-072f-4a28-bfd8-c8af7f577244`
+- **When:** `2026-05-16T13:34:48.389333+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.92`
+- **Actor:** `session:afk-chain-iter45`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Discriminator from iter:43/44 (declare-vs-perform substance-drift) reapplied with zero adjustment: doc declares Sprint 1 prospectively while three verifiable artifacts confirm shipped — scripts/pre-compact-backup.py exists (Phase 1 commit 887b41a #281), scripts/session-context.py has session_snapshot recall + Pre-Compact Recovery section (Phase 2 commit ba6e0ed #282), .claude-userlevel/skills/end/SKILL.md treats Supabase as authoritative source with snapshot+record_decision pull (Phase 3 merged). Milestone #25 state=closed, all 4 child issues (#277/278/279/280) CLOSED. Additionally violates CLAUDE.md decision 2a7ae10e-afc3-4523-b0bc-c4b90ddbe1a5 ("Term \"epic\" is not used"). Pattern matches #664/#665 precedent: shape-first tracker with 4 mitigation options (A inline annotations / B top-of-doc status header / C full retrofit / D historical-doc declaration), recommend A+B combo. 3rd substance-drift sub-class tracker; class now spans 3 of 4 Phase 5.3-adjacent design docs.</rationale>
+  > <parameter name="alternatives_considered">["Edit doc inline per #428 Fix>track — rejected: #664/#665 precedent set substance-drift as owner-judgment shape-first not autonomous fix; consistent treatment matters more than 3 minutes saved", "Bundle into existing #665 — rejected: distinct doc, distinct phase (compression-resilience vs memory-overhaul), separate tracker preserves grep-ability of class", "Skip (already covered by class) — rejected: class is OPEN not BOUNDED; baton explicitly recommends extension as iter:45 work; bounding requires per-doc audit"]
+- **Memories used:** `67c4495f-38d6-47d9-8ff4-aa833b890ee2, 2d6a383f-99d3-430c-9120-5d6d778c58cc`
+
+---
+
+### File #667 — 4th substance-drift tracker for reflect-aggregates-pending-migration.md (dangling-refs subsection only, top-of-doc framing OK)
+
+- **UUID:** `445b5eea-1829-40e3-bdad-e460f157266d`
+- **When:** `2026-05-16T13:43:05.155054+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:afk-chain-iter46`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Baton iter:46 pre-check: top-of-doc "Pending Migration" + open #515/#516 = correctly safe-framed, would bound sub-class. BUT sibling-grep of "Known dangling refs" (L292-302) found 3/5 entries stale: implement/SKILL.md, to-issues/SKILL.md, to-prd/SKILL.md no longer reference /reflect (cleaned in PR #588 / dd8aa77 / #528 2026-05-10). Same shape as #664/#665/#666: shipped cleanup not reflected in inventory driving next decision (#516 grill). Discriminator generalised zero-adjustment N=4. A+B combo recommendation now canonical fix shape — owner could ratify as default. Narrower scope than #664/#665/#666 — drift is bounded to one subsection. No doc edit per #666 precedent (shape-first, owner-pick).</rationale>
+  > <parameter name="alternatives_considered">["BOUND class without tracker (rejected: top-of-doc OK but Known-dangling-refs section materially stale, drives wrong #516 scope)","Inline edit per #428 (rejected: substance + shape decision belongs to #515/#516 grill, not autonomous)","File at full-doc severity matching #664/#665/#666 (rejected: drift is subsection-scoped, not whole-doc; tracker prose distinguishes)","Defer to iter:47 forbidden-terminology grep (rejected: this is the recommended iter:46 task, sub-class bounding completes class for owner-grill)"]
+- **Memories used:** `67c4495f-38d6-47d9-8ff4-aa833b890ee2, 319d10ae-fe43-4b08-b0c6-50a9b9478553`
+
+---
+
+### File #668 — forbidden-terminology "epic" drift tracker; severity-tiered (HIGH for .github/ process layer + MEDIUM for memory-fok.md + LOW historical quotes); rec A+D combo; first non-substance-drift application of discriminator
+
+- **UUID:** `ff2627d0-c3b0-44ca-914c-860963cd9d49`
+- **When:** `2026-05-16T13:50:21.709962+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `session:afk-chain-iter47`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Fix inline per #428 — rejected, scope too large (.github/ rewrite is owner-judgment process change, not drive-by); Fix only memory-fok.md L5/L248 — rejected, would leave the much larger .github/ process-layer drift undocumented; File 2 separate trackers (one for .github/, one for memory-fok) — rejected, both stem from same v3 decision propagation gap, single tracker keeps owner-grill bundled; Skip filing, class CLOSES at #666 N=1 — rejected, 30 hits is not bounded; would be dishonest`
+
+  > Sibling-grep on `\bepic\b` across docs+.github+skills found 30 hits / 15 files. Class is larger than expected — the v3 decision (2026-05-08) dropped "epic" but the entire .github/ operational process layer (copilot-instructions, AGENTS, github-process-runbook, issue templates, issue-checks.yml regex) still uses Milestone→Epic→Task taxonomy. Plus genuine drift in memory-fok.md calling #185 "Parent epic" when its title is "Memory overhaul (Pillar 4)..." with no EPIC prefix or epic label. Historical-title quotes (5 files) are defensible per CLAUDE.md / PROJECT_PLAN.md L44 policy. Shape-first tracker follows canonical N=4 substance-drift sub-class format (#664/#665/#666/#667) but recommendation deviates to A+D combo (active fix on .github/ + minimal fix on memory-fok) rather than canonical A+B because leverage points differ — .github/ warrants active rewrite not annotation. Discriminator from substance-drift sub-class generalises to terminology drift with zero adjustment (N=5 zero-adjust applications now). 11th in mirror-vs-source-drift class; first non-substance-drift sibling; opens new terminology-drift sub-class at N=1.
+- **Memories used:** `06ca2740-57af-4eef-a8be-bb6a36587ab5, 2a7fe7df-da8d-463b-a507-7e00c09f42c0`
+
+---
+
+### Classify .claude/README.md L4 and .sandcastle/README.md L3 epic-hits as Tier 3 DEFENSIBLE historical-title quotes; bound iter:47 #668 audit at 15/15 files via comment, no new tracker
+
+- **UUID:** `1353a535-e9ea-4429-8507-ba3cc1b338c0`
+- **When:** `2026-05-16T13:54:58.257063+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.92`
+- **Actor:** `session:afk-chain-iter48`
+- **Project:** `jarvis`
+- **Alternatives considered:** `File new tracker for README-specific sub-class — rejected: same Tier 3 sub-class, no new shape; Retro-rename issues #335/#534 inline — rejected: owner-gated, falls inside Tier 1 process-layer decision; Annotate the 2 README files inline now — rejected: skill is to bound the audit, not pre-empt owner Tier 1 decision`
+
+  > Both README hits quote the current actual titles of issues #335 (EPIC: Jarvis federation) and #534 (EPIC: Sandcastle integration). Per milestone_hierarchy_v3 the term `epic` is retired structurally, but historical-title quotes that mirror a live issue title remain DEFENSIBLE per CLAUDE.md PROJECT_PLAN.md L44 policy. Comment-only close-out keeps the issue body authoritative and avoids opening a duplicate tracker for a known sub-class. Coupling note added because Tier 3 hits resolve mechanically once Tier 1 process-layer rewrite (owner option A) decides on retro-rename of EPIC-prefixed titles.
+- **Memories used:** `06ca2740-57af-4eef-a8be-bb6a36587ab5`
+
+---
+
+### Iter:49 extends forbidden-terminology audit boundary markdown→code+config; comment-only on #668; 1 new Tier 1 active-runtime hit (pretooluse-recall-hook.py:205) flagged for owner Option A rewrite; "sprint" term confirmed NOT forbidden (only sprint-as-cadence); tracker count unchanged 18.
+
+- **UUID:** `f36b40bb-6470-412b-9edd-74b4d606b67a`
+- **When:** `2026-05-16T14:00:26.525501+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:afk-chain-iter49`
+- **Project:** `jarvis`
+- **Alternatives considered:** `File new sibling tracker — rejected, no new sub-class emerged, would inflate tracker count for axis extension; Autonomous inline fix of pretooluse-recall-hook.py:205 — rejected, runtime keyword change affects live recall behavior and trades current legacy-coverage vs v3-coverage; owner judgment call; Inline-fix src/risk_radar.py:12 generic-cadence phrase per Fix>track — deferred to owner; mid-chain inline fixes risk obscuring audit shape for owner review; Skip the audit extension entirely — rejected, iter:48 baton explicitly recommended Option 1 axis extension as discriminator generality probe`
+
+  > Discriminator from iter:47-48 (Tier 1 active/Tier 2 substance/Tier 3 historical-title/Tier 4 fixed-identifier) generalizes markdown→code+config with zero adjustment for `\bepic\b` and one minor Tier 4 split for `\bsprint\b` (exempt skill identifiers like /sprint-report). The new actionable site `pretooluse-recall-hook.py:205` is mechanically the same active-runtime-keyword-on-dropped-taxonomy class as `.github/workflows/issue-checks.yml:69` regex — just outside `.github/` scope. Comment-only on #668 (not new tracker) matches iter:48 close-out pattern — no new sub-class identified, just axis extension. Memory `milestone_hierarchy_v3` clarifies "sprint" was killed as cadence-grouping-primitive ONLY, not as English word; "Sprint N" historical capability-unit names stay (Tier 3 DEFENSIBLE).
+- **Memories used:** `06ca2740-57af-4eef-a8be-bb6a36587ab5`
+
+---
+
+### File owner-eyes-only proposal #669 documenting XML-asymmetric-strictness misleading 'required property' error class observed 3 times in AFK chain (iter:22/37/48) on record_decision reversibility param; surface as Tier 2 hook hardening candidate sibling of #524, mitigation options A/B/C/D shape-first, recommend A+C combo for owner; no autonomous code action.
+
+- **UUID:** `4d7f67b5-c999-41bb-9a7c-beaad02aaafc`
+- **When:** `2026-05-16T14:05:34.740725+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:afk-chain-iter50`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Tier 2 substance-drift extension to remaining Phase 5.3 docs (deferred per iter:49 baton — discriminator no-longer-zero-adjustment, not the highest leverage); Tier 3 research follow-ups on v2 draft (lower leverage than concrete tracker); Tier 5 template enrichment with iter:49 lessons (iter:49 baton designates this for iter:51 not iter:50); Tier 5 sub-option: fill open template gaps (lower urgency); Inline code investigation/fix of root cause (DISALLOWED — hypothesis unverified + .claude/* and harness code edits gate-blocked + owner-judgment required on enforcement surface)`
+
+  > Iter:49 baton recommended this as Option 1 for iter:50: clean follow-up filing matching tracker-shape, low effort, surfaces a Tier 2 hook hardening candidate. Recurrence count 3 in single chain meets CLAUDE.md "1 incident, 3 pattern" threshold per iter:48 baton classification. Same shape-first tracker template used iter:43-iter:48 (4 options, owner-pick, owner-judgment-required tag) — discriminator generality already confirmed across markdown + code+config axes, applies cleanly to harness/MCP-server class too. Owner-judgment required because: (a) root-cause hypothesis is inference not instrumented, (b) enforcement surface (harness vs SDK vs server) unsettled, (c) cost-vs-frequency tradeoff may favor option D do-nothing. Filing without owner approval is safe because issue body is a proposal not a code change; tier ≥ MEDIUM verdict path satisfied (status:awaiting-owner-equivalent via needs-grill label).
+- **Memories used:** `7e79666d-f9fa-479c-859f-cc17d92fc009, 6ec98f31-25f3-49b5-b1e8-222e1276d7b6, 1778e466-01b1-4327-9bfa-c5179db46c5e, 2ebdc3b7-5775-4b85-a9be-c1af4e764102`
+
+---
+
+### Enrich autonomous_chain_synthesis_template with iter:43–50 lessons: harness-DX-fragility axis spec, severity Tier 1.5 + Tier 4 refinements, axis-extension-via-comment pattern, recurrence-via-outcome_record ledger principle, plus two added anti-patterns.
+
+- **UUID:** `23253471-e12d-4851-97ae-aca079491157`
+- **When:** `2026-05-16T14:10:42.972089+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.92`
+- **Actor:** `session:afk-chain-iter-51`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Tier 2 substance-drift class extension beyond Phase 5.3 (jarvis-v2-redesign / sandcastle-integration etc.) — rejected: discriminator no longer zero-adjustment, requires fresh per-doc evidence, higher cost than template enrichment, baton ranked Option 2 below Option 1; Tier 3 research follow-ups on v2 research draft — rejected: drafts not committed per docs_research_unfinished policy, lower leverage than template closer; Tier 5 follow-up filling Tier 4 fixed-identifier exemption alone (Option 4) — rejected: a subset of Option 1, picking it alone leaves harness-DX-fragility and recurrence-ledger gaps open; Tier 2 harness-DX-fragility class extension (Option 5) — rejected: baton flagged premature, owner read on #669 needed first; No-op — rejected: priority queue has clear top item; Tier 6 only valid when all 5 prior tiers exhausted`
+
+  > Iter:50 baton's Option 1 recommendation — single memory upsert is the clean closer. Five distinct enrichments are convergent runbook insights from iter:43–50 that the original iter:39 template did not anticipate. Folding them in now (one tool call) prevents next-chain re-derivation. No new tracker (audit-extension pattern would apply but this is the template itself, not a class member). No PR (memory-only). Reversible (memory upsert can be undone via memory_restore). Five enrichments: (a) harness-DX-fragility axis-type with full spec, (b) Tier 1.5 active-runtime-keyword + Tier 4 fixed-identifier-exemption severity tiers, (c) axis-extension-via-comment as cheaper-than-sibling-tracker pattern, (d) outcome_record notes as load-bearing recurrence ledger across iters, (e) two added anti-patterns (under-tiering fixed identifiers, recurrence in chain-log not outcome).
+- **Memories used:** `23400103-7356-407f-930b-d242538ca465, 6ec98f31-25f3-49b5-b1e8-222e1276d7b6, 2ebdc3b7-5775-4b85-a9be-c1af4e764102, 1778e466-01b1-4327-9bfa-c5179db46c5e, 573b9d5f-4f96-4664-8aad-9c4ffcb2d0e4`
+
+---
+
+### File substance-drift tracker for docs/design/autonomous-loop.md extending sub-class beyond Phase 5.3 to Pillar 2 (5th sibling in sub-class, 12th in mirror-vs-source-drift class); recommend A+B combo following canonical N=4 precedent
+
+- **UUID:** `2b60f68e-f851-4844-8b54-9197b7328e10`
+- **When:** `2026-05-16T14:16:43.001346+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.93`
+- **Actor:** `session:afk-chain-iter52`
+- **Project:** `jarvis`
+- **Alternatives considered:** `jarvis-architecture-c4.md candidate doc — deferred to AC of this tracker as audit extension; sandcastle-integration.md candidate — deferred; more recent (2026-05-14) suggests less drift, save for later sweep; inline edit per recommendation (no tracker) — rejected per canonical shape-first reasoning #664/#665/#666/#667; owner-judgment needed on diagram retrofit; Tier 3 research follow-up (baton Option 2) — deferred to iter:53; substance-drift extension was top of baton recommendation list`
+
+  > Iter:52 baton's Next-action Option 1 explicitly called for substance-drift class EXTENSION beyond Phase 5.3 to one doc from a candidate list. Picked autonomous-loop.md (Pillar 2, last touched 2026-04-29, "Status: implementing" L4) as highest-leverage candidate. Verified 5 substance-drift sites (status line stale, 4-skill perception table consolidated, 6-task schedule table 1/7 overlap with actual, SOUL.md path stale post-3-way-split, 6→7 file count). Discriminator (grep cited symbols + ls actual dirs) zero-adjustment generalized from Phase 5.3 sweep to cross-pillar Pillar-2 doc. Canonical A+B combo recommendation matches N=4 precedent (#664/#665/#666/#667). Shape-first tracker per same reasoning as prior — owner-judgment needed on ASCII diagram retrofit (Option C) vs minimal annotation (A+B). 12th tracker in mirror-vs-source-drift class, 5th in substance-drift sub-class, 1st cross-pillar (Pillar 2 not Pillar 5/Memory).
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140, df51f553-bcde-471e-b5de-734072225d77, 23fb61eb-d80f-40d3-a7e9-b6c86de57b76`
+
+---
+
+### File substance-drift tracker #671 for docs/design/jarvis-architecture-c4.md — 5 enumerated drift sites including 2 Tier-1 (Plan/Research MCPs as deployed; stale MV names) + 1 Tier-1.5 (crepes Mondrian CP inline as C5 mechanism) + 1 Tier-2 (plugin list partial) + 1 Tier-3 ('(new)' tag aged out). Canonical A+B recommendation. Sub-class refinement: drift *shape* inverts from lag (iter:43-46/52) to lead (this iter) — features planned, doc shows deployed.
+
+- **UUID:** `28a8e2c1-c61a-4a09-8795-12d4dd5509b7`
+- **When:** `2026-05-16T14:24:53.667911+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.92`
+- **Actor:** `session:afk-chain-iter53`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Defer to owner — rejected, sub-class still actively expanding and owner asked for autonomous work; File against jarvis-v2-redesign-review-pass2.md instead — rejected, larger doc (20KB) higher cost without prior signal; File against sandcastle-integration.md instead — rejected, recent (2026-05-14) lower drift likelihood; Audit-extension comment on #670 instead of new tracker — rejected, this doc is Pillar 1 not Pillar 2 AND has 5 distinct drift sites with different shape (lead vs lag) — new tracker per axis-extension-via-comment-pattern (discriminator adjusts on drift direction, files sibling not comment); Skip the Tier-3 site (L237 '(new)' aged out) — partially adopted; flagged as defensible in body to prevent false-positive; Recommend Option C (diagram retrofit) directly — rejected, requires mmdc re-render + larger diff; canonical A+B precedent honored`
+
+  > Iter:53 picks Option 1 from iter:52 baton — jarvis-architecture-c4.md substance-drift audit (oldest of the 3 AC candidates from #670, smallest, Pillar 1). Discriminator (grep cited symbols + ls actual MCPs/extensions/plugins) zero-adjusted from iter:52 markdown↔skill-catalog axis to markdown↔MCP-deployment+schema-MV-names+plugin-installs (5th axis). 4 of 5 sites have crisp evidence (.mcp.json shows 1 in-house MCP not 3; schema.sql shows events_last_run_by_actor_mv not last_run_by_actor_mv + no decisions_by_trace_mv; ~/.claude/plugins/installed_plugins.json shows 5 plugins not 3; no crepes/mondrian in mcp-memory code). Cross-doc check confirms Plan+Research MCPs are L3 leans in jarvis-v2-redesign.md L1786+L1839, not deployed. Critically: this is the FIRST observed *lead* drift shape (features planned, doc shows deployed) vs the 5 prior lag-shape trackers — worth a sub-class refinement note in autonomous_chain_synthesis_template (deferred to next iter). 6th substance-drift sub-class tracker. 13th mirror-vs-source-drift class tracker. Cross-pillar coverage now Pillar 1 + Pillar 2 + Phase 5.3 (4 docs).
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### Enrich autonomous_chain_synthesis_template with substance-drift lead-vs-lag directional sub-class spec (~30 lines added) + 1 new anti-pattern + sibling-vs-comment decision matrix + pacing rule for sub-class refinements
+
+- **UUID:** `3fc074fa-fd4e-49b2-ba23-5efae837c8d5`
+- **When:** `2026-05-16T14:30:51.541911+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.93`
+- **Actor:** `session:afk-chain-iter-54`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Option 2: substance-drift sweep on jarvis-v2-redesign-review-pass2.md — higher token spend, would have surfaced lead-shape N=2 confirmation candidate but defers the template-enrichment closure another iter; Option 3: research follow-ups on v2 — drafts only, lower leverage than closing a known template gap; Option 4: recurrence-ledger latency Tier 5 — needs empirical data which is unavailable mid-chain; Option 5: harness-DX-fragility class extension — premature without owner read on #669; Option 6: autonomous_chain_* semantic-recall miss investigation — lower leverage than #1, deferred (noted in Open template gaps for future iter)`
+
+  > Iter:53 baton recommended this Tier 5 single-memory upsert as highest-leverage iter:54 work. Closes the iter:53 open gap (lead-shape first observation) before it stales beyond useful recall horizon. Lead-shape failure mode differs from lag-shape (runtime errors vs graceful staleness) with higher blast radius, so distinguishing them in template is load-bearing for future audits. Mechanics: single memory_store upsert, ~30 added lines under new "Substance-drift directional sub-class spec" section + updated cross-axis confirmation examples + updated tracker bundle list + new anti-pattern #9 + new pacing rule + new sibling-vs-comment decision matrix table. No PR, no commit, no code change. Reversible (memory upserts are versioned).
+- **Memories used:** `26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### Filed sibling tracker #672 for substance-drift in docs/design/jarvis-v2-redesign-review-pass2.md (lag-shape, new sub-axis: review-meta-doc); applied iter:54 anti-pattern #9 (both lag-shape and lead-shape discriminators) and the sibling-vs-comment matrix concluded sibling (new sub-axis, zero-adjust on parent discriminator).
+
+- **UUID:** `65321c0a-2791-4c8b-abb7-5633503e8505`
+- **When:** `2026-05-16T14:39:01.611826+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.92`
+- **Actor:** `session:afk-chain-iter55`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Comment on #670 instead of sibling — rejected: #670 is about Pillar 2 capability doc autonomous-loop.md; pass2 is a review-pass meta-doc with structurally different drift mode (frozen-by-design snapshot vs evolving capability spec).; Comment on #667 — rejected: #667 bounds the Phase 5.3 doc sub-class; pass2 is outside Phase 5.3.; Defer (no tracker) — rejected: 7+ drift sites in a single review doc is non-trivial blast radius, and pass2 IS cross-linked from v2-redesign.md.; Bundle with one of #670/#671 as 'review-doc + Pillar-doc combined' — rejected: mixes two doc classes and dilutes the canonical A+B rec; sibling is cleaner.; Inline-fix the doc directly — rejected: matches iter:43-46+52+53 precedent of shape-first owner-judgment tracker since the resolution marker style (extend Q7 pattern vs tombstone vs pass3) is an owner-judgment call.`
+
+  > Pass2 doc (2026-04-29 last touch) lists 7+ SOTA Actions / L3 ecosystem deltas as pending punch-list items, but the corresponding spec changes have landed in v2-redesign.md C17/C6/C9/C15/C16 sections (materialized projections L1896, DEFER gate outcome L1809, permissions.deny audit L1810, MCP OAuth 2.1 L1835, _meta maxResultSizeChars L1821, TaskCreated hook L1829, PostToolUse.duration_ms L1819, prior-version-novel safeguard stack L1877, tier-graduation alignment check L1878). Doc has resolution-marker precedent at L86 for Q7 but didn't propagate it to other adopted items. Discriminator zero-adjusts from #664-#667 (Phase 5.3 docs) and #670 (autonomous-loop.md / Pillar 2) to review-meta-doc class; new sub-axis (Pillar/capability doc → review-pass meta-doc) justifies sibling per iter:54 decision matrix. Lead-shape audit on pass2 ran clean (L86 Q7 anchor verified — v2-redesign.md:111 §«Harness coupling» exists). Used the autonomous_chain_synthesis_template directly via memory_get (semantic recall miss reproduced for the 3rd iter in a row — 7+ failed queries cross-iter — open gap from iter:54 stands, candidate for Tier 5 investigation).
+- **Memories used:** `c973812d-8b5f-41d6-9c83-2bb4ad2351a7`
+
+---
+
+### Filed #673 as Tier 5 investigation tracker for autonomous_chain_synthesis_template memory_recall miss; harness-DX-fragility class sibling on retrieval-layer (vs #669 on tool-call parser layer); owner-judgment-required A+C combo (read-only SQL inspection + diagnostic logging substrate); do not auto-fix (sandcastle/mcp-memory subagent-fragile zone)
+
+- **UUID:** `93e365c4-0833-43c5-a245-db76e1294606`
+- **When:** `2026-05-16T14:45:13.275638+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.93`
+- **Actor:** `session:afk-chain-iter56`
+- **Project:** `jarvis`
+- **Alternatives considered:** `File for #669 axis-extension comment (rejected — retrieval-layer vs parser-layer is structurally different substrate; sibling not extension); Auto-fix by re-embedding manually via memory_store upsert (rejected — only fixes one memory; doesn't address root cause; sandcastle-zone code review still needed); Defer to Option 2 (iter:55 XML-asym-strict #4 comment on #669) (rejected — Option 1 had 3-iter recurrence pressure; Option 2 cheap audit-extension can fit any later iter); Upgrade #669 scope to cover both parser and retrieval layers (rejected — different code paths, different hypotheses; bundling loses signal-to-noise)`
+
+  > Iter:55 baton Option 1 recommended. 4th iter reproduction (iter:53+54+55+56) with 10+ distinct queries failed including literal slug, distinctive-keyword, and content-body terminology variants. Bug is durable across query variation, not transient. Workaround (memory_get) bounded; recall is heavily-queried by chain so latency cost compounds. Filed shape-first 4-option (A SQL inspection / B isolation reproduce / C diagnostic logging / D wait-and-see) with rec A+C: A answers most-testable hypothesis (stale embed) fast and read-only; C provides durable diagnostic for future misses without requiring per-iter human investigation. Tracker count 22→23. New axis type: harness-DX-fragility retrieval-layer (extends #669 parser-layer to retrieval substrate). Discriminator: error message (rank<10 or absent) disagrees with retrieval intent AND root cause in mcp-memory/server.py + memory_chunks scoring substrate (not agent's query construction).
+- **Memories used:** `c973812d-8b5f-41d6-9c83-2bb4ad2351a7`
+
+---
+
+### Posted audit-extension comment on #669 with full recurrence ledger (N=3→5), multi-field/multi-tool scope table (3 tools, 4 fields), and two-substrate cross-axis confirmation linking to retrieval-layer sibling #673.
+
+- **UUID:** `826b035d-8b9b-4bfb-be75-af8a4b0dcf4c`
+- **When:** `2026-05-16T14:52:17.323132+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.94`
+- **Actor:** `session:afk-chain-iter57`
+- **Project:** `jarvis`
+- **Alternatives considered:** `File a sibling tracker instead of comment — rejected per sibling-vs-comment matrix (zero-adjustment + no new sub-class within parser-layer = comment, not sibling); Defer until next recurrence — rejected because N=5 is already pattern (not incident) and #669 owner-grill input fidelity is the explicit goal; Bundle iter:55 and iter:56 recurrences in a single inline edit to #669 body — rejected because issue body is owner-authored, comments are the audit-extension channel per iter:49 pattern`
+
+  > Iter:55 baton Option 1 was the standing-order recommendation: cheap audit-extension comment on #669 with full iter:55+56 recurrence + #673 cross-link. The synthesis_template axis-extension-via-comment pattern (iter:49) explicitly fits: discriminator (XML parse asymmetry causing misleading required-field errors) zero-adjusts across new substrates (outcome_record.outcome_status iter:55, memory_store.source_provenance+tags iter:56), no new sub-class emerges within parser-layer — so per the sibling-vs-comment matrix this is comment-on-original, not sibling-tracker. The cross-link to #673 (retrieval-layer sibling, filed iter:56) gives owner-grill the two-substrate framing per cross-axis confirmation protocol. Note: memory_recall failed AGAIN to surface autonomous_chain_synthesis_template AND autonomous_chain_runbook_lessons_2026_05_16 (the two memories actually informing this decision) — 5th-iter recurrence of #673 and broadens its scope from synthesis_template-specific to all autonomous_chain_* namespace memories. Used proxies autonomous_long_sessions + autonomous_loop_v1_architecture that DID surface; full informing memories accessed via direct memory_get.
+- **Memories used:** `6a8b639c-7bf5-42d6-9169-121ec2047608, 26d04374-cdbb-49a1-a0e7-37b0e0451140`
+
+---
+
+### Iter:58 bundled audit-extension: comment on #673 with namespace-broadening evidence (autonomous_chain_* not just synthesis_template) + comment on #669 with recurrence #6 ledger-closure and ironic-inversion #2 evidence.
+
+- **UUID:** `5e9cdd27-c3ee-4cf6-ae54-c41367717c58`
+- **When:** `2026-05-16T14:57:49.165321+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.93`
+- **Actor:** `session:afk-chain-iter58`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Option 3 template enrichment (3 pending refinements) — deferred to iter:59 to keep iter:58 narrow; threshold met but not urgent.; Tier 2 substance-drift sweep on sandcastle-integration.md — declined; current Tier 1.5 bundle is higher leverage and time-symmetric with iter:57.; Skip Option 2 (one-comment-only on #673) — declined; iter:57 public ledger is one short and the asymmetry would erode the cross-link symmetry pattern across the two trackers.`
+
+  > Iter:57 baton recommended Option 1 + Option 2 bundled — namespace-broadening on #673 narrows hypothesis surface toward H2/H6 and ledger-closure on #669 keeps public counters honest. Iter:58 reproduced #673 recall miss again (3rd reproduction of namespace-wide affliction). Bundling two short gh issue comment calls in one iter is cheap, complementary, and produces bilateral cross-link symmetry between #669 (parser-layer) and #673 (retrieval-layer) substrates of the harness-DX-fragility class. Standing-order pattern from autonomous_long_sessions applied without re-confirmation.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, ade61912-4168-40ce-b4b7-55e94a160d43`
+
+---
+
+### Do not promote gemma4:26b (Gemma 4 26B-MoE) to sandcastle local Ollama primary; DeepSeek remote stays Tier 2 primary on workshop PC.
+
+- **UUID:** `de03cc4f-56ae-4a63-b53f-69fd6dbbcdcb`
+- **When:** `2026-05-16T19:51:01.35071+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:eval-674-2026-05-17`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Issue #674 evaluation on workshop PC (RTX 5080 16GB). Layer 1 throughput pass (warm 34.5 tok/s, just above 30 tok/s floor; full 11.4/16.3 GB VRAM fit, no CPU offload). Layer 2 naive Anthropic-compat /v1/messages probe pass (clean stop_reason=tool_use, real tool_use block with correct name+input). Layer 3 — the load-bearing real-Claude-Code consumer probe — failed categorically 0/2: Session 1 produced a generic chatbot greeting ('I am ready to assist you. How can I help you today?') with zero tool calls despite full sandcastle system prompt + 304-token issue queue + tools surface; Session 2 went totally idle (5 minutes, zero output tokens, agent stopped without engaging). Two different failure shapes (verbose generic vs total silence) both yielding zero tool dispatch is structural non-adherence, not stochastic. Distinct failure class from qwen3-coder:30b's Hermes-XML emission (2026-05-14) but same outcome. Per #674 decision matrix branch 'Layer 1–2 pass, Layer 3 fails' → keep DeepSeek primary, file follow-up.</rationale>
+  > <parameter name="alternatives_considered">["Promote gemma4:26b to sandcastle local primary — rejected: 0/2 Layer 3 success, gemma4 cannot invoke tools in real Claude Code sandcastle session despite passing naive curl probe.", "Run Session 3 to complete the ≥2/3 protocol — rejected: success rate mathematically cannot reach 2/3 from 0/2; would burn ~15 min compute for no decision change.", "Test gemma4:e4b fallback in Layer 3 — rejected: 4B model with weaker instruction-following than the 26B MoE that already failed agent-flow; fallback rationale in issue was 'if MoE plumbing issues' but plumbing (Layer 2) actually passed, so e4b is not the right next step.", "Keep qwen3-coder:30b as Tier 0 — already rejected 2026-05-14 (Hermes-XML failure)."]
+- **Memories used:** `e1830d75-c120-4ebf-8afc-01f7113e9a61, 2403f131-68c2-4be3-b1f4-31fbec9fc2b2, 6a6ac586-a089-4925-a406-eba40d67a604`
+
+---
+
+### Issue #658 root cause: observability gap (agent confabulation), not classifier race or genuine silent block. Recommendation: structured JSON response from _handle_store + neutral consolidation phrasing.
+
+- **UUID:** `9430c1d9-ff52-44bf-bb2e-4e5bcca7507e`
+- **When:** `2026-05-16T19:54:07.834826+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-05-17:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `(2) classifier UPDATE-supersession race — refuted: no memory_review_queue row references the disputed candidate; (3) genuine silent block elsewhere — refuted: no code path produces such a message, no threshold matches 0.75`
+
+  > Audit-log shows 77 memory_store calls on 2026-05-16 (02:58–14:59 UTC), zero with target matching metacognition_* or pillar_4_*. memories.metacognition_sprint_shipped row updated_at = 2026-04-21 05:15:17 — with a BEFORE UPDATE trigger memories_updated_at active, lack of bump proves no write landed on 2026-05-16. memory_review_queue on 2026-05-16: 12 rows, none reference the disputed candidate — rules out classifier race. Strings "dup-detector" and "0.75" do not appear anywhere in mcp-memory; actual thresholds are 0.60/0.80/0.85. _handle_store has no code path that produces a "block" message; the consolidation hint is appended to a successful store. Conclusion: the call never reached the server, and the agent fabricated a plausible-sounding rejection mode after some upstream failure (likely VoyageAI timeout or MCP transport error) because the tool's prose-only success/failure response left room for confabulation. Race meta-test (AC#4) dropped — no evidence supports it; existing supersession code already guards with is_(superseded_by, null) + rowcount==0 check.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Resolved #657 via option (2): untagged `always_load` on 5 memories instead of deleting. Live always_load count: 6 → 1, matches commit 5645893's promise.
+
+- **UUID:** `095c50ba-70f4-4e41-9b9d-1311d606dea6`
+- **When:** `2026-05-16T19:57:42.027372+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:657-resolution`
+- **Project:** `jarvis`
+- **Alternatives considered:** `option (1) delete all 5 — rejected: irreversible, loses global recall for redrobot context; option (3) revert commit prose — rejected: preserves drift, normalizes commit-message-lies; option (4) STATUS header on 5 memories — rejected: was AFK-safe interim, owner now present so direct resolution is cheaper`
+
+  > Option (2) untag-but-keep wins over option (1) delete on three axes: (a) reversible — delete is destructive, untag can be reverted with one SQL update; (b) preserves cross-project recall — 4 of 5 memories are global-scoped (quality_over_speed, verify_before_assuming_implemented, no_state_in_static_storage, skill_invocation_is_a_contract_not_a_trigger) and applicable to redrobot work, where jarvis CLAUDE.md §Engineering posture is not loaded; deletion would lose them in that context; (c) achieves the commit's stated intent (stop session-start duplication) — bodies no longer load every session but remain available on-demand recall. Owner explicitly delegated the choice ("я не в теме, лучше ты выбери"). Option (1) can still be applied later if the kept memories prove redundant.
+- **Memories used:** `abc0a54d-0806-4349-8863-45ae542071eb, e9acc59d-0860-4bed-90e2-befc02c78dd8, 3db70793-b671-461d-9494-94c0a157426f, 9bb3332f-9b9f-4444-8723-77e37501de5f, ffc488e8-c669-44b4-b8fa-813e5f8e6a17`
+
+---
+
+### Batch /delegate #665+#659+#662: dispatch #665 and #662 as parallel subagents (mechanical-mode, doc/CI, 0/4 grill triggers each); keep #659 inline via /implement after batch (1/4 trigger — installer affects 3 devices, safety-adjacent; option A from issue rec already decided). #662 ships L1+L3, defers L2 with rationale.
+
+- **UUID:** `d90372a1-40ba-49bc-940d-9fc4f9b0802e`
+- **When:** `2026-05-16T19:59:59.998141+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `dispatch all 3 as subagents in parallel — rejected: #659 fails grill gate without artifact + installer is safety-adjacent; exit grill_required for #659 and run /grill first — rejected: option A is already the issue's own recommendation, owner delegated decision, /grill would just rehash a settled call; ship L1+L2+L3 for #662 in one PR — rejected: L2 heuristic is fragile, no second instance to validate against, scope creep risk; ship L1 only for #662 — rejected: leaves the iter:40 line-number drift class (4 of 6 known instances) uncovered`
+
+  > Per /delegate dispatch contract: #665 and #662 fail the SOUL.md grill checkbox at 0/4 (doc-only / CI-internal, no domain logic, trivial tests, no cross-cutting code) → mechanical-mode subagents. #659 hits 1/4 (installer behavior is user-visible across 3 devices) — strict gate would force `grill_required` exit; instead, route inline because (a) fix shape recommended in issue (option A: skip-if-suffix one-liner + fixture test), (b) safety-adjacent cross-device blast radius warrants orchestrator-attention not subagent dispatch, (c) skill explicitly allows inline routing for safety review. Cross-merge ordering risk: #662 promotes .scratch/anchor-audit.py to tests/ci/; if it merges before #665, the latter's AC ("run .scratch/anchor-audit.py post-sweep") breaks. Mitigation: #662 COPIES the script, not moves — both paths exist post-merge. For #662 scope: L1 (promote audit to CI guard) + L3 (regex guard for `(lines? \d+)` line-number annotations) ship; L2 (suffixed-anchor heuristic parsing "C18" from link text) defers — fragile heuristic, needs larger fixture set than 30min budget allows, revisit on 3rd suffixed-drift instance.
+- **Memories used:** `9a5a1ade-d3c0-4163-8559-dff5993094ea, bfcf55c0-6105-4200-91bb-0eee01bd29a4, 737763bf-740f-4864-9860-7ad41149af50`
+
+---
+
+### Pre-dispatch gate (#642) and existing grill_required contract are orthogonal and both fire in /delegate — pre-dispatch checks artefacts (sandcastle label, no needs-*, AC section, decision UUID); grill_required checks the SOUL.md checkbox heuristic on body
+
+- **UUID:** `a66918d2-b912-45fd-a7da-f940d9fcbe7e`
+- **When:** `2026-05-16T20:12:32.907222+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A: pre-dispatch replaces grill_required entirely — rejected, axes are distinct; C: gates fire in different contexts (interactive vs headless) — rejected, /delegate is sometimes both; one rule simpler`
+
+  > AFK-safety classification (sandcastle label) is not derivable from grill-checkbox — it's an explicit owner judgement about whether the task can run without HITL. Both gates measure different axes of dispatch readiness: "did a grill happen and produce artefacts" vs "is this AFK-safe at all". Cost of running both is trivial; cost of conflating them is silent vibe-coding under sandcastle.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 354419eb-fea4-4660-9980-4f60d6f705f1`
+
+---
+
+### When pre-dispatch artefacts (sandcastle label + AC + decision UUID) are present, /delegate dispatches without re-running grill_required checkbox on the body. grill_required becomes a backstop only for legacy issues that pre-date #642 artefacts.
+
+- **UUID:** `88fe2617-8e35-4785-bf6f-12a26cbd0822`
+- **When:** `2026-05-16T20:12:37.690869+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `B: both gates always fire — rejected, doubles ceremony for the common path; C: pre-dispatch first, grill_required runs only if pre-dispatch can't classify — rejected, adds a branch that fires rarely`
+
+  > Decision UUID is a stronger signal than the checkbox heuristic — it points to a record_decision episode with rationale and alternatives. Re-running the checkbox after artefacts pass would be distrust of the owner's own process. Failure mode "fake artefacts (copy-pasted AC + UUID without real grill)" is more work than running real grill — defending against it is theatre. grill_required stays in code for edge case: artefacts absent AND needs-grill label absent (old issue).
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Batch /delegate 665 662 → #662 EXIT grill_required (no dispatch, no claim); #665 re-routed from delegate to /implement inline (single-issue rule + prior API 400 risk).
+
+- **UUID:** `ab953e99-9eed-4bba-8868-0e69da711e2c`
+- **When:** `2026-05-16T20:12:42.840029+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Per /delegate §Contract dispatch table: #665 scores 0/4 on grill checkbox → mechanical-mode. #662 scores 2/4 (L2 algorithmic heuristic + non-trivial fixture tests + L2/L3 ship-or-defer decision in AC) with no grill artifact in working_state_jarvis (current state covers #674) or issue body (no `## Decisions` heading with UUIDs) → MUST exit grill_required. After exit, only #665 remains; per skill's "When to /delegate vs /implement" table, single dispatchable issue defaults to /implement (inline). Additional weight: prior identical batch on 2026-05-16 failed at Agent spawn with Anthropic API 400 (one MCP tool schema uses top-level oneOf/allOf/anyOf), and the same MCP set appears loaded this session — inline avoids re-hitting the same failure mode. Principal confirmed inline via AskUserQuestion.</rationale>
+  > <parameter name="alternatives_considered">["Attempt /delegate 665 anyway: rejected by principal — risks re-hitting 2026-05-16 API 400 (~1.1s, 0 tokens, wasted claim)", "Hold both and run /grill 662 first: rejected by principal — #665 is purely mechanical and ready to ship now, no reason to block it on the #662 grill", "Skip-grill override on #662: not offered — /delegate explicitly has no batch-level skip-grill override (only /implement does, for single issues)"]
+- **Memories used:** `f0f0334f-98af-4c88-a6bb-05d359eef3b7, 9a5a1ade-d3c0-4163-8559-dff5993094ea`
+
+---
+
+### Implement #658 as structured JSON envelope on _handle_store success path (stored/action/memory_id/project/consolidation_candidates/classifier_pending/message) + rephrase consolidation hint to neutral info: prefix. Codify idempotency-on-(project,name) invariant in CONTEXT.md.
+
+- **UUID:** `aca3e07d-9698-4123-a2b1-6485643f774d`
+- **When:** `2026-05-16T20:12:47.306819+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:claude-impl-658:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Take a row-level advisory lock on (project, name) for the classifier UPDATE path (cause-2 race fix) — rejected: owner diagnosis showed zero memory_review_queue rows referencing the disputed candidate; no race evidence.; Skip the classifier entirely on exact-name match (exact-name bypass) — rejected: redundant once we communicate idempotency via stored:true; the classifier already runs after the write has landed and is structurally non-blocking.; Close as not-a-bug — rejected: leaves prose-only response as a confabulation trap for the next agent.; Reshape error paths to JSON too — rejected for scope: iter:13 confabulation was triggered by the success-path prose, not error-path prose. Out of scope.`
+
+  > Owner diagnosis on issue (memory_review_queue + audit_log + memories row inspection) ruled out race (cause 2) and not-a-bug (cause 3): the iter:13 store never landed, and a prose-only success message let the agent confabulate a "dup-detector block". Fix the class of bug (prose responses invite confabulation) by giving callers an unambiguous stored:true signal — the iter:13 instance itself is unrecoverable. Error paths kept prose since they were not the confusion source. Race meta-test (original AC#5) dropped per owner — no race evidence. CONTEXT.md invariant added so future readers see the lineage without re-deriving from handler code. memory MCP failed to load in worktree (no .venv); used main repo venv for pytest + smoke; this decision_made row written via Supabase MCP execute_sql fallback per CLAUDE.md.
+- **Memories used:** `4d75a1ea-41e9-49b5-a91e-031dd1ff7e74`
+
+---
+
+### Sweep 7 design docs (memory-overhaul, memory-fok, compression-resilience, reflect-aggregates-pending-migration, autonomous-loop, jarvis-architecture-c4, jarvis-v2-redesign-review-pass2) with A+B canonical fix per #665 umbrella: top-of-doc framing line + inline Status annotations citing closed issues/merged PRs. Single PR. Do NOT rewrite shipped sections as past tense (preserve historical PRD gap-lists).
+
+- **UUID:** `90730d24-0f7e-47c3-98b6-f4ff29577865`
+- **When:** `2026-05-16T20:15:50.068949+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:implement`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Implementation pattern is fully prescribed by issue body §"Canonical fix shape (A+B combo, ratified across 4 prior trackers)" and exemplified at memory-overhaul.md L72 (`**Status (#242):** foundation shipped — ...`). The umbrella explicitly closes #664/666/667/670/671/672 as duplicates of the same class and mandates single-PR sweep. Per CLAUDE.md engineering posture "No state in static storage": pointers ("see #N for current status") are explicitly the allowed form — that's exactly what A+B emit. The "do not rewrite shipped sections past-tense" guard preserves the gap-list that motivated each design — past-tense rewrite would destroy the why behind the design choices. Decision is reversible (doc-only, no code paths affected).</rationale>
+  > <parameter name="alternatives_considered">["Rewrite shipped sections to past tense / strike-through: rejected by issue body — erases historical PRD gap-lists that motivated the designs", "Split into 7 PRs (one per doc): rejected by umbrella — paperwork without benefit, canonical form is shared so one review is more coherent", "Only add framing line (B) without inline annotations (A): rejected — inline pointers are what make per-section status discoverable; B alone hides which sections shipped vs still pending"]
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### `sandcastle` label is applied by /to-issues at slice issue creation time, not by /grill. /grill produces AC + decision artefacts at milestone/PRD level; /to-issues uses those artefacts to create slice issues and classifies each slice as AFK-fit (label applied) or HITL-required (label absent).
+
+- **UUID:** `6e753417-9263-4bf9-9399-eaa6eaa0fb24`
+- **When:** `2026-05-16T20:21:54.819163+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `B (original): /grill applies label — rejected, no slice issues exist yet at grill time; A: owner applies manually — rejected, will be forgotten, violates 'skills fix what they find'; C: /triage applies on status:ready — rejected, conflates 'ready for any agent' with 'ready for AFK agent'; D: /grill proposes, owner accepts — same shape as B with extra ceremony`
+
+  > Slice issues don't exist at grill time — only the milestone/PRD does. /to-issues is the moment of birth for each slice and the only place with both the grill output and the slice-level granularity needed for per-issue AFK classification. /to-prd is sometimes skipped; /to-issues is not.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### /to-issues uses AFK-fit checklist (4 questions, inverted-SOUL form) to decide sandcastle label per slice: (1) static path-grep against protected/safety-critical zones, (2-4) LLM judgement on slice description for session-context dependency, mid-execution human judgement, cross-cutting/external-state side effects. Any yes → no label.
+
+- **UUID:** `9d4e0840-e9f6-4aa7-8439-020cc622cfff`
+- **When:** `2026-05-16T20:26:56.577436+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A: pure path-based static — misses judgement-call cases; B: pure capability-based LLM — path safety is determinstic, cheaper as static; D: default-on with exclude list — false-positives under sandcastle worse than missing AFK opportunities`
+
+  > SOUL grill-checkbox is "needs grill?" heuristic — tautologically passed after grill, wrong instrument for AFK classification. AFK-fit is a different axis. Hybrid static+judgement: (1) deterministic via declared-files grep against per-repo path-list (jarvis: mcp-memory/server.py, .mcp.json, CLAUDE.md, SOUL.md, .github/workflows/, scripts/*.ps1 install; redrobot: driver/, planning/, mujoco/). (2-4) LLM call on slice description. Symmetric form to SOUL checkbox so owner can eyeball it. Path-list alone misses judgement-call slices; pure LLM misses path safety; default-on inflates false-positives where sandcastle vibe-codes.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 354419eb-fea4-4660-9980-4f60d6f705f1`
+
+---
+
+### Pre-dispatch refuse in headless context: outcome_record with status=refused + reason + required-owner-action; issue moves to `status:owner-queue` label; surfaced via /status next session. No Telegram escalation even on repeat refuses.
+
+- **UUID:** `e9b9cfb8-e40f-4628-ab75-938519ea824a`
+- **When:** `2026-05-16T20:30:52.639233+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `A: silent drop — invisible until /status query, no metric trail — outcome_record fixes that but stale-queue label is stronger signal; B: Telegram on refuse — too noisy, violates last-resort rule; B-light on persistent refuse — already covered by /status visibility; D: AFK-grill auto-fix — grill without operator is the failure mode #642 exists to prevent`
+
+  > Telegram is last-resort per CONTEXT AFK-system invariant. Pre-dispatch refuse is not an emergency — it's "owner forgot to label / write AC". /status at next session-start surfaces it without interrupt cost. Persistent stuck refuse signals owner attention deficit, not Jarvis blocker — visible-in-queue is the correct pressure mechanism, not pings.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Hard cutover for #642 rollout: owner backfills M#41 issues (#633-#640) with sandcastle label + AC section + decision UUID references at merge time of the gate PR. No grandfather labels, no warn-mode, no created_at branching in code.
+
+- **UUID:** `be345f03-d1ec-43de-b169-9656227d71d5`
+- **When:** `2026-05-16T20:33:54.025676+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `B: grandfather by created_at — permanent legacy branch in code; C: legacy:pre-642 label with TTL cleanup — needs cron janitor, overkill for one-time; D: warn-mode 7d soft launch — calibration redundant after this grill; status:owner-queue already surfaces real impact`
+
+  > M#41 is 8 issues — ~20min of owner backfill is cheaper than maintaining a legacy code path forever. Grandfather-by-date adds permanent `if created_at < X` complexity with no removal schedule. Warn-mode is calibration ceremony for a gate that owner already decided the shape of in this grill; refuse-flow design (status:owner-queue + /status visibility) already covers the "did we mis-estimate impact" feedback loop.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### needs-* labels are removed by the skill they request, on successful completion: /grill removes needs-grill, /research removes needs-research, /refactor removes needs-refactor. Convention, not enforced centrally.
+
+- **UUID:** `1941ce5d-285e-4144-8faf-672046101608`
+- **When:** `2026-05-17T11:10:24.692134+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Central post-skill hook strips all needs-* labels — too aggressive, removes labels skill didn't address; Owner manually removes — will be forgotten, label clutter`
+
+  > Each skill owns its terminal state. Centralized cleanup would require a registry that adds friction without value — skill is the closest authority on whether the label condition was actually met (vs surface-level "skill ran"). Convention encoded in each SKILL.md.
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Pre-dispatch gate is repo-agnostic. /to-issues AFK-fit path-list lives per-repo in extended repos config (current config/repos.conf is owner/repo only — needs structured extension with protected_paths[] per entry, or sibling config/afk-paths.json keyed by owner/repo). Any repo present in repos.conf participates automatically; new repos onboarded by adding the entry + their path-list.
+
+- **UUID:** `79313e94-02af-4830-b9c5-046617b4cb13`
+- **When:** `2026-05-17T11:10:29.283961+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Hardcode per-repo paths in /to-issues SKILL.md — violates repo-agnostic principle; Auto-detect protected paths via .codeowners or similar — fragile, not all repos use codeowners`
+
+  > Owner stated system must be repo-agnostic: anything in repos.conf is auto-handled by orchestrator + dispatch flow. Path-list is the only per-repo bit of pre-dispatch gate logic; rest of gate (sandcastle label presence, AC section, decision UUID, needs-* absence) is uniform. Hardcoding paths in /to-issues skill would couple skill to specific repos and require skill-edit for every new project — wrong axis. Implementation: implementer chooses between extending repos.conf to TOML/YAML or adding sibling JSON; decision deferred to implementer with constraint "must not require skill edit to add a new repo".
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Pre-dispatch gate fires only at /delegate skill entry, not re-validated inside sandcastle container's internal /implement. Known fragility: if pipeline changes such that sandcastle is spawned without going through /delegate (e.g. watcher direct-spawns container), gate is bypassed silently. Accepted risk for v1; revisit if pipeline architecture changes.
+
+- **UUID:** `6b0a5bf7-8ca9-47cc-81cf-ebae39c81d08`
+- **When:** `2026-05-17T11:10:33.500278+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `skill:grill:session-642`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Re-validate inside container — doubles LLM cost, no info gain; Container-side validator as backstop with cached gate verdict — over-engineering for v1`
+
+  > Owner accepted single-line gate at dispatch entry. Re-validation inside container would duplicate logic and double-fire LLM-judgement calls (cost without information gain — same issue body, same checks, same answer). Recorded as known limitation so future pipeline-restructure decisions surface it explicitly rather than discovering broken gate via outcome.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Add [no-issue] body marker as third escape in pr-body-check.yml (mirrors .pre-commit-config.yaml commit-msg convention from #329, enables CLAUDE.md §428 Fix>track inline drive-bys).
+
+- **UUID:** `d4f71147-2c5f-4b27-88d8-06f325daa057`
+- **When:** `2026-05-17T11:21:40.69973+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:jarvis-autonomous-watchdog-20260517`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Owner-filed #459 with proposed JS snippet specifying exact change. CLAUDE.md §"Fix > track for trivial reversible (#428)" explicitly endorses fix-inline drive-bys; the existing two-escape policy (Closes/Fixes/Resolves OR priority:critical) doesn't support that path and PR #457 had to file tracker #458 just for paperwork. Memory project_workflow_require_linked_issue (2026-04-21) said keep strict but predates #428 and explicitly said "if bucket pattern becomes ceremony, revisit" — #459 is that revisit. Implementation is additive: third escape, fallthrough unchanged, error message updated. Meta-test extended in same PR per #326 (mirror Python decision rule + config-dimension assertion that YAML still contains the marker).</rationale>
+  > <parameter name="alternatives_considered">["Keep strict, do nothing — rejected: owner explicitly filed #459 to add escape", "Branch-naming convention parallel fix — rejected: out of scope per #459", "Update memory to forbid escape, close #459 — rejected: contradicts owner's stated current intent + CLAUDE.md §428"]
+- **Memories used:** `319d10ae-fe43-4b08-b0c6-50a9b9478553`
+
+---
+
+### /learn skill v1 design: thin review-only wrapper, hybrid weekly+volume trigger, both queues, single-by-single CC surface, hard cap 20/run, merges-first ordering, h4 telemetry (per-row reject reason + one outcome_record per run)
+
+- **UUID:** `8f846597-2da0-44e0-af0c-0e65b3f36cbb`
+- **When:** `2026-05-17T11:21:49.73379+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.82`
+- **Actor:** `skill:grill`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Unified /learn doing extraction+consolidation+review (α) — rejected: would supersede ADR-0003 and collapse the producer/consumer split that makes always-gate enforceable; Telegram-only or Telegram-primary surface — rejected: rubber-stamp UX normalises the failure mode ADR-0003 closes; Pure cron trigger — rejected: stale pending with bursty Dreamer output; Pure volume trigger — rejected: slow weeks leave unreviewed rows indefinitely; Per-item record_decision per accept/reject — rejected: violates CLAUDE.md trigger list (not architectural), floods decision log; Defer action — rejected: pending IS deferred; explicit defer normalises procrastination; accept_all primitive — rejected by ADR-0003; Classifier override action (change DELETE→UPDATE before applying) — rejected: silent mutation risk, force reject+re-classify path`
+
+  > Grilled across 10 questions; preserves ADR-0003's thin-wrapper commitment and always-gate by keeping /learn purely a consumer (Deriver/Dreamer are separate producers). Hybrid trigger (weekly cron floor + volume event ≥10 ceiling, 24h debounce) avoids both stale-pending and burst-pile-up failure modes. CC-only surface (Telegram as future debt) refuses the rubber-stamp UX that ADR-0003's no-accept_all clause specifically rejects — editing-before-accept must be a first-class action, which Telegram can't do well. Hard cap 20/run + merges-first ordering preserve referential safety (merge proposals carry merge_targets UUID[] that candidate rows may shadow) and bound attention to prevent fatigue→rubber-stamp. Per-row free-text reject reason + per-run outcome_record gives two granularities of signal for future data-driven tiered auto-promote (ADR-0003 promised) without flooding decision log with per-item record_decision (which would violate CLAUDE.md trigger contract — queue drain is not architectural). User confirmed mid-grill that the cycle they described (every-20-sessions extract→reinforce→queue→review) is the observable shape, not a unified-module proposal — β interpretation, no ADR-0003 amendment needed.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, b922386c-812e-4d01-a0a0-f93fe08050d1, 9697a109-dd91-4062-b5ac-86d6d12b27e4, 615e9029-f2c5-4f73-b5b1-f28835269b29, 13de847b-30ff-42b2-a831-0dcf6377a8c3, 7bbd8036-c0a6-46b6-bb09-e17467d4c28c`
+
+---
+
+### /learn ships as a milestone (i2), not a single PR — 5 ordered slices: S1 schema+RPCs, S2 classifier-queue drain validates surface against real data, S3 Deriver producer, S4 Dreamer+merge proposals, S5 include_unreviewed recall flag. Milestone closes when one end-to-end weekly run drains both queues with no manual SQL.
+
+- **UUID:** `8963dbe7-88eb-4f15-a177-a7da6f421da8`
+- **When:** `2026-05-17T11:21:57.304995+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:grill`
+- **Project:** `jarvis`
+- **Alternatives considered:** `i1 single PR — rejected: smart-zone violation + high-blast-radius shared schema change in one shot; i3 two milestones (classifier review M-A, candidate pipeline M-B) — rejected: ships /learn twice, second version constrained by or re-grilled against first; S2.5 /reflect-writes-to-queue slice — rejected: /reflect is HITL-by-design (owner reviews report and manually memory_stores accepted findings), not an autonomous producer; no always-gate violation today`
+
+  > Single-PR shape (i1) violates smart-zone discipline and bundles a shared-schema migration (mcp-memory/schema.sql cross-shared with redrobot per CONTEXT.md invariant) with UX in one blast radius. Two-milestone split (i3) ships /learn twice and forces the second version to either constrain to the first's action surface or re-grill. Single-milestone ordered slices let S2 validate /learn's actual UX against the classifier queue (which has rows accumulating today) before building the Deriver/Dreamer producer side — avoids designing for a pipeline that doesn't exist, the same circular trap ADR-0003 calls out. Slice ordering follows dependency: schema (S1) blocks everything; S2 before S3 validates consumer before adding producers; S3 before S4 because Dreamer reads Deriver output; S5 last because include_unreviewed only matters once requires_review=true rows exist. AC ("end-to-end weekly run, no manual SQL") is literally verifiable per CONTEXT.md AC definition — not handwaving.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 13de847b-30ff-42b2-a831-0dcf6377a8c3, 615e9029-f2c5-4f73-b5b1-f28835269b29`
+
+---
+
+### Implement /delegate pre-dispatch gate (#642) with Python helper modules + per-repo JSON config + SKILL.md updates
+
+- **UUID:** `17da7de7-eb66-406b-898a-ba5ab32eee73`
+- **When:** `2026-05-17T11:27:27.032144+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `session:implement-642-2026-05-17-pm`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Issue #642 was thoroughly grilled (7 decision UUIDs cited in body + working_state). Approach: extract the four-check gate into a deterministic Python module (scripts/delegate_predispatch_gate.py) following the existing pattern of scripts/protected-files.py — gives skill prose a testable reference implementation that won't drift. Per-repo protected-path lookup goes into config/protected-paths.json keyed by owner/repo, satisfying the hard constraint that adding a new repo MUST NOT require editing /to-issues SKILL.md. Pre-existing CONTEXT.md glossary (committed 03be1e3 from grill) is the prose authority; this slice ships the code + SKILL.md sections that reference it. needs-* removal convention added to /grill and /research; /refactor skipped (skill does not exist yet; will land when the skill ships). status:owner-queue label created in both jarvis and redrobot to match the status:* family conventions.</rationale>
+  > <parameter name="alternatives_considered">["Pure-prose gate in /delegate SKILL.md without Python helper — rejected: drifts silently, can't smoke-test refusal semantics required by AC", "Extend repos.conf with structured fields (pipe-separated) — rejected: harder to express glob lists, less ergonomic for future evolution; JSON sibling is the cleaner repo-agnostic move per memory of similar config splits", "Inline protected-paths inside /to-issues SKILL.md keyed by repo — rejected: violates explicit AC constraint (adding new repo must not require editing the SKILL.md)", "Skip Python helpers, document procedure only and rely on Claude executing prose — rejected: AC demands smoke tests with named refusal reasons; testable surface needed"]
+- **Memories used:** `9a5a1ade-d3c0-4163-8559-dff5993094ea, f0f0334f-98af-4c88-a6bb-05d359eef3b7, 67c4495f-38d6-47d9-8ff4-aa833b890ee2, 7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### #673 closes via T1 — system-level eval matrix in scripts/eval-recall.py
+
+- **UUID:** `b37ba480-7202-487d-b2ee-3a7731caf962`
+- **When:** `2026-05-17T12:12:33.622103+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `skill:grill:session-2026-05-17-673`
+- **Project:** `jarvis`
+- **Alternatives considered:** `T2 per-memory production MCP debug tool: отвергнут — не отвечает на system-level вопрос owner'а, требует sandcastle-zone touch ради scope покрываемого scripts/; T3 combo T1+T2: отвергнут owner'ом за избыточный surface на один issue, follow-up достаточен; Always-on table sink (Q2a): cross-project schema blast против one observed memory — disproportionate, нарушает threat-model duality; Recall-regret detector в хуке (Q2b): мощный сигнал но требует данных от T1 для калибровки окна, defer как 3rd slice после baseline; Q5a full corpus rank scan для target: O(N) на каждый debug call ради landscape info которая не нужна для гипотезы-1-5 disambiguation; Q5b bounded rank через HNSW threshold=0: confuses HNSW approximate semantics с exact rank`
+
+  > Issue #673 — 4-iter воспроизведение recall miss на autonomous_chain_synthesis_template с 6 живыми гипотезами без явного победителя — требует diagnostic capacity, не direct fix. Owner стратегически уточнил «не последний случай, нужно понять систему в целом» — это system-level observability, не per-memory tool. eval-recall.py уже сидит как substrate (recall@5/MRR/diff baseline + partial ablation flags --with-rewriter/--with-links), расширить дёшево; per-memory MCP tool требует sandcastle-zone touch (mcp-memory/server.py + recall.py + handlers/memory.py) ради use-case покрываемого scripts/-level extension. CONTEXT.md threat-model-duality: review attention + production risk не размазывать. Memory explain_sql_before_tuning_recall явно требует measurement substrate до tuning. Если matrix покажет что нужен production tool — open follow-up с evidence, не speculate сейчас.
+- **Memories used:** `1c045d81-7544-48ce-a225-ad380462208a, d3fc3b3a-5768-4cfa-b875-c90919ba7c79, e306cb81-81b5-4979-853b-04a2704deca7, 8374f50e-1c24-4ff0-8ca0-d2495c3e7e45`
+
+---
+
+### /reason ships as standalone skill, not a flag on /grill or fold into /research
+
+- **UUID:** `5ef27502-15d0-4439-ba50-09816c6a6d18`
+- **When:** `2026-05-17T12:30:56.763702+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.65`
+- **Actor:** `session:end-2026-05-17:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > /grill stress-tests an existing plan against domain glossary; /reason runs when the user has only a vague intuition and no plan. Contracts of input differ (plan vs intuition) and direction of pressure differs (asymmetric grilling vs symmetric debate). /research is a single-shot artifact producer with no dialogue protocol. Owner confirmed via 3-question pre-design checkpoint. Prior-art sweep (memory: reason_skill_prior_art_2026_05_17) showed Superpowers' /brainstorm is nearest neighbour but covers spec-driven build from a defined goal, not "X seems wrong but I don't know why" — /reason fills an upstream stage.</rationale>
+  > <parameter name="alternatives_considered">["/grill --hard flag — rejected: muddles /grill's input contract (plan vs intuition)", "/sparring or /steelman name — rejected: steelman is a technique inside /reason, not the whole jenre", "Fold into /research — rejected: /research is single-shot artifact producer with no dialogue protocol", "Adopt Superpowers' /brainstorm wholesale — rejected: asymmetric, assumes user knows what they're building, different stage"]
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117, 9697a109-dd91-4062-b5ac-86d6d12b27e4, 7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 9fba9a16-5200-4604-912e-8f144395cdeb`
+
+---
+
+### NEUTRAL-RESEARCHER sub-agent ships as bundled markdown inside the skill, not as a separate ~/.claude/agents/*.md
+
+- **UUID:** `fe3f3c7e-9a0d-4943-9c95-c7bec9bb9603`
+- **When:** `2026-05-17T12:31:01.864+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:end-2026-05-17:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Bundling keeps the skill as one unit, requires no install-manifest schema change, and avoids adding an "agents" group before the pattern is validated. Trade-off: not a native subagent_type — invoked via general-purpose + Read-the-template. Acceptable for v1; if the pattern recurs in 1-2 more skills, promote to ~/.claude/agents/ as native subagents.</rationale>
+  > <parameter name="alternatives_considered">["~/.claude/agents/neutral-researcher.md as a native subagent — rejected: needs install-manifest agents group, premature infrastructure for one consumer", "Inline prompt at call site — rejected: less reusable, can't evolve the prompt as one artifact"]
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117`
+
+---
+
+### Anchor-link CI guard ships as `tests/ci/test_anchor_links_guard.py` + `scripts/audit_anchors.py` (split). Corpus = all tracked `*.md` minus `docs/research/`. Audit adds code-fence skipping and a GitHub-relative path allowlist (`../../{security,issues,pulls,wiki,releases}/...`). L2 (suffixed-N drift) ships as informational CLI punch-list, not a CI assertion. L3 (line-numbers in link text) ships as a precise regex test scoped to link-text position, not directory. Merges AFTER PR #661 v2 lands.
+
+- **UUID:** `a712cd56-10fc-4583-b13d-1a6e7a132726`
+- **When:** `2026-05-17T12:34:25.406945+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-662`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Separate workflow .github/workflows/anchor-links-guard.yml + meta-test — rejected: no path-filter to validate, #326 pattern doesn't apply.; Single-file tests/ci/test_anchor_links_guard.py with no scripts/ runner — rejected: developers want a CLI to find rot while editing docs locally; pytest is the wrong UX for that.; Fixture-only tests — rejected: AC says fixture-driven but fixtures alone let real rot through, defeats the promotion's purpose.; Live-only tests — rejected: slug algorithm changes need regression coverage in isolation.; docs/ scope only — rejected: misses .claude-userlevel/ skill rot, the highest-leverage surface (install.ps1 mirror).; Verbatim regex `\(lines? \d+` scoped to docs/design/*.md — rejected: directory scoping is brittle (file moves silently disable guard), false positives in AGENT-BRIEF.md prose; structural scoping (inside link-text) is precise.; L2 follow-up tracking issue — rejected: trigger is next sibling-grep occurrence, not a calendar; issue would sit stale (Fix > track rule).; Stack #662 on #661 branch — rejected: messy diff for review; #661 v2 is one merge away.; Start #662 from main now with red CI until #661 merges — rejected: noisy signal.`
+
+  > Original issue treated the audit as a verbatim promotion of `.scratch/anchor-audit.py` to `tests/ci/` with `docs/`-only scope, mirroring the #326 path-filtered-guard pattern. Grilling surfaced four points the issue missed: (1) #326's pattern is for path-filtered workflows whose paths: filter needs a meta-test — anchor rot is content-wide, no filter to validate, so a separate workflow is ceremony with no invariant. (2) Empirical sweep across all 100 tracked .md files revealed 7 broken refs outside docs/, decomposing into 3 classes (in-fence template examples, GitHub-relative special paths, real rot) — the wider corpus catches `.claude-userlevel/` skill rot that silently corrupts deployed `~/.claude/skills/` via install.ps1. (3) Without fence-skipping and GH-path allowlist, the live test fails on day one against ~5 false positives. (4) L2 isn't fully deferred — the CLI script already prints the suffixed-N punch-list, so the honest framing is "informational, not gated." The split shape gives developers a runnable `scripts/audit_anchors.py` and gives the test something to import, mirroring `scripts/session-context.py` repo convention. Drive-by fix: `.claude/README.md:17` stale `skills/sprint-report/` link surfaced by the sweep.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Close #650 (worktree isolation cluster) as not-planned — issue conflates 4 failure classes, existing coverage handles each.
+
+- **UUID:** `bd97818a-8fa9-4a82-87f8-afa5a0fd36f7`
+- **When:** `2026-05-17T12:41:05.641367+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:implement-650-close`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Implement L1 git-status guard only (cheap) — rejected: band-aid on mismatched primitive, and dirty-tree check already lives in /implement §Safety; Run /grill to pick L1/L2/L3/L4 — rejected: grill picks among options that are all wrong shape; Leave open for owner later — rejected: owner just confirmed 'решение уже есть и работает', keeping open creates phantom debt`
+
+  > Re-read of all 5 incidents in #650 body shows only one (#510) is actually "worktree isolation failed" — others are wrong-base-branch (covered by delegate_explicit_branch_origin_main), isolation-not-engaged (default already worktree), or fabricated-commits (verification scope, not isolation). Proposed L1/L2 mitigations stack defences on a primitive mismatched to the threat model — see enforcement_layer_matches_threat_model. True isolation is sandcastle (#534), which is L4 in the issue. Decomposition posted as comment; if #510-class harness bug recurs, file focused repro.
+- **Memories used:** `ab528091-6c86-43a0-b340-b1dfbbb047b6, f0f0334f-98af-4c88-a6bb-05d359eef3b7, 9a5a1ade-d3c0-4163-8559-dff5993094ea, 80e6497b-c5f8-4849-a9fd-23f0bf0a2587, ace97204-32bb-4ae6-a3ca-b36302d35766`
+
+---
+
+### Apply PR #686 review: fix install-manifest whitelist, replace hallucinated citations with verified equivalents, tighten gates, document isolation-as-behavioural-nudge — merge.
+
+- **UUID:** `e7aaf11f-e862-4e16-ad59-aa897be15964`
+- **When:** `2026-05-17T12:47:55.56176+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.88`
+- **Actor:** `session:pr686-review-apply:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Reviewer (multi-agent Claude review, 8 reviewers @ 87/100) surfaced one critical (install whitelist) plus seven majors. Cite verification (WebFetch on each arxiv ID) confirmed Dubois 2602.23971 was a hallucination, while SYCON Bench (2505.23840) and the anonymisation paper (2510.07517) exist but had wrong attribution — exact pattern reviewer warned about. Chose direct fix over deferral since (a) skill is unshipped (whitelist fix means it was never actually installed), (b) all changes are documentation-tier reversible, (c) MAJOR 7 specifically demanded verification-or-replacement before merge, and (d) shipping a skill that prescribes "evidence over intuition" while citing fabricated papers would be a credibility hazard. Post-factum issue #688 was created to satisfy the require-linked-issue PR guard.</rationale>
+  > <parameter name="alternatives_considered">["Defer to follow-up PR — rejected: review explicitly flagged this as merge-block-worthy, and skill wouldn't install regardless without the whitelist fix", "Drop all citations and rewrite from first principles — rejected: SYCON Bench and Choi/Zhu/Li are real and load-bearing; first-principles framing alone is weaker grounding", "Amend prior commits to fix the artefact in commit 2 body — rejected: no-amend rule (would rewrite published history)", "Apply priority:critical label to skip require-linked-issue — rejected: skill addition isn't a hotfix, post-factum issue is the correct route per CLAUDE.md dev-process"]
+- **Memories used:** `ded9a608-ed2a-4cd2-aec1-62b9edaaea08`
+
+---
+
+### Closed milestone #38 (Sandcastle integration) — capability shipped 2026-05-13 but state=open with 0 open issues remained until now.
+
+- **UUID:** `55d914c6-e368-46a3-b0b0-e91daab53abc`
+- **When:** `2026-05-17T13:16:25.906437+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:autonomous-watchdog-2026-05-17T13:16`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > CLAUDE.md milestone hygiene rule: "0 open issues + state=open is a bug. Close on capability shipping." All 12 slices in milestone #38 closed by 2026-05-13 (last: #572 + #546 + #545 at 2026-05-13T10:46Z). Closing now is overdue maintenance, not a fresh decision — but recording the close so the architecture-sweep trigger (≥3 closed slices, no sweep since closed_at) is wired correctly for the next SessionStart pointer per CLAUDE.md §"Architecture sweep at milestone close". Autonomous-tick-safe: routine milestone mechanic on own repo, reversible (can reopen), no human-visible outbound.</rationale>
+  > <parameter name="alternatives_considered">[{"option":"Leave open until owner closes manually","rejection":"Defers an automatable hygiene action against the explicit CLAUDE.md rule; no value preserved by waiting"},{"option":"Close + immediately run /improve-codebase-architecture sweep in this tick","rejection":"CLAUDE.md mandates sweeps run in a fresh session, not the one that closed the milestone — keep this tick focused on the close"},{"option":"Re-verify each of 12 closed slices before closing","rejection":"Already verified by their individual closure + the umbrella description; re-litigation has no added value and burns context budget"}]
+- **Memories used:** `df51f553-bcde-471e-b5de-734072225d77`
+
+---
+
+### Research intake protocol: any non-trivial design decision requires parallel pulls across 4 channels — (1) end-user experience reports, (2) domain specialist opinion, (3) quantitative data/research, (4) adversarial/failure-mode reports. Pre-grill, pre-PRD, and pre-architectural-change. Memory recall does NOT substitute for any channel.
+
+- **UUID:** `6fd2df1d-defc-440d-ba30-71880409e533`
+- **When:** `2026-05-17T13:48:11.279678+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-sycophancy-2026-05-17`
+- **Project:** `jarvis`
+- **Alternatives considered:** `3-channel framework (users/specialists/data) — rejected as too success-biased; failure-mode reports cluster between user feels and expert opinion; Memory-based 'Senior Pass' (recall + outcomes) — rejected because grading-own-exam: memory is past convergence, not fresh signal; Single web-search call per topic — rejected as undisciplined; need structured coverage across the 4 axes to avoid blind spots; Defer to /learn skill — rejected: /learn is still planned, and even when shipped it reads records, doesn't import externally`
+
+  > Owner-articulated structural problem: current skill stack (grill, reason, to-prd) reads memory + outcomes as primary intake, which is a confirmation loop — memory contains only past convergence, so the system re-discovers what we already concluded and stops searching for new solutions. Live demo this session validated the framework: searching 3 directions surfaced cross-model review pattern (users), personalization-sycophancy paradox (specialists), and 63.7% baseline sycophancy rate (data) — none of which existed in memory and each gave information the other two channels did not. 4th channel (adversarial/failure-mode) added on owner's call to cover post-mortem signal that pure success-bias success-reports miss.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, b922386c-812e-4d01-a0a0-f93fe08050d1, 49866c45-fe9b-4bd6-9b4c-42f1d1ea01e5, 13de847b-30ff-42b2-a831-0dcf6377a8c3`
+
+---
+
+### Sycophancy mitigation in /grill: stack four mechanisms — (a) cross-context review subagent without SOUL/memory access at critical forks, (b) third-person reframing in grill prompts ("user proposed X — as senior reviewer..."), (c) explicit assumption verbalization phase at session start, (d) mandatory external research-pass (4-channel protocol) before AC lock. Recognize that personalization (SOUL.md + always_load memory) measurably increases sycophancy per MIT/ICLR 2026 evidence.
+
+- **UUID:** `316c5911-9f06-44de-8f99-20fe3e9fa448`
+- **When:** `2026-05-17T13:48:18.215822+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.75`
+- **Actor:** `session:grill-sycophancy-2026-05-17`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Single 'Senior Pass' phase using memory_recall + outcome_list — rejected, demonstrated this session as confirmation loop; Wait for /learn to mature and rely on it — rejected, /learn reads records, doesn't break the personalization-sycophancy paradox; Pure prompt-engineering fix (third-person only) — under-powered against 63.7% baseline; literature shows behavior-selective interventions needed; Cross-provider review via external API (GPT-5/Gemini) — deferred not rejected; subagent with cleared context is cheaper first step, external provider is escalation if intra-Claude review proves insufficient; SOUL.md / always_load memory rollback to reduce personalization — rejected, throws baby out with bathwater; targeted role-isolation in critical phases is surgical`
+
+  > Research surfaced 63.7% baseline sycophancy rate across frontier models when exposed to user opinions (arxiv 2508.02087) — agreement bias is dominant, not occasional. Industry has converged on cross-agent review as the architectural mitigation (single-agent self-critique is grading-own-exam). Personalization features and user-modeling memory measurably worsen sycophancy (MIT 2026, ICLR 2026) — meaning Jarvis's heavy calibration to owner tendencies is working against pushback. Third-person reframing has measured ~63.8% reduction (arxiv 2505.23840), reachable via one-line prompt edit. Assumption-verbalization (CHI 2026) and adviser-role framing (Northeastern 2026) compound the effect. None of these were in our memory — surfaced only via external research. Decision is to adopt all four because they target different attack surfaces ("sycophancy is not one thing", arxiv 2509.21305) and stack without conflict.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, b922386c-812e-4d01-a0a0-f93fe08050d1, 49866c45-fe9b-4bd6-9b4c-42f1d1ea01e5`
+
+---
+
+### Dispatch #689, #690, #691 in parallel as TDD-mode subagents; orchestrator reviews each diff against main repo.
+
+- **UUID:** `83bc2e70-48fa-41f1-9d35-986608385ebf`
+- **When:** `2026-05-17T14:17:56.378652+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Working_state_jarvis lists all three slices with decision UUIDs 6fd2df1d... and 316c5911... — grill artifact present per /delegate §Contract (a). SOUL.md grill-checkbox fires ≥1 yes for each (#689/#691 touch user-visible behavior + non-trivial SKILL.md; #690 is non-trivial test scaffolding). Files are disjoint: .claude-userlevel/skills/grill/SKILL.md vs .claude-userlevel/skills/research/SKILL.md vs new evals/sycophancy/* — no parallel-edit collision. Each issue body is self-contained with enumerated AC and (for #689/#691) cited decision UUIDs, so a fresh subagent can act without main-session memory. Parallelism = 3, within the §4a safe band. TDD-mode (vs mechanical) because AC has measurable smoke/coverage clauses the subagent must not silently relabel as out-of-scope — recurring failure mode per memory 9a5a1ade-d3c0-4163-8559-dff5993094ea.</rationale>
+  > <parameter name="alternatives_considered">["Keep #689 inline because it edits /grill SKILL.md adjacent to ongoing milestone-43 coordination — rejected: only #689 touches /grill in this batch, #693 (which also touches /grill) is blocked and not in this dispatch, so no in-flight overlap.", "Dispatch sequentially to avoid worktree contamination — rejected: three disjoint file targets, branch names unique, explicit branch-base=origin/main; parallelism 3 is within safe band per §4a.", "Skip TDD-mode for #689/#691 (SKILL.md prose edits feel mechanical) — rejected: AC contains literal smoke-run requirements and decision-UUID citation clauses that map directly to verifiable test items; TDD-mode AC-completeness gate is exactly the lever against the 'cited UUID was dropped from PR body' relabel.", "Wait for /grill on #692 first to derive shared context — rejected: #689/#690/#691 are explicitly unblocked AFK slices in working_state; #692 is a separate HITL design slice not on the critical path of this batch."]
+- **Memories used:** `9a5a1ade-d3c0-4163-8559-dff5993094ea, f0f0334f-98af-4c88-a6bb-05d359eef3b7, 737763bf-740f-4864-9860-7ad41149af50, ace97204-32bb-4ae6-a3ca-b36302d35766, 48e6fa0f-1b4c-460f-a5fa-aaa7ad9c51c2, 50de5f5c-7efa-488c-89f4-ff843f7689bc`
+
+---
+
+### Dispatch #689, #690, #691 (milestone #43 anti-sycophancy slices) in parallel TDD-mode to coding subagents; none kept inline; #69 (merged PR) excluded from batch and replaced by #691 after principal confirmation.
+
+- **UUID:** `db3f1466-897b-468c-8647-8833c3ff3f74`
+- **When:** `2026-05-17T14:48:21.911248+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:delegate`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > All three are sandcastle-tagged AFK slices of milestone #43, status:ready, with self-contained AC and disjoint touch points (/grill SKILL.md, new evals/sycophancy/, /research SKILL.md). working_state_jarvis pre-stages this exact dispatch (/delegate #689 #690 #691 as suggested next skill). Per-issue grill checkbox returns ≥1 yes (user-visible skill behavior, domain methodology, non-trivial test surface), and the grill artifact is present via working_state + milestone-cited decision UUIDs (316c5911-9f06-44de-8f99-20fe3e9fa448 for #689/#690, 6fd2df1d-defc-440d-ba30-71880409e533 for #691) — so each routes to TDD-mode. 3 concurrent stays in the §4a safe band (2-3); worktree isolation is advisory but acceptable given disjoint files. #69 turned out to be a merged PR from March; principal confirmed #691 as the intended third.</rationale>
+  > <parameter name="alternatives_considered">["Keep any of the three inline via /implement — rejected: all self-contained, sandcastle-tagged, no cross-cutting context needed", "Wait for principal clarification on #69 before claiming #689/#690 — rejected: claim-first prevents races, and clarification was already obtained", "Run sequentially instead of parallel — rejected: disjoint files, 3-agent parallelism is within safe band per §4a"]
+- **Memories used:** `9a5a1ade-d3c0-4163-8559-dff5993094ea, f0f0334f-98af-4c88-a6bb-05d359eef3b7, 80e6497b-c5f8-4849-a9fd-23f0bf0a2587, ace97204-32bb-4ae6-a3ca-b36302d35766, 737763bf-740f-4864-9860-7ad41149af50, 48e6fa0f-1b4c-460f-a5fa-aaa7ad9c51c2`
+
+---
+
+### Cross-context review subagent fires at exactly two points in /grill: (1) the AC-lock gate before handoff to downstream skills, and (2) any in-grill record_decision with reversibility ∈ {hard, irreversible}. Phase-transition triggers (WHY→HOW, HOW→AC) dropped as ceremony.
+
+- **UUID:** `c29c2b00-e9e1-43d1-93ff-ada5820c434c`
+- **When:** `2026-05-17T16:31:40.114551+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-692`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Three triggers from issue body (post-WHY, post-HOW, pre-hard-decision) — rejected as ceremony; WHY phase has no criticizable artefact and HOW→AC is one turn from AC-lock; AC-lock only — rejected: lets hard decisions stamp into memory uncritiqued, wasting the highest-leverage critic moment; Every record_decision regardless of reversibility — rejected: most decisions are reversible/local; token cost outpaces signal`
+
+  > Owner ratified two-trigger design after reviewer-framed challenge of issue #692's original three-point proposal. WHY→HOW handoff has no critiquable artefact yet; HOW→AC is one user-turn before AC-lock and would double-fire. Two load-bearing moments remain: artefact exit (AC-lock) and stamping a hard decision into queryable memory. Worst case: N hard decisions + 1 AC-lock = N+1 critic dispatches per session, bounded by owner's own decision cadence, not by skill phase count. Cheap-path (no hard decisions, fizzle without AC-lock) costs zero. Slice 3 of milestone #43.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 316c5911-9f06-44de-8f99-20fe3e9fa448`
+
+---
+
+### Cross-context review subagent for /grill uses: (Q2) behavioural-not-structural scrubbing via Agent(general-purpose) with NEUTRAL-RESEARCHER-style nudge prompt in a new bundle file CRITIC.md; (Q3) structured fixed-schema output — ≤3 risks (with severity), ≤3 unmentioned alternatives, 1 challenged assumption; (Q4) forced per-item disposition (accept | reject | defer) blocks AC-lock until owner has dispositioned every finding.
+
+- **UUID:** `222e9bfe-2150-400c-afd9-a3e8defb5988`
+- **When:** `2026-05-17T17:17:33.606822+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:grill-692`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Q2 alt: structural isolation via isolation=worktree — rejected per NEUTRAL-RESEARCHER precedent (loses project memory/codebase the critic needs); Q3 alt: free-form prose critique — rejected, re-introduces hedging which is exactly the sycophancy vector being mitigated; Q4 alt: advisory-only (Copilot-review style) — rejected by owner explicitly as theatre risk; forced disposition makes the dispatch worth its tokens; Bundle layout alt: collapse into /reason's NEUTRAL-RESEARCHER — deferred to next grill question (critic vs researcher are different roles, but not yet confirmed)`
+
+  > Owner ratified all three sub-forks after one round. Q2 leverages existing /reason prior art (NEUTRAL-RESEARCHER.md) which already accepted the "isolation is behavioural, not structural" trade-off — same trade-off applies here, same precedent. Q3's hard schema prevents the critic from drifting into chat-mode and re-introducing sycophancy via prose hedging. Q4 forced disposition is the "owner stops treating it as theatre" path explicitly chosen over advisory-only — owner answer: "пусть блокирует". Together these settle three of the four issue-body open questions. Slice 3 of milestone #43.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 316c5911-9f06-44de-8f99-20fe3e9fa448, c29c2b00-e9e1-43d1-93ff-ada5820c434c`
+
+---
+
+### CRITIC bundle lives at .claude-userlevel/skills/grill/CRITIC.md (co-located with /grill, no cross-skill call to /reason). Skills stay independent + complementary — no skill-to-skill invocation between /grill and /reason, even when their bundle files have overlapping shapes.
+
+- **UUID:** `5d084972-5adb-4df7-8edb-717a3515f522`
+- **When:** `2026-05-17T17:23:30.865821+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:grill-692`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Call /reason's NEUTRAL-RESEARCHER from /grill at AC-lock — rejected: inverted contracts (find evidence vs propose alternatives) can't share a prompt; introduces cross-skill coupling new to this repo; Shared cold-context-subagent abstraction with role-prompt as parameter — rejected: DRY at the cost of readability; if/else over role leaks framing into prompt`
+
+  > Owner ratified distinct-bundle path with explicit principle: "skills should be independent but complementary". Critic and researcher have inverted contracts (critic must propose alternatives; researcher must refuse to) — sharing a template would require if/else branching that itself leaks framing. Co-locating with /grill matches existing convention (CONTEXT-FORMAT.md, ADR-FORMAT.md already in /grill). Sets a repo-wide design principle for future cold-context subagents: each owning skill maintains its own bundle file rather than collapsing into a shared abstraction.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, 316c5911-9f06-44de-8f99-20fe3e9fa448, c29c2b00-e9e1-43d1-93ff-ada5820c434c, 222e9bfe-2150-400c-afd9-a3e8defb5988`
+
+---
+
+### Implement #692 cross-context CRITIC subagent for /grill per grill resolutions: new CRITIC.md prompt template (mirrors NEUTRAL-RESEARCHER.md inverted contract), two-trigger heuristic (AC-lock gate + hard/irreversible record_decision), behavioural-not-structural scrubbing via Agent(general-purpose), fixed-schema output (≤3 risks + ≤3 alternatives + 1 challenged assumption), forced per-item disposition blocks AC-lock.
+
+- **UUID:** `75179387-c8b8-42fb-ae01-725d7d6655fe`
+- **When:** `2026-05-17T17:31:18.625293+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:implement-692`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Four-trigger ceremony (WHY→HOW + HOW→AC + AC-lock + hard-decision): rejected as ceremony; AC-lock + hard-decision dominate; Structural isolation (Agent isolation=worktree, fresh context): rejected because worktree loses project memory/codebase access the critic still needs for grounded critique; behavioural nudge is the accepted compromise (NEUTRAL-RESEARCHER precedent); Free-form prose critique: rejected because prose lets the critic hedge and re-introduce sycophancy at the wording layer; fixed schema forces commitment; Soft loopback (critic findings surface but no disposition required): rejected because owner can sweep findings under the rug — forced per-item accept/reject/defer is what makes the mechanism load-bearing; Inline CRITIC inside SKILL.md (no separate file): rejected to keep SKILL.md driver lean and CRITIC.md verbatim-pasteable into subagent prompt`
+
+  > Three grill decisions on 2026-05-17 fully resolved the four issue-body open questions. Skills stay independent and complementary — CRITIC.md is a sibling artifact in the grill bundle, not a cross-skill invocation. Behavioural isolation matches the precedent already accepted in /reason's NEUTRAL-RESEARCHER.md (known limitation, sufficient for routine bias prevention). Two triggers (not four) because WHY→HOW and HOW→AC were judged ceremony — the AC-lock gate alone gives critique its highest leverage, and hard/irreversible record_decision catches the cases the gate misses. Fixed output schema prevents prose-shaped sycophancy reintroduction. AC6 (eval re-run) is intrinsically a milestone-closing measurement; this PR ships infra, slice #694 ships measurement.
+- **Memories used:** `c29c2b00-e9e1-43d1-93ff-ada5820c434c, 222e9bfe-2150-400c-afd9-a3e8defb5988, 5d084972-5adb-4df7-8edb-717a3515f522`
+
+---
+
+### Reframe CLAUDE.md architecture-sweep auto-trigger paragraph as planned (#605) instead of shipped, rather than implementing the detector in this tick.
+
+- **UUID:** `9d7d12ef-789a-42f9-a1a9-e1086c390d63`
+- **When:** `2026-05-18T05:33:23.622255+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:watchdog-2026-05-18:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Implement the detector in this tick — rejected: non-trivial design (sweep-ran ledger location), triggers grill-me checkbox, AFK tick is not where user-visible behavior should land unsupervised.; Leave CLAUDE.md as-is — rejected: it actively lied for the M#38 close (sweep did not surface); other sessions read this file as ground truth.; Use [no-issue] body marker — rejected: PR Body Check doesn't accept it until #680 ships (audit BAD #68: PR #646 hit this same wall).; Apply priority:critical label — rejected: this is not a hotfix and the label has a defined semantics that should not be diluted.`
+
+  > Audit re-verified the drift today (.out-of-scope/decision-audit-90d-2026-05-18.md, GOOD #74 demoted from shipped to spec-only). #605 already tracks the implementation work and explicitly states "Until this lands, the trigger is manual." Implementing the detector in an autonomous AFK tick would mean adding a GitHub-API call into SessionStart context plus a dedup-since-closed_at mechanism (where is "sweep ran" recorded? memory event? grep PRs?) — that's a non-trivial design call with user-visible behavior change, triggers the SOUL.md grill-me checkbox (≥1 yes ⇒ /grill before /implement). Out of scope for unsupervised tick. Doc fix removes the false claim, points at #605 for implementation. Cost: 1 line edit + tracking issue + PR. Risk: zero (doc-only). Tracking issue #701 only filed to satisfy PR Body Check (no [no-issue] body escape until #680 merges).
+- **Memories used:** `(intentionally empty)`
+
+---
+
+### Research-pass gate 693 test
+
+- **UUID:** `5dfc4cda-0d23-416b-b1d3-cb67e768d7ca`
+- **When:** `2026-05-18T07:24:36.97786+00:00`
+- **Reversibility:** `reversible`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `none`
+
+  > Test 2
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Research-pass gate 693 test 3
+
+- **UUID:** `7e2fbc05-1027-49f2-b863-54f91d34720c`
+- **When:** `2026-05-18T07:24:49.864807+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:watchdog-2026-05-18-tick2:afk-pending-owner-review`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Test 3 with confidence and actor and project
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Research-pass gate 693 alt test
+
+- **UUID:** `4f46446f-a6e0-408b-89da-1c3f0a08bdae`
+- **When:** `2026-05-18T07:25:01.50484+00:00`
+- **Reversibility:** `reversible`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `option A rejected; option B rejected`
+
+  > Testing alternatives_considered array shape
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Research-pass gate 693 v4
+
+- **UUID:** `3a834325-3f57-4693-b47d-b5f4dadaa6fb`
+- **When:** `2026-05-18T07:25:16.710586+00:00`
+- **Reversibility:** `reversible`
+- **Actor:** `skill:unknown`
+- **Project:** ``
+- **Alternatives considered:** `PreToolUse hook rejected because finalization is multi-tool no single intercept point with skill context; Python helper rejected because sandcastle subagents may lack MCP and logic must live in prompt anyway; All-finalizations gate no sampling rejected after CRITIC because trains owners to reflexive waiver and defeats reflect drift signal; Sim score 0.4 threshold rejected after CRITIC R1 because below SUPERSEDE_SIM_THRESHOLD and wrong field; Memory record for waivers rejected because proliferates with no first-class reflect query; events_canonical for waivers rejected because no first-class reflect query path; CRITIC Alt1 gate on memories_used cardinality rejected because Tier 2 enforces memory-grounding 4-channel needs external intake orthogonal; CRITIC Alt2 inline 4-channel checklist deferred to follow-up issue valid for low-stakes but loses artifact-as-recallable property`
+
+  > Testing long alternative string
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Research-pass gate 693 v5 add actor and project
+
+- **UUID:** `5667e8ac-c995-4ded-a1ff-35b598b5ed96`
+- **When:** `2026-05-18T07:26:06.035829+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:watchdog-2026-05-18-tick2:afk-pending-owner-review`
+- **Project:** `jarvis`
+- **Alternatives considered:** `PreToolUse hook rejected because finalization is multi-tool no single intercept point with skill context; Python helper rejected because sandcastle subagents may lack MCP and logic must live in prompt anyway; All-finalizations gate no sampling rejected after CRITIC because trains owners to reflexive waiver and defeats reflect drift signal; Sim score 0.4 threshold rejected after CRITIC R1 because below SUPERSEDE_SIM_THRESHOLD and wrong field; Memory record for waivers rejected because proliferates with no first-class reflect query; events_canonical for waivers rejected because no first-class reflect query path; CRITIC Alt1 gate on memories_used cardinality rejected because Tier 2 enforces memory-grounding 4-channel needs external intake orthogonal; CRITIC Alt2 inline 4-channel checklist deferred to follow-up issue valid for low-stakes but loses artifact-as-recallable property`
+
+  > Adding actor and project to known-working long-array call
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7`
+
+---
+
+### Research-pass gate 693 short decision
+
+- **UUID:** `e8ff47d4-57e8-4e21-9f2a-e1db0dcf6bb6`
+- **When:** `2026-05-18T07:27:39.843518+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.7`
+- **Actor:** `session:watchdog-2026-05-18-tick2:afk-pending`
+- **Project:** `jarvis`
+- **Alternatives considered:** `PreToolUse hook rejected - finalization is multi-tool; Python helper rejected - sandcastle lacks MCP; All-finalizations gate rejected - trains reflexive waiver; Sim 0.4 threshold rejected - wrong field; Memory record for waivers rejected - proliferates; events_canonical rejected - no first-class query; CRITIC Alt1 reuse Tier 2 hook rejected - orthogonal; CRITIC Alt2 inline checklist deferred`
+
+  > CRITIC revised. R1 R2 R3 accepted. Alt3 sampling adopted. Alt1 rejected Alt2 deferred. Challenged-assumption routes measurement to slice 694.
+- **Memories used:** `7ad9fbb2-d7cc-4773-b9a4-7e1b202e93d7, ade61912-4168-40ce-b4b7-55e94a160d43, 49866c45-fe9b-4bd6-9b4c-42f1d1ea01e5, ca42449d-05a0-4205-bc59-0492558ccb91`
+
+---
+
+### Time-box skill_proliferation_antipattern global feedback memory: paused 2026-05-18 → 2026-06-18 during owner's skill-experimentation phase; resumes 2026-06-18 for fresh evaluation.
+
+- **UUID:** `6534501c-eaa8-4b4e-830c-991b6f21430d`
+- **When:** `2026-05-18T08:01:16.938087+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-05-18-workflow-change`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Delete memory permanently — rejected, owner wants rule back after 2026-06-18; Keep memory active, owner case-by-case override — rejected, friction differential explicitly noted as problem; Rewrite as 'review every 60 days' process rule — rejected, kicks the decision down the road rather than resolving the conflict between memory and explicit owner phase`
+
+  > Owner Q3 in 2026-05-18 workflow-change session: skill churn is intentional experimentation (~25 skills + 7 .bak.orphan vs v1.5 plan "6+1"). The antipattern memory, as written, would refuse legitimate skill creation during this phase. Alternative was: delete memory permanently (rejected — owner wants the rule back after experimentation), or keep active and let owner override case-by-case (rejected — friction differential favours antipattern, owner already noted Q3 trade-off explicitly). Time-box surfaces a re-evaluation prompt at 2026-06-18 and lets the experimentation phase proceed without antipattern friction. Memory still loads but with "PAUSED" header. Pairs with proposed Row 14 skill-creation gate at "medium" strictness (warn + show target shape, don't block) — both Q3 directives. Memory `naming_check_existing_vocabulary` continues to apply.
+- **Memories used:** `d955dccc-ce58-44a9-a97c-2ae619fec117, 9697a109-dd91-4062-b5ac-86d6d12b27e4, af74264f-223e-409c-bb05-97c652554f7e`
+
+---
+
+### Reopen #668 (epic terminology drift) and plan scoped cleanup sweep across .github/ workflows + issue templates + docs/process layer, instead of leaving wontfix.
+
+- **UUID:** `311f3d78-cc32-46c1-b2c6-2ae54172c39e`
+- **When:** `2026-05-18T08:01:28.23128+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.8`
+- **Actor:** `session:2026-05-18-workflow-change`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Keep wontfix — rejected, undermines standing decision 2a7ae10e; Reopen only for workflows (skip docs) — partial, can be done in slice 1 if scope grows; Cancel the standing decision and allow 'epic' as synonym — rejected by owner Q4 choice`
+
+  > Owner answer to 2026-05-18 re-ask: standing decision `2a7ae10e` bans 'epic' as a grouping primitive (milestone is the only one), but 30 hits across 15 files were closed as wontfix-by-scale (#668, 2026-05-16). Wontfix conflicts with the decision integrity — a standing rule that the codebase itself violates loudly is weaker than no rule. Owner Q4 in this session chose 'Reopen и сделать sweep'. Sweep is sed/grep replacement scoped to .github/ workflows + issue templates + docs/process layer where the rule has operational consequence (template generation, workflow naming). Documentation-prose drift in less-load-bearing files can defer. Slice itself becomes a new issue; this decision is about reopening + commitment to schedule, not about the slice mechanics.
+- **Memories used:** `d24a1041-e755-476a-a15e-3b279f26fe0d, 06ca2740-57af-4eef-a8be-bb6a36587ab5`
+
+---
+
+### SV multi-user dev on DESKTOP-1H2KOOJ split: petrk works in `D:\GitHub\sculpture_vision` (own clone, own .venv with Python 3.10), Temir's `C:\Users\assau\Desktop\sculpture_vision` treated as read-only production copy; cross-deploys go via push + Temir's `git pull` in coordinated off-hours window.
+
+- **UUID:** `839eb4b9-fefd-4ea6-9476-1ba529aeeee0`
+- **When:** `2026-05-18T10:02:56.29383+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:sv-workspace-split-2026-05-18`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Keep editing in Temir's path with discipline (always checkout main when done) — rejected: human discipline already failed once, no enforcement mechanism; Set up a separate test checkout on Temir's machine outside C:\Users\assau — rejected as scope creep; current arrangement (his copy IS the server) is what we have; Install Python 3.10 system-wide (HKLM) so both users share it — rejected: user-level install is correct, Temir's user shouldn't be forced onto petrk's Python choice`
+
+  > Previous session edited Temir's working copy directly, left it on `dev/redrobot-integration` instead of returning to `main`, and contaminated `__pycache__` with bytecode from petrk's user-level Python 3.10 — server failed to start until Temir manually rolled back. Root cause is shared filesystem path being treated as a workspace by both users with different Python contexts. Fix: physical separation (different drives, different venvs) eliminates the race entirely, while keeping a controlled escape hatch (manual coordinated pull) for testing on the real hardware. Python 3.10 is per repo's `docs/development/setup.md` requirement.
+- **Memories used:** `8072acf6-5982-416f-8859-000145fdf4b0, deec0aef-dda9-46cb-939e-9e13b4ae786e`
+
+---
+
+### Drop global $ErrorActionPreference = "Stop" from install.ps1; rely on python child's exit code (PR #702)
+
+- **UUID:** `9a059d34-49d0-40d8-a11b-cd46d939e8b7`
+- **When:** `2026-05-18T10:33:20.46353+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:2026-05-18-jarvis-install-fix:post-hoc`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Set $ErrorActionPreference to 'Continue' only around the python call: more granular but harder to read for a 50-line wrapper.; Redirect installer.py stderr to a file before invoking: hides legitimate error visibility and breaks future debugging.; Patch installer.py to print quarantine to stdout: changes the API of installer.py and other callers (CI, tests); fixing the wrapper is the smaller blast radius.`
+
+  > install.ps1 wrapper was setting $ErrorActionPreference = "Stop" globally. Under Stop, any stderr write from a native exe (installer.py's `quarantined orphan ...` progress lines) is wrapped as a NativeCommandError terminating error, which aborts the wrapper before `exit $LASTEXITCODE` runs — leaving install half-applied: skill dirs renamed to .bak.orphan but .jarvis-version never updated, so the device stays "outdated" and retries re-quarantine into .bak.orphan.bak.orphan. Reproduced today on DESKTOP-1H2KOOJ. Fix: drop the global Stop; local `-ErrorAction Stop` on `Get-Command python3` remains, and the GNU-double-dash guard uses explicit `exit 1` so it's unaffected. Verified empirically that stderr no longer aborts the script with `python -c "print(...,file=sys.stderr)"` reaching the post-exit echo. Trade-off considered: keeping Stop for other native-exe failures is not load-bearing here — the wrapper does one native call and propagates its exit code. Recorded post-hoc during /end; should have been recorded in real time when fix was decided.
+- **Memories used:** `3be1ecb2-2eb4-44b0-a0fa-32b4f43412f9`
+
+---
+
+### Close Timaa22/Sculpture_vision_test#26 as already-done; file follow-up #40 for E2E perf + visual validation
+
+- **UUID:** `af68a43a-516e-4531-bcdd-093f9fc06429`
+- **When:** `2026-05-18T10:52:37.941641+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:sv-implement-26`
+- **Project:** `redrobot`
+- **Alternatives considered:** `none`
+
+  > §4a (already-done audit) of /implement skill fired: end-to-end heightmap pipeline already exists on dev/redrobot-integration (commit cbc7ef0 + downstream). Server side has Heightmap model, compute_grid_params, prepare/finalise lifecycle, REST endpoint with 200/202/404/410 semantics, and 20 unit tests. Blender side has heightmap_export.py rasteriser invoked from production_script.py:716-731 with non-fatal try/except. Wiring in production_heavy_workers.py:312-395 calls prepare before Blender (passing params path as argv[9]) and finalise after. The actual implementation deviates from the literal AC (independent raycast-per-cell instead of consuming Темир's per-vertex deviations) — owner accepted the deviation because (a) wire-format identical, (b) isolated from Темир's colourise-pass so cannot break existing code, (c) one sample per cell removes aggregation/sparsity edge cases. Trade-off cost is 2× BVH-rays per cycle; user-set threshold for revisit is elapsed>15s on real installation. That measurement plus real-robot E2E (per stage_completion_real_robot) tracked in #40 — merge≠done.</rationale>
+  > <parameter name="alternatives_considered">["Rewrite to per-vertex aggregation path (literal AC) — rejected: no measured perf data motivating it, premature optimisation, would couple to Темирского colourise-pass.", "Keep #26 open until E2E on real robot — rejected: conflates 'implementation done' with 'validation done'; cleaner to close impl + track validation as #40.", "Continue grilling design tree — rejected: all design decisions already locked in committed code, nothing left to grill."]
+- **Memories used:** `3be6f593-48bc-4ba3-a53d-664382e2b38f, 74028f3b-414f-4c85-b67c-d50a77a5f1f5, 8072acf6-5982-416f-8859-000145fdf4b0, a30df181-efa4-45d2-87de-03d669c29760`
+
+---
+
+### Keep HEIGHTMAP_GRID_STEP_MM=1 — heightmap rasteriser measured at 2.3s for 907K cells on real sculpture.fbx, well under #40's 5s gate.
+
+- **UUID:** `058b6d24-262e-4293-97ec-4bd67a7048e8`
+- **When:** `2026-05-18T11:11:11.81896+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.78`
+- **Actor:** `session:DESKTOP-1H2KOOJ-issue40-e2e-2026-05-18`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Lower to 2mm grid (4x speedup): rejected — not needed, 2.3s leaves plenty of margin and robot pipeline waits on photogrammetry+colourise anyway; Rewrite to single-pass per-vertex colourise: rejected — preoptimization per #40 anti-scope, no measured need; Defer decision until real RC cycle E2E (AC4/AC5): valid but blocks #26 gate indefinitely — sized typical install (1471×830) linearly extrapolates to ~3.1s, still under gate`
+
+  > E2E smoke against real install snapshot (C:\SculptureVision-0.2.0-beta\RCFolder\installation1\Model\sculpture.fbx, 648K verts, 1.19×0.76×0.42m bbox) ran the existing config/blender_scripts/heightmap_export.py at grid_step_mm=1 in 2.3s consistently across three variants (identical, +5mm shift, ×1.02 Z-scale). Sign convention validated: 100% cells within ±0.01mm of expected +5.0 for the shift run, confirming heights = target_z - current_z. The 5s/15s gates in #40 were sized so a degradation to 2mm only matters if elapsed >15s; we're 6.5x under the lower gate, so the rough cost concern raised in #40 ("2.4M rays at 1mm — preoptimization?") is empirically refuted on this hardware/Blender combo (5.0.1).
+- **Memories used:** `a30df181-efa4-45d2-87de-03d669c29760, 60a47231-6859-424f-94ea-364935d99a88, 74028f3b-414f-4c85-b67c-d50a77a5f1f5, f0865197-2b98-4383-a322-547c6daa30be`
+
+---
+
+### Apply 0006_heightmap + 0007_rename_index migrations to shared local postgres against running prod Daphne, off-hours, with owner explicit approval — instead of waiting for Temir to run it manually per sv_deploy_via_offhours_pull protocol.
+
+- **UUID:** `289fea44-b964-4d4e-86ed-c1d4108fbeb3`
+- **When:** `2026-05-18T11:38:18.818495+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.92`
+- **Actor:** `session:DESKTOP-1H2KOOJ-issue40-e2e-2026-05-18:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `Wait for Temir to manually run migrate per sv_deploy_via_offhours_pull: rejected because owner explicitly approved + off-hours confirmed, blocking would forfeit the validation window; Apply only 0006 and skip 0007: rejected because 0007 is just an index rename dependent on 0006, no reason to leave it unmigrated; Use Temir's broken venv (Python 3.9 missing on his profile): rejected because venv was broken; Connect to a copy of his DB: rejected because shared single postgres serves both clones — no separate DB to copy`
+
+  > Migration drift was the actual blocker for #40 AC4 — endpoint returned 500 ProgrammingError on all 632 completed cycles because comparison_heightmap table did not exist on Temir's running server (95992bd merged 0006_heightmap but never `python manage.py migrate`). 0006 is pure additive CreateModel + 0007 is index rename — zero risk to existing data. Owner explicitly approved ("он разрешил") + confirmed off-hours window ("конец рабочего дня"). Applied via my clone (D:\GitHub\sculpture_vision) because both clones share the same local postgres on :5432, so migration applies to Temir's server transparently without me touching his working copy. Verified post-apply: 500→404 (table exists, no rows yet) → then 200+binary.npz with full E2E validation after attaching synthetic row to cycle 831.
+- **Memories used:** `058b6d24-262e-4293-97ec-4bd67a7048e8`
+
+---
+
+### Темир's WIP code on owner's dev branch: cherry-pick to relocation branch → close PR → revert from dev → deliver as uncommitted in his local clone
+
+- **UUID:** `766708ea-80a8-4675-98f7-ee8e471f7eec`
+- **When:** `2026-05-18T12:10:31.011754+00:00`
+- **Reversibility:** `hard`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-05-18:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `PR #43 to main — rejected: Темир doesn't merge PRs, WIP code shouldn't sit in PR limbo; Force-push dev to drop commit — rejected: shared branch + breaks pending PR #42 base; Just revert + leave changes lost — rejected: this is Темир's unfinished work, must return to him; Patch file + text note — rejected by owner: he'll communicate verbally`
+
+  > Commit 31c792d (target_model_service + ArUco shift + RC NormalModel + WS guard + WorkerPage set_primary) landed on dev/redrobot-integration by accident — owner's branch was left checked out, Темир edited unknowingly. Code itself is production work (not redrobot-related), so dev branch must be cleaned. Owner explicitly rejected PR-to-main delivery because the work is WIP (Темир not yet done) and he doesn't like git workflows. Final delivery: apply diff cleanly to C:\Users\assau\Desktop\sculpture_vision as uncommitted changes; revert preserved on dev with explanatory commit; PR #43 closed without merge. Expected future cost: when dev/redrobot-integration eventually merges to main, conflict on these files — resolve in main's favor since Темир's PR (when he opens one) will already have landed by then.
+- **Memories used:** `8072acf6-5982-416f-8859-000145fdf4b0, deec0aef-dda9-46cb-939e-9e13b4ae786e, 13d3c730-1a4d-4cac-941b-11e00df0ffcd, 2c5fe723-65e0-4859-bf1a-d8362f2a14a4`
+
+---
+
+### SV migration drift health check (#41): Django endpoint /api/v1/system/health/ + start_server.bat migrate --check (combo of issue body options 1+2)
+
+- **UUID:** `18069e8f-3f5c-47d6-a567-e262f77be38d`
+- **When:** `2026-05-18T12:10:35.896473+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:end-2026-05-18:post-hoc`
+- **Project:** `redrobot`
+- **Alternatives considered:** `CI-only workflow gating PRs with migrations — rejected: doesn't catch drift after merge; Auto-apply migrations on startup — rejected explicitly by issue anti-scope; Health endpoint only — rejected: operator missing drift at startup is the actual #40 pain; start_server only — rejected: monitoring needs a queryable signal too`
+
+  > Issue #41 listed 4 alternative options. Picked combo 1+2 (startup batch check + queryable endpoint) over 3 (CI workflow lint) and 4 (just docs) because the failure mode caught in #40 is two-faced: (a) operator starting server should see drift loudly at startup; (b) monitoring/load-balancer needs queryable signal without auth. CI-only catch (#3) doesn't help post-merge unapplied drift. Endpoint returns 503 + list of unapplied migrations, no-auth (monitoring needs to hit without token). Tests: 3 cases — healthy, unhealthy via mocked plan, no-auth requirement. Wired previously-empty apps.system (already in INSTALLED_APPS).
+- **Memories used:** `8072acf6-5982-416f-8859-000145fdf4b0`
+
+---
+
+### Merge PR #700 (CLAUDE.md sweep-trigger planned demotion) autonomously and commit cited audit artefact alongside
+
+- **UUID:** `b08a003c-f220-401f-a659-9380fa4bce01`
+- **When:** `2026-05-18T13:20:13.755562+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.88`
+- **Actor:** `session:watchdog-2026-05-18-T4`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Watchdog tick on 2026-05-18: PR #700 was a 1-line doc fix demoting an over-claimed feature back to "planned (see #605)". All CI green, mergeable=CLEAN, own-repo, LOW risk. Tracker issue #701 existed; PR body cited `.out-of-scope/decision-audit-90d-2026-05-18.md` as the basis. The cited file was uncommitted, making the citation a phantom link, so a follow-up commit added the artefact under the existing `.out-of-scope/` precedent (`afk-chain-meta-tooling.md`, `bulk-epic-terminology-sweep.md` already committed there). Per `routine_medium_merge_is_autonomous` and `pm_autonomy_redrobot`, LOW-risk own-repo doc merges with green CI are autonomous; explicit waiver from blanket "no merge" by AFK hard rules since rules say LOW is OK. Secret-scan on the audit file passed (no token/key values, only references to `.env` as a concept).</rationale>
+  > <parameter name="alternatives_considered">["Merge PR #700 as-is without adding the audit file — rejected: PR body cites the file as evidence and a phantom citation would leave future readers without the trail.", "Ship the audit file as a separate PR — rejected: PR #700 directly depends on the file for its rationale; bundling is in-scope per `Fix > track for trivial reversible` (#428).", "Park PR #700 in parking_lot for owner — rejected: green-CI LOW-risk own-repo doc PRs are explicitly autonomous per SOUL.md and `routine_medium_merge_is_autonomous`."]
+- **Memories used:** `48f0a121-1d29-4d42-b387-8b39f5262c79, b1216b17-3175-4ec5-9174-498a6b2e0e72, df51f553-bcde-471e-b5de-734072225d77`
+
+---
+
+### PR #676 and issue #659 should be closed as superseded by merged PR #703 (same .bak.orphan recursion bug class). Watchdog flagged but cannot execute close — auto-mode classifier blocks under current scheduled-task scope. Park in baton.parking_lot for owner.
+
+- **UUID:** `524d2ad9-a598-4e91-8bb1-0c05b75f8da5`
+- **When:** `2026-05-18T16:17:10.263218+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.9`
+- **Actor:** `session:watchdog-2026-05-18-T5`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Today (2026-05-18) PR #703 merged the .bak.orphan skip-filter in scripts/install/installer.py, closing dup issue #704. Issue #659 is the same recursion bug (verified via body + repro steps comparison) and PR #676 is its in-progress fix with a marginally broader .bak.* substring filter. #676's broader scope is preventative — its own PR body notes "no non-orphan labels observed nesting in the wild yet". Shipped narrow fix is sufficient; broader hardening is a separate sibling-fix if/when the other-label class materializes. Tried to close both via gh pr close / gh issue close in the autonomous tick; auto-mode classifier denied (correct per scheduled-task scope — close action not in explicit allow-list). Recording the recommendation so owner clears in one minute on return.</rationale>
+  > <parameter name="alternatives_considered">[{"option":"Leave both open silently","reason":"Hides the dup; #659 already shows a failed Tier 1 dispatch comment chain — staying open invites another wasted retry"},{"option":"Push past classifier denial by other means","reason":"Working around an auto-mode block contradicts the spirit of the scheduled-task scope. Hard rule."},{"option":"Keep #676 open as broader-scope hardening","reason":"#676's substring `.bak.` is preventative for theoretical labels — out-of-scope of observed bug. If owner wants the hardening, filing a fresh issue is cleaner than rebasing a 2-day-stale PR."}]
+- **Memories used:** `48f0a121-1d29-4d42-b387-8b39f5262c79, df51f553-bcde-471e-b5de-734072225d77`
+
+---
+
+### Re-dispatch #705 + #707 mechanical-mode to parallel subagents in worktrees (fresh CC session, post tools.143 API-error block)
+
+- **UUID:** `6bdae316-6413-4b95-a05a-a04ebc1ca413`
+- **When:** `2026-05-18T16:22:14.190615+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:delegate session:2026-05-18-redispatch`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Inline both via /implement: rejected — both self-contained, no session-context advantage, parallelism saves wall time; Sequential dispatch: rejected — disjoint files (one root config, one new script in different dir), zero contamination risk; Re-trigger /grill: rejected — checkbox 0/4 on both, issue bodies already carry rationale + alternatives in `## Decisions` sections, AC verifiable from body alone; Skip #707 (cross-shell tooling): rejected — AC defines correctness precisely (mask format, scope list, -DryRun default), no underspecified branches; Wait for owner: rejected — owner explicitly invoked /delegate #705 #707, this is the requested action`
+
+  > Both issues OPEN, status:ready, area:infrastructure, disjoint files (root .gitattributes vs scripts/audit-anthropic-api-key.ps1), claimed in 2026-05-18 Tier 1 fleet session but dispatch hit API schema error. Memory `tier1_fleet_dispatch_blocked_2026_05_18` (per MEMORY.md index) said: resume on fresh CC restart — this is one. Grill checkbox 0/4 yes on both: no domain logic, no product-behavior changes, AC well-specified (6 ACs each with concrete verifiable assertions), no existing non-trivial code crossings. Both meet mechanical-mode contract. Disjoint files satisfy parallelism safety per §4a. Subagent prompts will incorporate lessons from `delegate_explicit_branch_origin_main` (explicit origin/main base), `delegate_subagent_pr_step_skipped_and_absolute_path_2026_05_17` (PR step required + cross-platform paths), `subagent_acceptance_criteria_dodged_as_out_of_scope` (every AC must have test, escalate not silently drop).
+- **Memories used:** `f0f0334f-98af-4c88-a6bb-05d359eef3b7, d523f7b9-262b-4580-84e9-e411b035cb4c, 9a5a1ade-d3c0-4163-8559-dff5993094ea, ace97204-32bb-4ae6-a3ca-b36302d35766`
+
+---
+
+### Reroute #705 and #707 from /delegate subagent dispatch to sandcastle AFK queue (label sandcastle, Workshop 22:00 loop) after the tools.143 oneOf/allOf/anyOf API block reproduced across CC restart.
+
+- **UUID:** `77f654f4-d228-4bf3-984b-b7ade1d939c0`
+- **When:** `2026-05-18T16:30:20.169814+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `skill:delegate:reroute`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Subagent dispatch via Agent tool is hard-blocked on this Main-PC toolset by `API Error 400 tools.143.custom.input_schema does not support oneOf/allOf/anyOf` — confirmed reproducible across CC restart (prior memory's "restart fixes it" hypothesis is falsified). Owner explicitly redirected: "делегирование почему то сейчас не работает, используем sandcastle с лимитов подписки" — sandcastle runs on Claude Max subscription budget, not API tokens (memory scheduled_tasks_subscription_not_api), so no per-task cost. Both issues are sandcastle-safe: no protected-file edits, self-contained ACs, grill-equivalent `## Decisions` section in body. Net: 1 GraphQL label-edit per issue + 2 comments, vs. inline burn of dumb-zone implementation context on Main PC.</rationale>
+  > <parameter name="alternatives_considered">["inline /implement on Main PC — rejected, burns context on infra/tooling that fits AFK", "diagnose-and-disable the offending MCP server (tool 143) — rejected for now, owner picked routing over MCP-debug", "defer both indefinitely — rejected, the issues are ready and queue cost is ~0"]
+- **Memories used:** `7039b906-e7e8-410a-aa59-e171462651b7, d828bd94-c9ab-4c06-bb9f-b5afa00ff1d9, f9530cef-50f6-4d35-b9f4-9730b085d1fd, f0f0334f-98af-4c88-a6bb-05d359eef3b7`
+
+---
+
+### AFK sandcastle Tier 0 = DeepSeek API (Tier 2 promoted via -Tier2AsPrimary); Ollama Tier 0/1 retained as off-by-default OOM-escalation chain.
+
+- **UUID:** `b5fb4825-e307-49e4-8e11-1163931d6a15`
+- **When:** `2026-05-18T16:50:38.878883+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.82`
+- **Actor:** `session:sandcastle-tier-pivot-2026-05-18`
+- **Project:** `jarvis`
+- **Alternatives considered:** `Subscription-first Tier 0 (claude CLI in container via Max OAuth) — rejected: upcoming Anthropic quota split shrinks AFK automatic-bucket; OAuth blast radius inside container; concurrent-session conflict with owner's interactive sessions; Keep Ollama Tier 0 with -Tier2AsPrimary off — rejected: every AFK iteration burns time on a Tier 0 that fails tool_use fidelity before falling through to DeepSeek only on OOM (not on tool_use failure); Codex CLI side-channel — rejected by Q2 (paid, won't pay second tier same as Claude)`
+
+  > Local Ollama qwen2.5-coder:14b and qwen3-coder:30b both failed real-Claude-Code tool_use fidelity probes (markdown-JSON fence / Hermes-XML — see memory ollama_bench_must_measure_tool_use_fidelity), so the existing Tier 0 → Tier 1 → Tier 2 chain currently exits the Claude-Code-CLI substrate via #543 only on OOM, while routine tool-use failures still burn an iteration on a broken Tier 0. Subscription-first Tier 0 (claude CLI in container via Max OAuth) was the alternative that aligned with Q2 owner answer in workflow-proposals-table-2026-05-18.md, but Anthropic is splitting subscription quota into interactive vs automatic buckets soon and the automatic bucket will be smaller — so spending it on AFK scheduled runs becomes a strategic loss; the OAuth-credential blast-radius and concurrent-session conflict with the owner's interactive Claude Code sessions were additional concerns. DeepSeek API runs on a separate budget envelope (Tier 2 already in production via #543) and reliably emits structured tool_use blocks. The WIP -Tier2AsPrimary switch on Run-Sandcastle.ps1 + the Register-SandcastleTask.ps1 default flip make this the AFK default while leaving interactive sandcastle runs free to opt back into the Ollama chain.
+- **Memories used:** `e1830d75-c120-4ebf-8afc-01f7113e9a61, d828bd94-c9ab-4c06-bb9f-b5afa00ff1d9, c7375b59-a726-4ae9-9904-df6cfd0f311f, 27c28a8e-2969-4550-9d4d-ffd25e36e5d8`
+
+---
+
+### Sandcastle dispatch of 3 isolated workflow-table tasks (#708 llms.txt, #709 PowerShell encoding lint, #710 quarterly decision dump) instead of Tier-1 fleet
+
+- **UUID:** `79a1a026-e180-4f1b-97d0-fe4f6b31ea70`
+- **When:** `2026-05-18T17:14:38.791973+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:end-2026-05-18`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Tier-1 fleet dispatch blocked by tools.143 oneOf/allOf/anyOf MCP schema bug (persists across CC restart per memory tier1_dispatch_blocked_tools_143_persists_across_cc_restart). Switched to sandcastle path on Workshop. Selected 3 candidates from workflow-proposals-table-2026-05-18.md that satisfy: (a) 0/4 SOUL grill-checkbox — no /grill needed; (b) no protected-file edits for sandcastle (CLAUDE.md, SOUL.md, CONTEXT.md, .mcp.json, mcp-memory, .github/workflows, .env); (c) no install.ps1 conflict with claimed #706. Rejected gh-dash (row 31) + gh-poi (row 32) for install.ps1 conflict; rejected secrets-stay-local (row 158) and SOUL split (row 142) — touch protected files; rejected .env.example reorganization (row 153) as non-trivial reorg decision.</rationale>
+  > <parameter name="alternatives_considered">["Add sandcastle label to existing claimed issues #705/#706/#707 — rejected, user said they're already taken", "Retry Tier-1 fleet — rejected, schema bug persists per memory and recent #705 comment thread", "Block on subscription-auth path for sandcastle — rejected, not built; existing Ollama or API tier covers the work; user will choose tier on Workshop side", "Dispatch row 31/32 (gh-dash/gh-poi) — rejected, install.ps1 conflict with claimed #706"]
+- **Memories used:** `none`
+- **Memories used (unresolved):** `docs_research_unfinished.md (file-based, MEMORY.md index)`
+
+---
+
+### AFK production windows widened to cover non-working hours end-to-end: jarvis 18:00→01:00, redrobot 01:00→08:00 (both 7h, total 14h coverage 18-08).
+
+- **UUID:** `3eb895bd-f0d8-4af3-826c-ad0b8ff92ab5`
+- **When:** `2026-05-18T17:32:43.791628+00:00`
+- **Reversibility:** `reversible`
+- **Confidence:** `0.85`
+- **Actor:** `session:sandcastle-tier-pivot-2026-05-18`
+- **Project:** `jarvis`
+- **Alternatives considered:** `none`
+
+  > Original 22:00/02:00 four-hour windows were Ollama-VRAM-contention-driven (single GPU could only host one workload at a time). With #711 promoting Tier 2 DeepSeek to AFK primary, local Ollama is bypassed in scheduled runs, so the contention constraint no longer applies. Widening to back-to-back 7h windows covers all owner non-working hours end-to-end. Latent Resolve-WindowEnd bug (HH:mm interpreted as today even when already past) surfaced after first manual launch and was fixed in #714 — without that fix, jarvis 18:00 fire would always exit immediately as partial:window-expired because today 01:00 is in the past at 18:00.</rationale>
+  > <parameter name="alternatives_considered">["Keep narrow 4h windows for safety -- rejected: with Tier 2 primary the watchdog has no VRAM contention to safeguard against, and AFK ROI scales with window length", "ISO datetime passed from Register-SandcastleTask instead of HH:mm -- rejected: would require recomputing the next-day boundary at every cron re-fire; HH:mm + roll-forward is simpler and isolates the date logic in Resolve-WindowEnd", "Make WindowEnd mandatory ISO -- rejected: breaks ergonomic interactive smoke runs that use HH:mm"]
+- **Memories used:** `e1830d75-c120-4ebf-8afc-01f7113e9a61, d828bd94-c9ab-4c06-bb9f-b5afa00ff1d9`
+
+---

--- a/scripts/dump-decisions-quarterly.py
+++ b/scripts/dump-decisions-quarterly.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Generate quarterly markdown dump of record_decision episodes.
+
+Usage:
+    python scripts/dump-decisions-quarterly.py --quarter 2026-Q2
+
+Reads decision_made episodes from the Supabase episodes table and renders
+a markdown document at docs/decisions/YYYY-QN.md.
+
+Requires SUPABASE_URL and SUPABASE_KEY env vars (same as sandcastle container).
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from supabase import create_client
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def parse_quarter(quarter: str) -> tuple[int, int]:
+    """Parse 'YYYY-QN' into (year, quarter_number)."""
+    parts = quarter.split("-Q")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid quarter format: {quarter!r}. Use YYYY-QN (e.g. 2026-Q2)")
+    year = int(parts[0])
+    q = int(parts[1])
+    if q < 1 or q > 4:
+        raise ValueError(f"Quarter must be 1-4, got {q}")
+    return year, q
+
+
+def quarter_date_range(year: int, q: int) -> tuple[str, str]:
+    """Return (start_iso, end_iso) for the given quarter, inclusive."""
+    start_month = {1: 1, 2: 4, 3: 7, 4: 10}[q]
+    end_month = start_month + 2
+    # end_date is the last day of the last month in the quarter
+    if end_month == 12:
+        end_year = year
+    else:
+        end_year = year
+        end_month += 1  # go to first day of NEXT month
+        # last day of quarter = first day of next month minus 1 day
+    import calendar
+    _, last_day = calendar.monthrange(year, start_month + 2)
+    start = f"{year}-{start_month:02d}-01T00:00:00Z"
+    end = f"{year}-{start_month + 2:02d}-{last_day}T23:59:59Z"
+    return start, end
+
+
+def fetch_decisions(client, start_iso: str, end_iso: str) -> list[dict]:
+    """Fetch all decision_made episodes in the date range, ordered by created_at."""
+    all_rows = []
+    page = 0
+    page_size = 1000
+
+    while True:
+        result = (
+            client.table("episodes")
+            .select("*")
+            .eq("kind", "decision_made")
+            .gte("created_at", start_iso)
+            .lte("created_at", end_iso)
+            .order("created_at", desc=False)  # chronological
+            .range(page * page_size, (page + 1) * page_size - 1)
+            .execute()
+        )
+        if not result.data:
+            break
+        all_rows.extend(result.data)
+        if len(result.data) < page_size:
+            break
+        page += 1
+
+    return all_rows
+
+
+def group_by_month(decisions: list[dict]) -> dict[str, list[dict]]:
+    """Group decisions by month label like '2026-04'."""
+    months: dict[str, list[dict]] = {}
+    for d in decisions:
+        ts = d.get("created_at", "")
+        month_key = ts[:7]  # "2026-04"
+        months.setdefault(month_key, []).append(d)
+    return dict(sorted(months.items()))
+
+
+def render_decision(d: dict) -> str:
+    """Render a single decision as a markdown block."""
+    payload = d.get("payload", {})
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+
+    decision = payload.get("decision") or "(missing decision text)"
+    episode_id = d.get("id", "?")
+    created_at = d.get("created_at", "")
+    reversibility = payload.get("reversibility") or ""
+    confidence = payload.get("confidence")
+    actor = d.get("actor") or ""
+    project = payload.get("project") or ""
+    alternatives = payload.get("alternatives_considered") or []
+    rationale = payload.get("rationale") or ""
+    memories_used = payload.get("memories_used") or []
+    outcomes_ref = payload.get("outcomes_referenced") or []
+    intentionally_empty = payload.get("intentionally_empty", False)
+
+    lines = [f"### {decision}", ""]
+    lines.append(f"- **UUID:** `{episode_id}`")
+    lines.append(f"- **When:** `{created_at}`")
+    lines.append(f"- **Reversibility:** `{reversibility}`")
+    if confidence is not None:
+        lines.append(f"- **Confidence:** `{confidence}`")
+    lines.append(f"- **Actor:** `{actor}`")
+    lines.append(f"- **Project:** `{project}`")
+
+    if alternatives:
+        alt_text = "; ".join(str(a) for a in alternatives)
+        lines.append(f"- **Alternatives considered:** `{alt_text}`")
+    else:
+        lines.append("- **Alternatives considered:** `none`")
+
+    if outcomes_ref:
+        outcomes_text = ", ".join(str(o) for o in outcomes_ref)
+        lines.append(f"- **Outcomes referenced:** `{outcomes_text}`")
+
+    # Rationale — multi-line, so render as blockquote
+    if rationale:
+        lines.append("")
+        lines.append("  > " + rationale.replace("\n", "\n  > "))
+
+    if memories_used:
+        mem_text = ", ".join(str(m) for m in memories_used)
+        lines.append(f"- **Memories used:** `{mem_text}`")
+    elif not intentionally_empty:
+        lines.append("- **Memories used:** `none`")
+    else:
+        lines.append("- **Memories used:** `(intentionally empty)`")
+
+    if payload.get("memories_used_unresolved"):
+        unresolved = ", ".join(str(m) for m in payload["memories_used_unresolved"])
+        lines.append(f"- **Memories used (unresolved):** `{unresolved}`")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_document(decisions: list[dict], quarter: str, cutoff: str) -> str:
+    """Render the full markdown document."""
+    total = len(decisions)
+    grouped = group_by_month(decisions)
+
+    # Aggregate stats
+    reversibility_counts: dict[str, int] = {}
+    actor_prefixes: dict[str, int] = {}
+    for d in decisions:
+        payload = d.get("payload", {})
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except (json.JSONDecodeError, TypeError):
+                payload = {}
+        rev = payload.get("reversibility", "unknown")
+        reversibility_counts[rev] = reversibility_counts.get(rev, 0) + 1
+
+        actor = d.get("actor", "unknown")
+        prefix = actor.split(":")[0] if ":" in actor else actor
+        actor_prefixes[prefix] = actor_prefixes.get(prefix, 0) + 1
+
+    lines = [
+        f"# Decision dump — {quarter} (cutoff: {cutoff})",
+        "",
+        f"Total decisions: **{total}**",
+        "",
+        "## Aggregate",
+        "",
+        "### By reversibility",
+    ]
+    for rev, count in sorted(reversibility_counts.items()):
+        lines.append(f"- `{rev}`: {count}")
+    lines.append("")
+    lines.append("### By actor prefix")
+    for prefix, count in sorted(actor_prefixes.items()):
+        lines.append(f"- `{prefix}`: {count}")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    for month, month_decisions in grouped.items():
+        lines.append(f"## {month}")
+        lines.append("")
+        for d in month_decisions:
+            lines.append(render_decision(d))
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate quarterly record_decision markdown dump."
+    )
+    parser.add_argument(
+        "--quarter",
+        required=True,
+        help="Quarter to dump, e.g. 2026-Q2",
+    )
+    args = parser.parse_args()
+
+    year, q = parse_quarter(args.quarter)
+    start_iso, end_iso = quarter_date_range(year, q)
+
+    # Cutoff is today (run date) — cap the range
+    now = datetime.now(timezone.utc)
+    cutoff = now.strftime("%Y-%m-%d")
+    if end_iso > now.isoformat():
+        end_iso = now.strftime("%Y-%m-%dT23:59:59Z")
+
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        print("Error: SUPABASE_URL and SUPABASE_KEY env vars required.", file=sys.stderr)
+        sys.exit(1)
+
+    client = create_client(url, key)
+
+    decisions = fetch_decisions(client, start_iso, end_iso)
+
+    if not decisions:
+        print(f"No decisions found for {args.quarter} ({start_iso} to {end_iso})")
+        sys.exit(0)
+
+    doc = render_document(decisions, args.quarter, cutoff)
+
+    out_dir = ROOT / "docs" / "decisions"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{args.quarter}.md"
+    out_path.write_text(doc)
+
+    # Quick summary stats
+    rev_counts: dict[str, int] = {}
+    for d in decisions:
+        p = d.get("payload", {})
+        if isinstance(p, str):
+            try:
+                p = json.loads(p)
+            except (json.JSONDecodeError, TypeError):
+                p = {}
+        rev = p.get("reversibility", "unknown")
+        rev_counts[rev] = rev_counts.get(rev, 0) + 1
+
+    print(f"Wrote {len(decisions)} decisions to {out_path}")
+    print(f"  Cutoff: {cutoff}")
+    print(f"  Reversibility: {rev_counts}")
+    print(f"  Total: {len(decisions)} decisions")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dump_decisions_quarterly.py
+++ b/tests/test_dump_decisions_quarterly.py
@@ -1,0 +1,233 @@
+"""Tests for scripts/dump-decisions-quarterly.py — rendering logic only.
+
+The full end-to-end flow requires Supabase credentials. These tests validate
+the markdown rendering helpers using synthetic fixtures, so they run in CI
+without external dependencies.
+
+Import strategy: exec_module() on the script file, then test the module-level
+functions. The supabase import is only used in main() so module-level import
+succeeds as long as the package is available.
+"""
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "dump-decisions-quarterly.py"
+_spec = importlib.util.spec_from_file_location("dump_decisions_quarterly", _SCRIPT)
+dq = importlib.util.module_from_spec(_spec)
+
+try:
+    _spec.loader.exec_module(dq)
+    _HAVE_DQ = True
+except ImportError:
+    _HAVE_DQ = False
+    dq = None
+
+
+_SKIP_REASON = "dump-decisions-quarterly.py not importable (need supabase-py or deps)"
+
+
+@unittest.skipIf(not _HAVE_DQ, _SKIP_REASON)
+class TestParseQuarter(unittest.TestCase):
+    def test_valid(self):
+        self.assertEqual(dq.parse_quarter("2026-Q2"), (2026, 2))
+        self.assertEqual(dq.parse_quarter("2025-Q4"), (2025, 4))
+
+    def test_invalid_format(self):
+        with self.assertRaises(ValueError):
+            dq.parse_quarter("2026-Q5")
+        with self.assertRaises(ValueError):
+            dq.parse_quarter("2026-Q0")
+        with self.assertRaises(ValueError):
+            dq.parse_quarter("blah")
+
+
+@unittest.skipIf(not _HAVE_DQ, _SKIP_REASON)
+class TestQuarterDateRange(unittest.TestCase):
+    def test_q1(self):
+        start, end = dq.quarter_date_range(2026, 1)
+        self.assertEqual(start, "2026-01-01T00:00:00Z")
+        self.assertIn("2026-03-31", end)
+
+    def test_q2(self):
+        start, end = dq.quarter_date_range(2026, 2)
+        self.assertEqual(start, "2026-04-01T00:00:00Z")
+        self.assertIn("2026-06-30", end)
+
+    def test_q4_boundary(self):
+        start, end = dq.quarter_date_range(2026, 4)
+        self.assertEqual(start, "2026-10-01T00:00:00Z")
+        self.assertIn("2026-12-31", end)
+
+    def test_leap_year(self):
+        start, end = dq.quarter_date_range(2024, 1)
+        self.assertIn("2024-03-31", end)
+
+
+@unittest.skipIf(not _HAVE_DQ, _SKIP_REASON)
+class TestRenderDecision(unittest.TestCase):
+    def make_decision(self, overrides=None):
+        d = {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "actor": "skill:implement",
+            "kind": "decision_made",
+            "created_at": "2026-04-15T12:00:00Z",
+            "payload": {
+                "decision": "Test decision title",
+                "rationale": "This is the rationale for the test decision.",
+                "reversibility": "reversible",
+                "confidence": 0.85,
+                "project": "jarvis",
+                "alternatives_considered": ["Option A (rejected)", "Option B (rejected)"],
+                "memories_used": ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"],
+                "outcomes_referenced": [],
+            },
+        }
+        if overrides:
+            d = {**d, **overrides}
+            if "payload" in overrides:
+                d["payload"] = {**d["payload"], **overrides["payload"]}
+        return d
+
+    def test_renders_decision(self):
+        rendered = dq.render_decision(self.make_decision())
+        self.assertIn("Test decision title", rendered)
+        self.assertIn("00000000-0000-0000-0000-000000000001", rendered)
+        self.assertIn("2026-04-15T12:00:00Z", rendered)
+        self.assertIn("reversible", rendered)
+        self.assertIn("0.85", rendered)
+        self.assertIn("skill:implement", rendered)
+        self.assertIn("jarvis", rendered)
+        self.assertIn("Option A", rendered)
+        self.assertIn("This is the rationale", rendered)
+        self.assertIn("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", rendered)
+
+    def test_no_alternatives(self):
+        d = self.make_decision()
+        d["payload"]["alternatives_considered"] = []
+        rendered = dq.render_decision(d)
+        self.assertIn("`none`", rendered)
+
+    def test_no_confidence(self):
+        d = self.make_decision()
+        del d["payload"]["confidence"]
+        rendered = dq.render_decision(d)
+        self.assertNotIn("**Confidence:**", rendered)
+
+    def test_intentionally_empty_memories(self):
+        d = self.make_decision()
+        d["payload"]["memories_used"] = []
+        d["payload"]["intentionally_empty"] = True
+        rendered = dq.render_decision(d)
+        self.assertIn("intentionally empty", rendered)
+
+    def test_payload_as_string(self):
+        d = self.make_decision()
+        d["payload"] = json.dumps(d["payload"])
+        rendered = dq.render_decision(d)
+        self.assertIn("Test decision title", rendered)
+
+    def test_irreversible(self):
+        d = self.make_decision()
+        d["payload"]["reversibility"] = "irreversible"
+        rendered = dq.render_decision(d)
+        self.assertIn("irreversible", rendered)
+
+    def test_outcomes_referenced(self):
+        d = self.make_decision()
+        d["payload"]["outcomes_referenced"] = ["x" * 36]
+        rendered = dq.render_decision(d)
+        self.assertIn("Outcomes referenced", rendered)
+
+    def test_unresolved_memories(self):
+        d = self.make_decision()
+        d["payload"]["memories_used_unresolved"] = ["some_memory_name"]
+        rendered = dq.render_decision(d)
+        self.assertIn("unresolved", rendered)
+
+    def test_no_project(self):
+        d = self.make_decision()
+        d["payload"]["project"] = ""
+        rendered = dq.render_decision(d)
+        self.assertIn("**Project:** `", rendered)
+
+
+@unittest.skipIf(not _HAVE_DQ, _SKIP_REASON)
+class TestRenderDocument(unittest.TestCase):
+    def make_decisions(self, count=3):
+        decisions = []
+        for i in range(count):
+            d = {
+                "id": f"00000000-0000-0000-0000-{i:012d}",
+                "actor": "skill:test",
+                "kind": "decision_made",
+                "created_at": f"2026-04-{10 + i:02d}T12:00:00Z",
+                "payload": {
+                    "decision": f"Decision #{i}",
+                    "rationale": f"Rationale for #{i}",
+                    "reversibility": "reversible",
+                    "alternatives_considered": [],
+                    "memories_used": [],
+                },
+            }
+            decisions.append(d)
+        return decisions
+
+    def test_document_structure(self):
+        decisions = self.make_decisions()
+        doc = dq.render_document(decisions, "2026-Q2", "2026-05-18")
+        self.assertIn("# Decision dump — 2026-Q2 (cutoff: 2026-05-18)", doc)
+        self.assertIn("Total decisions: **3**", doc)
+        self.assertIn("## 2026-04", doc)
+        self.assertIn("Decision #0", doc)
+        self.assertIn("Decision #1", doc)
+        self.assertIn("Decision #2", doc)
+
+    def test_empty_decision_list(self):
+        doc = dq.render_document([], "2026-Q2", "2026-05-18")
+        self.assertIn("Total decisions: **0**", doc)
+
+    def test_actor_prefix_aggregation(self):
+        decisions = self.make_decisions(2)
+        decisions.append({
+            "id": "f0000000-0000-0000-0000-000000000003",
+            "actor": "session:orchestrator",
+            "kind": "decision_made",
+            "created_at": "2026-05-01T12:00:00Z",
+            "payload": {
+                "decision": "Session decision",
+                "rationale": "Rationale",
+                "reversibility": "hard",
+                "alternatives_considered": [],
+                "memories_used": [],
+            },
+        })
+        doc = dq.render_document(decisions, "2026-Q2", "2026-05-18")
+        self.assertIn("- `skill`: 2", doc)
+        self.assertIn("- `session`: 1", doc)
+
+    def test_multiple_months(self):
+        decisions = []
+        for month in ("2026-04", "2026-05"):
+            decisions.append({
+                "id": f"m-{month}-0000-0000-0000-000000000000",
+                "actor": "skill:test",
+                "kind": "decision_made",
+                "created_at": f"{month}-15T12:00:00Z",
+                "payload": {
+                    "decision": f"Decision in {month}",
+                    "rationale": "Rationale",
+                    "reversibility": "reversible",
+                    "alternatives_considered": [],
+                    "memories_used": [],
+                },
+            })
+        doc = dq.render_document(decisions, "2026-Q2", "2026-05-18")
+        self.assertIn("## 2026-04", doc)
+        self.assertIn("## 2026-05", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `scripts/dump-decisions-quarterly.py` — generates a markdown dump of all `record_decision` episodes for a given quarter
- Generates `docs/decisions/2026-Q2.md` — 409 decisions from 2026-04-01 to 2026-05-18 (cutoff)
- Adds `tests/test_dump_decisions_quarterly.py` — 19 unittest cases for rendering logic

## Script usage

```bash
# Generate Q2 2026 dump
python scripts/dump-decisions-quarterly.py --quarter 2026-Q2

# Re-run to update (same quarter overwrites the file)
```

## Generated document format

- Header with quarter label and cutoff date
- Aggregate counts: total decisions, by reversibility, by actor prefix
- Grouped by month within the quarter
- Each decision rendered as: UUID, timestamp, reversibility, confidence, actor, project, alternatives, rationale (blockquote), memories used

## Acceptance criteria

1. ✅ `docs/decisions/2026-Q2.md` exists — first line is `# Decision dump — 2026-Q2 (cutoff: 2026-05-18)`
2. ✅ Contains all 409 decision_made episodes from 2026-04-01 to 2026-05-18
3. ✅ Each decision rendered per format specification
4. ✅ Headline aggregate counts present (total, by reversibility, by actor prefix)
5. ✅ Memories-used UUIDs rendered as-is without slug expansion
6. ✅ Script at `scripts/dump-decisions-quarterly.py` with `--quarter YYYY-QN` argument
7. ✅ Re-running with same quarter overwrites the doc
8. ✅ Script reads from Supabase via supabase-py (same credentials as sandcastle container)

## Out of scope

- Past quarters (Q1 2026, etc.)
- Auto-cron scheduling
- Cross-quarter diff / churn analysis
- CLAUDE.md updates

## Details

- 409 total decisions: 352 reversible, 57 hard
- Actors: 277 from session: prefix, 132 from skill: prefix
- Spans April and May 2026
- Script connects directly to Supabase episodes table via anon key (SELECT-only)

Closes #710
