### PR TITLE
feat(deriver): S3 Stop-hook + SessionEnd derive job → requires_review candidates

### DIFF
--- a/.claude-userlevel/settings.json
+++ b/.claude-userlevel/settings.json
@@ -114,6 +114,10 @@
           {
             "type": "command",
             "command": "python scripts/deriver-accumulator.py"
+          },
+          {
+            "type": "command",
+            "command": "python scripts/deriver-sessionend.py"
           }
         ]
       }

--- a/scripts/deriver-sessionend.py
+++ b/scripts/deriver-sessionend.py
@@ -1,0 +1,147 @@
+"""Stop-hook entry: Deriver — per-session-end implicit-memory pass.
+
+Invokes the Deriver pipeline to extract ``user`` and ``feedback`` memory
+candidates from the accumulated session transcript, then inserts them
+with ``requires_review=true`` for later owner review via ``/learn``.
+
+Must run **after** ``deriver-accumulator.py`` in the Stop hook chain, so
+the buffer is populated before the Deriver reads it.
+
+Hook input on stdin (Claude Code Stop event)::
+
+  {
+    "session_id": "...",
+    "transcript_path": "/path/to/file.jsonl",
+    "cwd": "...",
+    "hook_event_name": "Stop",
+    ...
+  }
+
+Invariants:
+  * **Never** blocks the session end.  Exits 0 on every path.
+  * Sandcastle / worktree / headless sessions skip silently (delegated to
+    the accumulator — if the accumulator skipped, the buffer is absent,
+    and the Deriver returns empty).
+  * All inserted rows have ``requires_review=true`` and
+    ``source_provenance='deriver:<session-id>'``.
+
+Registered in ``.claude-userlevel/settings.json`` under the ``Stop`` event.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Bootstrap: re-exec under venv if running under system Python.
+# Same shape as scripts/deriver-accumulator.py and scripts/comm-patterns-extract.py.
+# ---------------------------------------------------------------------------
+_root = Path(__file__).resolve().parent.parent
+_venv_py = _root / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+if (
+    __name__ == "__main__"
+    and _venv_py.exists()
+    and Path(sys.executable).resolve() != _venv_py.resolve()
+):
+    # Coerce any non-zero child exit to 0 — Stop hook must never block session
+    # end. Child already prints diagnostics to stderr.
+    sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]) and 0)
+
+# ---------------------------------------------------------------------------
+# Under venv — import deps
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(_root / "scripts"))
+
+try:
+    from dotenv import load_dotenv
+
+    for _env in [_root / ".env", _root.parent / ".env"]:
+        if _env.exists():
+            load_dotenv(_env, override=True)
+            break
+except Exception:
+    pass
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except Exception:
+        pass
+if sys.stderr.encoding and sys.stderr.encoding.lower() != "utf-8":
+    try:
+        sys.stderr.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+try:
+    from deriver.pipeline import derive_from_session, project_hash
+except Exception as _import_err:
+    print(f"[deriver-sessionend] import skipped: {_import_err}", file=sys.stderr)
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Hook input
+# ---------------------------------------------------------------------------
+
+
+def _read_hook_input() -> dict:
+    raw = sys.stdin.read() if not sys.stdin.isatty() else ""
+    if not raw or not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except Exception as e:
+        print(f"[deriver-sessionend] bad hook input: {type(e).__name__}", file=sys.stderr)
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    payload = _read_hook_input()
+    session_id = payload.get("session_id") or ""
+    cwd = payload.get("cwd") or os.environ.get("CLAUDE_CWD", "")
+
+    if not session_id:
+        print("[deriver-sessionend] missing session_id; skip", file=sys.stderr)
+        return 0
+
+    if not cwd:
+        print("[deriver-sessionend] missing cwd; skip", file=sys.stderr)
+        return 0
+
+    phash = project_hash(cwd)
+    try:
+        inserted = derive_from_session(
+            session_id,
+            project_hash=phash,
+        )
+        count = len(inserted)
+        if count:
+            ids = ",".join(str(u)[:8] for u in inserted)
+            print(
+                f"[deriver-sessionend] session={session_id[:8]} "
+                f"candidates={count} ids={ids}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"[deriver-sessionend] session={session_id[:8]} no candidates", file=sys.stderr)
+    except Exception as e:
+        msg = f"{type(e).__name__}: {str(e)[:200]}"
+        print(f"[deriver-sessionend] error: {msg}", file=sys.stderr)
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deriver-sessionend.py
+++ b/scripts/deriver-sessionend.py
@@ -50,7 +50,17 @@ if (
 ):
     # Coerce any non-zero child exit to 0 — Stop hook must never block session
     # end. Child already prints diagnostics to stderr.
-    sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]) and 0)
+    #
+    # subprocess.call itself can raise OSError (PermissionError, ENOEXEC) if
+    # the venv binary exists but isn't executable — e.g. permissions stripped
+    # by a git checkout on a case-sensitive filesystem, or a botched reinstall.
+    # The docstring contract is "Never blocks the session end. Exits 0 on
+    # every path." — so we swallow OSError too.
+    try:
+        sys.exit(subprocess.call([str(_venv_py), str(Path(__file__).resolve())]) and 0)
+    except OSError as _e:
+        print(f"[deriver-sessionend] venv re-exec failed: {_e}", file=sys.stderr)
+        sys.exit(0)
 
 # ---------------------------------------------------------------------------
 # Under venv — import deps
@@ -129,8 +139,7 @@ def main() -> int:
         if count:
             ids = ",".join(str(u)[:8] for u in inserted)
             print(
-                f"[deriver-sessionend] session={session_id[:8]} "
-                f"candidates={count} ids={ids}",
+                f"[deriver-sessionend] session={session_id[:8]} candidates={count} ids={ids}",
                 file=sys.stderr,
             )
         else:

--- a/scripts/deriver/__init__.py
+++ b/scripts/deriver/__init__.py
@@ -1,0 +1,11 @@
+"""Deriver — per-session-end implicit-memory pass.
+
+Reads the scrubbed session transcript from the accumulator buffer
+(``~/.claude/.deriver-buffer/``), invokes Ollama (Workshop, primary) or
+DeepSeek (fallback) with the derive prompt, and inserts ≤5 candidate
+memories with ``requires_review=true``.
+
+Owner-level scope — fires on every owner session regardless of project.
+Candidates self-classify scope: ``user``-type → global; ``feedback`` →
+session's project or global per content.
+"""

--- a/scripts/deriver/derive.md
+++ b/scripts/deriver/derive.md
@@ -1,0 +1,26 @@
+You are analysing a Claude Code session transcript. Extract memory-worthy
+insights that the user's AI agent should remember for future sessions.
+
+For each insight, determine the following fields:
+
+- **type** — ``user`` (personal trait, habit, preference, communication
+  style) or ``feedback`` (project-specific lesson, process improvement,
+  tooling preference, architecture decision).
+- **project** — null for ``user`` type (always global).  For
+  ``feedback``, one of ``"jarvis"``, ``"redrobot"``, or null if the
+  insight is cross-project.
+- **name** — short kebab-case slug that uniquely identifies this
+  insight (e.g. ``"prefers-early-return-over-nested-if"``).
+- **description** — one-line summary (under 100 chars).
+- **content** — 2–5 sentences with enough context to be useful without
+  rereading the transcript.  Include the *why* behind the insight, not
+  just the *what*.
+- **tags** — 1–5 lowercase tags (single words, e.g.
+  ``["coding-style", "python"]``).
+
+Return **only** a valid JSON array of objects.  Maximum **5** objects.
+If nothing is worth remembering, return an empty array: ``[]``.
+
+--- Transcript follows ---
+
+{transcript}

--- a/scripts/deriver/pipeline.py
+++ b/scripts/deriver/pipeline.py
@@ -339,7 +339,11 @@ def derive_from_session(
 
     # 6. Validate and insert (≤MAX_CANDIDATES)
     if insert_fn is None:
-        insert_fn = _build_supabase_insert_fn()
+        try:
+            insert_fn = _build_supabase_insert_fn()
+        except Exception as e:
+            print(f"[deriver-pipeline] failed to build Supabase insert fn: {e}", file=__import__("sys").stderr)
+            return []
 
     inserted: list[UUID] = []
     errors: list[str] = []
@@ -389,7 +393,7 @@ def _build_supabase_insert_fn() -> InsertFn:
 
     from dotenv import load_dotenv
 
-    _root = Path(__file__).resolve().parent.parent
+    _root = Path(__file__).resolve().parent.parent.parent  # scripts/deriver → scripts → repo root
     for _env in [_root / ".env", _root.parent / ".env"]:
         if _env.exists():
             load_dotenv(_env, override=True)
@@ -398,7 +402,12 @@ def _build_supabase_insert_fn() -> InsertFn:
     from supabase import create_client
 
     url = os.environ.get("SUPABASE_URL", "")
-    key = os.environ.get("SUPABASE_KEY", "")
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_KEY", "")
+    if not (url and key):
+        raise RuntimeError(
+            "Missing Supabase credentials: SUPABASE_URL and "
+            "SUPABASE_SERVICE_KEY (or SUPABASE_KEY) must be set"
+        )
     client = create_client(url, key)
 
     def _insert(row: dict[str, Any]) -> UUID:

--- a/scripts/deriver/pipeline.py
+++ b/scripts/deriver/pipeline.py
@@ -244,11 +244,22 @@ def _build_row(candidate: dict[str, Any], *, session_id: str) -> dict[str, Any] 
     # Also scrub the name (paths, keys are unlikely in names, but defensively)
     scrubbed_name, _ = scrub(name)
 
-    # Normalise tags
+    # Normalise tags. Per the module-level invariant, every text field
+    # written to memories MUST pass through scrub() — including tags, which
+    # the LLM can occasionally populate with paths or secret-like fragments
+    # (e.g. classifier tags derived from raw transcript phrases).
     if isinstance(raw_tags, list):
-        cleaned_tags = [
-            str(t).strip().lower()[:50] for t in raw_tags if isinstance(t, (str, int, float))
-        ]
+        cleaned_tags: list[str] = []
+        for t in raw_tags:
+            if not isinstance(t, (str, int, float)):
+                continue
+            t_str = str(t).strip().lower()[:50]
+            if not t_str:
+                continue
+            scrubbed_t, _ = scrub(t_str)
+            scrubbed_t = scrubbed_t.strip()
+            if scrubbed_t:
+                cleaned_tags.append(scrubbed_t)
         # Deduplicate, preserve order, cap at 15
         seen: set[str] = set()
         tags: list[str] = []
@@ -367,33 +378,46 @@ def derive_from_session(
     inserted: list[UUID] = []
     errors: list[str] = []
 
-    # The cap counts VALID-and-INSERTED candidates, not raw list indices.
-    # If the LLM returns leading nulls or malformed entries, an index-based
-    # cap would silently drop valid candidates past index MAX_CANDIDATES-1
-    # even when fewer than MAX_CANDIDATES were inserted. Counting
-    # valid_seen mirrors the spirit of the cap ("at most N memories written
-    # per session").
-    valid_seen = 0
+    # Two counters with different semantics:
+    #   * attempted_seen — incremented for every VALID candidate we tried to
+    #     insert, regardless of whether the insert itself succeeded. This is
+    #     what bounds the cap so a misconfigured Supabase (all inserts fail)
+    #     can't loop through 20+ candidates burning errors.
+    #   * inserted (the return value) — only candidates that landed.
+    # Pre-round-3 used a single counter that only incremented on success, so
+    # a persistent RLS rejection turned MAX_CANDIDATES into "no cap".
+    attempted_seen = 0
     for i, candidate in enumerate(candidates):
-        if valid_seen >= MAX_CANDIDATES:
+        if attempted_seen >= MAX_CANDIDATES:
             break
         err = _validate_candidate(candidate)
         if err:
             errors.append(f"candidate #{i}: {err}")
             continue
 
-        row = _build_row(candidate, session_id=session_id)
+        # _build_row defensively runs scrub() on three text fields plus tags.
+        # scrub() is pure regex replacement — but if a future change makes it
+        # raise on pathological input, the "No exception escapes" contract in
+        # this function's docstring would break. Wrap in try/except as
+        # belt-and-braces.
+        try:
+            row = _build_row(candidate, session_id=session_id)
+        except Exception as e:
+            errors.append(f"candidate #{i}: row build crashed: {e}")
+            attempted_seen += 1
+            continue
         if isinstance(row, str):
             errors.append(f"candidate #{i}: row build failed: {row}")
+            attempted_seen += 1
             continue
 
+        attempted_seen += 1
         try:
             uid = insert_fn(row)
             inserted.append(uid)
-            valid_seen += 1
         except Exception as e:
             errors.append(f"candidate #{i}: insert failed: {e}")
-            # Continue inserting remaining candidates
+            # Continue inserting remaining candidates (cap still enforced).
             continue
 
     if errors:

--- a/scripts/deriver/pipeline.py
+++ b/scripts/deriver/pipeline.py
@@ -59,13 +59,23 @@ def project_hash(cwd: str) -> str:
     the buffer the accumulator wrote to.
     """
     import hashlib
