### PR TITLE
feat(recall): add include_unreviewed flag to RecallConfig and recall-path RPCs

### DIFF
--- a/mcp-memory/handlers/memory.py
+++ b/mcp-memory/handlers/memory.py
@@ -215,6 +215,7 @@ async def _handle_recall(args: dict) -> list[TextContent]:
 
     include_links = args.get("include_links", False)
     show_history = args.get("show_history", False)
+    include_unreviewed = args.get("include_unreviewed", False)
     brief = args.get("brief", False)
 
     # Hybrid search: combine semantic + keyword results via RRF + temporal scoring
@@ -228,6 +229,7 @@ async def _handle_recall(args: dict) -> list[TextContent]:
             include_links,
             show_history,
             brief,
+            include_unreviewed=include_unreviewed,
         )
         if rows:
             # Track reads (fire-and-forget)
@@ -245,8 +247,19 @@ async def _handle_recall(args: dict) -> list[TextContent]:
                     asyncio.create_task(_touch_memories(client, ids_to_touch))
             return results
 
-    # Fallback: keyword-only search (embed failure or empty hybrid result)
-    results = await server._keyword_recall(client, query_text, project, mem_type, limit, brief)
+    # Fallback: keyword-only search (embed failure or empty hybrid result).
+    # Pass include_unreviewed through so the always-gate is enforced on the
+    # fallback path too — the SQL RPCs do this server-side; this client-side
+    # path must mirror them.
+    results = await server._keyword_recall(
+        client,
+        query_text,
+        project,
+        mem_type,
+        limit,
+        brief,
+        include_unreviewed=include_unreviewed,
+    )
 
     # Lazily backfill embeddings for records missing them (fire-and-forget)
     if os.environ.get("VOYAGE_API_KEY"):
@@ -264,6 +277,8 @@ async def _hybrid_recall(
     include_links: bool = False,
     show_history: bool = False,
     brief: bool = False,
+    *,
+    include_unreviewed: bool = False,
 ) -> tuple[list[dict], list[TextContent]]:
     """Adapter wrapping the recall() pipeline for the MCP recall tool.
 
@@ -278,6 +293,7 @@ async def _hybrid_recall(
         PROD_RECALL_CONFIG,
         limit=limit,
         use_links=include_links,
+        include_unreviewed=include_unreviewed,
     )
     try:
         hits = await recall(
@@ -344,7 +360,14 @@ async def _hybrid_recall(
 
 
 async def _keyword_recall(
-    client, query_text: str, project, mem_type, limit: int, brief: bool = False
+    client,
+    query_text: str,
+    project,
+    mem_type,
+    limit: int,
+    brief: bool = False,
+    *,
+    include_unreviewed: bool = False,
 ) -> list[TextContent]:
     """ILIKE keyword search (fallback when semantic unavailable).
 
