### PR TITLE
fix(ci): reword Set-Content comment to clear powershell-encoding-guard false positive

### DIFF
--- a/scripts/audit-anthropic-api-key.ps1
+++ b/scripts/audit-anthropic-api-key.ps1
@@ -195,7 +195,7 @@ foreach ($f in $hits) {
             Write-Host "  [REMOVED] $path (file deleted — was only ANTHROPIC_API_KEY)" -ForegroundColor Green
         } else {
             $newLines | Set-Content -Path $path -NoNewline -Encoding UTF8
-            # Add trailing newline that Set-Content -NoNewline strips
+            # Restore trailing newline stripped by -NoNewline above
             Add-Content -Path $path -Value ''
             Write-Host "  [CLEANED] $path — ANTHROPIC_API_KEY line removed" -ForegroundColor Green
         }


### PR DESCRIPTION
## Summary
- `tests/ci/test_powershell_encoding_guard.py::test_all_calls_have_encoding` regressed on `main` after commit 3c633b2 (#716 / feat: ANTHROPIC_API_KEY audit script).
- The guard's regex `\b(Set-Content|Out-File)\b` matched the literal token `Set-Content` inside a **comment** at `scripts/audit-anthropic-api-key.ps1:198`. The actual `Set-Content` call on the preceding line already passes `-Encoding UTF8`, so there is no real encoding bug — only a false positive.
- Reworded the comment from "Add trailing newline that Set-Content -NoNewline strips" → "Restore trailing newline stripped by -NoNewline above". Same intent, no `Set-Content` token.

Followed CLAUDE.md "Fix > track for trivial reversible (#428)" — sub-30min, fully reversible, scope-obvious. `[no-issue]` marker present per `.pre-commit-config.yaml` regex from #329.

The deeper engineering fix — teaching the guard to strip PowerShell line comments before regex-matching — is left for a follow-up if this class of false positive recurs. Today it's a single instance.

[no-issue]

## Test plan
- [x] `pytest tests/ci/test_powershell_encoding_guard.py -q` → `3 passed` locally
- [ ] Same on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)