+
     raw = os.path.realpath(cwd).encode("utf-8", errors="replace")
     return hashlib.sha256(raw).hexdigest()[:HASH_LENGTH]
+
+
 _PROMPT_CACHE: str | None = None
 
 # JSON array extraction regex (the LLM often wraps in code fences or
 # explanatory text around the JSON).
-_JSON_ARRAY_RE = re.compile(r"\[[\s\S]*?\]")
+#
+# Greedy on purpose: when the LLM wraps the candidates array in prose, each
+# candidate has a nested `tags` array. Non-greedy `*?` stopped at the FIRST
+# `]` — i.e. an inner tags array — `json.loads` then succeeded on a list of
+# strings, every _validate_candidate failed, and zero candidates were
+# inserted silently. Greedy extends to the OUTERMOST `]`, capturing the
+# real candidates array.
+_JSON_ARRAY_RE = re.compile(r"\[[\s\S]*\]")
 
 # Allowed values
 VALID_TYPES = {"user", "feedback"}
@@ -237,9 +247,7 @@ def _build_row(candidate: dict[str, Any], *, session_id: str) -> dict[str, Any] 
     # Normalise tags
     if isinstance(raw_tags, list):
         cleaned_tags = [
-            str(t).strip().lower()[:50]
-            for t in raw_tags
-            if isinstance(t, (str, int, float))
+            str(t).strip().lower()[:50] for t in raw_tags if isinstance(t, (str, int, float))
         ]
         # Deduplicate, preserve order, cap at 15
         seen: set[str] = set()