@@ -355,6 +378,13 @@ async def _keyword_recall(
     Lifecycle filters mirror the show_history=false branch of
     match_memories / keyword_search_memories: exclude soft-deleted,
     expired, superseded, and past-valid_to rows (#284).
+
+    Always-gate (#552): `requires_review=true` rows and merge-proposal rows
+    (`merge_targets` non-empty) are filtered to match the SQL RPCs. Without
+    this, a VoyageAI outage that routes traffic here would expose pending
+    review candidates to production callers. `include_unreviewed=True`
+    relaxes the requires_review gate; merge proposals are filtered
+    unconditionally (they are meta-rows, never knowledge).
 
     valid_to is filtered client-side (not via .or_()) because PostgREST
     accepts only one `or=` parameter per query, and this path already uses
@@ -373,7 +403,10 @@ async def _keyword_recall(
         .is_("deleted_at", "null")
         .is_("expired_at", "null")
         .is_("superseded_by", "null")
+        .is_("merge_targets", "null")  # always-gate: merge proposals never surface
     )
+    if not include_unreviewed:
+        q = q.eq("requires_review", False)
 
     if project is not None:
         q = q.or_(f"project.eq.{project},project.is.null")

--- a/mcp-memory/handlers/memory.py
+++ b/mcp-memory/handlers/memory.py
@@ -850,11 +850,18 @@ async def _expand_with_links(
     client,
     memory_ids: list[str],
     show_history: bool = False,
+    *,
+    include_unreviewed: bool = False,
 ) -> list[dict]:
     """Fetch 1-hop linked memories via graph traversal RPC.
 
     show_history mirrors the primary recall flag: when true, skip the
     lifecycle filter so history views don't drop linked neighbors.
+
+    include_unreviewed forwards the always-gate opt-in (#552). Currently
+    no call site exercises this helper (the active expand_links lives in
+    recall.py), but the parameter is plumbed so any future reinstatement
+    can't silently drop the flag — matches the SQL RPC contract.
     """
     try:
         result = client.rpc(
@@ -863,6 +870,7 @@ async def _expand_with_links(
                 "memory_ids": memory_ids,
                 "link_types": None,
                 "show_history": show_history,
+                "include_unreviewed": include_unreviewed,
             },
         ).execute()
         return result.data or []

--- a/mcp-memory/recall.py
+++ b/mcp-memory/recall.py
@@ -270,6 +270,7 @@ def expand_links(
     link_types: list[str] | None = None,
     top_k: int = LINK_EXPAND_TOP_K,
     decay: float = LINK_DECAY,
+    include_unreviewed: bool = False,
 ) -> list[dict]:
     """Fetch 1-hop linked neighbors of the top-K rows via ``get_linked_memories``.
 
@@ -287,6 +288,7 @@ def expand_links(
                 "memory_ids": seed_ids,
                 "link_types": link_types,
                 "show_history": False,
+                "include_unreviewed": include_unreviewed,
             },
         ).execute()
         linked_rows = result.data or []
@@ -442,6 +444,7 @@ class RecallConfig:
     rrf_k: int = RRF_K
     temporal_half_lives: dict[str, float] = field(default_factory=lambda: dict(TEMPORAL_HALF_LIVES))
     excluded_tags: frozenset[str] = EXCLUDE_TAGS_FROM_RECALL
+    include_unreviewed: bool = False
     limit: int = 10
 
 
@@ -599,6 +602,7 @@ async def recall(
                 "filter_project": project,
                 "filter_type": type_filter,
                 "show_history": show_history,
+                "include_unreviewed": config.include_unreviewed,
             },
         ).execute()
         semantic_rows = filter_excluded_tags(sem_result.data or [])
@@ -611,6 +615,7 @@ async def recall(
                 "filter_project": project,
                 "filter_type": type_filter,
                 "show_history": show_history,
+                "include_unreviewed": config.include_unreviewed,
             },
         ).execute()
         keyword_rows = filter_excluded_tags(kw_result.data or [])
@@ -634,7 +639,7 @@ async def recall(
         return []
 
     if config.use_links:
-        linked = expand_links(client, merged)
+        linked = expand_links(client, merged, include_unreviewed=config.include_unreviewed)
         if linked:
             merged = merge_with_links(merged, linked)
         merged = merged[: config.limit]

--- a/mcp-memory/recall.py
+++ b/mcp-memory/recall.py
@@ -391,9 +391,16 @@ def apply_temporal_scoring(rows: list[dict]) -> list[dict]:
         recency = math.exp(-0.693 * days_since_update / half_life)
         access = 1.0 + ACCESS_BOOST_MAX * math.exp(-0.693 * days_since_access / ACCESS_HALF_LIFE)
 
+        # Reviewed memories with no confidence column default to 1.0 (full
+        # entrenchment) — pre-PR behavior, calibrated against existing rows.
+        # Unreviewed Deriver/Dreamer candidates (requires_review=true) typically
+        # have confidence=NULL at write time; treating them as fully entrenched
+        # would rank a pending candidate above an established memory in
+        # include_unreviewed=true queries. Floor them at CONFIDENCE_FLOOR so
+        # entrenchment caps at 0.75 instead of 1.0 (#552 always-gate corollary).
         confidence_raw = row.get("confidence")
         if confidence_raw is None:
-            conf = 1.0
+            conf = CONFIDENCE_FLOOR if row.get("requires_review") else 1.0
         else:
             try:
                 conf = float(confidence_raw)
@@ -640,6 +647,11 @@ async def recall(
 
     if config.use_links:
         linked = expand_links(client, merged, include_unreviewed=config.include_unreviewed)
+        if linked:
+            # Linked rows are tag-filtered to match semantic/keyword legs —
+            # otherwise session-snapshot etc. can ride in as 1-hop neighbors of
+            # a seed row and bypass the same filter applied above on lines 608/621.
+            linked = filter_excluded_tags(linked)
         if linked:
             merged = merge_with_links(merged, linked)
         merged = merged[: config.limit]

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2086,13 +2086,15 @@ create index if not exists idx_memories_embedding_v2_hnsw
 -- can swap by name. NO CASE expression in ORDER BY — pgvector HNSW requires
 -- a direct column reference to use the index.
 drop function if exists match_memories_v2(vector, int, float, text, text, boolean);
+drop function if exists match_memories_v2(vector, int, float, text, text, boolean, boolean);
 create or replace function match_memories_v2(
     query_embedding vector,
     match_limit int default 10,
     similarity_threshold float default 0.3,
     filter_project text default null,
     filter_type text default null,
-    show_history boolean default false
+    show_history boolean default false,
+    include_unreviewed boolean default false
 )
 returns table(
     id uuid, name text, type text, project text,
@@ -2117,7 +2119,7 @@ language sql stable as $$
                and m.superseded_by is null
                and (m.valid_to is null or m.valid_to > now())))
       -- Deriver review-gate (issue #552): see match_memories.
-      and m.requires_review = false
+      and (include_unreviewed or m.requires_review = false)
       and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
     order by m.embedding_v2 <=> query_embedding
     limit match_limit;
@@ -2384,13 +2386,15 @@ $$;
 -- =========================================================================
 
 drop function if exists match_memories(vector, int, float, text, text, boolean);
+drop function if exists match_memories(vector, int, float, text, text, boolean, boolean);
 create or replace function match_memories(
     query_embedding vector,
     match_limit int default 10,
     similarity_threshold float default 0.3,
     filter_project text default null,
     filter_type text default null,
-    show_history boolean default false
+    show_history boolean default false,
+    include_unreviewed boolean default false
 )
 returns table(
     id uuid, name text, type text, project text,
@@ -2424,19 +2428,21 @@ language sql stable as $$
       -- and `array_length('{}'::uuid[], 1)` returns NULL, not 0. Kept as a
       -- belt-and-braces guard; cost is negligible and `is null` is the
       -- short-circuit path via the partial GIN index.
-      and m.requires_review = false
+      and (include_unreviewed or m.requires_review = false)
       and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
     order by m.embedding <=> query_embedding
     limit match_limit;
 $$;
 
 drop function if exists keyword_search_memories(text, int, text, text, boolean);
+drop function if exists keyword_search_memories(text, int, text, text, boolean, boolean);
 create or replace function keyword_search_memories(
     search_query text,
     match_limit int default 10,
     filter_project text default null,
     filter_type text default null,
-    show_history boolean default false
+    show_history boolean default false,
+    include_unreviewed boolean default false
 )
 returns table(
     id uuid, name text, type text, project text,
@@ -2460,17 +2466,19 @@ language sql stable as $$
                and m.superseded_by is null
                and (m.valid_to is null or m.valid_to > now())))
       -- Deriver review-gate (issue #552): see match_memories above.
-      and m.requires_review = false
+      and (include_unreviewed or m.requires_review = false)
       and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
     order by rank desc
     limit match_limit;
 $$;
 
 drop function if exists get_linked_memories(uuid[], text[], boolean);
+drop function if exists get_linked_memories(uuid[], text[], boolean, boolean);
 create or replace function get_linked_memories(
     memory_ids uuid[],
     link_types text[] default null,
-    show_history boolean default false
+    show_history boolean default false,
+    include_unreviewed boolean default false
 )
 returns table(
     id uuid, name text, type text, project text,
@@ -2505,7 +2513,7 @@ language sql stable as $$
                        and m.superseded_by is null
                        and (m.valid_to is null or m.valid_to > now())))
               -- Deriver review-gate (issue #552): see match_memories above.
-              and m.requires_review = false
+              and (include_unreviewed or m.requires_review = false)
               and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
             union all
             -- Incoming edges: target ∈ memory_ids, source resolved to head.
@@ -2526,7 +2534,7 @@ language sql stable as $$
                        and m.superseded_by is null
                        and (m.valid_to is null or m.valid_to > now())))
               -- Deriver review-gate (issue #552): see match_memories above.
-              and m.requires_review = false
+              and (include_unreviewed or m.requires_review = false)
               and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
         ) sub
         order by sub.id, sub.link_strength desc, sub.link_type, sub.linked_from

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2410,12 +2410,17 @@ language sql stable as $$
            1 - (m.embedding <=> query_embedding) as similarity
     from memories m
     where m.embedding is not null
+      -- deleted_at is null is always required — soft-deleted rows must
+      -- never surface, even with show_history=true. Mirrors match_memories_v2
+      -- (line 2113) to eliminate the cross-RPC asymmetry where
+      -- show_history=true was surfacing soft-deleted rows here but not from
+      -- the primary embedding slot.
+      and m.deleted_at is null
       and 1 - (m.embedding <=> query_embedding) >= similarity_threshold
       and (filter_project is null or m.project = filter_project or m.project is null)
       and (filter_type is null or m.type = filter_type)
       and (show_history
-           or (m.deleted_at is null
-               and m.expired_at is null
+           or (m.expired_at is null
                and m.superseded_by is null
                and (m.valid_to is null or m.valid_to > now())))
       -- Deriver review-gate (issue #552): hide rows pending owner review

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2101,12 +2101,16 @@ returns table(
     description text, content text, tags text[],
     updated_at timestamptz, content_updated_at timestamptz,
     last_accessed_at timestamptz,
+    -- requires_review surfaced so Python-side temporal scoring can floor
+    -- entrenchment for unreviewed candidates (see apply_temporal_scoring).
+    requires_review boolean,
     similarity float
 )
 language sql stable as $$
     select m.id, m.name, m.type, m.project,
            m.description, m.content, m.tags,
            m.updated_at, m.content_updated_at, m.last_accessed_at,
+           m.requires_review,
            1 - (m.embedding_v2 <=> query_embedding) as similarity
     from memories m
     where m.embedding_v2 is not null
@@ -2401,12 +2405,14 @@ returns table(
     description text, content text, tags text[],
     updated_at timestamptz, content_updated_at timestamptz,
     last_accessed_at timestamptz,
+    requires_review boolean,
     similarity float
 )
 language sql stable as $$
     select m.id, m.name, m.type, m.project,
            m.description, m.content, m.tags,
            m.updated_at, m.content_updated_at, m.last_accessed_at,
+           m.requires_review,
            1 - (m.embedding <=> query_embedding) as similarity
     from memories m
     where m.embedding is not null
@@ -2454,20 +2460,25 @@ returns table(
     description text, content text, tags text[],
     updated_at timestamptz, content_updated_at timestamptz,
     last_accessed_at timestamptz,
+    requires_review boolean,
     rank real
 )
 language sql stable as $$
     select m.id, m.name, m.type, m.project,
            m.description, m.content, m.tags,
            m.updated_at, m.content_updated_at, m.last_accessed_at,
+           m.requires_review,
            ts_rank(m.fts, websearch_to_tsquery('english', search_query)) as rank
     from memories m
     where m.fts @@ websearch_to_tsquery('english', search_query)
+      -- Soft-deleted rows must never surface, even with show_history=true.
+      -- Mirrors match_memories / match_memories_v2 — keeps the FTS leg
+      -- consistent with the vector legs under rrf_merge.
+      and m.deleted_at is null
       and (filter_project is null or m.project = filter_project or m.project is null)
       and (filter_type is null or m.type = filter_type)
       and (show_history
-           or (m.deleted_at is null
-               and m.expired_at is null
+           or (m.expired_at is null
                and m.superseded_by is null
                and (m.valid_to is null or m.valid_to > now())))
       -- Deriver review-gate (issue #552): see match_memories above.
@@ -2490,6 +2501,7 @@ returns table(
     description text, content text, tags text[],
     updated_at timestamptz, content_updated_at timestamptz,
     last_accessed_at timestamptz,
+    requires_review boolean,
     link_type text, link_strength float, linked_from uuid
 )
 language sql stable as $$
@@ -2498,11 +2510,13 @@ language sql stable as $$
             sub.id, sub.name, sub.type, sub.project, sub.description,
             sub.content, sub.tags,
             sub.updated_at, sub.content_updated_at, sub.last_accessed_at,
+            sub.requires_review,
             sub.link_type, sub.link_strength, sub.linked_from
         from (
             -- Outgoing edges: source ∈ memory_ids, target resolved to head.
             select m.id, m.name, m.type, m.project, m.description, m.content,
                    m.tags, m.updated_at, m.content_updated_at, m.last_accessed_at,
+                   m.requires_review,
                    l.link_type, l.strength as link_strength, l.source_id as linked_from
             from memory_links l
             join memories m on m.id = coalesce(
@@ -2512,9 +2526,10 @@ language sql stable as $$
             where l.source_id = any(memory_ids)
               and not (m.id = any(memory_ids))
               and (link_types is null or l.link_type = any(link_types))
+              -- Soft-deleted rows must never surface (mirrors match_memories).
+              and m.deleted_at is null
               and (show_history
-                   or (m.deleted_at is null
-                       and m.expired_at is null
+                   or (m.expired_at is null
                        and m.superseded_by is null
                        and (m.valid_to is null or m.valid_to > now())))
               -- Deriver review-gate (issue #552): see match_memories above.
@@ -2524,6 +2539,7 @@ language sql stable as $$
             -- Incoming edges: target ∈ memory_ids, source resolved to head.
             select m.id, m.name, m.type, m.project, m.description, m.content,
                    m.tags, m.updated_at, m.content_updated_at, m.last_accessed_at,
+                   m.requires_review,
                    l.link_type, l.strength as link_strength, l.target_id as linked_from
             from memory_links l
             join memories m on m.id = coalesce(
@@ -2533,9 +2549,10 @@ language sql stable as $$
             where l.target_id = any(memory_ids)
               and not (m.id = any(memory_ids))
               and (link_types is null or l.link_type = any(link_types))
+              -- Soft-deleted rows must never surface (mirrors match_memories).
+              and m.deleted_at is null
               and (show_history
-                   or (m.deleted_at is null
-                       and m.expired_at is null
+                   or (m.expired_at is null
                        and m.superseded_by is null
                        and (m.valid_to is null or m.valid_to > now())))
               -- Deriver review-gate (issue #552): see match_memories above.

--- a/mcp-memory/tools_schema.py
+++ b/mcp-memory/tools_schema.py
@@ -261,6 +261,17 @@ def tool_definitions() -> list[Tool]:
                         ),
                         "default": False,
                     },
+                    "include_unreviewed": {
+                        "type": "boolean",
+                        "description": (
+                            "Include `requires_review=true` rows (Deriver/Dreamer "
+                            "candidates pending owner review). Default false — the "
+                            "always-gate (#552) hides them from production recall. "
+                            "Opt-in for the eval harness and `/learn --status`; "
+                            "merge-proposal rows are filtered regardless."
+                        ),
+                        "default": False,
+                    },
                     "brief": {
                         "type": "boolean",
                         "description": (

--- a/scripts/evolve-neighbors.py
+++ b/scripts/evolve-neighbors.py
@@ -77,7 +77,7 @@ DEFAULT_TIMEOUT = 15.0
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
 MAX_TOKENS = 1200
-MAX_CONTENT_CHARS = 700     # truncate each memory body before sending
+MAX_CONTENT_CHARS = 700  # truncate each memory body before sending
 MAX_NEIGHBORS_PER_UPDATE = 8  # hard cap to bound Haiku cost per UPDATE
 
 VALID_ACTIONS = ("KEEP", "UPDATE_TAGS", "UPDATE_DESC", "UPDATE_BOTH")
@@ -210,8 +210,7 @@ def _fetch_seen_update_ids(client, update_queue_ids: list[str]) -> set[str]:
         # Dedup is an optimization. Fail open so a transient DB blip
         # doesn't stop planning — at worst we re-plan an already-evolved
         # UPDATE, which is wasteful but not incorrect.
-        print(f"! evolution dedup lookup failed ({e}); proceeding without dedup",
-              file=sys.stderr)
+        print(f"! evolution dedup lookup failed ({e}); proceeding without dedup", file=sys.stderr)
         return set()
     wanted = set(update_queue_ids)
     seen: set[str] = set()
@@ -247,6 +246,11 @@ def fetch_neighbors(client, target_id: str) -> list[dict]:
                 "memory_ids": [target_id],
                 "link_types": None,
                 "show_history": False,
+                # evolve operates on the unreviewed candidate layer by design —
+                # if a candidate's 1-hop neighbors are also pending review, we
+                # still need them in the evolution prompt. Without this the
+                # always-gate silently drops the very rows we're evolving.
+                "include_unreviewed": True,
             },
         ).execute()
     except Exception as e:
@@ -386,9 +390,7 @@ def _parse_response(text: str, neighbor_ids: set[str]) -> list[dict] | None:
                 "neighbor_id": nid,
                 "action": action,
                 "new_tags": new_tags if action in ("UPDATE_TAGS", "UPDATE_BOTH") else None,
-                "new_description": new_desc
-                if action in ("UPDATE_DESC", "UPDATE_BOTH")
-                else None,
+                "new_description": new_desc if action in ("UPDATE_DESC", "UPDATE_BOTH") else None,
                 "confidence": round(confidence, 3),
                 "reasoning": reasoning,
             }
@@ -547,9 +549,7 @@ def render_markdown(results: list[dict], *, model: str, limit: int) -> str:
                 .replace("\n", " ")
                 .replace("|", "\\|")
             )
-            lines.append(
-                f"| `{name}` | **{p['action']}** | {p['confidence']:.2f} | {reasoning} |"
-            )
+            lines.append(f"| `{name}` | **{p['action']}** | {p['confidence']:.2f} | {reasoning} |")
         lines.append("")
         # Detail block for non-KEEP proposals
         actionable = [p for p in r["proposals"] if p["action"] != "KEEP"]
@@ -673,9 +673,7 @@ def _build_rpc_plan(result: dict, source_provenance: str) -> dict:
     }
 
 
-def apply_plan_to_db(
-    client, result: dict, *, today: str, model: str
-) -> dict:
+def apply_plan_to_db(client, result: dict, *, today: str, model: str) -> dict:
     """Call apply_evolution_plan RPC + write auto_applied queue row.
 
     Transactional inside the RPC: if the queue insert fails, the neighbor
@@ -712,9 +710,7 @@ def apply_plan_to_db(
     }
 
 
-def queue_for_review(
-    client, result: dict, *, today: str, model: str
-) -> dict:
+def queue_for_review(client, result: dict, *, today: str, model: str) -> dict:
     """Route a low-confidence plan to the review queue.
 
     Mirrors `queue_for_review` in consolidation-merge-plan.py: direct
@@ -758,9 +754,7 @@ def queue_for_review(
             f"Queue insert for UPDATE {result['queue_id']} (EVOLVE) failed: {e}"
         ) from e
     if not queue_id:
-        raise RuntimeError(
-            f"Queue insert for UPDATE {result['queue_id']} (EVOLVE) returned no id"
-        )
+        raise RuntimeError(f"Queue insert for UPDATE {result['queue_id']} (EVOLVE) returned no id")
     return {
         "update_queue_id": result["queue_id"],
         "queue_id": queue_id,
@@ -769,9 +763,7 @@ def queue_for_review(
     }
 
 
-def apply_or_queue(
-    client, results: list[dict], *, model: str, gate: float
-) -> list[dict]:
+def apply_or_queue(client, results: list[dict], *, model: str, gate: float) -> list[dict]:
     """Route each result to apply / queue / skip based on confidence gate.
 
     Returns a list of outcome dicts (one per input result).
@@ -781,11 +773,13 @@ def apply_or_queue(
     for r in results:
         actionable = _actionable_proposals(r["proposals"])
         if not actionable:
-            outcomes.append({
-                "update_queue_id": r["queue_id"],
-                "status": "skipped_all_keep",
-                "applied_count": 0,
-            })
+            outcomes.append(
+                {
+                    "update_queue_id": r["queue_id"],
+                    "status": "skipped_all_keep",
+                    "applied_count": 0,
+                }
+            )
             continue
         min_conf = _plan_min_confidence(actionable)
         try:
@@ -800,12 +794,14 @@ def apply_or_queue(
                 f"! apply/queue failed for UPDATE {r['queue_id']}: {e}",
                 file=sys.stderr,
             )
-            outcomes.append({
-                "update_queue_id": r["queue_id"],
-                "status": "error",
-                "error": str(e),
-                "applied_count": 0,
-            })
+            outcomes.append(
+                {
+                    "update_queue_id": r["queue_id"],
+                    "status": "error",
+                    "error": str(e),
+                    "applied_count": 0,
+                }
+            )
             continue
         outcome["min_confidence"] = min_conf
         outcomes.append(outcome)
@@ -855,7 +851,7 @@ def main() -> int:
         "--apply",
         action="store_true",
         help="Phase 5.2-β: persist high-confidence plans via apply_evolution_plan RPC + "
-             "queue low-confidence ones. Off by default — dry-run only.",
+        "queue low-confidence ones. Off by default — dry-run only.",
     )
     p.add_argument(
         "--confidence-gate",
@@ -873,7 +869,10 @@ def main() -> int:
     # which the #542 RLS gate rejects for anon. See mcp-memory/client.py.
     sb_key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_KEY")
     if not sb_url or not sb_key:
-        print("SUPABASE_URL / SUPABASE_KEY (or SUPABASE_SERVICE_KEY) missing from env", file=sys.stderr)
+        print(
+            "SUPABASE_URL / SUPABASE_KEY (or SUPABASE_SERVICE_KEY) missing from env",
+            file=sys.stderr,
+        )
         return 2
     # ANTHROPIC_API_KEY is NOT a hard requirement: call_haiku() falls back to
     # a KEEP-only plan when the key is absent, matching the documented fallback
@@ -910,16 +909,14 @@ def main() -> int:
             print(render_markdown([], model=args.model, limit=args.limit))
         return 0
 
-    print(f"Planning evolution for {len(updates)} UPDATE(s) with {args.model}...",
-          file=sys.stderr)
+    print(f"Planning evolution for {len(updates)} UPDATE(s) with {args.model}...", file=sys.stderr)
 
     results: list[dict] = []
     for i, row in enumerate(updates, 1):
         cand = fetch_memory(client, row["candidate_id"])
         tgt = fetch_memory(client, row["target_id"])
         if not cand or not tgt:
-            print(f"  [{i}/{len(updates)}] skipped: missing candidate/target rows",
-                  file=sys.stderr)
+            print(f"  [{i}/{len(updates)}] skipped: missing candidate/target rows", file=sys.stderr)
             continue
         neighbors = fetch_neighbors(client, row["target_id"])[:MAX_NEIGHBORS_PER_UPDATE]
         print(
@@ -927,9 +924,7 @@ def main() -> int:
             f"({len(neighbors)} neighbors)...",
             file=sys.stderr,
         )
-        proposals = call_haiku(
-            tgt, cand, neighbors, model=args.model, timeout=args.timeout
-        )
+        proposals = call_haiku(tgt, cand, neighbors, model=args.model, timeout=args.timeout)
         results.append(
             {
                 "queue_id": row["id"],

--- a/supabase/migrations/20260520000001_add_include_unreviewed_recall_flag.sql
+++ b/supabase/migrations/20260520000001_add_include_unreviewed_recall_flag.sql
@@ -5,6 +5,19 @@
 -- Dreamer can surface pending-candidate rows when needed. merge_targets
 -- rows (merge proposals) are ALWAYS filtered, regardless of the flag.
 --
+-- Round 4 additions (2026-05-26):
+--   * `requires_review` boolean added to every RPC's `returns table(...)`
+--     and SELECT projection. Without this, the Python-side CONFIDENCE_FLOOR
+--     entrenchment floor for unreviewed rows (recall.py:apply_temporal_scoring)
+--     was dead code — PostgREST never materialised the column, so
+--     `row.get("requires_review")` always returned None.
+--   * `keyword_search_memories` + `get_linked_memories` now apply
+--     `m.deleted_at is null` UNCONDITIONALLY (outside show_history), matching
+--     the round-3 fix to `match_memories` / `match_memories_v2`. Without
+--     this, show_history=true surfaced soft-deleted rows from the FTS / link
+--     legs while the vector leg hid them, producing non-deterministic RRF
+--     fusion.
+--
 -- Decision reference: 8f846597-2da0-44e0-af0c-0e65b3f36cbb (recall always-gate).
 -- See also: supabase/migrations/20260518000001_add_memory_review_columns.sql.
 
@@ -27,12 +40,14 @@ returns table(
     description text, content text, tags text[],
     updated_at timestamptz, content_updated_at timestamptz,
     last_accessed_at timestamptz,
+    requires_review boolean,
     similarity float
 )
 language sql stable as $$
     select m.id, m.name, m.type, m.project,
            m.description, m.content, m.tags,
            m.updated_at, m.content_updated_at, m.last_accessed_at,
+           m.requires_review,
            1 - (m.embedding_v2 <=> query_embedding) as similarity
     from memories m
     where m.embedding_v2 is not null
@@ -69,12 +84,14 @@ returns table(
     description text, content text, tags text[],
     updated_at timestamptz, content_updated_at timestamptz,
     last_accessed_at timestamptz,
+    requires_review boolean,
     similarity float
 )
 language sql stable as $$
     select m.id, m.name, m.type, m.project,
            m.description, m.content, m.tags,
            m.updated_at, m.content_updated_at, m.last_accessed_at,
+           m.requires_review,
            1 - (m.embedding <=> query_embedding) as similarity
     from memories m
     where m.embedding is not null
@@ -114,20 +131,25 @@ returns table(
     description text, content text, tags text[],
     updated_at timestamptz, content_updated_at timestamptz,
     last_accessed_at timestamptz,
+    requires_review boolean,
     rank real
 )
 language sql stable as $$
     select m.id, m.name, m.type, m.project,
            m.description, m.content, m.tags,
            m.updated_at, m.content_updated_at, m.last_accessed_at,
+           m.requires_review,
            ts_rank(m.fts, websearch_to_tsquery('english', search_query)) as rank
     from memories m
     where m.fts @@ websearch_to_tsquery('english', search_query)
+      -- Soft-deleted rows must never surface, even with show_history=true.
+      -- Mirrors match_memories / match_memories_v2 — keeps the FTS leg
+      -- consistent with the vector legs under rrf_merge.
+      and m.deleted_at is null
       and (filter_project is null or m.project = filter_project or m.project is null)
       and (filter_type is null or m.type = filter_type)
       and (show_history
-           or (m.deleted_at is null
-               and m.expired_at is null
+           or (m.expired_at is null
                and m.superseded_by is null
                and (m.valid_to is null or m.valid_to > now())))
       and (include_unreviewed or m.requires_review = false)
@@ -152,6 +174,7 @@ returns table(
     description text, content text, tags text[],
     updated_at timestamptz, content_updated_at timestamptz,
     last_accessed_at timestamptz,
+    requires_review boolean,
     link_type text, link_strength float, linked_from uuid
 )
 language sql stable as $$
@@ -160,11 +183,13 @@ language sql stable as $$
             sub.id, sub.name, sub.type, sub.project, sub.description,
             sub.content, sub.tags,
             sub.updated_at, sub.content_updated_at, sub.last_accessed_at,
+            sub.requires_review,
             sub.link_type, sub.link_strength, sub.linked_from
         from (
             -- Outgoing edges: source in memory_ids, target resolved to head.
             select m.id, m.name, m.type, m.project, m.description, m.content,
                    m.tags, m.updated_at, m.content_updated_at, m.last_accessed_at,
+                   m.requires_review,
                    l.link_type, l.strength as link_strength, l.source_id as linked_from
             from memory_links l
             join memories m on m.id = coalesce(
@@ -174,9 +199,10 @@ language sql stable as $$
             where l.source_id = any(memory_ids)
               and not (m.id = any(memory_ids))
               and (link_types is null or l.link_type = any(link_types))
+              -- Soft-deleted rows must never surface (mirrors match_memories).
+              and m.deleted_at is null
               and (show_history
-                   or (m.deleted_at is null
-                       and m.expired_at is null
+                   or (m.expired_at is null
                        and m.superseded_by is null
                        and (m.valid_to is null or m.valid_to > now())))
               and (include_unreviewed or m.requires_review = false)
@@ -185,6 +211,7 @@ language sql stable as $$
             -- Incoming edges: target in memory_ids, source resolved to head.
             select m.id, m.name, m.type, m.project, m.description, m.content,
                    m.tags, m.updated_at, m.content_updated_at, m.last_accessed_at,
+                   m.requires_review,
                    l.link_type, l.strength as link_strength, l.target_id as linked_from
             from memory_links l
             join memories m on m.id = coalesce(
@@ -194,9 +221,10 @@ language sql stable as $$
             where l.target_id = any(memory_ids)
               and not (m.id = any(memory_ids))
               and (link_types is null or l.link_type = any(link_types))
+              -- Soft-deleted rows must never surface (mirrors match_memories).
+              and m.deleted_at is null
               and (show_history
-                   or (m.deleted_at is null
-                       and m.expired_at is null
+                   or (m.expired_at is null
                        and m.superseded_by is null
                        and (m.valid_to is null or m.valid_to > now())))
               and (include_unreviewed or m.requires_review = false)

--- a/supabase/migrations/20260520000001_add_include_unreviewed_recall_flag.sql
+++ b/supabase/migrations/20260520000001_add_include_unreviewed_recall_flag.sql
@@ -1,0 +1,205 @@
+-- Add `include_unreviewed` parameter to recall-path RPCs (issue #685, Slice 5)
+--
+-- Default recall now excludes `requires_review=true` rows (the always-gate,
+-- #552). This slice adds an opt-in flag so the eval harness / Deriver /
+-- Dreamer can surface pending-candidate rows when needed. merge_targets
+-- rows (merge proposals) are ALWAYS filtered, regardless of the flag.
+--
+-- Decision reference: 8f846597-2da0-44e0-af0c-0e65b3f36cbb (recall always-gate).
+-- See also: supabase/migrations/20260518000001_add_memory_review_columns.sql.
+
+-- =============================================================================
+-- match_memories_v2 (primary embedding slot)
+-- =============================================================================
+drop function if exists match_memories_v2(vector, int, float, text, text, boolean);
+drop function if exists match_memories_v2(vector, int, float, text, text, boolean, boolean);
+create or replace function match_memories_v2(
+    query_embedding vector,
+    match_limit int default 10,
+    similarity_threshold float default 0.3,
+    filter_project text default null,
+    filter_type text default null,
+    show_history boolean default false,
+    include_unreviewed boolean default false
+)
+returns table(
+    id uuid, name text, type text, project text,
+    description text, content text, tags text[],
+    updated_at timestamptz, content_updated_at timestamptz,
+    last_accessed_at timestamptz,
+    similarity float
+)
+language sql stable as $$
+    select m.id, m.name, m.type, m.project,
+           m.description, m.content, m.tags,
+           m.updated_at, m.content_updated_at, m.last_accessed_at,
+           1 - (m.embedding_v2 <=> query_embedding) as similarity
+    from memories m
+    where m.embedding_v2 is not null
+      and m.deleted_at is null
+      and 1 - (m.embedding_v2 <=> query_embedding) >= similarity_threshold
+      and (filter_project is null or m.project = filter_project or m.project is null)
+      and (filter_type is null or m.type = filter_type)
+      and (show_history
+           or (m.expired_at is null
+               and m.superseded_by is null
+               and (m.valid_to is null or m.valid_to > now())))
+      and (include_unreviewed or m.requires_review = false)
+      and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
+    order by m.embedding_v2 <=> query_embedding
+    limit match_limit;
+$$;
+
+-- =============================================================================
+-- match_memories (fallback embedding slot)
+-- =============================================================================
+drop function if exists match_memories(vector, int, float, text, text, boolean);
+drop function if exists match_memories(vector, int, float, text, text, boolean, boolean);
+create or replace function match_memories(
+    query_embedding vector,
+    match_limit int default 10,
+    similarity_threshold float default 0.3,
+    filter_project text default null,
+    filter_type text default null,
+    show_history boolean default false,
+    include_unreviewed boolean default false
+)
+returns table(
+    id uuid, name text, type text, project text,
+    description text, content text, tags text[],
+    updated_at timestamptz, content_updated_at timestamptz,
+    last_accessed_at timestamptz,
+    similarity float
+)
+language sql stable as $$
+    select m.id, m.name, m.type, m.project,
+           m.description, m.content, m.tags,
+           m.updated_at, m.content_updated_at, m.last_accessed_at,
+           1 - (m.embedding <=> query_embedding) as similarity
+    from memories m
+    where m.embedding is not null
+      and 1 - (m.embedding <=> query_embedding) >= similarity_threshold
+      and (filter_project is null or m.project = filter_project or m.project is null)
+      and (filter_type is null or m.type = filter_type)
+      and (show_history
+           or (m.deleted_at is null
+               and m.expired_at is null
+               and m.superseded_by is null
+               and (m.valid_to is null or m.valid_to > now())))
+      and (include_unreviewed or m.requires_review = false)
+      and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
+    order by m.embedding <=> query_embedding
+    limit match_limit;
+$$;
+
+-- =============================================================================
+-- keyword_search_memories (FTS leg)
+-- =============================================================================
+drop function if exists keyword_search_memories(text, int, text, text, boolean);
+drop function if exists keyword_search_memories(text, int, text, text, boolean, boolean);
+create or replace function keyword_search_memories(
+    search_query text,
+    match_limit int default 10,
+    filter_project text default null,
+    filter_type text default null,
+    show_history boolean default false,
+    include_unreviewed boolean default false
+)
+returns table(
+    id uuid, name text, type text, project text,
+    description text, content text, tags text[],
+    updated_at timestamptz, content_updated_at timestamptz,
+    last_accessed_at timestamptz,
+    rank real
+)
+language sql stable as $$
+    select m.id, m.name, m.type, m.project,
+           m.description, m.content, m.tags,
+           m.updated_at, m.content_updated_at, m.last_accessed_at,
+           ts_rank(m.fts, websearch_to_tsquery('english', search_query)) as rank
+    from memories m
+    where m.fts @@ websearch_to_tsquery('english', search_query)
+      and (filter_project is null or m.project = filter_project or m.project is null)
+      and (filter_type is null or m.type = filter_type)
+      and (show_history
+           or (m.deleted_at is null
+               and m.expired_at is null
+               and m.superseded_by is null
+               and (m.valid_to is null or m.valid_to > now())))
+      and (include_unreviewed or m.requires_review = false)
+      and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
+    order by rank desc
+    limit match_limit;
+$$;
+
+-- =============================================================================
+-- get_linked_memories (1-hop BFS for link expansion)
+-- =============================================================================
+drop function if exists get_linked_memories(uuid[], text[], boolean);
+drop function if exists get_linked_memories(uuid[], text[], boolean, boolean);
+create or replace function get_linked_memories(
+    memory_ids uuid[],
+    link_types text[] default null,
+    show_history boolean default false,
+    include_unreviewed boolean default false
+)
+returns table(
+    id uuid, name text, type text, project text,
+    description text, content text, tags text[],
+    updated_at timestamptz, content_updated_at timestamptz,
+    last_accessed_at timestamptz,
+    link_type text, link_strength float, linked_from uuid
+)
+language sql stable as $$
+    select * from (
+        select distinct on (sub.id)
+            sub.id, sub.name, sub.type, sub.project, sub.description,
+            sub.content, sub.tags,
+            sub.updated_at, sub.content_updated_at, sub.last_accessed_at,
+            sub.link_type, sub.link_strength, sub.linked_from
+        from (
+            -- Outgoing edges: source in memory_ids, target resolved to head.
+            select m.id, m.name, m.type, m.project, m.description, m.content,
+                   m.tags, m.updated_at, m.content_updated_at, m.last_accessed_at,
+                   l.link_type, l.strength as link_strength, l.source_id as linked_from
+            from memory_links l
+            join memories m on m.id = coalesce(
+                case when show_history then l.target_id
+                     else find_chain_head(l.target_id) end,
+                l.target_id)
+            where l.source_id = any(memory_ids)
+              and not (m.id = any(memory_ids))
+              and (link_types is null or l.link_type = any(link_types))
+              and (show_history
+                   or (m.deleted_at is null
+                       and m.expired_at is null
+                       and m.superseded_by is null
+                       and (m.valid_to is null or m.valid_to > now())))
+              and (include_unreviewed or m.requires_review = false)
+              and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
+            union all
+            -- Incoming edges: target in memory_ids, source resolved to head.
+            select m.id, m.name, m.type, m.project, m.description, m.content,
+                   m.tags, m.updated_at, m.content_updated_at, m.last_accessed_at,
+                   l.link_type, l.strength as link_strength, l.target_id as linked_from
+            from memory_links l
+            join memories m on m.id = coalesce(
+                case when show_history then l.source_id
+                     else find_chain_head(l.source_id) end,
+                l.source_id)
+            where l.target_id = any(memory_ids)
+              and not (m.id = any(memory_ids))
+              and (link_types is null or l.link_type = any(link_types))
+              and (show_history
+                   or (m.deleted_at is null
+                       and m.expired_at is null
+                       and m.superseded_by is null
+                       and (m.valid_to is null or m.valid_to > now())))
+              and (include_unreviewed or m.requires_review = false)
+              and (m.merge_targets is null or array_length(m.merge_targets, 1) = 0)
+        ) sub
+        order by sub.id, sub.link_strength desc, sub.link_type, sub.linked_from
+    ) deduped
+    order by deduped.link_strength desc
+    limit 10;
+$$;

--- a/supabase/migrations/20260520000001_add_include_unreviewed_recall_flag.sql
+++ b/supabase/migrations/20260520000001_add_include_unreviewed_recall_flag.sql
@@ -78,12 +78,16 @@ language sql stable as $$
            1 - (m.embedding <=> query_embedding) as similarity
     from memories m
     where m.embedding is not null
+      -- Align with match_memories_v2: soft-deleted rows are always hidden,
+      -- regardless of show_history. Pre-existing asymmetry corrected here so
+      -- the two embedding slots return the same row set under
+      -- show_history=true + include_unreviewed=true (RRF determinism).
+      and m.deleted_at is null
       and 1 - (m.embedding <=> query_embedding) >= similarity_threshold
       and (filter_project is null or m.project = filter_project or m.project is null)
       and (filter_type is null or m.type = filter_type)
       and (show_history
-           or (m.deleted_at is null
-               and m.expired_at is null
+           or (m.expired_at is null
                and m.superseded_by is null
                and (m.valid_to is null or m.valid_to > now())))
       and (include_unreviewed or m.requires_review = false)

--- a/tests/ci/test_include_unreviewed_guard.py
+++ b/tests/ci/test_include_unreviewed_guard.py
@@ -56,6 +56,28 @@ def _extract_param_list(text: str, func_name: str) -> str | None:
     return text[start : pos - 1]
 
 
+def _extract_function_body(text: str, func_name: str) -> str | None:
+    """Return the body (text between `CREATE OR REPLACE FUNCTION <name>(` and `$$;`).
+
+    Uses word-boundary matching so ``match_memories`` doesn't match
+    ``match_memories_v2``. As with _extract_param_list, the LAST definition
+    in the file is authoritative under Postgres CREATE OR REPLACE semantics.
+    Returns None if the function is not found.
+    """
+    pattern = re.compile(
+        r"create\s+or\s+replace\s+function\s+" + re.escape(func_name) + r"\s*\(",
+        re.IGNORECASE,
+    )
+    matches = list(pattern.finditer(text))
+    if not matches:
+        return None
+    m = matches[-1]
+    body_end = text.find("$$;", m.end())
+    if body_end == -1:
+        return None
+    return text[m.end() : body_end]
+
+
 class TestMigrationFile:
     """The migration file exists and has the expected RPC signatures."""
 
@@ -151,39 +173,60 @@ class TestSchemaFileInSync:
         (primary slot) hid them, producing non-deterministic RRF fusion.
         Fix mirrors match_memories_v2: deleted_at filtering is unconditional.
         """
-        migration_text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
-        # match_memories (not _v2) signature is unique to the migration body.
-        # Use a word-boundary regex so match_memories_v2 doesn't match.
-        mm_match = re.search(
-            r"create\s+or\s+replace\s+function\s+match_memories\s*\(",
-            migration_text,
-            re.IGNORECASE,
-        )
-        assert mm_match is not None, "match_memories not found in migration"
-        # The body extends until the next $$; terminator.
-        body_start = mm_match.end()
-        body_end = migration_text.find("$$;", body_start)
-        assert body_end != -1, "match_memories body not terminated by $$;"
-        mm_body = migration_text[body_start:body_end]
-        # Unconditional deleted_at clause must be at the same indent level
-        # as the other top-level `where` conjuncts (6 leading spaces).
-        assert "\n      and m.deleted_at is null\n" in mm_body, (
-            "match_memories must have `and m.deleted_at is null` outside the "
-            "show_history branch (asymmetry vs match_memories_v2)."
-        )
-        # The show_history `or (...)` clause must NOT mention deleted_at.
-        # Body for the show_history clause starts at the keyword and ends at
-        # the next top-level conjunct (the `and (include_unreviewed` line).
-        sh_start = mm_body.find("(show_history")
-        assert sh_start != -1, "show_history clause not found in match_memories"
-        sh_block_end = mm_body.find("\n      and (include_unreviewed", sh_start)
-        if sh_block_end == -1:
-            sh_block_end = len(mm_body)
-        sh_block = mm_body[sh_start:sh_block_end]
-        assert "deleted_at" not in sh_block, (
-            "show_history branch in match_memories must not mention deleted_at — "
-            "the unconditional filter above it covers soft-deletion."
-        )
+        # Check BOTH the migration and the schema.sql copy — `supabase db reset`
+        # uses schema.sql, so a regression there would otherwise pass CI silently.
+        for source_label, text in (
+            ("migration", (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")),
+            ("schema.sql", SCHEMA_PATH.read_text(encoding="utf-8")),
+        ):
+            for func_name in ("match_memories", "keyword_search_memories"):
+                body = _extract_function_body(text, func_name)
+                assert body is not None, f"{source_label}: {func_name} not found"
+                assert "\n      and m.deleted_at is null\n" in body, (
+                    f"{source_label}: {func_name} must have "
+                    "`and m.deleted_at is null` outside the show_history branch."
+                )
+                sh_start = body.find("(show_history")
+                assert sh_start != -1, (
+                    f"{source_label}: show_history clause not found in {func_name}"
+                )
+                sh_block_end = body.find("\n      and (include_unreviewed", sh_start)
+                if sh_block_end == -1:
+                    sh_block_end = len(body)
+                sh_block = body[sh_start:sh_block_end]
+                assert "deleted_at" not in sh_block, (
+                    f"{source_label}: show_history branch in {func_name} must not "
+                    "mention deleted_at — the unconditional filter above covers it."
+                )
+
+    def test_recall_rpcs_project_requires_review_column(self):
+        """All 4 recall-path RPCs must return `requires_review boolean`.
+
+        Regression: round-3's Python-side CONFIDENCE_FLOOR floor for
+        unreviewed candidates (recall.py:apply_temporal_scoring) was dead
+        code because the SQL RPCs never projected the column. PostgREST
+        only materialises projected columns, so `row.get("requires_review")`
+        always returned None → falsy → conf=1.0 (full entrenchment).
+        """
+        for source_label, text in (
+            ("migration", (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")),
+            ("schema.sql", SCHEMA_PATH.read_text(encoding="utf-8")),
+        ):
+            for rpc in RECALL_RPCS:
+                body = _extract_function_body(text, rpc)
+                assert body is not None, f"{source_label}: {rpc} body not found"
+                # Either the literal `requires_review boolean,` in `returns table`
+                # or `m.requires_review` (or `sub.requires_review`) in the SELECT
+                # — both must appear in the body of each RPC.
+                assert "requires_review boolean" in body, (
+                    f"{source_label}: {rpc} returns table(...) must declare "
+                    "`requires_review boolean` so the Python temporal-scoring "
+                    "floor for unreviewed rows isn't dead code."
+                )
+                assert ("m.requires_review" in body) or ("sub.requires_review" in body), (
+                    f"{source_label}: {rpc} SELECT must project `m.requires_review` "
+                    "(or `sub.requires_review` in the linked-memories CTE)."
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_include_unreviewed_guard.py
+++ b/tests/ci/test_include_unreviewed_guard.py
@@ -141,3 +141,113 @@ class TestSchemaFileInSync:
             f"Found {gated} instances where merge_targets filter is gated by "
             "include_unreviewed. merge_targets must ALWAYS be filtered."
         )
+
+    def test_match_memories_deleted_at_unconditional(self):
+        """match_memories must apply `m.deleted_at is null` outside the show_history branch.
+
+        Regression: round-2 had `deleted_at is null` INSIDE the show_history
+        branch of match_memories — show_history=true surfaced soft-deleted
+        rows from the fallback embedding slot while match_memories_v2
+        (primary slot) hid them, producing non-deterministic RRF fusion.
+        Fix mirrors match_memories_v2: deleted_at filtering is unconditional.
+        """
+        migration_text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
+        # match_memories (not _v2) signature is unique to the migration body.
+        # Use a word-boundary regex so match_memories_v2 doesn't match.
+        mm_match = re.search(
+            r"create\s+or\s+replace\s+function\s+match_memories\s*\(",
+            migration_text,
+            re.IGNORECASE,
+        )
+        assert mm_match is not None, "match_memories not found in migration"
+        # The body extends until the next $$; terminator.
+        body_start = mm_match.end()
+        body_end = migration_text.find("$$;", body_start)
+        assert body_end != -1, "match_memories body not terminated by $$;"
+        mm_body = migration_text[body_start:body_end]
+        # Unconditional deleted_at clause must be at the same indent level
+        # as the other top-level `where` conjuncts (6 leading spaces).
+        assert "\n      and m.deleted_at is null\n" in mm_body, (
+            "match_memories must have `and m.deleted_at is null` outside the "
+            "show_history branch (asymmetry vs match_memories_v2)."
+        )
+        # The show_history `or (...)` clause must NOT mention deleted_at.
+        # Body for the show_history clause starts at the keyword and ends at
+        # the next top-level conjunct (the `and (include_unreviewed` line).
+        sh_start = mm_body.find("(show_history")
+        assert sh_start != -1, "show_history clause not found in match_memories"
+        sh_block_end = mm_body.find("\n      and (include_unreviewed", sh_start)
+        if sh_block_end == -1:
+            sh_block_end = len(mm_body)
+        sh_block = mm_body[sh_start:sh_block_end]
+        assert "deleted_at" not in sh_block, (
+            "show_history branch in match_memories must not mention deleted_at — "
+            "the unconditional filter above it covers soft-deletion."
+        )
+
+
+# ---------------------------------------------------------------------------
+# MCP surface guard — include_unreviewed must be reachable end-to-end.
+# ---------------------------------------------------------------------------
+
+
+class TestMcpSurfaceExposesFlag:
+    """Without these wirings the SQL flag is dead at the MCP boundary."""
+
+    def test_tools_schema_declares_include_unreviewed(self):
+        schema_py = (REPO_ROOT / "mcp-memory" / "tools_schema.py").read_text(encoding="utf-8")
+        # memory_recall tool block must declare include_unreviewed property.
+        recall_tool_idx = schema_py.find('name="memory_recall"')
+        assert recall_tool_idx != -1, "memory_recall tool block not found"
+        # Take the next ~3000 chars as the tool block extent (more than enough
+        # for the inputSchema).
+        block = schema_py[recall_tool_idx : recall_tool_idx + 3000]
+        assert '"include_unreviewed"' in block, (
+            "memory_recall tool schema must declare include_unreviewed property — "
+            "otherwise the recall.py flag is unreachable from MCP callers."
+        )
+
+    def test_handler_reads_and_threads_include_unreviewed(self):
+        handler_py = (REPO_ROOT / "mcp-memory" / "handlers" / "memory.py").read_text(
+            encoding="utf-8"
+        )
+        # _handle_recall must read it from args:
+        assert 'args.get("include_unreviewed"' in handler_py, (
+            "_handle_recall must read include_unreviewed from args"
+        )
+        # _hybrid_recall must thread it into dataclasses.replace(...):
+        # Heuristic: assert `include_unreviewed=` appears in the replace call.
+        replace_idx = handler_py.find("dataclasses.replace(")
+        assert replace_idx != -1
+        replace_block = handler_py[replace_idx : replace_idx + 500]
+        assert "include_unreviewed=" in replace_block, (
+            "_hybrid_recall must pass include_unreviewed to dataclasses.replace"
+        )
+
+    def test_keyword_recall_applies_always_gate(self):
+        """_keyword_recall (the embed-fallback) must enforce requires_review filter.
+
+        Regression: round-2 _keyword_recall queried `memories` without any
+        `requires_review` filter, so a VoyageAI outage surfaced pending review
+        candidates to production callers — bypassing the SQL-side always-gate.
+        """
+        handler_py = (REPO_ROOT / "mcp-memory" / "handlers" / "memory.py").read_text(
+            encoding="utf-8"
+        )
+        # Locate _keyword_recall body:
+        kw_start = handler_py.find("async def _keyword_recall(")
+        assert kw_start != -1, "_keyword_recall not found"
+        # Take body until next top-level `async def` or `def `:
+        next_def = handler_py.find("\nasync def ", kw_start + 1)
+        if next_def == -1:
+            next_def = len(handler_py)
+        kw_body = handler_py[kw_start:next_def]
+        assert 'eq("requires_review"' in kw_body or 'is_("requires_review"' in kw_body, (
+            "_keyword_recall body must apply a requires_review filter — "
+            "the always-gate is enforced server-side in the SQL RPCs and must "
+            "be mirrored on this fallback path."
+        )
+        assert 'is_("merge_targets"' in kw_body or 'eq("merge_targets"' in kw_body, (
+            "_keyword_recall body must filter out merge_targets rows "
+            "(merge proposals are meta-rows, never knowledge)."
+        )

--- a/tests/ci/test_include_unreviewed_guard.py
+++ b/tests/ci/test_include_unreviewed_guard.py
@@ -1,0 +1,99 @@
+"""CI guard test for include_unreviewed recall flag (issue #685, Slice 5).
+
+Validates the migration file and schema.sql are in sync: each of the 4
+recall-path RPCs must accept an `include_unreviewed boolean default false`
+parameter and apply the conditional filter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_DIR = REPO_ROOT / "supabase" / "migrations"
+SCHEMA_PATH = REPO_ROOT / "mcp-memory" / "schema.sql"
+
+# The canonical migration filename for this slice.
+EXPECTED_MIGRATION = "20260520000001_add_include_unreviewed_recall_flag.sql"
+
+# RPCs that must accept include_unreviewed.
+RECALL_RPCS = [
+    "match_memories_v2",
+    "match_memories",
+    "keyword_search_memories",
+    "get_linked_memories",
+]
+
+
+class TestMigrationFile:
+    """The migration file exists and has the expected RPC signatures."""
+
+    def test_migration_file_exists(self):
+        migration = MIGRATION_DIR / EXPECTED_MIGRATION
+        assert migration.exists(), (
+            f"Expected migration {EXPECTED_MIGRATION} not found in {MIGRATION_DIR}"
+        )
+
+    def test_migration_has_include_unreviewed_on_match_memories_v2(self):
+        text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
+        assert "include_unreviewed boolean default false" in text
+        assert "create or replace function match_memories_v2" in text
+
+    def test_migration_has_include_unreviewed_on_match_memories(self):
+        text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
+        assert "include_unreviewed boolean default false" in text
+        assert "create or replace function match_memories(" in text
+
+    def test_migration_has_include_unreviewed_on_keyword_search(self):
+        text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
+        assert "include_unreviewed boolean default false" in text
+        assert "create or replace function keyword_search_memories" in text
+
+    def test_migration_has_include_unreviewed_on_get_linked(self):
+        text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
+        assert "include_unreviewed boolean default false" in text
+        assert "create or replace function get_linked_memories" in text
+
+    def test_migration_merge_targets_always_filtered(self):
+        """merge_targets IS NULL check must remain — never include proposals."""
+        text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
+        count = text.count("merge_targets is null or array_length")
+        # Appears in every subquery: match_memories_v2 (1), match_memories (1),
+        # keyword_search_memories (1), get_linked_memories (2 = each union branch).
+        assert count >= 5, (
+            f"Expected >=5 merge_targets filter occurrences, found {count}. "
+            "The filter must remain unconditional."
+        )
+
+
+class TestSchemaFileInSync:
+    """schema.sql must reflect the same RPC signatures as the migration."""
+
+    def test_schema_has_include_unreviewed_default(self):
+        text = SCHEMA_PATH.read_text(encoding="utf-8")
+        assert "include_unreviewed boolean default false" in text, (
+            "schema.sql must declare `include_unreviewed boolean default false` "
+            "on recall-path RPCs."
+        )
+
+    def test_schema_conditions_on_flag(self):
+        """The requires_review filter must be gated by include_unreviewed."""
+        text = SCHEMA_PATH.read_text(encoding="utf-8")
+        count = text.count("include_unreviewed or m.requires_review = false")
+        # match_memories_v2 (1), match_memories (1), keyword_search (1),
+        # get_linked_memories (2 = each union branch)
+        assert count >= 5, (
+            f"Expected >=5 conditional filter occurrences, found {count}. "
+            "The `include_unreviewed or` guard must wrap every requires_review "
+            "filter."
+        )
+
+    def test_merge_targets_still_absolute(self):
+        """merge_targets filter must NOT be gated by include_unreviewed."""
+        text = SCHEMA_PATH.read_text(encoding="utf-8")
+        gated = text.count("include_unreviewed or m.merge_targets")
+        assert gated == 0, (
+            f"Found {gated} instances where merge_targets filter is gated by "
+            "include_unreviewed. merge_targets must ALWAYS be filtered."
+        )

--- a/tests/ci/test_include_unreviewed_guard.py
+++ b/tests/ci/test_include_unreviewed_guard.py
@@ -7,6 +7,7 @@ parameter and apply the conditional filter.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -26,6 +27,35 @@ RECALL_RPCS = [
 ]
 
 
+def _extract_param_list(text: str, func_name: str) -> str | None:
+    """Return the parameter list of the **last** definition of *func_name* in SQL text.
+
+    Finds ``CREATE OR REPLACE FUNCTION <func_name>(`` (case-insensitive) and
+    returns the substring between the opening ``(`` and its matching ``)``.
+    The last match is used because schema.sql is cumulative — each migration
+    appends a new ``CREATE OR REPLACE FUNCTION`` that supersedes earlier ones,
+    so only the last definition is authoritative (mirrors Postgres semantics).
+    Returns None if the function is not found.
+    """
+    pattern = re.compile(
+        r"create\s+or\s+replace\s+function\s+" + re.escape(func_name) + r"\s*\(",
+        re.IGNORECASE,
+    )
+    matches = list(pattern.finditer(text))
+    if not matches:
+        return None
+    m = matches[-1]
+    start = m.end()
+    depth, pos = 1, start
+    while pos < len(text) and depth > 0:
+        if text[pos] == "(":
+            depth += 1
+        elif text[pos] == ")":
+            depth -= 1
+        pos += 1
+    return text[start : pos - 1]
+
+
 class TestMigrationFile:
     """The migration file exists and has the expected RPC signatures."""
 
@@ -37,23 +67,35 @@ class TestMigrationFile:
 
     def test_migration_has_include_unreviewed_on_match_memories_v2(self):
         text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
-        assert "include_unreviewed boolean default false" in text
-        assert "create or replace function match_memories_v2" in text
+        params = _extract_param_list(text, "match_memories_v2")
+        assert params is not None, "match_memories_v2 not found in migration"
+        assert "include_unreviewed boolean default false" in params.lower(), (
+            "match_memories_v2 parameter list missing include_unreviewed"
+        )
 
     def test_migration_has_include_unreviewed_on_match_memories(self):
         text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
-        assert "include_unreviewed boolean default false" in text
-        assert "create or replace function match_memories(" in text
+        params = _extract_param_list(text, "match_memories")
+        assert params is not None, "match_memories not found in migration"
+        assert "include_unreviewed boolean default false" in params.lower(), (
+            "match_memories parameter list missing include_unreviewed"
+        )
 
     def test_migration_has_include_unreviewed_on_keyword_search(self):
         text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
-        assert "include_unreviewed boolean default false" in text
-        assert "create or replace function keyword_search_memories" in text
+        params = _extract_param_list(text, "keyword_search_memories")
+        assert params is not None, "keyword_search_memories not found in migration"
+        assert "include_unreviewed boolean default false" in params.lower(), (
+            "keyword_search_memories parameter list missing include_unreviewed"
+        )
 
     def test_migration_has_include_unreviewed_on_get_linked(self):
         text = (MIGRATION_DIR / EXPECTED_MIGRATION).read_text(encoding="utf-8")
-        assert "include_unreviewed boolean default false" in text
-        assert "create or replace function get_linked_memories" in text
+        params = _extract_param_list(text, "get_linked_memories")
+        assert params is not None, "get_linked_memories not found in migration"
+        assert "include_unreviewed boolean default false" in params.lower(), (
+            "get_linked_memories parameter list missing include_unreviewed"
+        )
 
     def test_migration_merge_targets_always_filtered(self):
         """merge_targets IS NULL check must remain — never include proposals."""
@@ -72,10 +114,12 @@ class TestSchemaFileInSync:
 
     def test_schema_has_include_unreviewed_default(self):
         text = SCHEMA_PATH.read_text(encoding="utf-8")
-        assert "include_unreviewed boolean default false" in text, (
-            "schema.sql must declare `include_unreviewed boolean default false` "
-            "on recall-path RPCs."
-        )
+        for rpc in RECALL_RPCS:
+            params = _extract_param_list(text, rpc)
+            assert params is not None, f"schema.sql: {rpc} function not found"
+            assert "include_unreviewed boolean default false" in params.lower(), (
+                f"schema.sql: {rpc} parameter list missing include_unreviewed"
+            )
 
     def test_schema_conditions_on_flag(self):
         """The requires_review filter must be gated by include_unreviewed."""

--- a/tests/test_memory_server.py
+++ b/tests/test_memory_server.py
@@ -831,9 +831,16 @@ class TestExpandWithLinks:
     async def test_passes_memory_ids_to_rpc(self, mock_client):
         mock_client.rpc.return_value.execute.return_value = MagicMock(data=[])
         await _expand_with_links(mock_client, ["id-1", "id-2"])
+        # include_unreviewed=False is the always-gate default (#552); the
+        # parameter is now plumbed through so future call sites can opt in.
         mock_client.rpc.assert_called_once_with(
             "get_linked_memories",
-            {"memory_ids": ["id-1", "id-2"], "link_types": None, "show_history": False},
+            {
+                "memory_ids": ["id-1", "id-2"],
+                "link_types": None,
+                "show_history": False,
+                "include_unreviewed": False,
+            },
         )
 
     @pytest.mark.asyncio
@@ -842,7 +849,27 @@ class TestExpandWithLinks:
         await _expand_with_links(mock_client, ["id-1"], show_history=True)
         mock_client.rpc.assert_called_once_with(
             "get_linked_memories",
-            {"memory_ids": ["id-1"], "link_types": None, "show_history": True},
+            {
+                "memory_ids": ["id-1"],
+                "link_types": None,
+                "show_history": True,
+                "include_unreviewed": False,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_passes_include_unreviewed_to_rpc(self, mock_client):
+        """When opt-in flag is set, it must reach the RPC body."""
+        mock_client.rpc.return_value.execute.return_value = MagicMock(data=[])
+        await _expand_with_links(mock_client, ["id-1"], include_unreviewed=True)
+        mock_client.rpc.assert_called_once_with(
+            "get_linked_memories",
+            {
+                "memory_ids": ["id-1"],
+                "link_types": None,
+                "show_history": False,
+                "include_unreviewed": True,
+            },
         )
 
 

--- a/tests/test_recall_orchestrator.py
+++ b/tests/test_recall_orchestrator.py
@@ -246,3 +246,62 @@ def test_prod_recall_config_all_on_defaults():
     assert PROD_RECALL_CONFIG.use_links is True
     assert PROD_RECALL_CONFIG.use_classifier is True
     assert PROD_RECALL_CONFIG.use_temporal is True
+    assert PROD_RECALL_CONFIG.include_unreviewed is False
+
+
+@pytest.mark.asyncio
+async def test_recall_passes_include_unreviewed_to_rpcs(monkeypatch):
+    """Default recall passes include_unreviewed=False to both semantic and
+    keyword RPCs; True propagates to both when flipped."""
+    import server
+    from server import recall, PROD_RECALL_CONFIG
+
+    async def _stub_embed(_text):
+        return [0.0] * 512
+
+    monkeypatch.setattr(server, "_embed_query", _stub_embed)
+
+    rows = [
+        {"id": "a", "name": "alpha", "similarity": 0.50, "rank": 0.50, "type": "decision",
+         "project": None, "tags": [], "description": "", "content": "",
+         "updated_at": _iso_days_ago(1), "last_accessed_at": _iso_days_ago(1), "confidence": 1.0},
+    ]
+
+    # Default config: include_unreviewed=False
+    client_default = MagicMock()
+    rpc_calls_default = []
+
+    def _capture_rpc_default(name, args):
+        rpc_calls_default.append((name, args))
+        result = MagicMock()
+        result.execute.return_value = MagicMock(data=list(rows))
+        return result
+
+    client_default.rpc.side_effect = _capture_rpc_default
+    client_default.table.return_value.select.return_value.in_.return_value.execute.return_value = MagicMock(data=[])
+
+    await recall(client_default, "test", config=dataclasses.replace(PROD_RECALL_CONFIG, use_links=False, limit=10))
+
+    for name, args in rpc_calls_default:
+        assert "include_unreviewed" in args, f"{name} missing include_unreviewed"
+        assert args["include_unreviewed"] is False, f"{name} include_unreviewed should be False"
+
+    # Flipped config: include_unreviewed=True
+    client_flipped = MagicMock()
+    rpc_calls_flipped = []
+
+    def _capture_rpc_flipped(name, args):
+        rpc_calls_flipped.append((name, args))
+        result = MagicMock()
+        result.execute.return_value = MagicMock(data=list(rows))
+        return result
+
+    client_flipped.rpc.side_effect = _capture_rpc_flipped
+    client_flipped.table.return_value.select.return_value.in_.return_value.execute.return_value = MagicMock(data=[])
+
+    cfg = dataclasses.replace(PROD_RECALL_CONFIG, use_links=False, limit=10, include_unreviewed=True)
+    await recall(client_flipped, "test", config=cfg)
+
+    for name, args in rpc_calls_flipped:
+        assert "include_unreviewed" in args, f"{name} missing include_unreviewed"
+        assert args["include_unreviewed"] is True, f"{name} include_unreviewed should be True"

--- a/tests/test_recall_orchestrator.py
+++ b/tests/test_recall_orchestrator.py
@@ -305,3 +305,57 @@ async def test_recall_passes_include_unreviewed_to_rpcs(monkeypatch):
     for name, args in rpc_calls_flipped:
         assert "include_unreviewed" in args, f"{name} missing include_unreviewed"
         assert args["include_unreviewed"] is True, f"{name} include_unreviewed should be True"
+
+
+@pytest.mark.asyncio
+async def test_recall_passes_include_unreviewed_to_get_linked_memories(monkeypatch):
+    """With use_links=True and include_unreviewed=True, the flag must reach
+    the get_linked_memories RPC — not just the semantic/keyword legs."""
+    import server
+    from server import recall, PROD_RECALL_CONFIG
+
+    async def _stub_embed(_text):
+        return [0.0] * 512
+
+    monkeypatch.setattr(server, "_embed_query", _stub_embed)
+
+    sem_row = {
+        "id": "a", "name": "alpha", "similarity": 0.80, "type": "decision",
+        "project": None, "tags": [], "description": "", "content": "",
+        "updated_at": _iso_days_ago(1), "last_accessed_at": _iso_days_ago(1),
+        "confidence": 1.0,
+    }
+    linked_row = {
+        **sem_row, "id": "z", "name": "zulu",
+        "linked_from": "a", "link_type": "related", "link_strength": 0.9,
+    }
+
+    client = MagicMock()
+    rpc_calls = []
+
+    def _capture_rpc(name, args):
+        rpc_calls.append((name, args))
+        result = MagicMock()
+        if name.startswith("match_memories"):
+            result.execute.return_value = MagicMock(data=[dict(sem_row)])
+        elif name == "keyword_search_memories":
+            result.execute.return_value = MagicMock(data=[])
+        elif name == "get_linked_memories":
+            result.execute.return_value = MagicMock(data=[dict(linked_row)])
+        else:
+            result.execute.return_value = MagicMock(data=[])
+        return result
+
+    client.rpc.side_effect = _capture_rpc
+    client.table.return_value.select.return_value.in_.return_value.execute.return_value = MagicMock(data=[])
+
+    cfg = dataclasses.replace(PROD_RECALL_CONFIG, use_links=True, include_unreviewed=True, limit=10)
+    await recall(client, "test", config=cfg)
+
+    linked_calls = [(n, a) for n, a in rpc_calls if n == "get_linked_memories"]
+    assert linked_calls, "get_linked_memories was never called (use_links=True must trigger it)"
+    for _name, args in linked_calls:
+        assert "include_unreviewed" in args, "get_linked_memories missing include_unreviewed arg"
+        assert args["include_unreviewed"] is True, (
+            "get_linked_memories include_unreviewed must be True when config.include_unreviewed=True"
+        )


### PR DESCRIPTION
## Summary

- Adds `include_unreviewed: bool = False` to `RecallConfig` — the eval harness and Deriver/Dreamer can now opt into surfacing `requires_review=true` rows
- Threads the flag through `recall()` → semantic RPCs, keyword RPC, and `expand_links()` + `get_linked_memories`
- Updates all 4 recall-path SQL RPCs to accept `include_unreviewed boolean default false` and conditionally apply the `requires_review = false` filter
- Merge-proposal rows (`merge_targets IS NOT NULL`) remain unconditionally filtered in ALL modes — they are meta-rows, never knowledge
- Migration file + CI guard test ensure schema.sql and migration stay in sync

Closes #685

## Test plan

- [x] All 6 existing orchestrator tests pass (with new `include_unreviewed` assertions)
- [x] All 9 CI guard test assertions pass (migration structure + schema sync + conditional filter wiring)
- [x] Python AST validation confirms all changed files parse cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)