### PR TITLE
feat: loop-stop policy as pure-function module (#634)

### DIFF
--- a/scripts/rework_policy.py
+++ b/scripts/rework_policy.py
@@ -1,0 +1,294 @@
+"""Pure-function policy module for /rework loop-stop decision (#634).
+
+Decides whether a PR rework loop should continue, has converged, or has
+terminated due to one of four guard conditions. Zero side effects, zero I/O.
+
+The interface is single:
+    decide(attempts, history, initial_files) →
+        PolicyResult(decision, reason)
+
+where `decision` is one of:
+    - CONTINUE: loop should continue to next attempt
+    - CONVERGED: findings targets met, loop may terminate successfully
+    - STUCK_ATTEMPTS: ≥3 attempts reached without convergence
+    - STUCK_SCOPE: LOC delta >50% or files outside initial diff
+    - STUCK_NO_CONVERGENCE: critical+major not strictly decreasing
+    - STUCK_CONFLICT: same file:line touched in multiple attempts
+
+The policy evaluates all guards independently; any single guard firing
+triggers a STUCK verdict. Convergence is checked last — if no guard fires
+and findings targets are met, the loop converged.
+
+Strictly decreasing: (n_critical, n_major) lex-decreases per attempt.
+Specifically: comparing attempt t to attempt t-1, both components must
+strictly decrease: (n_critical_t < n_critical_{t-1}) AND
+(n_major_t < n_major_{t-1}).
+
+Convergence target: n_critical == 0 AND n_major <= 2.
+
+Constants (per #634):
+    MAX_ATTEMPTS_THRESHOLD = 3
+    LOC_DELTA_THRESHOLD = 50 (percent)
+    MAX_MAJOR_FINDINGS = 2
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+# ============================================================================
+# Constants (per #634)
+# ============================================================================
+
+MAX_ATTEMPTS_THRESHOLD = 3
+LOC_DELTA_THRESHOLD_PERCENT = 50
+MAX_MAJOR_FINDINGS = 2
+TARGET_CRITICAL = 0
+
+
+# ============================================================================
+# Return types
+# ============================================================================
+
+
+class LoopDecision(str, Enum):
+    """Loop verdict enum."""
+
+    CONTINUE = "continue"
+    CONVERGED = "converged"
+    STUCK_ATTEMPTS = "stuck_attempts"
+    STUCK_SCOPE = "stuck_scope"
+    STUCK_NO_CONVERGENCE = "stuck_no_convergence"
+    STUCK_CONFLICT = "stuck_conflict"
+
+
+@dataclass
+class PolicyResult:
+    """Result of the policy decision.
+
+    Attributes:
+        decision: One of LoopDecision enum values.
+        reason: Human-readable explanation of the verdict.
+    """
+
+    decision: LoopDecision
+    reason: str
+
+
+# ============================================================================
+# Guards (independent checks)
+# ============================================================================
+
+
+def _check_max_attempts(attempts: int) -> tuple[bool, str]:
+    """Guard: ≥3 attempts → stuck_attempts.
+
+    Returns:
+        (fired: bool, reason: str)
+    """
+    if attempts >= MAX_ATTEMPTS_THRESHOLD:
+        reason = f"Reached maximum attempts threshold ({MAX_ATTEMPTS_THRESHOLD})"
+        return True, reason
+    return False, ""
+
+
+def _check_scope_creep(
+    history: list[dict], initial_files: set[str]
+) -> tuple[bool, str]:
+    """Guard: LOC delta >50% OR files outside initial diff → stuck_scope.
+
+    LOC delta is measured as a percentage of the first attempt's LOC count.
+    Files must stay within the union of files touched in the initial diff.
+
+    Returns:
+        (fired: bool, reason: str)
+    """
+    if not history:
+        return False, ""
+
+    first_attempt = history[0]
+    initial_loc = first_attempt.get("loc_delta", 0)
+
+    for attempt in history[1:]:
+        # Check LOC delta threshold
+        current_loc = attempt.get("loc_delta", 0)
+        if initial_loc > 0:
+            loc_delta_percent = ((current_loc - initial_loc) / initial_loc) * 100
+            if loc_delta_percent > LOC_DELTA_THRESHOLD_PERCENT:
+                reason = (
+                    f"LOC delta {loc_delta_percent:.1f}% exceeds threshold "
+                    f"({LOC_DELTA_THRESHOLD_PERCENT}%)"
+                )
+                return True, reason
+
+        # Check files stay within initial diff
+        files_touched = attempt.get("files_touched", set())
+        outside_files = files_touched - initial_files
+        if outside_files:
+            reason = (
+                f"Attempt {attempt.get('attempt', '?')} touched files "
+                f"outside initial diff: {', '.join(sorted(outside_files))}"
+            )
+            return True, reason
+
+    return False, ""
+
+
+def _check_no_convergence(history: list[dict]) -> tuple[bool, str]:
+    """Guard: n_critical + n_major not strictly decreasing → stuck_no_convergence.
+
+    Strictly decreasing: (n_critical, n_major) as a lexicographic pair
+    must have both components strictly decrease between consecutive attempts.
+
+    Returns:
+        (fired: bool, reason: str)
+    """
+    if len(history) < 2:
+        return False, ""
+
+    for i in range(1, len(history)):
+        prev = history[i - 1]
+        curr = history[i]
+
+        prev_critical = prev.get("n_critical", 0)
+        prev_major = prev.get("n_major", 0)
+        curr_critical = curr.get("n_critical", 0)
+        curr_major = curr.get("n_major", 0)
+
+        # Both must strictly decrease
+        if not (curr_critical < prev_critical and curr_major < prev_major):
+            reason = (
+                f"Findings not strictly decreasing: "
+                f"attempt {prev.get('attempt', '?')} ({prev_critical}c, {prev_major}m) → "
+                f"attempt {curr.get('attempt', '?')} ({curr_critical}c, {curr_major}m)"
+            )
+            return True, reason
+
+    return False, ""
+
+
+def _check_conflict(history: list[dict]) -> tuple[bool, str]:
+    """Guard: same file:line touched in 2 different attempts → stuck_conflict.
+
+    Maintains a map of (file, line) pairs seen in previous attempts.
+    If any pair appears in multiple attempts, guard fires.
+
+    Returns:
+        (fired: bool, reason: str)
+    """
+    seen_locations: dict[tuple[str, int], int] = {}  # (file, line) -> attempt_num
+
+    for attempt in history:
+        attempt_num = attempt.get("attempt", 0)
+        conflicts = attempt.get("conflicts", {})
+
+        for file, lines in conflicts.items():
+            for line in lines:
+                location = (file, line)
+                if location in seen_locations:
+                    prev_attempt = seen_locations[location]
+                    reason = (
+                        f"Location {file}:{line} touched in both "
+                        f"attempt {prev_attempt} and attempt {attempt_num}"
+                    )
+                    return True, reason
+                seen_locations[location] = attempt_num
+
+    return False, ""
+
+
+# ============================================================================
+# Convergence check
+# ============================================================================
+
+
+def _check_convergence(history: list[dict]) -> bool:
+    """Check if convergence target is met.
+
+    Convergence target: n_critical == 0 AND n_major <= 2.
+
+    Returns:
+        True if the latest attempt meets both targets.
+    """
+    if not history:
+        return False
+
+    latest = history[-1]
+    n_critical = latest.get("n_critical", 0)
+    n_major = latest.get("n_major", 0)
+
+    return n_critical == TARGET_CRITICAL and n_major <= MAX_MAJOR_FINDINGS
+
+
+# ============================================================================
+# Main decision function
+# ============================================================================
+
+
+def decide(
+    attempts: int,
+    history: list[dict],
+    initial_files: set[str],
+) -> PolicyResult:
+    """Decide whether the rework loop should continue, converge, or get stuck.
+
+    Args:
+        attempts: Current attempt number (1-indexed).
+        history: List of attempt records. Each record should have:
+            {
+                "attempt": int,
+                "n_critical": int,
+                "n_major": int,
+                "files_touched": set[str],
+                "loc_delta": int,
+                "conflicts": dict[str, set[int]],  # {file: {line_nums}}
+            }
+        initial_files: Set of file paths from the initial PR diff.
+
+    Returns:
+        PolicyResult with decision and reason.
+
+    Notes:
+        - Guards are evaluated in order; the first to fire determines the verdict.
+        - Convergence is checked first: if converged, return immediately.
+        - Then remaining guards are checked.
+        - The policy module is side-effect-free; callers handle GH/memory writes.
+    """
+    # Check convergence first — convergence takes precedence
+    if _check_convergence(history):
+        reason = (
+            f"Convergence target met: "
+            f"n_critical={history[-1].get('n_critical', 0)} (target=0), "
+            f"n_major={history[-1].get('n_major', 0)} (target≤{MAX_MAJOR_FINDINGS})"
+        )
+        return PolicyResult(decision=LoopDecision.CONVERGED, reason=reason)
+
+    # Check guards in order (after convergence check).
+    # Order: more specific reasons before generic limits, so that we report
+    # the actual reason a loop is stuck rather than just the attempt count.
+    guards = [
+        ("scope", _check_scope_creep(history, initial_files)),
+        ("convergence", _check_no_convergence(history)),
+        ("conflict", _check_conflict(history)),
+        ("attempts", _check_max_attempts(attempts)),
+    ]
+
+    for guard_name, (fired, reason) in guards:
+        if fired:
+            if guard_name == "attempts":
+                decision = LoopDecision.STUCK_ATTEMPTS
+            elif guard_name == "scope":
+                decision = LoopDecision.STUCK_SCOPE
+            elif guard_name == "convergence":
+                decision = LoopDecision.STUCK_NO_CONVERGENCE
+            elif guard_name == "conflict":
+                decision = LoopDecision.STUCK_CONFLICT
+            else:
+                decision = LoopDecision.CONTINUE  # Should not reach
+            return PolicyResult(decision=decision, reason=reason)
+
+    # No guard fired and not converged yet
+    reason = "No guard fired; loop may continue to next attempt"
+    return PolicyResult(decision=LoopDecision.CONTINUE, reason=reason)

--- a/tests/test_rework_policy.py
+++ b/tests/test_rework_policy.py
@@ -1,0 +1,500 @@
+"""Tests for rework loop-stop policy decision module (#634).
+
+Verifies that the pure-function policy module correctly decides whether
+a PR rework loop should continue, has converged, or has terminated due to
+one of four guard conditions:
+  - max_attempts: ≥3 attempts
+  - scope_creep: LOC delta >50% OR files outside initial PR diff
+  - no_convergence: critical+major finding counts not strictly decreasing
+  - conflict: same file:line touched in multiple attempts
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rework_policy import (
+    LoopDecision,
+    decide,
+)
+
+
+# -- Test data helpers -------------------------------------------------------
+
+
+def make_attempt(
+    attempt_num: int,
+    n_critical: int,
+    n_major: int,
+    files_touched: set[str] | None = None,
+    loc_delta: int | None = None,
+    conflicts: dict[str, set[int]] | None = None,
+) -> dict:
+    """Helper to construct an attempt record."""
+    return {
+        "attempt": attempt_num,
+        "n_critical": n_critical,
+        "n_major": n_major,
+        "files_touched": files_touched or set(),
+        "loc_delta": loc_delta or 0,
+        "conflicts": conflicts or {},  # {file: {line_nums}}
+    }
+
+
+# ============================================================================
+# AC Tests: Max Attempts Guard
+# ============================================================================
+
+
+class TestMaxAttemptsGuard:
+    """max_attempts: ≥3 attempts → stuck_attempts."""
+
+    def test_attempt_3_no_convergence_returns_stuck_attempts(self):
+        """AC: attempt 3, no convergence → stuck_attempts."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=3, n_major=4),
+            make_attempt(3, n_critical=2, n_major=3),
+        ]
+        result = decide(
+            attempts=3,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.STUCK_ATTEMPTS
+
+    def test_attempt_2_within_attempts_continues(self):
+        """AC: history [(5,6),(3,4)] at attempt 2 within scope → continue."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=3, n_major=4),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.CONTINUE
+
+
+# ============================================================================
+# AC Tests: Scope Creep Guard
+# ============================================================================
+
+
+class TestScopeCreepGuard:
+    """scope_creep: LOC delta >50% OR files outside initial diff → stuck_scope."""
+
+    def test_loc_delta_51_percent_triggers_scope_creep(self):
+        """AC: attempt 2, LOC delta = 51% of original → stuck_scope."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6, loc_delta=100),
+            make_attempt(2, n_critical=3, n_major=4, loc_delta=151),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.STUCK_SCOPE
+
+    def test_loc_delta_exactly_50_percent_is_safe(self):
+        """Edge: LOC delta exactly 50% should NOT trigger scope_creep."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6, loc_delta=100),
+            make_attempt(2, n_critical=3, n_major=4, loc_delta=150),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.CONTINUE
+
+    def test_file_outside_initial_diff_triggers_scope_creep(self):
+        """AC: attempt 2, files touched include one outside initial diff → stuck_scope."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6, files_touched={"a.py", "b.py"}),
+            make_attempt(2, n_critical=3, n_major=4, files_touched={"a.py", "c.py"}),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.STUCK_SCOPE
+
+    def test_all_files_within_initial_diff_is_safe(self):
+        """All files in attempt stay within initial diff → scope OK."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6, files_touched={"a.py", "b.py"}),
+            make_attempt(2, n_critical=3, n_major=4, files_touched={"a.py"}),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.CONTINUE
+
+
+# ============================================================================
+# AC Tests: No Convergence Guard
+# ============================================================================
+
+
+class TestNoConvergenceGuard:
+    """no_convergence: n_critical + n_major not strictly decreasing → stuck_no_convergence."""
+
+    def test_flat_finding_counts_triggers_no_convergence(self):
+        """AC: [(5,6),(3,4),(3,4)] attempt 3==2 → stuck_no_convergence."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=3, n_major=4),
+            make_attempt(3, n_critical=3, n_major=4),
+        ]
+        result = decide(
+            attempts=3,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.STUCK_NO_CONVERGENCE
+
+    def test_strictly_decreasing_allows_continue(self):
+        """AC: history [(5,6),(3,4),(0,2)] → converged."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=3, n_major=4),
+            make_attempt(3, n_critical=0, n_major=2),
+        ]
+        result = decide(
+            attempts=3,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.CONVERGED
+
+    def test_increase_in_findings_triggers_no_convergence(self):
+        """If findings go up (not strictly decreasing), guard fires."""
+        history = [
+            make_attempt(1, n_critical=2, n_major=3),
+            make_attempt(2, n_critical=3, n_major=2),  # critical went up
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        # Violation of strictly decreasing — both components must decrease
+        assert result.decision == LoopDecision.STUCK_NO_CONVERGENCE
+
+
+# ============================================================================
+# AC Tests: Conflict Guard
+# ============================================================================
+
+
+class TestConflictGuard:
+    """conflict: same file:line touched in 2 different attempts → stuck_conflict."""
+
+    def test_same_file_line_in_two_attempts_triggers_conflict(self):
+        """AC: file.py:42 touched in attempts 1 and 2 → stuck_conflict."""
+        history = [
+            make_attempt(
+                1,
+                n_critical=5,
+                n_major=6,
+                conflicts={"file.py": {42}},
+            ),
+            make_attempt(
+                2,
+                n_critical=3,
+                n_major=4,
+                conflicts={"file.py": {42}},
+            ),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"file.py"},
+        )
+        assert result.decision == LoopDecision.STUCK_CONFLICT
+
+    def test_different_lines_in_same_file_is_safe(self):
+        """Same file, different lines → no conflict."""
+        history = [
+            make_attempt(
+                1,
+                n_critical=5,
+                n_major=6,
+                conflicts={"file.py": {42}},
+            ),
+            make_attempt(
+                2,
+                n_critical=3,
+                n_major=4,
+                conflicts={"file.py": {43}},
+            ),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"file.py"},
+        )
+        assert result.decision == LoopDecision.CONTINUE
+
+    def test_different_files_is_safe(self):
+        """Different files → no conflict."""
+        history = [
+            make_attempt(
+                1,
+                n_critical=5,
+                n_major=6,
+                conflicts={"a.py": {42}},
+            ),
+            make_attempt(
+                2,
+                n_critical=3,
+                n_major=4,
+                conflicts={"b.py": {42}},
+            ),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.CONTINUE
+
+
+# ============================================================================
+# AC Tests: Convergence
+# ============================================================================
+
+
+class TestConvergence:
+    """Convergence target: n_critical == 0 AND n_major <= 2 → converged."""
+
+    def test_convergence_at_attempt_3(self):
+        """AC: history [(5,6),(2,3),(0,2)] → converged."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=2, n_major=3),
+            make_attempt(3, n_critical=0, n_major=2),
+        ]
+        result = decide(
+            attempts=3,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.CONVERGED
+
+    def test_convergence_at_attempt_2(self):
+        """Hitting the convergence target at attempt 2."""
+        history = [
+            make_attempt(1, n_critical=3, n_major=4),
+            make_attempt(2, n_critical=0, n_major=2),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.CONVERGED
+
+    def test_not_converged_with_critical_remaining(self):
+        """n_critical > 0 means not converged."""
+        history = [
+            make_attempt(1, n_critical=3, n_major=4),
+            make_attempt(2, n_critical=1, n_major=2),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.CONTINUE
+
+    def test_not_converged_with_too_many_majors(self):
+        """n_major > 2 means not converged."""
+        history = [
+            make_attempt(1, n_critical=3, n_major=4),
+            make_attempt(2, n_critical=0, n_major=3),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.CONTINUE
+
+    def test_convergence_with_exactly_2_majors(self):
+        """Edge: n_major exactly = 2 with n_critical = 0 → converged."""
+        history = [
+            make_attempt(1, n_critical=3, n_major=4),
+            make_attempt(2, n_critical=0, n_major=2),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.CONVERGED
+
+
+# ============================================================================
+# Edge Tests: Boundaries
+# ============================================================================
+
+
+class TestBoundaryConditions:
+    """Edge cases: exact boundaries for guards."""
+
+    def test_attempt_exactly_3_is_stuck(self):
+        """Edge: attempt exactly = 3 → stuck (not ≥ 4)."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=3, n_major=4),
+            make_attempt(3, n_critical=2, n_major=3),
+        ]
+        result = decide(
+            attempts=3,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.STUCK_ATTEMPTS
+
+    def test_attempt_2_is_allowed(self):
+        """Edge: attempt exactly = 2 → still allowed (not yet stuck)."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=3, n_major=4),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        # Will continue unless another guard fires
+        assert result.decision in (LoopDecision.CONTINUE, LoopDecision.CONVERGED)
+
+    def test_loc_delta_exactly_50_is_boundary(self):
+        """Edge: LOC delta exactly 50% → allowed (> not >=)."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6, loc_delta=100),
+            make_attempt(2, n_critical=3, n_major=4, loc_delta=150),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision != LoopDecision.STUCK_SCOPE
+
+    def test_n_major_exactly_2_converges(self):
+        """Edge: n_major exactly = 2 with n_critical = 0 → converged."""
+        history = [
+            make_attempt(1, n_critical=3, n_major=5),
+            make_attempt(2, n_critical=0, n_major=2),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert result.decision == LoopDecision.CONVERGED
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestIntegration:
+    """Multi-guard scenarios."""
+
+    def test_multiple_guards_could_fire_first_one_wins(self):
+        """If multiple guards would fire, which takes precedence?
+
+        Current design: guards are independent, any one firing terminates.
+        We assert the actual result, not a precedence order.
+        """
+        # Scope creep + no convergence both present
+        history = [
+            make_attempt(1, n_critical=5, n_major=6, loc_delta=100),
+            make_attempt(2, n_critical=5, n_major=6, loc_delta=151),  # scope + no conv
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py"},
+        )
+        # Should hit one of the stuck guards
+        assert result.decision in (
+            LoopDecision.STUCK_SCOPE,
+            LoopDecision.STUCK_NO_CONVERGENCE,
+        )
+
+    def test_happy_path_attempt_2_converging(self):
+        """Happy path: attempt 2, converging towards target."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=0, n_major=2),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.CONVERGED
+
+    def test_happy_path_attempt_2_still_improving(self):
+        """Happy path: attempt 2, still making progress."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=2, n_major=3),
+        ]
+        result = decide(
+            attempts=2,
+            history=history,
+            initial_files={"a.py", "b.py"},
+        )
+        assert result.decision == LoopDecision.CONTINUE
+
+
+# ============================================================================
+# Return Value Structure
+# ============================================================================
+
+
+class TestReturnStructure:
+    """Verify the return value has all required fields."""
+
+    def test_result_has_decision_field(self):
+        """Result object must have .decision field."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+        ]
+        result = decide(
+            attempts=1,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert hasattr(result, "decision")
+        assert isinstance(result.decision, LoopDecision)
+
+    def test_result_has_reason_field(self):
+        """Result object must have .reason field for debugging."""
+        history = [
+            make_attempt(1, n_critical=5, n_major=6),
+            make_attempt(2, n_critical=3, n_major=4),
+            make_attempt(3, n_critical=2, n_major=3),
+        ]
+        result = decide(
+            attempts=3,
+            history=history,
+            initial_files={"a.py"},
+        )
+        assert hasattr(result, "reason")
+        assert isinstance(result.reason, str)
+        assert len(result.reason) > 0


### PR DESCRIPTION
## Summary

Implements pure-function policy module for /rework loop termination logic per #634.

- **decide(attempts, history, initial_files)** returns PolicyResult with verdict
- Six decision states: CONTINUE, CONVERGED, STUCK_ATTEMPTS, STUCK_SCOPE, STUCK_NO_CONVERGENCE, STUCK_CONFLICT
- Zero side effects, zero I/O — pure decision logic only
- Guards independent: any one firing terminates the loop

## Acceptance Criteria Met

- ✅ Module exports `decide(...)` with correct signature
- ✅ AC1: attempt 3, no convergence → stuck_attempts
- ✅ AC2: attempt 2, LOC delta 51% → stuck_scope
- ✅ AC3: attempt 2, files outside initial diff → stuck_scope
- ✅ AC4: `(n_critical, n_major)` history `[(5,6),(3,4),(3,4)]` → stuck_no_convergence
- ✅ AC5: file:line touched in attempts 1 and 2 → stuck_conflict
- ✅ AC6: history `[(5,6),(2,3),(0,2)]` → converged
- ✅ AC7: history `[(5,6),(3,4)]` at attempt 2 → continue
- ✅ AC8+: edge tests (attempt=3, LOC=50%, n_major=2)

## Tests

All 26 tests passing in CI:
- 2 max_attempts tests
- 4 scope_creep tests
- 3 no_convergence tests
- 3 conflict tests
- 5 convergence tests
- 4 boundary condition tests
- 3 integration tests
- 2 return value structure tests

## Implementation Details

- **Location**: scripts/rework_policy.py
- **Tests**: tests/test_rework_policy.py
- **Constants**: MAX_ATTEMPTS_THRESHOLD=3, LOC_DELTA_THRESHOLD_PERCENT=50, MAX_MAJOR_FINDINGS=2, TARGET_CRITICAL=0
- **Guard order**: scope → convergence → conflict → attempts (specific before generic)
- **Strictly decreasing**: both n_critical and n_major must decrease between attempts (lex order)
- **Convergence target**: n_critical == 0 AND n_major <= 2

## Caller Responsibility

This module is side-effect-free. The /rework skill (#636) is responsible for:
- Emitting `rework_stuck` event (severity=medium) on any stuck verdict
- Adding `status:needs-human` label
- Posting summary comment with findings
- Recording `outcome_status=partial`

Realizes decision 8e757f01-839b-4be2-a98b-a479452b5ec1 (Q4 loop-stop guards).

Closes #634