@@ -305,7 +313,9 @@ def derive_from_session(
     # 1. Read buffer
     transcript = _read_buffer(session_id, project_hash, buffer_root=buffer_root)
     if transcript is None:
-        print(f"[deriver-pipeline] no buffer for session {session_id}", file=__import__("sys").stderr)
+        print(
+            f"[deriver-pipeline] no buffer for session {session_id}", file=__import__("sys").stderr
+        )
         return []
 
     # 2. Scrub input transcript before LLM sees it
@@ -328,13 +338,19 @@ def derive_from_session(
     prompt = _render_prompt(scrubbed_transcript)
     response = llm_fn(prompt)
     if response is None:
-        print("[deriver-pipeline] LLM returned None (both backends failed)", file=__import__("sys").stderr)
+        print(
+            "[deriver-pipeline] LLM returned None (both backends failed)",
+            file=__import__("sys").stderr,
+        )
         return []
 
     # 5. Parse response
     candidates = _parse_json_response(response)
     if not candidates:
-        print("[deriver-pipeline] LLM returned empty or unparseable response", file=__import__("sys").stderr)
+        print(
+            "[deriver-pipeline] LLM returned empty or unparseable response",
+            file=__import__("sys").stderr,
+        )
         return []
 
     # 6. Validate and insert (≤MAX_CANDIDATES)
@@ -342,14 +358,24 @@ def derive_from_session(
         try:
             insert_fn = _build_supabase_insert_fn()
         except Exception as e:
-            print(f"[deriver-pipeline] failed to build Supabase insert fn: {e}", file=__import__("sys").stderr)
+            print(
+                f"[deriver-pipeline] failed to build Supabase insert fn: {e}",
+                file=__import__("sys").stderr,
+            )
             return []
 
     inserted: list[UUID] = []
     errors: list[str] = []
 
+    # The cap counts VALID-and-INSERTED candidates, not raw list indices.
+    # If the LLM returns leading nulls or malformed entries, an index-based
+    # cap would silently drop valid candidates past index MAX_CANDIDATES-1
+    # even when fewer than MAX_CANDIDATES were inserted. Counting
+    # valid_seen mirrors the spirit of the cap ("at most N memories written
+    # per session").
+    valid_seen = 0
     for i, candidate in enumerate(candidates):
-        if i >= MAX_CANDIDATES:
+        if valid_seen >= MAX_CANDIDATES:
             break
         err = _validate_candidate(candidate)
         if err:
@@ -364,13 +390,17 @@ def derive_from_session(
         try:
             uid = insert_fn(row)
             inserted.append(uid)
+            valid_seen += 1
         except Exception as e:
             errors.append(f"candidate #{i}: insert failed: {e}")
             # Continue inserting remaining candidates
             continue
 
     if errors:
-        print(f"[deriver-pipeline] {len(errors)} error(s): {'; '.join(errors)}", file=__import__("sys").stderr)
+        print(
+            f"[deriver-pipeline] {len(errors)} error(s): {'; '.join(errors)}",
+            file=__import__("sys").stderr,
+        )
 
     return inserted
 
@@ -413,9 +443,21 @@ def _build_supabase_insert_fn() -> InsertFn:
     def _insert(row: dict[str, Any]) -> UUID:
         resp = client.table("memories").insert(row).execute()
         data = resp.data
-        if data and len(data) > 0:
-            return UUID(data[0]["id"])
-        raise RuntimeError(f"Supabase insert returned no data: {resp}")
+        if not (data and len(data) > 0):
+            raise RuntimeError(f"Supabase insert returned no data: {resp}")
+        # Defensive .get() instead of direct subscript: PostgREST
+        # `Prefer: return=minimal` (or an RLS policy stripping returned
+        # columns) yields a row dict without "id". Direct `data[0]["id"]`
+        # raised KeyError → outer except caught it → row reported as
+        # "insert failed" but the row WAS persisted → re-run created
+        # duplicates. Surface this explicitly as a deployment
+        # misconfiguration instead of as a silent dup-create.
+        row_id = data[0].get("id")
+        if not row_id:
+            raise RuntimeError(
+                f"Supabase insert succeeded but returned row without 'id': {data[0]!r}"
+            )
+        return UUID(row_id)
 
     _SUPABASE_INSERT_FN = _insert
     return _SUPABASE_INSERT_FN

--- a/scripts/deriver/pipeline.py
+++ b/scripts/deriver/pipeline.py
@@ -1,0 +1,412 @@
+"""Deep module: ``derive_from_session(session_id) → list[UUID]``.
+
+Reads the accumulator buffer, scrubs the transcript, calls the LLM
+(Ollama primary → DeepSeek fallback), validates and scrubs the output,
+and inserts ≤5 candidates into ``memories``.
+
+Interface (the "small interface"):
+  - ``derive_from_session(session_id, *, ...)`` — primary entry.
+  - Inject ``insert_fn`` and ``llm_fn`` for testing (see tests/).
+
+Invariants:
+  - **No candidate is inserted without going through the scrubber.**
+    Enforced by pipeline shape: scrub is called on output inside
+    ``_build_row()``, before ``insert_fn`` is invoked.
+  - **≤5 candidates per run.**  The LLM prompt caps at 5; the code
+    truncates whatever the LLM returns.
+  - **All rows** have ``requires_review=true`` and
+    ``source_provenance='deriver:<session-id>'``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable
+from uuid import UUID
+
+from lib.llm_client import call_llm
+from lib.secret_scrubber import scrub
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+# Matches the accumulator's buffer root.
+BUFFER_ROOT = Path.home() / ".claude" / ".deriver-buffer"
+
+# Cap: never insert more than this many candidates per run.
+MAX_CANDIDATES = 5
+
+# Path to the prompt template (co-located with this file).
+_PROMPT_PATH = Path(__file__).resolve().parent / "derive.md"
+
+# Stable hash of project root directory.  Must produce the same value as
+# ``deriver-accumulator._project_hash`` so the SessionEnd hook finds the
+# same buffer the accumulator wrote to.
+HASH_LENGTH = 12  # first N hex chars of SHA-256
+
+
+def project_hash(cwd: str) -> str:
+    """Stable hash of the project root directory.
+
+    Uses the first *HASH_LENGTH* hex chars of SHA-256 of the absolute,
+    resolved cwd path.  Same project → same hash across devices (assuming
+    the same clone path within the user's home), so the Deriver can find
+    the buffer the accumulator wrote to.
+    """
+    import hashlib
+    raw = os.path.realpath(cwd).encode("utf-8", errors="replace")
+    return hashlib.sha256(raw).hexdigest()[:HASH_LENGTH]
+_PROMPT_CACHE: str | None = None
+
+# JSON array extraction regex (the LLM often wraps in code fences or
+# explanatory text around the JSON).
+_JSON_ARRAY_RE = re.compile(r"\[[\s\S]*?\]")
+
+# Allowed values
+VALID_TYPES = {"user", "feedback"}
+VALID_PROJECTS = {"jarvis", "redrobot", None}
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+InsertFn = Callable[[dict[str, Any]], UUID]
+"""Signature: ``insert_fn(row) → UUID`` — persists a candidate row and
+returns the new row's UUID."""
+
+LLMFn = Callable[[str], str | None]
+"""Signature: ``llm_fn(prompt) → response_text | None`` — calls an LLM."""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_prompt_template() -> str:
+    global _PROMPT_CACHE
+    if _PROMPT_CACHE is None:
+        _PROMPT_CACHE = _PROMPT_PATH.read_text(encoding="utf-8")
+    return _PROMPT_CACHE
+
+
+def _render_prompt(transcript_text: str) -> str:
+    template = _load_prompt_template()
+    return template.replace("{transcript}", transcript_text)
+
+
+def _read_buffer(session_id: str, project_hash: str, buffer_root: Path | None = None) -> str | None:
+    """Read the accumulator buffer for *session_id*.
+
+    Returns the concatenated transcript text, or None if the buffer file
+    does not exist or is empty.
+    """
+    root = buffer_root or BUFFER_ROOT
+    buffer_dir = root / project_hash
+    buffer_path = buffer_dir / f"{session_id}.jsonl"
+    if not buffer_path.exists():
+        return None
+
+    turns: list[str] = []
+    with buffer_path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            content = _extract_text(obj)
+            if content:
+                role = obj.get("role", "unknown")
+                turns.append(f"[{role}]\n{content}")
+
+    if not turns:
+        return None
+    return "\n\n".join(turns)
+
+
+def _extract_text(obj: dict[str, Any]) -> str:
+    """Extract human-readable text from a transcript JSON object."""
+    content = obj.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content", "")
+                if isinstance(text, str):
+                    parts.append(text)
+                elif isinstance(text, list):
+                    for t in text:
+                        if isinstance(t, dict) and "text" in t:
+                            parts.append(t["text"])
+        return "\n".join(parts)
+    return ""
+
+
+def _parse_json_response(raw: str) -> list[dict[str, Any]]:
+    """Parse a JSON array from the LLM response.
+
+    Handles code fences, leading/trailing text, and truncated arrays.
+    Returns an empty list on parse failure.
+    """
+    raw = raw.strip()
+    # Strip markdown code fences
+    raw = re.sub(r"^```(?:json)?\s*", "", raw)
+    raw = re.sub(r"\s*```\s*$", "", raw)
+    raw = raw.strip()
+
+    # Try direct parse first
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            return parsed
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back to regex extraction of first array
+    m = _JSON_ARRAY_RE.search(raw)
+    if not m:
+        return []
+    try:
+        parsed = json.loads(m.group(0))
+        if isinstance(parsed, list):
+            return parsed
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return []
+
+
+def _validate_candidate(candidate: dict[str, Any]) -> str | None:
+    """Validate a single candidate dict.  Returns an error message or None."""
+    if not isinstance(candidate, dict):
+        return "candidate is not a dict"
+    name = candidate.get("name")
+    if not name or not isinstance(name, str) or not name.strip():
+        return "missing or empty 'name'"
+    typ = candidate.get("type")
+    if typ not in VALID_TYPES:
+        return f"invalid type: {typ!r} (valid: {sorted(VALID_TYPES)})"
+    content = candidate.get("content")
+    if not content or not isinstance(content, str) or not content.strip():
+        return "missing or empty 'content'"
+    if len(name.strip()) > 200:
+        return f"name too long ({len(name.strip())} chars, max 200)"
+    return None
+
+
+def _normalize_project(typ: str, raw_project: Any) -> str | None:
+    """Normalise the project field.
+
+    ``user``-type candidates are always global (None).  ``feedback``-type
+    candidates may be ``"jarvis"``, ``"redrobot"``, or None (cross-project).
+    """
+    if typ == "user":
+        return None
+    if raw_project in ("jarvis", "redrobot"):
+        return raw_project
+    return None
+
+
+def _build_row(candidate: dict[str, Any], *, session_id: str) -> dict[str, Any] | str:
+    """Build a memory row dict from a validated candidate.
+
+    Returns the row dict on success, or an error message string on failure
+    (e.g. scrub returns something the DB rejects — though scrub is pure
+    string replacement, so this is a defensive catch).
+    """
+    name = candidate["name"].strip()
+    typ = candidate["type"]
+    raw_content = candidate.get("content", "").strip()
+    raw_description = candidate.get("description", "").strip() or name
+    raw_tags = candidate.get("tags", [])
+
+    # ---- Scrubbing (mandatory before any insert) ----
+    scrubbed_content, _ = scrub(raw_content)
+    scrubbed_description, _ = scrub(raw_description)
+    # Also scrub the name (paths, keys are unlikely in names, but defensively)
+    scrubbed_name, _ = scrub(name)
+
+    # Normalise tags
+    if isinstance(raw_tags, list):
+        cleaned_tags = [
+            str(t).strip().lower()[:50]
+            for t in raw_tags
+            if isinstance(t, (str, int, float))
+        ]
+        # Deduplicate, preserve order, cap at 15
+        seen: set[str] = set()
+        tags: list[str] = []
+        for t in cleaned_tags:
+            if t and t not in seen:
+                seen.add(t)
+                tags.append(t)
+                if len(tags) >= 15:
+                    break
+    else:
+        tags = []
+
+    project = _normalize_project(typ, candidate.get("project"))
+
+    return {
+        "name": scrubbed_name[:200],
+        "type": typ,
+        "project": project,
+        "description": scrubbed_description[:500],
+        "content": scrubbed_content,
+        "tags": tags,
+        "requires_review": True,
+        "source_provenance": f"deriver:{session_id}",
+        "derivation_run_id": None,  # S4 Dreamer populates this; Deriver leaves null
+        "merge_targets": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def derive_from_session(
+    session_id: str,
+    *,
+    project_hash: str,
+    llm_fn: LLMFn | None = None,
+    insert_fn: InsertFn | None = None,
+    buffer_root: Path | None = None,
+) -> list[UUID]:
+    """Run the Deriver pipeline for one session.
+
+    Parameters:
+      session_id:       Session ID (from hook input).
+      project_hash:     Stable hash of the project root (see
+                        ``deriver-accumulator._project_hash``).
+      llm_fn:           Callable ``(prompt) → text or None``.  Defaults to
+                        ``partial(call_llm, system_prompt=…)``.
+      insert_fn:        Callable ``(row_dict) → UUID``.  Defaults to
+                        ``_insert_memory`` (writes to Supabase).
+      buffer_root:      Override the buffer directory root.  Defaults to
+                        ``~/.claude/.deriver-buffer``.
+
+    Returns:
+      List of inserted candidate UUIDs (≤5).  Empty list on empty buffer
+      or all-parsing-fail.
+
+    No exception escapes — errors are logged to stderr and the function
+    returns whatever was inserted before the error.
+    """
+    # 1. Read buffer
+    transcript = _read_buffer(session_id, project_hash, buffer_root=buffer_root)
+    if transcript is None:
+        print(f"[deriver-pipeline] no buffer for session {session_id}", file=__import__("sys").stderr)
+        return []
+
+    # 2. Scrub input transcript before LLM sees it
+    scrubbed_transcript, _ = scrub(transcript)
+
+    # 3. Resolve LLM
+    system_prompt = (
+        "You are a memory-extraction assistant. "
+        "Analyse the session transcript and return ONLY a JSON array of memory-worthy insights. "
+        "Each object must have: type, project, name, description, content, tags."
+    )
+    if llm_fn is None:
+        llm_fn = partial(
+            call_llm,
+            system_prompt=system_prompt,
+            format_json=True,
+        )
+
+    # 4. Call LLM
+    prompt = _render_prompt(scrubbed_transcript)
+    response = llm_fn(prompt)
+    if response is None:
+        print("[deriver-pipeline] LLM returned None (both backends failed)", file=__import__("sys").stderr)
+        return []
+
+    # 5. Parse response
+    candidates = _parse_json_response(response)
+    if not candidates:
+        print("[deriver-pipeline] LLM returned empty or unparseable response", file=__import__("sys").stderr)
+        return []
+
+    # 6. Validate and insert (≤MAX_CANDIDATES)
+    if insert_fn is None:
+        insert_fn = _build_supabase_insert_fn()
+
+    inserted: list[UUID] = []
+    errors: list[str] = []
+
+    for i, candidate in enumerate(candidates):
+        if i >= MAX_CANDIDATES:
+            break
+        err = _validate_candidate(candidate)
+        if err:
+            errors.append(f"candidate #{i}: {err}")
+            continue
+
+        row = _build_row(candidate, session_id=session_id)
+        if isinstance(row, str):
+            errors.append(f"candidate #{i}: row build failed: {row}")
+            continue
+
+        try:
+            uid = insert_fn(row)
+            inserted.append(uid)
+        except Exception as e:
+            errors.append(f"candidate #{i}: insert failed: {e}")
+            # Continue inserting remaining candidates
+            continue
+
+    if errors:
+        print(f"[deriver-pipeline] {len(errors)} error(s): {'; '.join(errors)}", file=__import__("sys").stderr)
+
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Default Supabase insert (lazy singleton)
+# ---------------------------------------------------------------------------
+
+_SUPABASE_INSERT_FN: InsertFn | None = None
+
+
+def _build_supabase_insert_fn() -> InsertFn:
+    """Build a default insert function that writes to Supabase ``memories``.
+
+    The result is cached so the Supabase client is created once per process.
+    """
+    global _SUPABASE_INSERT_FN
+    if _SUPABASE_INSERT_FN is not None:
+        return _SUPABASE_INSERT_FN
+
+    from dotenv import load_dotenv
+
+    _root = Path(__file__).resolve().parent.parent
+    for _env in [_root / ".env", _root.parent / ".env"]:
+        if _env.exists():
+            load_dotenv(_env, override=True)
+            break
+
+    from supabase import create_client
+
+    url = os.environ.get("SUPABASE_URL", "")
+    key = os.environ.get("SUPABASE_KEY", "")
+    client = create_client(url, key)
+
+    def _insert(row: dict[str, Any]) -> UUID:
+        resp = client.table("memories").insert(row).execute()
+        data = resp.data
+        if data and len(data) > 0:
+            return UUID(data[0]["id"])
+        raise RuntimeError(f"Supabase insert returned no data: {resp}")
+
+    _SUPABASE_INSERT_FN = _insert
+    return _SUPABASE_INSERT_FN

--- a/scripts/lib/llm_client.py
+++ b/scripts/lib/llm_client.py
@@ -1,0 +1,168 @@
+"""Shared LLM client — Ollama primary with DeepSeek fallback.
+
+Patterns (not a library — too small to extract):
+  - ``call_ollama(prompt, ...)`` — POST to ``/api/generate``.
+  - ``call_deepseek(prompt, ...)`` — POST to OpenAI-compatible ``/chat/completions``.
+  - ``call_llm(prompt)`` — tries Ollama first, falls back to DeepSeek.
+
+All return the response text on success, or None on any error (timeout,
+network, parse).  Caller decides what to do with None.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+DEFAULT_OLLAMA_MODEL = "qwen2.5-coder:14b"  # Workshop primary (docs/agents/ollama-workshop-bench-538.md)
+DEFAULT_OLLAMA_TIMEOUT_S = 120
+
+DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+DEFAULT_DEEPSEEK_MODEL = "deepseek-chat"
+DEFAULT_DEEPSEEK_TIMEOUT_S = 180
+
+# ---------------------------------------------------------------------------
+# Ollama
+# ---------------------------------------------------------------------------
+
+
+def call_ollama(
+    prompt: str,
+    *,
+    host: str | None = None,
+    model: str | None = None,
+    timeout_s: int = DEFAULT_OLLAMA_TIMEOUT_S,
+    system_prompt: str | None = None,
+    format_json: bool = True,
+) -> str | None:
+    """Call Ollama ``/api/generate`` with *prompt* and return the response text.
+
+    Returns None on any error.  *system_prompt* is passed as the ``system``
+    field (supported by Ollama 0.3+).  When *format_json* is true (default)
+    the request sets ``"format": "json"``.
+    """
+    host = host or os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST)
+    model = model or os.environ.get("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL)
+
+    body: dict = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        "options": {"temperature": 0, "num_predict": 1500},
+    }
+    if system_prompt:
+        body["system"] = system_prompt
+    if format_json:
+        body["format"] = "json"
+
+    payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{host.rstrip('/')}/api/generate",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+
+    try:
+        envelope = json.loads(raw)
+    except Exception:
+        return None
+    return envelope.get("response")
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek (OpenAI-compatible API)
+# ---------------------------------------------------------------------------
+
+
+def call_deepseek(
+    prompt: str,
+    *,
+    base_url: str | None = None,
+    model: str | None = None,
+    api_key: str | None = None,
+    timeout_s: int = DEFAULT_DEEPSEEK_TIMEOUT_S,
+    system_prompt: str | None = None,
+) -> str | None:
+    """Call DeepSeek chat-completions API and return the response text.
+
+    Returns None on any error.  Uses ``requests``-style JSON POST via
+    stdlib ``urllib`` — no extra dependency.
+    """
+    base_url = base_url or os.environ.get("DEEPSEEK_BASE_URL", DEFAULT_DEEPSEEK_BASE_URL)
+    model = model or os.environ.get("DEEPSEEK_MODEL", DEFAULT_DEEPSEEK_MODEL)
+    api_key = api_key or os.environ.get("DEEPSEEK_API_KEY", "")
+
+    if not api_key:
+        return None
+
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": prompt})
+
+    body = {
+        "model": model,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": 1500,
+    }
+    payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/v1/chat/completions",
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+
+    try:
+        envelope = json.loads(raw)
+    except Exception:
+        return None
+
+    choices = envelope.get("choices", [])
+    if not choices:
+        return None
+    return choices[0].get("message", {}).get("content")
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator: Ollama primary, DeepSeek fallback
+# ---------------------------------------------------------------------------
+
+
+def call_llm(
+    prompt: str,
+    *,
+    system_prompt: str | None = None,
+    format_json: bool = True,
+) -> str | None:
+    """Try Ollama first; fall back to DeepSeek on any error.
+
+    Returns None only if **both** backends fail.
+    """
+    result = call_ollama(prompt, system_prompt=system_prompt, format_json=format_json)
+    if result is not None:
+        return result
+    # Fallback
+    return call_deepseek(prompt, system_prompt=system_prompt)

--- a/scripts/lib/llm_client.py
+++ b/scripts/lib/llm_client.py
@@ -2,7 +2,7 @@
 
 Patterns (not a library — too small to extract):
   - ``call_ollama(prompt, ...)`` — POST to ``/api/generate``.
-  - ``call_deepseek(prompt, ...)`` — POST to OpenAI-compatible ``/chat/completions``.
+  - ``call_deepseek(prompt, ...)`` — POST to OpenAI-compatible ``/v1/chat/completions``.
   - ``call_llm(prompt)`` — tries Ollama first, falls back to DeepSeek.
 
 All return the response text on success, or None on any error (timeout,

--- a/scripts/lib/llm_client.py
+++ b/scripts/lib/llm_client.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import urllib.error
 import urllib.request
 
@@ -29,6 +30,12 @@ DEFAULT_OLLAMA_TIMEOUT_S = 120
 DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com"
 DEFAULT_DEEPSEEK_MODEL = "deepseek-chat"
 DEFAULT_DEEPSEEK_TIMEOUT_S = 180
+
+# Max output tokens for both backends. 1500 was a Deriver-era heuristic but
+# triggered silent truncation on verbose sessions (5 candidates × 2-5 sentences
+# each easily exceeds 1500). 4096 is comfortably within both Ollama qwen2.5
+# and DeepSeek limits.
+DEFAULT_MAX_OUTPUT_TOKENS = 4096
 
 # ---------------------------------------------------------------------------
 # Ollama
@@ -57,7 +64,7 @@ def call_ollama(
         "model": model,
         "prompt": prompt,
         "stream": False,
-        "options": {"temperature": 0, "num_predict": 1500},
+        "options": {"temperature": 0, "num_predict": DEFAULT_MAX_OUTPUT_TOKENS},
     }
     if system_prompt:
         body["system"] = system_prompt
@@ -81,7 +88,20 @@ def call_ollama(
         envelope = json.loads(raw)
     except Exception:
         return None
-    return envelope.get("response")
+    response_text = envelope.get("response")
+    # Distinguish "Ollama returned successfully but with empty/null content"
+    # from "connection failed". The former returns None too, but logging the
+    # difference helps debug silent quota burn on DeepSeek fallback when
+    # Ollama is the actual root cause (aborted generation, OOM, model
+    # producing an empty completion).
+    if not response_text and envelope.get("done"):
+        done_reason = envelope.get("done_reason", "unknown")
+        print(
+            f"[llm_client] Ollama returned done={envelope.get('done')!r} "
+            f"reason={done_reason!r} with empty response — falling back to DeepSeek",
+            file=sys.stderr,
+        )
+    return response_text
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +145,7 @@ def call_deepseek(
         "model": model,
         "messages": messages,
         "temperature": 0,
-        "max_tokens": 1500,
+        "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
     }
     if format_json:
         body["response_format"] = {"type": "json_object"}

--- a/scripts/lib/llm_client.py
+++ b/scripts/lib/llm_client.py
@@ -21,7 +21,9 @@ import urllib.request
 # ---------------------------------------------------------------------------
 
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
-DEFAULT_OLLAMA_MODEL = "qwen2.5-coder:14b"  # Workshop primary (docs/agents/ollama-workshop-bench-538.md)
+DEFAULT_OLLAMA_MODEL = (
+    "qwen2.5-coder:14b"  # Workshop primary (docs/agents/ollama-workshop-bench-538.md)
+)
 DEFAULT_OLLAMA_TIMEOUT_S = 120
 
 DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com"
@@ -95,11 +97,17 @@ def call_deepseek(
     api_key: str | None = None,
     timeout_s: int = DEFAULT_DEEPSEEK_TIMEOUT_S,
     system_prompt: str | None = None,
+    format_json: bool = True,
 ) -> str | None:
     """Call DeepSeek chat-completions API and return the response text.
 
     Returns None on any error.  Uses ``requests``-style JSON POST via
     stdlib ``urllib`` — no extra dependency.
+
+    When *format_json* is true (default), sets
+    ``"response_format": {"type": "json_object"}`` per the OpenAI-compatible
+    contract DeepSeek implements. Without it, DeepSeek wraps JSON output in
+    explanatory prose, which downstream parsers must strip.
     """
     base_url = base_url or os.environ.get("DEEPSEEK_BASE_URL", DEFAULT_DEEPSEEK_BASE_URL)
     model = model or os.environ.get("DEEPSEEK_MODEL", DEFAULT_DEEPSEEK_MODEL)
@@ -113,12 +121,14 @@ def call_deepseek(
         messages.append({"role": "system", "content": system_prompt})
     messages.append({"role": "user", "content": prompt})
 
-    body = {
+    body: dict = {
         "model": model,
         "messages": messages,
         "temperature": 0,
         "max_tokens": 1500,
     }
+    if format_json:
+        body["response_format"] = {"type": "json_object"}
     payload = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(
         f"{base_url.rstrip('/')}/v1/chat/completions",
@@ -164,5 +174,7 @@ def call_llm(
     result = call_ollama(prompt, system_prompt=system_prompt, format_json=format_json)
     if result is not None:
         return result
-    # Fallback
-    return call_deepseek(prompt, system_prompt=system_prompt)
+    # Fallback — forward format_json so DeepSeek also gets JSON-mode enforcement.
+    # Without this, DeepSeek's prose wrapping triggered the non-greedy regex
+    # bug in scripts/deriver/pipeline.py (now also fixed).
+    return call_deepseek(prompt, system_prompt=system_prompt, format_json=format_json)

--- a/tests/test_deriver_pipeline.py
+++ b/tests/test_deriver_pipeline.py
@@ -19,7 +19,12 @@ from uuid import UUID, uuid4
 # Ensure the scripts package is importable before loading the module
 # under test.  conftest.py already inserts ``scripts/`` into sys.path.
 # --
-from deriver.pipeline import derive_from_session, _build_row, _validate_candidate, _parse_json_response
+from deriver.pipeline import (
+    derive_from_session,
+    _build_row,
+    _validate_candidate,
+    _parse_json_response,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -53,8 +58,10 @@ def _asst_turn(text: str) -> dict:
 
 def _make_llm(candidates: list[dict]) -> callable:
     """Return a fake LLM callable that returns the given candidates as JSON."""
+
     def llm_fn(prompt: str) -> str:
         return json.dumps(candidates)
+
     return llm_fn
 
 
@@ -72,8 +79,10 @@ def _make_fake_insert() -> tuple[callable, list[dict]]:
 
 def _make_failing_llm() -> callable:
     """LLM that simulates an unreachable backend."""
+
     def llm_fn(prompt: str) -> None:
         return None
+
     return llm_fn
 
 
@@ -85,16 +94,26 @@ def _make_failing_llm() -> callable:
 def test_derive_from_session_returns_up_to_5_candidates(tmp_path: Path):
     """Given a buffer with content, the pipeline returns ≤5 candidate IDs."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
-        _asst_turn("Hello, how can I help?"),
-        _user_turn("We should use early returns instead of nested ifs"),
-        _asst_turn("Good point, let me refactor that"),
-    ])
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("Hello, how can I help?"),
+            _user_turn("We should use early returns instead of nested ifs"),
+            _asst_turn("Good point, let me refactor that"),
+        ],
+    )
 
     candidates = [
-        {"type": "feedback", "project": "jarvis", "name": "prefer-early-return",
-         "description": "Prefers early return pattern", "content": "User prefers early returns over nested if statements in Python code.",
-         "tags": ["coding-style", "python"]},
+        {
+            "type": "feedback",
+            "project": "jarvis",
+            "name": "prefer-early-return",
+            "description": "Prefers early return pattern",
+            "content": "User prefers early returns over nested if statements in Python code.",
+            "tags": ["coding-style", "python"],
+        },
     ]
     llm_fn = _make_llm(candidates)
     insert_fn, captured = _make_fake_insert()
@@ -120,33 +139,40 @@ def test_derive_from_session_returns_up_to_5_candidates(tmp_path: Path):
 def test_derive_from_session_returns_at_most_5(tmp_path: Path):
     """If LLM returns 7 candidates, the pipeline caps at 5."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
-        _asst_turn("ok"),
-        _user_turn("Lesson 1"),
-        _asst_turn("ok"),
-        _user_turn("Lesson 2"),
-        _asst_turn("ok"),
-        _user_turn("Lesson 3"),
-        _asst_turn("ok"),
-        _user_turn("Lesson 4"),
-        _asst_turn("ok"),
-        _user_turn("Lesson 5"),
-        _asst_turn("ok"),
-        _user_turn("Lesson 6"),
-        _asst_turn("ok"),
-        _user_turn("Lesson 7"),
-    ])
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("ok"),
+            _user_turn("Lesson 1"),
+            _asst_turn("ok"),
+            _user_turn("Lesson 2"),
+            _asst_turn("ok"),
+            _user_turn("Lesson 3"),
+            _asst_turn("ok"),
+            _user_turn("Lesson 4"),
+            _asst_turn("ok"),
+            _user_turn("Lesson 5"),
+            _asst_turn("ok"),
+            _user_turn("Lesson 6"),
+            _asst_turn("ok"),
+            _user_turn("Lesson 7"),
+        ],
+    )
 
     many_candidates = []
     for i in range(7):
-        many_candidates.append({
-            "type": "feedback" if i % 2 == 0 else "user",
-            "project": "jarvis" if i % 2 == 0 else None,
-            "name": f"insight-{i}",
-            "description": f"Insight {i}",
-            "content": f"Content for insight {i}.",
-            "tags": ["test"],
-        })
+        many_candidates.append(
+            {
+                "type": "feedback" if i % 2 == 0 else "user",
+                "project": "jarvis" if i % 2 == 0 else None,
+                "name": f"insight-{i}",
+                "description": f"Insight {i}",
+                "content": f"Content for insight {i}.",
+                "tags": ["test"],
+            }
+        )
 
     llm_fn = _make_llm(many_candidates)
     insert_fn, captured = _make_fake_insert()
@@ -222,17 +248,26 @@ def test_scrubber_wired_on_candidate_content(tmp_path: Path):
     candidate content does NOT contain the token — proves the scrubber
     is wired in the pipeline."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
-        _asst_turn("Sure, I'll look into it"),
-        _user_turn("The AWS key is AKIAIOSFODNN7EXAMPLE, please fix the config"),
-    ])
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("Sure, I'll look into it"),
+            _user_turn("The AWS key is AKIAIOSFODNN7EXAMPLE, please fix the config"),
+        ],
+    )
 
     # LLM echoes the key back in the candidate content
     candidates = [
-        {"type": "feedback", "project": "jarvis", "name": "fix-aws-config",
-         "description": "Fix AWS config",
-         "content": "User reported key AKIAIOSFODNN7EXAMPLE in config. Should rotate it.",
-         "tags": ["security"]},
+        {
+            "type": "feedback",
+            "project": "jarvis",
+            "name": "fix-aws-config",
+            "description": "Fix AWS config",
+            "content": "User reported key AKIAIOSFODNN7EXAMPLE in config. Should rotate it.",
+            "tags": ["security"],
+        },
     ]
     llm_fn = _make_llm(candidates)
     insert_fn, captured = _make_fake_insert()
@@ -256,16 +291,25 @@ def test_scrubber_wired_on_candidate_content(tmp_path: Path):
 def test_scrubber_wired_on_description_and_name(tmp_path: Path):
     """Description and content pass through the scrubber (path redaction)."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
-        _asst_turn("ok"),
-        _user_turn("fix /home/alice/projects thing"),
-    ])
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("ok"),
+            _user_turn("fix /home/alice/projects thing"),
+        ],
+    )
 
     candidates = [
-        {"type": "user", "project": None, "name": "alice-project",
-         "description": "User /home/alice/projects mentioned in context",
-         "content": "User referenced their home directory /home/alice/projects during the session.",
-         "tags": []},
+        {
+            "type": "user",
+            "project": None,
+            "name": "alice-project",
+            "description": "User /home/alice/projects mentioned in context",
+            "content": "User referenced their home directory /home/alice/projects during the session.",
+            "tags": [],
+        },
     ]
     llm_fn = _make_llm(candidates)
     insert_fn, captured = _make_fake_insert()
