### PR TITLE
feat(session-context): detect milestone-close and surface sweep recommendation

### DIFF
--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -56,6 +56,11 @@ if sys.stderr.encoding != "utf-8":
 
 KNOWN_PROJECTS = {"jarvis", "redrobot"}
 
+_PROJECT_REPO: dict[str, str] = {
+    "jarvis": "Osasuwu/jarvis",
+    "redrobot": "SergazyNarynov/redrobot",
+}
+
 # Pre-compact snapshots older than this are treated as stale. They most
 # likely belong to a different run that happened to reuse the same
 # session_id — Claude Code does reuse ids across `--resume` invocations.
@@ -362,7 +367,7 @@ def main():
     #     enough closed slices to warrant a /improve-codebase-architecture run.
     #     Only fires in a known project dir where the sweep is meaningful.
     if project:
-        sweep_section = _check_milestone_sweep()
+        sweep_section = _check_milestone_sweep(repo=_PROJECT_REPO.get(project))
         if sweep_section:
             sections.append(sweep_section)
 
@@ -667,15 +672,22 @@ def _fmt_goal(g):
 # ---------------------------------------------------------------------------
 
 # How far back (days) to consider a milestone "recently closed".
-_MILESTONE_SWEEP_DAYS = int(os.environ.get("MILESTONE_SWEEP_DAYS", "7"))
+try:
+    _MILESTONE_SWEEP_DAYS = int(os.environ.get("MILESTONE_SWEEP_DAYS", "7"))
+except (ValueError, TypeError):
+    _MILESTONE_SWEEP_DAYS = 7
 # Minimum closed issues to qualify as a "capability-shipping" milestone.
-_MILESTONE_SWEEP_MIN_SLICES = int(os.environ.get("MILESTONE_SWEEP_MIN_SLICES", "3"))
+try:
+    _MILESTONE_SWEEP_MIN_SLICES = int(os.environ.get("MILESTONE_SWEEP_MIN_SLICES", "3"))
+except (ValueError, TypeError):
+    _MILESTONE_SWEEP_MIN_SLICES = 3
 
 
 def _check_milestone_sweep(
-    repo: str = "Osasuwu/jarvis",
+    repo: str | None = None,
     days: int | None = None,
     min_slices: int | None = None,
+    _now=None,
 ) -> str | None:
     """Check if any GitHub milestones were recently closed with enough slices
     to warrant an architecture-sweep recommendation.
@@ -688,9 +700,12 @@ def _check_milestone_sweep(
     """
     from datetime import datetime, timedelta, timezone
 
+    if repo is None:
+        return None
+
+    now = _now if _now is not None else datetime.now(timezone.utc)
     window_days = days if days is not None else _MILESTONE_SWEEP_DAYS
     min_count = min_slices if min_slices is not None else _MILESTONE_SWEEP_MIN_SLICES