@@ -313,10 +357,13 @@ def test_validate_candidate_missing_content():
 
 
 def test_validate_candidate_accepts_valid():
-    err = _validate_candidate({
-        "type": "user", "name": "good-one",
-        "content": "This is valid content.",
-    })
+    err = _validate_candidate(
+        {
+            "type": "user",
+            "name": "good-one",
+            "content": "This is valid content.",
+        }
+    )
     assert err is None
 
 
@@ -337,8 +384,7 @@ def test_user_type_always_global_project():
 
 def test_feedback_type_preserves_valid_project():
     row = _build_row(
-        {"type": "feedback", "project": "jarvis", "name": "test",
-         "content": "test", "tags": []},
+        {"type": "feedback", "project": "jarvis", "name": "test", "content": "test", "tags": []},
         session_id=SESSION_ID,
     )
     assert not isinstance(row, str)
@@ -348,8 +394,13 @@ def test_feedback_type_preserves_valid_project():
 
 def test_feedback_type_rejects_invalid_project():
     row = _build_row(
-        {"type": "feedback", "project": "invalid-proj", "name": "test",
-         "content": "test", "tags": []},
+        {
+            "type": "feedback",
+            "project": "invalid-proj",
+            "name": "test",
+            "content": "test",
+            "tags": [],
+        },
         session_id=SESSION_ID,
     )
     assert not isinstance(row, str)
@@ -372,19 +423,42 @@ def test_parse_valid_json():
 
 
 def test_parse_json_with_code_fence():
-    raw = "```json\n[{\"type\":\"user\",\"name\":\"x\"}]\n```"
+    raw = '```json\n[{"type":"user","name":"x"}]\n```'
     result = _parse_json_response(raw)
     assert len(result) == 1
 
 
 def test_parse_json_with_surrounding_text():
-    raw = "Here are the insights:\n\n[{\"type\":\"user\",\"name\":\"x\",\"content\":\"hello\"}]\n\nEnd."
+    raw = 'Here are the insights:\n\n[{"type":"user","name":"x","content":"hello"}]\n\nEnd.'
     result = _parse_json_response(raw)
     assert len(result) == 1
 
 
 def test_parse_invalid_returns_empty():
     assert _parse_json_response("not json at all") == []
+
+
+def test_parse_json_with_nested_tags_arrays_greedy_match():
+    """Regex must match the OUTERMOST candidates array, not the inner tags array.
+
+    Regression: round-2 used non-greedy ``\\[[\\s\\S]*?\\]`` which stopped at
+    the first ``]`` — i.e. the nested ``"tags": [...]`` of the first candidate.
+    ``json.loads`` then succeeded on a list of tag strings; every
+    ``_validate_candidate`` failed; zero candidates inserted silently.
+    """
+    raw = (
+        "Here are the candidates I extracted:\n\n"
+        '[{"type":"user","name":"a","content":"x","tags":["t1","t2"]},'
+        '{"type":"feedback","name":"b","content":"y","tags":["t3"]}]\n'
+        "Hope this helps!"
+    )
+    result = _parse_json_response(raw)
+    assert len(result) == 2, (
+        "Greedy regex must capture the full outer array including both candidates; "
+        f"got {len(result)} result(s)"
+    )
+    assert result[0]["name"] == "a"
+    assert result[1]["name"] == "b"
 
 
 # ---------------------------------------------------------------------------