-    cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
 
     try:
         result = subprocess.run(
@@ -712,7 +727,7 @@ def _check_milestone_sweep(
         return None
 
     # Collect milestones qualifying for a sweep recommendation.
-    qualified: list[tuple[int, str, str, int, float]] = []
+    qualified: list[tuple[int, str, int, float]] = []
     for m in milestones:
         closed_at_str = m.get("closed_at")
         closed_issues = m.get("closed_issues", 0)
@@ -724,13 +739,12 @@ def _check_milestone_sweep(
             closed_at = datetime.fromisoformat(closed_at_str.replace("Z", "+00:00"))
         except (ValueError, TypeError):
             continue
-        age_days = (datetime.now(timezone.utc) - closed_at).total_seconds() / 86400
+        age_days = (now - closed_at).total_seconds() / 86400
         if age_days > window_days:
             continue
         qualified.append((
             m.get("number", 0),
             m.get("title", f"Milestone #{m.get('number', '?')}"),
-            closed_at_str,
             int(closed_issues),
             age_days,
         ))
@@ -739,14 +753,14 @@ def _check_milestone_sweep(
         return None
 
     # Sort by age (most recently closed first).
-    qualified.sort(key=lambda x: x[4])
+    qualified.sort(key=lambda x: x[3])
     lines: list[str] = []
-    for num, title, closed_at, count, age in qualified:
+    for num, title, count, age in qualified:
         age_str = f"{age:.0f}d"
         lines.append(
             f"- Milestone #{num} ({title}) closed {age_str} ago with "
             f"{count} closed slice{'s' if count != 1 else ''} — "
-            f"consider `{_root}/improve-codebase-architecture`"
+            f"consider `/improve-codebase-architecture`"
         )
     plural = "s" if len(qualified) > 1 else ""
     return (

--- a/scripts/session-context.py
+++ b/scripts/session-context.py
@@ -358,6 +358,14 @@ def main():
             f"{pending_count} (run `/learn` to review)"
         )
 
+    # 5b. Architecture sweep recommendation -- recently closed milestones with
+    #     enough closed slices to warrant a /improve-codebase-architecture run.
+    #     Only fires in a known project dir where the sweep is meaningful.
+    if project:
+        sweep_section = _check_milestone_sweep()
+        if sweep_section:
+            sections.append(sweep_section)
+
     # 6. Memory catalog — lazy awareness (Phase 7.1). One-line inventory of
     #    live memories (name + type + scope + short description) so Jarvis
     #    knows what exists and can pull full content on demand via memory_get
@@ -651,6 +659,99 @@ def _fmt_goal(g):
     return (
         f"- [{g['priority']}] {g['title']} "
         f"(`{g['slug']}` | {scope} | {pct_str}{deadline}){tail}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Milestone-close detection for architecture sweep recommendation (issue #605)
+# ---------------------------------------------------------------------------
+
+# How far back (days) to consider a milestone "recently closed".
+_MILESTONE_SWEEP_DAYS = int(os.environ.get("MILESTONE_SWEEP_DAYS", "7"))
+# Minimum closed issues to qualify as a "capability-shipping" milestone.
+_MILESTONE_SWEEP_MIN_SLICES = int(os.environ.get("MILESTONE_SWEEP_MIN_SLICES", "3"))
+
+
+def _check_milestone_sweep(
+    repo: str = "Osasuwu/jarvis",
+    days: int | None = None,
+    min_slices: int | None = None,
+) -> str | None:
+    """Check if any GitHub milestones were recently closed with enough slices
+    to warrant an architecture-sweep recommendation.
+
+    Returns a formatted hint string (e.g. "Milestone N closed M days ago —
+    run /improve-codebase-architecture") or None when no milestone qualifies.
+
+    Thresholds are configurable via env (MILESTONE_SWEEP_DAYS,
+    MILESTONE_SWEEP_MIN_SLICES) or overridden per-call.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    window_days = days if days is not None else _MILESTONE_SWEEP_DAYS
+    min_count = min_slices if min_slices is not None else _MILESTONE_SWEEP_MIN_SLICES
+    cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
+
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/milestones?state=closed&per_page=100"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    try:
+        milestones = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    if not isinstance(milestones, list):
+        return None
+
+    # Collect milestones qualifying for a sweep recommendation.
+    qualified: list[tuple[int, str, str, int, float]] = []
+    for m in milestones:
+        closed_at_str = m.get("closed_at")
+        closed_issues = m.get("closed_issues", 0)
+        if not closed_at_str or not isinstance(closed_issues, (int, float)):
+            continue
+        if closed_issues < min_count:
+            continue
+        try:
+            closed_at = datetime.fromisoformat(closed_at_str.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            continue
+        age_days = (datetime.now(timezone.utc) - closed_at).total_seconds() / 86400
+        if age_days > window_days:
+            continue
+        qualified.append((
+            m.get("number", 0),
+            m.get("title", f"Milestone #{m.get('number', '?')}"),
+            closed_at_str,
+            int(closed_issues),
+            age_days,
+        ))
+
+    if not qualified:
+        return None
+
+    # Sort by age (most recently closed first).
+    qualified.sort(key=lambda x: x[4])
+    lines: list[str] = []
+    for num, title, closed_at, count, age in qualified:
+        age_str = f"{age:.0f}d"
+        lines.append(
+            f"- Milestone #{num} ({title}) closed {age_str} ago with "
+            f"{count} closed slice{'s' if count != 1 else ''} — "
+            f"consider `{_root}/improve-codebase-architecture`"
+        )
+    plural = "s" if len(qualified) > 1 else ""
+    return (
+        f"## Architecture Sweep{plural}\n"
+        f"{chr(10).join(lines)}"
     )
 
 

--- a/tests/test_milestone_sweep.py
+++ b/tests/test_milestone_sweep.py
@@ -11,15 +11,24 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import types
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-
-import pytest
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPTS_DIR = _REPO_ROOT / "scripts"
 _MODULE_PATH = _SCRIPTS_DIR / "session-context.py"
+
+# Stub optional deps before exec_module so collection works without them installed.
+_dotenv_stub = types.ModuleType("dotenv")
+_dotenv_stub.load_dotenv = lambda *a, **kw: None
+sys.modules.setdefault("dotenv", _dotenv_stub)
+
+_supabase_mod = sys.modules.setdefault("supabase", types.ModuleType("supabase"))
+if not hasattr(_supabase_mod, "create_client"):
+    _supabase_mod.create_client = MagicMock()
 
 # Load session-context.py via importlib (hyphen in filename prevents normal import).
 _spec = importlib.util.spec_from_file_location("session_context", _MODULE_PATH)
@@ -31,6 +40,9 @@ sys.path = _sys_path_restore
 
 # The function under test.
 _check_milestone_sweep = _session_context._check_milestone_sweep
+
+# Frozen "now" so date arithmetic doesn't drift as real time passes.
+_NOW = datetime(2026, 5, 24, 0, 0, 0, tzinfo=timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +99,7 @@ def test_qualified_milestone_triggers_sweep():
     """A recently-closed milestone with >=3 closed issues triggers a recommendation."""
     with patch.object(_session_context.subprocess, "run") as mock_run:
         mock_run.return_value = _mock_subprocess([_MILESTONE_WITHIN_WINDOW])
-        result = _check_milestone_sweep(days=7, min_slices=3)
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis", days=7, min_slices=3, _now=_NOW)
 
     assert result is not None
     assert "#42" in result
@@ -99,7 +111,7 @@ def test_old_milestone_no_trigger():
     """A milestone closed outside the window does NOT trigger a recommendation."""
     with patch.object(_session_context.subprocess, "run") as mock_run:
         mock_run.return_value = _mock_subprocess([_MILESTONE_OLD])
-        result = _check_milestone_sweep(days=7, min_slices=3)
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis", days=7, min_slices=3, _now=_NOW)
 
     assert result is None
 
@@ -108,7 +120,7 @@ def test_too_few_slices_no_trigger():
     """A milestone with <3 closed issues does NOT trigger a recommendation."""
     with patch.object(_session_context.subprocess, "run") as mock_run:
         mock_run.return_value = _mock_subprocess([_MILESTONE_TOO_FEW_SLICES])
-        result = _check_milestone_sweep(days=7, min_slices=3)
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis", days=7, min_slices=3, _now=_NOW)
 
     assert result is None
 
@@ -117,7 +129,7 @@ def test_borderline_qualifies():
     """A milestone with exactly min_slices qualifies."""
     with patch.object(_session_context.subprocess, "run") as mock_run:
         mock_run.return_value = _mock_subprocess([_MILESTONE_BORDERLINE])
-        result = _check_milestone_sweep(days=7, min_slices=3)
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis", days=7, min_slices=3, _now=_NOW)
 
     assert result is not None
     assert "#44" in result
@@ -134,10 +146,10 @@ def test_mixed_milestones_filters_correctly():
     ]
     with patch.object(_session_context.subprocess, "run") as mock_run:
         mock_run.return_value = _mock_subprocess(all_milestones)
-        result = _check_milestone_sweep(days=7, min_slices=3)
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis", days=7, min_slices=3, _now=_NOW)
 
     assert result is not None
-    # Only #42 (5 slices, 2d ago) and #44 (3 slices, 1d ago) qualify.
+    # #42 (5 slices) and #44 (3 slices) are within the 7-day window; #1 is old; #43 too few slices.
     assert "#42" in result
     assert "#44" in result
     assert "#1" not in result
@@ -148,7 +160,7 @@ def test_mixed_milestones_filters_correctly():
 def test_gh_not_available_returns_none():
     """When gh CLI is missing, function returns None gracefully."""
     with patch.object(_session_context.subprocess, "run", side_effect=FileNotFoundError):
-        result = _check_milestone_sweep()
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis")
 
     assert result is None
 
@@ -157,7 +169,7 @@ def test_gh_api_error_returns_none():
     """When gh API call fails, function returns None gracefully."""
     with patch.object(_session_context.subprocess, "run") as mock_run:
         mock_run.return_value = _mock_subprocess([], returncode=1)
-        result = _check_milestone_sweep()
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis")
 
     assert result is None
 
@@ -169,7 +181,7 @@ def test_gh_malformed_json_returns_none():
         mock_result.stdout = "not valid json"
         mock_result.returncode = 0
         mock_run.return_value = mock_result
-        result = _check_milestone_sweep()
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis")
 
     assert result is None
 
@@ -178,6 +190,6 @@ def test_empty_milestone_list_returns_none():
     """When no milestones exist, function returns None."""
     with patch.object(_session_context.subprocess, "run") as mock_run:
         mock_run.return_value = _mock_subprocess([])
-        result = _check_milestone_sweep(days=7, min_slices=3)
+        result = _check_milestone_sweep(repo="Osasuwu/jarvis", days=7, min_slices=3, _now=_NOW)
 
     assert result is None

--- a/tests/test_milestone_sweep.py
+++ b/tests/test_milestone_sweep.py
@@ -1,0 +1,183 @@
+"""Tests for _check_milestone_sweep in scripts/session-context.py (issue #605).
+
+Tests the milestone-close detection logic using mocked subprocess.run calls.
+
+The tested module has a hyphen in its filename so it's loaded via importlib
+rather than a regular import statement.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_MODULE_PATH = _SCRIPTS_DIR / "session-context.py"
+
+# Load session-context.py via importlib (hyphen in filename prevents normal import).
+_spec = importlib.util.spec_from_file_location("session_context", _MODULE_PATH)
+_session_context = importlib.util.module_from_spec(_spec)
+_sys_path_restore = list(sys.path)
+sys.path.insert(0, str(_REPO_ROOT))
+_spec.loader.exec_module(_session_context)
+sys.path = _sys_path_restore
+
+# The function under test.
+_check_milestone_sweep = _session_context._check_milestone_sweep
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_MILESTONE_WITHIN_WINDOW = {
+    "number": 42,
+    "title": "Test Milestone",
+    "closed_at": "2026-05-18T10:00:00Z",
+    "closed_issues": 5,
+    "open_issues": 0,
+}
+
+_MILESTONE_OLD = {
+    "number": 1,
+    "title": "Old Milestone",
+    "closed_at": "2026-03-01T10:00:00Z",
+    "closed_issues": 10,
+    "open_issues": 0,
+}
+
+_MILESTONE_TOO_FEW_SLICES = {
+    "number": 43,
+    "title": "Small Milestone",
+    "closed_at": "2026-05-19T10:00:00Z",
+    "closed_issues": 1,
+    "open_issues": 0,
+}
+
+_MILESTONE_BORDERLINE = {
+    "number": 44,
+    "title": "Borderline Milestone",
+    "closed_at": "2026-05-19T10:00:00Z",
+    "closed_issues": 3,
+    "open_issues": 0,
+}
+
+
+def _mock_subprocess(data: list[dict], returncode: int = 0):
+    """Create a mocked subprocess.run return."""
+    result = MagicMock()
+    result.stdout = json.dumps(data)
+    result.returncode = returncode
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_qualified_milestone_triggers_sweep():
+    """A recently-closed milestone with >=3 closed issues triggers a recommendation."""
+    with patch.object(_session_context.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_subprocess([_MILESTONE_WITHIN_WINDOW])
+        result = _check_milestone_sweep(days=7, min_slices=3)
+
+    assert result is not None
+    assert "#42" in result
+    assert "Test Milestone" in result
+    assert "architecture" in result
+
+
+def test_old_milestone_no_trigger():
+    """A milestone closed outside the window does NOT trigger a recommendation."""
+    with patch.object(_session_context.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_subprocess([_MILESTONE_OLD])
+        result = _check_milestone_sweep(days=7, min_slices=3)
+
+    assert result is None
+
+
+def test_too_few_slices_no_trigger():
+    """A milestone with <3 closed issues does NOT trigger a recommendation."""
+    with patch.object(_session_context.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_subprocess([_MILESTONE_TOO_FEW_SLICES])
+        result = _check_milestone_sweep(days=7, min_slices=3)
+
+    assert result is None
+
+
+def test_borderline_qualifies():
+    """A milestone with exactly min_slices qualifies."""
+    with patch.object(_session_context.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_subprocess([_MILESTONE_BORDERLINE])
+        result = _check_milestone_sweep(days=7, min_slices=3)
+
+    assert result is not None
+    assert "#44" in result
+
+
+def test_mixed_milestones_filters_correctly():
+    """Only milestones meeting BOTH criteria (recency + slice count) trigger."""
+
+    all_milestones = [
+        _MILESTONE_WITHIN_WINDOW,
+        _MILESTONE_OLD,
+        _MILESTONE_TOO_FEW_SLICES,
+        _MILESTONE_BORDERLINE,
+    ]
+    with patch.object(_session_context.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_subprocess(all_milestones)
+        result = _check_milestone_sweep(days=7, min_slices=3)
+
+    assert result is not None
+    # Only #42 (5 slices, 2d ago) and #44 (3 slices, 1d ago) qualify.
+    assert "#42" in result
+    assert "#44" in result
+    assert "#1" not in result
+    assert "#43" not in result
+    assert "milestone" in result.lower() or "Milestone" in result
+
+
+def test_gh_not_available_returns_none():
+    """When gh CLI is missing, function returns None gracefully."""
+    with patch.object(_session_context.subprocess, "run", side_effect=FileNotFoundError):
+        result = _check_milestone_sweep()
+
+    assert result is None
+
+
+def test_gh_api_error_returns_none():
+    """When gh API call fails, function returns None gracefully."""
+    with patch.object(_session_context.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_subprocess([], returncode=1)
+        result = _check_milestone_sweep()
+
+    assert result is None
+
+
+def test_gh_malformed_json_returns_none():
+    """When gh returns malformed JSON, function returns None gracefully."""
+    with patch.object(_session_context.subprocess, "run") as mock_run:
+        mock_result = MagicMock()
+        mock_result.stdout = "not valid json"
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+        result = _check_milestone_sweep()
+
+    assert result is None
+
+
+def test_empty_milestone_list_returns_none():
+    """When no milestones exist, function returns None."""
+    with patch.object(_session_context.subprocess, "run") as mock_run:
+        mock_run.return_value = _mock_subprocess([])
+        result = _check_milestone_sweep(days=7, min_slices=3)
+
+    assert result is None


### PR DESCRIPTION
## Summary

- Adds `_check_milestone_sweep()` to `scripts/session-context.py` — queries GitHub for recently-closed milestones with ≥3 closed issues
- Tunable thresholds via `MILESTONE_SWEEP_DAYS` (default 7) and `MILESTONE_SWEEP_MIN_SLICES` (default 3) env vars
- Surfaces "Milestone N closed M days ago — run /improve-codebase-architecture" hint in SessionStart context
- Only fires in known project directories (e.g. `jarvis`, `redrobot`) where the sweep recommendation is meaningful
- 9 fixture tests cover: qualified milestone, old milestone, too-few-slices, borderline, mixed filtering, missing CLI, API failure, malformed JSON, empty results

Closes #605

## Test plan

- [x] All 9 milestone sweep unit tests pass (mocked subprocess.run)
- [x] Graceful fallback when `gh` CLI unavailable or API returns errors
- [x] Existing tests unaffected (no changes to recall pipeline, schema, or CI guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)