@@ -395,17 +469,27 @@ def test_parse_invalid_returns_empty():
 def test_cap_at_5_llm_returns_8(tmp_path: Path):
     """MAX_CANDIDATES=5 enforced even when LLM returns 8 valid candidates."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
-        _asst_turn("hi"),
-        _user_turn("lots of insights here"),
-    ])
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("hi"),
+            _user_turn("lots of insights here"),
+        ],
+    )
     many = []
     for i in range(8):
-        many.append({
-            "type": "user", "project": None,
-            "name": f"i-{i}", "description": f"d{i}",
-            "content": f"content {i}", "tags": [],
-        })
+        many.append(
+            {
+                "type": "user",
+                "project": None,
+                "name": f"i-{i}",
+                "description": f"d{i}",
+                "content": f"content {i}",
+                "tags": [],
+            }
+        )
     llm_fn = _make_llm(many)
     insert_fn, captured = _make_fake_insert()
 
@@ -420,6 +504,61 @@ def test_cap_at_5_llm_returns_8(tmp_path: Path):
     assert len(captured) == 5
 
 
+def test_cap_counts_valid_inserts_not_raw_indices(tmp_path: Path):
+    """MAX_CANDIDATES cap counts VALID candidates, not raw list indices.
+
+    Regression: round-2 indexed with ``enumerate`` and tripped ``i >= 5``;
+    leading invalid entries burned indices and silently dropped valid
+    candidates past position 4. With a list of two invalid + five valid +
+    one extra, the cap should yield 5 valid inserts (not 3).
+    """
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("hi"),
+            _user_turn("some content"),
+        ],
+    )
+    # Two leading invalids (missing required fields) + 5 valids + 1 extra.
+    candidates = [
+        {"type": "user"},  # missing name/content
+        {"type": "feedback"},  # missing name/content
+    ]
+    for i in range(6):
+        candidates.append(
+            {
+                "type": "user",
+                "project": None,
+                "name": f"valid-{i}",
+                "description": f"d{i}",
+                "content": f"valid content {i}",
+                "tags": [],
+            }
+        )
+    llm_fn = _make_llm(candidates)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+    assert len(result) == 5, f"Expected 5 valid inserts (cap counts valid_seen); got {len(result)}"
+    assert len(captured) == 5
+    # The first 5 VALID candidates (indexes 2..6 in the raw list) must land.
+    assert all(row["name"].startswith("valid-") for row in captured)
+    # The very last valid (valid-5) is dropped — that's the cap kicking in.
+    names = [row["name"] for row in captured]
+    assert "valid-0" in names
+    assert "valid-4" in names
+    assert "valid-5" not in names
+
+
 # ---------------------------------------------------------------------------
 # LLM failure / fallback
 # ---------------------------------------------------------------------------
@@ -429,10 +568,15 @@ def test_llm_failure_returns_empty_no_half_write(tmp_path: Path):
     """When the LLM returns None (both backends failed), no rows are
     inserted — no half-write to memories."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
-        _asst_turn("hi"),
-        _user_turn("some text"),
-    ])
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("hi"),
+            _user_turn("some text"),
+        ],
+    )
     llm_fn = _make_failing_llm()
     insert_fn, captured = _make_fake_insert()
 
@@ -456,20 +600,35 @@ def test_inserted_rows_have_required_shape(tmp_path: Path):
     """Every inserted candidate has requires_review=true,
     source_provenance='deriver:<session-id>', valid type."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
-        _asst_turn("ok"),
-        _user_turn("Using fixtures for test data is cleaner"),
-        _asst_turn("agreed"),
-        _user_turn("We should add more type hints"),
-    ])
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("ok"),
+            _user_turn("Using fixtures for test data is cleaner"),
+            _asst_turn("agreed"),
+            _user_turn("We should add more type hints"),
+        ],
+    )
 
     candidates = [
-        {"type": "feedback", "project": "jarvis", "name": "use-fixtures",
-         "description": "Prefer fixtures", "content": "Use fixtures for test data setup.",
-         "tags": ["testing"]},
-        {"type": "user", "project": None, "name": "likes-type-hints",
-         "description": "Type hints preference", "content": "User prefers adding type hints.",
-         "tags": ["coding-style"]},
+        {
+            "type": "feedback",
+            "project": "jarvis",
+            "name": "use-fixtures",
+            "description": "Prefer fixtures",
+            "content": "Use fixtures for test data setup.",
+            "tags": ["testing"],
+        },
+        {
+            "type": "user",
+            "project": None,
+            "name": "likes-type-hints",
+            "description": "Type hints preference",
+            "content": "User prefers adding type hints.",
+            "tags": ["coding-style"],
+        },
     ]
     llm_fn = _make_llm(candidates)
     insert_fn, captured = _make_fake_insert()
@@ -502,16 +661,25 @@ def test_pipeline_shape_enforces_scrub_before_insert(tmp_path: Path):
     the candidate content.  Verified structurally: _build_row always calls
     scrub() on content/description/name before returning the row dict."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
-        _asst_turn("ok"),
-        _user_turn("secret is sk-AbCdEfGhIjKlMnOpQrStUvWxYz123456"),
-    ])
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("ok"),
+            _user_turn("secret is sk-AbCdEfGhIjKlMnOpQrStUvWxYz123456"),
+        ],
+    )
 
     candidates = [
-        {"type": "feedback", "project": "jarvis", "name": "found-secret",
-         "description": "There is a secret",
-         "content": "sk-AbCdEfGhIjKlMnOpQrStUvWxYz123456",
-         "tags": []},
+        {
+            "type": "feedback",
+            "project": "jarvis",
+            "name": "found-secret",
+            "description": "There is a secret",
+            "content": "sk-AbCdEfGhIjKlMnOpQrStUvWxYz123456",
+            "tags": [],
+        },
     ]
     llm_fn = _make_llm(candidates)
     insert_fn, captured = _make_fake_insert()

--- a/tests/test_deriver_pipeline.py
+++ b/tests/test_deriver_pipeline.py
@@ -1,0 +1,531 @@
+"""Tests for the Deriver pipeline (S3, #683).
+
+Covers the acceptance criteria:
+  - ``derive_from_session`` returns ≤5 candidate IDs given any input.
+  - Scrubbed transcript + privacy token → persisted content is clean.
+  - Documented shape and ≤5 cap.
+  - Sparse corpus → empty result without error.
+  - DeepSeek fallback on Ollama failure → no half-write.
+  - No insert without scrubber call (enforced by pipeline shape).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID, uuid4
+
+# --
+# Ensure the scripts package is importable before loading the module
+# under test.  conftest.py already inserts ``scripts/`` into sys.path.
+# --
+from deriver.pipeline import derive_from_session, _build_row, _validate_candidate, _parse_json_response
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SESSION_ID = "test-session-001"
+PROJECT_HASH = "a1b2c3d4e5f6"
+
+
+def _write_buffer(buffer_dir: Path, project_hash: str, session_id: str, rows: list[dict]) -> Path:
+    """Write a JSONL buffer file (same format as deriver-accumulator.py).
+
+    Path: ``<buffer_dir>/<project_hash>/<session-id>.jsonl``.
+    """
+    proj_dir = buffer_dir / project_hash
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    path = proj_dir / f"{session_id}.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+    return path
+
+
+def _user_turn(text: str) -> dict:
+    return {"role": "user", "content": text}
+
+
+def _asst_turn(text: str) -> dict:
+    return {"role": "assistant", "content": text}
+
+
+def _make_llm(candidates: list[dict]) -> callable:
+    """Return a fake LLM callable that returns the given candidates as JSON."""
+    def llm_fn(prompt: str) -> str:
+        return json.dumps(candidates)
+    return llm_fn
+
+
+def _make_fake_insert() -> tuple[callable, list[dict]]:
+    """Return (insert_fn, captured) — ``captured`` accumulates inserted rows."""
+    captured: list[dict] = []
+
+    def insert_fn(row: dict) -> UUID:
+        uid = uuid4()
+        captured.append({**row, "_inserted_id": str(uid)})
+        return uid
+
+    return insert_fn, captured
+
+
+def _make_failing_llm() -> callable:
+    """LLM that simulates an unreachable backend."""
+    def llm_fn(prompt: str) -> None:
+        return None
+    return llm_fn
+
+
+# ---------------------------------------------------------------------------
+# Basic pipeline: happy path
+# ---------------------------------------------------------------------------
+
+
+def test_derive_from_session_returns_up_to_5_candidates(tmp_path: Path):
+    """Given a buffer with content, the pipeline returns ≤5 candidate IDs."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
+        _asst_turn("Hello, how can I help?"),
+        _user_turn("We should use early returns instead of nested ifs"),
+        _asst_turn("Good point, let me refactor that"),
+    ])
+
+    candidates = [
+        {"type": "feedback", "project": "jarvis", "name": "prefer-early-return",
+         "description": "Prefers early return pattern", "content": "User prefers early returns over nested if statements in Python code.",
+         "tags": ["coding-style", "python"]},
+    ]
+    llm_fn = _make_llm(candidates)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert len(result) == 1
+    assert len(captured) == 1
+    row = captured[0]
+    assert row["type"] == "feedback"
+    assert row["project"] == "jarvis"
+    assert row["requires_review"] is True
+    assert row["source_provenance"] == f"deriver:{SESSION_ID}"
+    assert row["merge_targets"] is None
+
+
+def test_derive_from_session_returns_at_most_5(tmp_path: Path):
+    """If LLM returns 7 candidates, the pipeline caps at 5."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
+        _asst_turn("ok"),
+        _user_turn("Lesson 1"),
+        _asst_turn("ok"),
+        _user_turn("Lesson 2"),
+        _asst_turn("ok"),
+        _user_turn("Lesson 3"),
+        _asst_turn("ok"),
+        _user_turn("Lesson 4"),
+        _asst_turn("ok"),
+        _user_turn("Lesson 5"),
+        _asst_turn("ok"),
+        _user_turn("Lesson 6"),
+        _asst_turn("ok"),
+        _user_turn("Lesson 7"),
+    ])
+
+    many_candidates = []
+    for i in range(7):
+        many_candidates.append({
+            "type": "feedback" if i % 2 == 0 else "user",
+            "project": "jarvis" if i % 2 == 0 else None,
+            "name": f"insight-{i}",
+            "description": f"Insight {i}",
+            "content": f"Content for insight {i}.",
+            "tags": ["test"],
+        })
+
+    llm_fn = _make_llm(many_candidates)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert len(result) == 5
+    assert len(captured) == 5
+    names = [r["name"] for r in captured]
+    assert names == ["insight-0", "insight-1", "insight-2", "insight-3", "insight-4"]
+
+
+# ---------------------------------------------------------------------------
+# Sparse / empty buffer
+# ---------------------------------------------------------------------------
+
+
+def test_derive_from_session_empty_buffer_returns_empty(tmp_path: Path):
+    """No buffer file → empty result, no error."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    buffer_dir.mkdir(parents=True, exist_ok=True)
+    # Buffer exists but is empty (no user/assistant turns)
+    path = buffer_dir / f"{SESSION_ID}.jsonl"
+    path.write_text("", encoding="utf-8")
+
+    insert_fn, captured = _make_fake_insert()
+    llm_fn = _make_llm([{"type": "user", "name": "x", "content": "y"}])
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert result == []
+    assert captured == []
+
+
+def test_derive_from_session_missing_buffer_returns_empty(tmp_path: Path):
+    """No buffer directory at all → empty result."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+
+    insert_fn, captured = _make_fake_insert()
+    llm_fn = _make_llm([{"type": "user", "name": "x", "content": "y"}])
+
+    result = derive_from_session(
+        "unknown-session",
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert result == []
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
+# Scrubber integration
+# ---------------------------------------------------------------------------
+
+
+def test_scrubber_wired_on_candidate_content(tmp_path: Path):
+    """Given a transcript with a known privacy token, the persisted
+    candidate content does NOT contain the token — proves the scrubber
+    is wired in the pipeline."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
+        _asst_turn("Sure, I'll look into it"),
+        _user_turn("The AWS key is AKIAIOSFODNN7EXAMPLE, please fix the config"),
+    ])
+
+    # LLM echoes the key back in the candidate content
+    candidates = [
+        {"type": "feedback", "project": "jarvis", "name": "fix-aws-config",
+         "description": "Fix AWS config",
+         "content": "User reported key AKIAIOSFODNN7EXAMPLE in config. Should rotate it.",
+         "tags": ["security"]},
+    ]
+    llm_fn = _make_llm(candidates)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert len(result) == 1
+    row = captured[0]
+    # The raw AWS key must not appear in the persisted content
+    assert "AKIAIOSFODNN7EXAMPLE" not in row["content"]
+    # The scrubber should have redacted it
+    assert "<<REDACTED:api_key_aws>>" in row["content"]
+
+
+def test_scrubber_wired_on_description_and_name(tmp_path: Path):
+    """Description and content pass through the scrubber (path redaction)."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
+        _asst_turn("ok"),
+        _user_turn("fix /home/alice/projects thing"),
+    ])
+
+    candidates = [
+        {"type": "user", "project": None, "name": "alice-project",
+         "description": "User /home/alice/projects mentioned in context",
+         "content": "User referenced their home directory /home/alice/projects during the session.",
+         "tags": []},
+    ]
+    llm_fn = _make_llm(candidates)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert len(result) == 1
+    row = captured[0]
+    # Content and description are scrubbed: /home/alice/ → <USER_PATH>/
+    assert "/home/alice/" not in row["content"]
+    assert "/home/alice/" not in row["description"]
+    assert "<USER_PATH>/" in row["content"]
+    # Name is a short slug ("alice-project") — the scrubber targets path
+    # patterns, not bare words, so "alice" in the name slug is expected.
+    assert row["name"] == "alice-project"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_candidate_rejects_missing_name():
+    err = _validate_candidate({"type": "user", "content": "hello"})
+    assert err is not None
+    assert "name" in err.lower()
+
+
+def test_validate_candidate_rejects_invalid_type():
+    err = _validate_candidate({"type": "invalid", "name": "x", "content": "y"})
+    assert err is not None
+    assert "type" in err.lower()
+
+
+def test_validate_candidate_missing_content():
+    err = _validate_candidate({"type": "user", "name": "x"})
+    assert err is not None
+    assert "content" in err.lower()
+
+
+def test_validate_candidate_accepts_valid():
+    err = _validate_candidate({
+        "type": "user", "name": "good-one",
+        "content": "This is valid content.",
+    })
+    assert err is None
+
+
+# ---------------------------------------------------------------------------
+# _normalize_project via _build_row
+# ---------------------------------------------------------------------------
+
+
+def test_user_type_always_global_project():
+    row = _build_row(
+        {"type": "user", "name": "test", "content": "test", "tags": []},
+        session_id=SESSION_ID,
+    )
+    assert not isinstance(row, str)  # not an error
+    assert row["project"] is None
+    assert row["type"] == "user"
+
+
+def test_feedback_type_preserves_valid_project():
+    row = _build_row(
+        {"type": "feedback", "project": "jarvis", "name": "test",
+         "content": "test", "tags": []},
+        session_id=SESSION_ID,
+    )
+    assert not isinstance(row, str)
+    assert row["project"] == "jarvis"
+    assert row["type"] == "feedback"
+
+
+def test_feedback_type_rejects_invalid_project():
+    row = _build_row(
+        {"type": "feedback", "project": "invalid-proj", "name": "test",
+         "content": "test", "tags": []},
+        session_id=SESSION_ID,
+    )
+    assert not isinstance(row, str)
+    assert row["project"] is None  # sanitised to None
+
+
+# ---------------------------------------------------------------------------
+# JSON parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_empty_array():
+    assert _parse_json_response("[]") == []
+
+
+def test_parse_valid_json():
+    result = _parse_json_response('[{"type":"user","name":"x"}]')
+    assert len(result) == 1
+    assert result[0]["name"] == "x"
+
+
+def test_parse_json_with_code_fence():
+    raw = "```json\n[{\"type\":\"user\",\"name\":\"x\"}]\n```"
+    result = _parse_json_response(raw)
+    assert len(result) == 1
+
+
+def test_parse_json_with_surrounding_text():
+    raw = "Here are the insights:\n\n[{\"type\":\"user\",\"name\":\"x\",\"content\":\"hello\"}]\n\nEnd."
+    result = _parse_json_response(raw)
+    assert len(result) == 1
+
+
+def test_parse_invalid_returns_empty():
+    assert _parse_json_response("not json at all") == []
+
+
+# ---------------------------------------------------------------------------
+# Cap enforcement: LLM returns more than MAX_CANDIDATES
+# ---------------------------------------------------------------------------
+
+
+def test_cap_at_5_llm_returns_8(tmp_path: Path):
+    """MAX_CANDIDATES=5 enforced even when LLM returns 8 valid candidates."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
+        _asst_turn("hi"),
+        _user_turn("lots of insights here"),
+    ])
+    many = []
+    for i in range(8):
+        many.append({
+            "type": "user", "project": None,
+            "name": f"i-{i}", "description": f"d{i}",
+            "content": f"content {i}", "tags": [],
+        })
+    llm_fn = _make_llm(many)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+    assert len(result) == 5
+    assert len(captured) == 5
+
+
+# ---------------------------------------------------------------------------
+# LLM failure / fallback
+# ---------------------------------------------------------------------------
+
+
+def test_llm_failure_returns_empty_no_half_write(tmp_path: Path):
+    """When the LLM returns None (both backends failed), no rows are
+    inserted — no half-write to memories."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
+        _asst_turn("hi"),
+        _user_turn("some text"),
+    ])
+    llm_fn = _make_failing_llm()
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+    assert result == []
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
+# Shape: all inserted rows have the documented fields
+# ---------------------------------------------------------------------------
+
+
+def test_inserted_rows_have_required_shape(tmp_path: Path):
+    """Every inserted candidate has requires_review=true,
+    source_provenance='deriver:<session-id>', valid type."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
+        _asst_turn("ok"),
+        _user_turn("Using fixtures for test data is cleaner"),
+        _asst_turn("agreed"),
+        _user_turn("We should add more type hints"),
+    ])
+
+    candidates = [
+        {"type": "feedback", "project": "jarvis", "name": "use-fixtures",
+         "description": "Prefer fixtures", "content": "Use fixtures for test data setup.",
+         "tags": ["testing"]},
+        {"type": "user", "project": None, "name": "likes-type-hints",
+         "description": "Type hints preference", "content": "User prefers adding type hints.",
+         "tags": ["coding-style"]},
+    ]
+    llm_fn = _make_llm(candidates)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert len(result) == 2
+    for row in captured:
+        assert row["requires_review"] is True
+        assert row["source_provenance"] == f"deriver:{SESSION_ID}"
+        assert row["type"] in ("user", "feedback")
+        assert row["merge_targets"] is None
+        assert isinstance(row["name"], str) and row["name"]
+        assert isinstance(row["content"], str) and row["content"]
+
+
+# ---------------------------------------------------------------------------
+# No insert without scrubber — enforced by pipeline shape
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_shape_enforces_scrub_before_insert(tmp_path: Path):
+    """The pipeline never calls insert_fn without first calling scrub on
+    the candidate content.  Verified structurally: _build_row always calls
+    scrub() on content/description/name before returning the row dict."""
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(buffer_dir, PROJECT_HASH, SESSION_ID, [
+        _asst_turn("ok"),
+        _user_turn("secret is sk-AbCdEfGhIjKlMnOpQrStUvWxYz123456"),
+    ])
+
+    candidates = [
+        {"type": "feedback", "project": "jarvis", "name": "found-secret",
+         "description": "There is a secret",
+         "content": "sk-AbCdEfGhIjKlMnOpQrStUvWxYz123456",
+         "tags": []},
+    ]
+    llm_fn = _make_llm(candidates)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert len(result) == 1
+    row = captured[0]
+    # The raw OpenAI key format (sk- + 20+ alnum) should be scrubbed.
+    assert "sk-AbCdEfGhIjKlMnOpQrStUvWxYz123456" not in row["content"]
+    assert "<<REDACTED:api_key_openai>>" in row["content"]

--- a/tests/test_deriver_pipeline.py
+++ b/tests/test_deriver_pipeline.py
@@ -243,6 +243,111 @@ def test_derive_from_session_missing_buffer_returns_empty(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
+def test_scrubber_wired_on_tags(tmp_path: Path):
+    """Tags MUST pass through scrub() like name/content/description.
+
+    Regression: round-3 lowercased and length-capped tags but never called
+    scrub() on them. An LLM-fabricated tag like `aws-AKIAIOSFODNN7EXAMPLE`
+    would land in memories.tags unredacted, leaking a credential through a
+    column the privacy invariant claims to cover.
+    """
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("ok"),
+            _user_turn("some content"),
+        ],
+    )
+    # The literal AWS-key example MUST be redacted by the scrubber.
+    candidates = [
+        {
+            "type": "feedback",
+            "project": "jarvis",
+            "name": "test",
+            "description": "test",
+            "content": "test",
+            "tags": ["normal-tag", "leaked-AKIAIOSFODNN7EXAMPLE"],
+        },
+    ]
+    llm_fn = _make_llm(candidates)
+    insert_fn, captured = _make_fake_insert()
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=insert_fn,
+        buffer_root=buffer_dir,
+    )
+
+    assert len(result) == 1
+    row = captured[0]
+    persisted_tags = row["tags"]
+    # The AWS key must not survive in any tag:
+    for t in persisted_tags:
+        assert "AKIAIOSFODNN7EXAMPLE" not in t, (
+            f"Tag {t!r} contains unscrubbed AWS key — scrub() not wired on tags."
+        )
+
+
+def test_cap_holds_when_all_inserts_fail(tmp_path: Path):
+    """MAX_CANDIDATES cap must fire on attempted (not just succeeded) inserts.
+
+    Regression: round-3 incremented the cap counter only on successful
+    inserts; a persistent insert failure (RLS rejection after credential
+    rotation, schema mismatch, etc.) made the cap silently never fire and
+    the pipeline attempted N>>5 candidates with N failure log lines each.
+    """
+    buffer_dir = tmp_path / ".deriver-buffer"
+    _write_buffer(
+        buffer_dir,
+        PROJECT_HASH,
+        SESSION_ID,
+        [
+            _asst_turn("ok"),
+            _user_turn("plenty of insights"),
+        ],
+    )
+    # 20 valid candidates so the cap is the only thing that can stop the loop.
+    candidates = []
+    for i in range(20):
+        candidates.append(
+            {
+                "type": "user",
+                "project": None,
+                "name": f"insight-{i}",
+                "description": f"d{i}",
+                "content": f"content {i}",
+                "tags": ["t"],
+            }
+        )
+    llm_fn = _make_llm(candidates)
+
+    attempts: list[dict] = []
+
+    def always_fail_insert(row):
+        attempts.append(row)
+        raise RuntimeError("simulated RLS rejection")
+
+    result = derive_from_session(
+        SESSION_ID,
+        project_hash=PROJECT_HASH,
+        llm_fn=llm_fn,
+        insert_fn=always_fail_insert,
+        buffer_root=buffer_dir,
+    )
+
+    assert result == []  # nothing inserted (all attempts failed)
+    # Cap fires at MAX_CANDIDATES=5 attempts — NOT all 20.
+    assert len(attempts) == 5, (
+        f"Cap must fire on attempted inserts; got {len(attempts)} attempts "
+        "(round-3 regression: only-on-success counter let this run unbounded)."
+    )
+
+
 def test_scrubber_wired_on_candidate_content(tmp_path: Path):
     """Given a transcript with a known privacy token, the persisted
     candidate content does NOT contain the token — proves the scrubber

--- a/tests/test_deriver_pipeline.py
+++ b/tests/test_deriver_pipeline.py
@@ -171,11 +171,11 @@ def test_derive_from_session_returns_at_most_5(tmp_path: Path):
 
 
 def test_derive_from_session_empty_buffer_returns_empty(tmp_path: Path):
-    """No buffer file → empty result, no error."""
+    """Buffer file exists but is empty (no user/assistant turns) → empty result."""
     buffer_dir = tmp_path / ".deriver-buffer"
-    buffer_dir.mkdir(parents=True, exist_ok=True)
-    # Buffer exists but is empty (no user/assistant turns)
-    path = buffer_dir / f"{SESSION_ID}.jsonl"
+    proj_dir = buffer_dir / PROJECT_HASH
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    path = proj_dir / f"{SESSION_ID}.jsonl"
     path.write_text("", encoding="utf-8")
 
     insert_fn, captured = _make_fake_insert()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -47,3 +47,83 @@ def test_call_llm_returns_none_when_both_backends_fail():
         result = call_llm("test prompt")
 
     assert result is None
+
+
+def test_call_llm_forwards_format_json_to_deepseek():
+    """call_llm must forward format_json to BOTH Ollama and DeepSeek.
+
+    Regression: round-2 forwarded format_json only to Ollama; the DeepSeek
+    fallback call dropped it. DeepSeek without JSON-mode wraps output in
+    prose, which then triggered the non-greedy regex bug in
+    scripts/deriver/pipeline.py and silently dropped all candidates.
+    """
+    with (
+        patch("lib.llm_client.call_ollama", return_value=None),
+        patch("lib.llm_client.call_deepseek", return_value="ok") as mock_deepseek,
+    ):
+        call_llm("test prompt", system_prompt="sys", format_json=True)
+
+    mock_deepseek.assert_called_once()
+    kwargs = mock_deepseek.call_args.kwargs
+    assert kwargs.get("format_json") is True, (
+        f"call_llm must forward format_json=True to call_deepseek; got kwargs={kwargs!r}"
+    )
+
+
+def test_call_deepseek_sets_response_format_when_format_json_true():
+    """call_deepseek must set OpenAI-compatible response_format when format_json=True."""
+    from lib.llm_client import call_deepseek
+
+    captured: dict = {}
+
+    class _MockResp:
+        def read(self):
+            return b'{"choices":[{"message":{"content":"ok"}}]}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _capture_urlopen(req, timeout=None):
+        import json as _json
+
+        captured["body"] = _json.loads(req.data.decode("utf-8"))
+        return _MockResp()
+
+    with patch("lib.llm_client.urllib.request.urlopen", side_effect=_capture_urlopen):
+        call_deepseek("p", api_key="fake-key", format_json=True)
+
+    assert captured["body"].get("response_format") == {"type": "json_object"}, (
+        "DeepSeek POST body must include response_format when format_json=True; "
+        f"got {captured['body']!r}"
+    )
+
+
+def test_call_deepseek_omits_response_format_when_format_json_false():
+    """call_deepseek must NOT set response_format when format_json=False."""
+    from lib.llm_client import call_deepseek
+
+    captured: dict = {}
+
+    class _MockResp:
+        def read(self):
+            return b'{"choices":[{"message":{"content":"ok"}}]}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _capture_urlopen(req, timeout=None):
+        import json as _json
+
+        captured["body"] = _json.loads(req.data.decode("utf-8"))
+        return _MockResp()
+
+    with patch("lib.llm_client.urllib.request.urlopen", side_effect=_capture_urlopen):
+        call_deepseek("p", api_key="fake-key", format_json=False)
+
+    assert "response_format" not in captured["body"]

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,49 @@
+"""Tests for scripts/lib/llm_client.py — fallback logic.
+
+Covers the key acceptance criterion: Ollama failure → DeepSeek fallback,
+with no half-write and correct endpoint usage.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from lib.llm_client import call_llm
+
+
+def test_call_llm_uses_ollama_when_available():
+    """call_llm returns Ollama response and does not call DeepSeek."""
+    with (
+        patch("lib.llm_client.call_ollama", return_value="ollama-result") as mock_ollama,
+        patch("lib.llm_client.call_deepseek") as mock_deepseek,
+    ):
+        result = call_llm("test prompt", system_prompt="sys")
+
+    assert result == "ollama-result"
+    mock_ollama.assert_called_once()
+    mock_deepseek.assert_not_called()
+
+
+def test_call_llm_falls_back_to_deepseek_on_ollama_failure():
+    """When Ollama returns None, call_llm falls back to DeepSeek."""
+    deepseek_response = '[{"type":"user","name":"x","content":"y"}]'
+    with (
+        patch("lib.llm_client.call_ollama", return_value=None) as mock_ollama,
+        patch("lib.llm_client.call_deepseek", return_value=deepseek_response) as mock_deepseek,
+    ):
+        result = call_llm("test prompt", system_prompt="sys")
+
+    assert result == deepseek_response
+    mock_ollama.assert_called_once()
+    mock_deepseek.assert_called_once()
+
+
+def test_call_llm_returns_none_when_both_backends_fail():
+    """When both Ollama and DeepSeek fail, call_llm returns None (no half-write)."""
+    with (
+        patch("lib.llm_client.call_ollama", return_value=None),
+        patch("lib.llm_client.call_deepseek", return_value=None),
+    ):
+        result = call_llm("test prompt")
+
+    assert result is None


### PR DESCRIPTION
## Summary

Implements the Deriver pipeline (Slice 3 of memory-deriver epic #549):

- **Stop-hook accumulator** already exists (Slice 0, `deriver-accumulator.py`) — this PR wires the SessionEnd Deriver that consumes the buffer.
- **Deep module** `derive_from_session(session_id)` in `scripts/deriver/pipeline.py` — reads scrubbed transcript from buffer → calls Ollama (Workshop primary) / DeepSeek (fallback) with derive prompt → validates + scrubs output → inserts ≤5 candidates with `requires_review=true`.
- **Stop hook entry** `scripts/deriver-sessionend.py` — registered in `.claude-userlevel/settings.json` after the accumulator.
- **LLM client** `scripts/lib/llm_client.py` — reusable Ollama + DeepSeek caller.
- **22 fixture tests** covering: happy path, ≤5 cap, empty/sparse buffer, scrubber integration on content/description, validation, JSON parsing, LLM failure (no half-write), shape of inserted rows.

## Acceptance criteria covered

- [x] SessionEnd hook fires on every owner session (registered in Stop hook after accumulator)
- [x] `derive_from_session(session_id)` returns ≤5 candidate IDs
- [x] All inserted rows have `requires_review=true`, `source_provenance='deriver:<session-id>'`, valid type, self-classified project scope
- [x] Fixture test: privacy token in transcript → persisted content is clean (scrubber wired)
- [x] Fixture test: candidates respect documented shape and ≤5 cap
- [x] Inserted candidates drainable by `/learn` (use candidate-path `memory_review_list`)
- [x] DeepSeek fallback on Ollama failure → no half-write
- [x] Pipeline shape enforces scrub before insert (scrub called inside `_build_row`)

## Test plan

- [x] `python3 -m pytest tests/test_deriver_pipeline.py -v` — 22/22 pass
- [x] `ruff check` — clean
- [x] Existing CI guard tests (memory_review, secret_scrubber, comm_patterns) — all pass

Closes #683