### PR TITLE
feat(memory): S4 Dreamer pipeline — scheduled cross-corpus consolidation pass

### DIFF
--- a/scripts/dreamer-run.py
+++ b/scripts/dreamer-run.py
@@ -45,7 +45,6 @@ import os
 import sys
 import time
 import uuid
-from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -188,11 +187,12 @@ def _llm_config() -> tuple[str, str, str]:
 
 
 def fetch_pending_count(client) -> int:
-    """Count memories with ``requires_review=true`` (unreviewed candidates)."""
+    """Count feedback memories with ``requires_review=true`` (unreviewed candidates)."""
     rows = (
         client.table("memories")
         .select("id", count="exact")
         .eq("requires_review", True)
+        .eq("type", "feedback")
         .is_("deleted_at", "null")
         .limit(1)
         .execute()
@@ -200,8 +200,8 @@ def fetch_pending_count(client) -> int:
     return rows.count if hasattr(rows, "count") and rows.count is not None else 0
 
 
-def fetch_days_since_last_run(client) -> int | None:
-    """Return days since the last ``dreamer_run`` event, or None if no prior run."""
+def fetch_days_since_last_run(client) -> timedelta | None:
+    """Return elapsed time since the last ``dreamer_run`` event, or None if no prior run."""
     rows = (
         client.table("events")
         .select("created_at")
@@ -218,7 +218,7 @@ def fetch_days_since_last_run(client) -> int | None:
         return None
     try:
         last = datetime.fromisoformat(str(last_ts).replace("Z", "+00:00"))
-        return (datetime.now(timezone.utc) - last).days
+        return datetime.now(timezone.utc) - last
     except (TypeError, ValueError):
         return None
 
@@ -233,10 +233,11 @@ def check_trigger(client) -> tuple[bool, str]:
     if pending >= PENDING_THRESHOLD:
         return True, f"pending_candidate_count={pending} >= threshold={PENDING_THRESHOLD}"
 
-    days = fetch_days_since_last_run(client)
-    if days is None:
+    delta = fetch_days_since_last_run(client)
+    if delta is None:
         return True, "no prior dreamer_run found — first run"
-    if days >= DAYS_SINCE_LAST_RUN:
+    days = delta.days  # whole days for display; full timedelta used for comparison
+    if delta >= timedelta(days=DAYS_SINCE_LAST_RUN):
         return True, f"days_since_last_run={days} >= threshold={DAYS_SINCE_LAST_RUN}"
 
     return False, (
@@ -259,7 +260,9 @@ def fetch_corpus(client, *, max_rows: int = MAX_CORPUS_ROWS) -> list[dict]:
     cutoff = (datetime.now(timezone.utc) - timedelta(days=CORPUS_LOOKBACK_DAYS)).isoformat()
     rows = (
         client.table("memories")
-        .select("id, name, type, description, content, tags, project, created_at, updated_at, requires_review")
+        .select(
+            "id, name, type, description, content, tags, project, created_at, updated_at, requires_review"
+        )
         .eq("type", "feedback")
         .gte("created_at", cutoff)
         .is_("deleted_at", "null")
@@ -291,7 +294,7 @@ def _build_corpus_prompt(corpus: list[dict]) -> str:
             f"  created_at: {m.get('created_at', '?')}",
         ]
         if m.get("tags"):
-            block.append(f"  tags: {', '.join(m['tags'])}")
+            block.append(f"  tags: {', '.join(str(t) for t in m['tags'])}")
         if m.get("description"):
             block.append(f"  description: {m['description']}")
         if m.get("content"):
@@ -515,7 +518,13 @@ def insert_candidates(client, candidates: list[dict], run_id: str) -> list[str]:
         try:
             resp = client.table("memories").insert(row).execute()
             data = resp.data or []
-            if data and data[0].get("id"):
+            if not data:
+                print(
+                    f"  ! candidate insert returned no data ({c.get('name')}) "
+                    "— possible RLS rejection (anon key lacks sandcastle provenance)",
+                    file=sys.stderr,
+                )
+            elif data[0].get("id"):
                 ids.append(data[0]["id"])
         except Exception as e:
             print(f"  ! candidate insert failed ({c.get('name')}): {e}", file=sys.stderr)
@@ -530,7 +539,13 @@ def insert_merge_proposals(client, proposals: list[dict], run_id: str) -> list[s
         try:
             resp = client.table("memories").insert(row).execute()
             data = resp.data or []
-            if data and data[0].get("id"):
+            if not data:
+                print(
+                    f"  ! merge_proposal insert returned no data ({p.get('name')}) "
+                    "— possible RLS rejection (anon key lacks sandcastle provenance)",
+                    file=sys.stderr,
+                )
+            elif data[0].get("id"):
                 ids.append(data[0]["id"])
         except Exception as e:
             print(f"  ! merge_proposal insert failed ({p.get('name')}): {e}", file=sys.stderr)
@@ -607,9 +622,25 @@ def main() -> int:
     args = p.parse_args()
 
     sb_url = os.environ.get("SUPABASE_URL")
-    sb_key = os.environ.get("SUPABASE_KEY")
+    # Mirror mcp-memory/client.py: prefer service-role key so host writes bypass
+    # the RLS policy (source_provenance LIKE 'sandcastle:%' for anon INSERTs).
+    # Dreamer writes 'dreamer:<run_id>' provenance — anon key gets 403 from RLS.
+    sb_key = os.environ.get("SUPABASE_SERVICE_KEY")
+    if not sb_key:
+        sb_key = os.environ.get("SUPABASE_KEY")
+        if sb_key and not os.environ.get("SANDCASTLE_RUN_ID"):
+            print(
+                "WARNING: dreamer using SUPABASE_KEY (anon). RLS requires "
+                "source_provenance LIKE 'sandcastle:%' for anon INSERTs — "
+                "dreamer writes 'dreamer:...' provenance and inserts will be rejected. "
+                "Set SUPABASE_SERVICE_KEY in .env.",
+                file=sys.stderr,
+            )
     if not sb_url or not sb_key:
-        print("SUPABASE_URL / SUPABASE_KEY missing from env", file=sys.stderr)
+        print(
+            "SUPABASE_URL / SUPABASE_SERVICE_KEY (or SUPABASE_KEY) missing from env",
+            file=sys.stderr,
+        )
         return 2
 
     api_key, api_url, model = _llm_config()
@@ -656,13 +687,15 @@ def main() -> int:
             "new_candidates": 0,
             "merge_proposals": 0,
         }
-        event_id = write_event(
-            client,
-            run_id=run_id,
-            status="ok",
-            title="Dreamer run — corpus empty, no output",
-            payload={**recap, "event_id": None},
-        )
+        event_id = None
+        if not args.dry_run:
+            event_id = write_event(
+                client,
+                run_id=run_id,
+                status="ok",
+                title="Dreamer run — corpus empty, no output",
+                payload={**recap, "event_id": None},
+            )
         recap["event_id"] = event_id
         print(json.dumps(recap, indent=2, default=str))
         return 0
@@ -732,7 +765,6 @@ def main() -> int:
         "dry_run": args.dry_run,
         "force": args.force,
     }
-    total = len(new_candidates) + len(merge_proposals)
     total_inserted = len(candidate_ids) + len(proposal_ids)
     title_status = "dry-run" if args.dry_run else "ok"
     title = (
@@ -761,7 +793,7 @@ def main() -> int:
         "candidate_ids": candidate_ids,
         "proposal_ids": proposal_ids,
         "dry_run": args.dry_run,
-        "needs_review": total_inserted > 0,
+        "needs_review": (not args.dry_run) and total_inserted > 0,
     }
     print(json.dumps(recap, indent=2, default=str))
     return 0

--- a/scripts/dreamer-run.py
+++ b/scripts/dreamer-run.py
@@ -194,6 +194,7 @@ def fetch_pending_count(client) -> int:
         .select("id", count="exact")
         .eq("requires_review", True)
         .is_("deleted_at", "null")
+        .limit(1)
         .execute()
     )
     return rows.count if hasattr(rows, "count") and rows.count is not None else 0
@@ -347,6 +348,7 @@ def _parse_response(text: str, corpus_ids: set[str]) -> tuple[list[dict], list[d
         name = c.get("name")
         if not isinstance(name, str) or not name.strip():
             continue
+        name = name.strip()
         if name in seen_names:
             continue
         mtype = c.get("type")
@@ -370,6 +372,7 @@ def _parse_response(text: str, corpus_ids: set[str]) -> tuple[list[dict], list[d
         name = p.get("name")
         if not isinstance(name, str) or not name.strip():
             continue
+        name = name.strip()
         if name in seen_names_p:
             continue
         mtype = p.get("type")
@@ -554,7 +557,7 @@ def write_event(
             .insert(
                 {
                     "event_type": "dreamer_run",
-                    "severity": "info" if status == "ok" else "medium",
+                    "severity": "info" if status in ("ok", "dry-run") else "medium",
                     "repo": "Osasuwu/jarvis",
                     "source": "scheduled_task",
                     "title": title,
@@ -587,7 +590,7 @@ def main() -> int:
         "--dry-run",
         action="store_true",
         help="Run the pipeline but skip all DB writes (inserts + event). "
-        "Prints what would be written to stderr.",
+        "Prints candidate/proposal details to stderr.",
     )
     p.add_argument(
         "--model",
@@ -700,7 +703,18 @@ def main() -> int:
             f"{len(merge_proposals)} merge proposal(s)",
             file=sys.stderr,
         )
-        # Still report IDs for recap
+        if new_candidates:
+            print("  New candidates:", file=sys.stderr)
+            for c in new_candidates:
+                print(f"    - {c.get('name')}: {c.get('description', '')}", file=sys.stderr)
+        if merge_proposals:
+            print("  Merge proposals:", file=sys.stderr)
+            for mp in merge_proposals:
+                targets = mp.get("merge_targets", [])
+                print(
+                    f"    - {mp.get('name')} (merge {targets}): {mp.get('description', '')}",
+                    file=sys.stderr,
+                )
         candidate_ids = [f"(dry-run) {c.get('name', '?')}" for c in new_candidates]
         proposal_ids = [f"(dry-run) {p.get('name', '?')}" for p in merge_proposals]
 

--- a/scripts/dreamer-run.py
+++ b/scripts/dreamer-run.py
@@ -1,0 +1,757 @@
+"""S4: Dreamer pipeline — scheduled cross-corpus consolidation pass.
+
+Phase 1 — producer: emit new candidates and merge proposals from a
+corpus of pending + accepted ``feedback`` memories using an LLM.
+
+Two-phase pipeline:
+  1. ``consolidate(corpus)`` — pure function returning
+     ``(new_candidates, merge_proposals)``. Both lists may be empty.
+  2. Write results to the ``memories`` table with ``requires_review=true``
+     and ``source_provenance='dreamer:<run-id>'``.
+
+Trigger: (pending-candidate count >= 30) OR (>= 7 days since last run).
+
+Blocked by:
+  - #681 (S1 — ``merge_targets`` column + atomic merge RPC) — **done**
+  - #683 (S3 — Deriver feeds the candidate corpus Dreamer reads) —
+    **in-progress**; the pure function and scheduled task are independent.
+    Without S3, the corpus fetch will return zero rows and the run will
+    be a no-op rather than an error.
+
+Usage::
+
+    python scripts/dreamer-run.py                          # triggered run
+    python scripts/dreamer-run.py --force                  # skip trigger check
+    python scripts/dreamer-run.py --force --dry-run        # smoke test only
+    python scripts/dreamer-run.py --model deepseek-chat    # alternate LLM
+
+Env: SUPABASE_URL, SUPABASE_KEY, plus one of:
+  - ``ANTHROPIC_API_KEY`` (default — uses ``claude-sonnet-4-6``).
+  - ``DREAMER_API_KEY`` + ``DREAMER_API_URL`` + ``DREAMER_MODEL``
+    (alt provider such as Ollama / DeepSeek — ``DREAMER_API_URL`` must be a
+    ``/v1/messages``-compatible endpoint that accepts the Anthropic Messages
+    schema).
+  - ``DREAMER_API_KEY`` alone overrides the key; ``DREAMER_MODEL`` alone
+    overrides the model.
+
+``.env`` is auto-loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+try:
+    from dotenv import load_dotenv
+
+    here = Path(__file__).resolve().parent
+    for c in (here.parent / ".env", here.parent.parent / ".env"):
+        if c.exists():
+            load_dotenv(c, override=True)
+            break
+except ImportError:
+    pass
+
+import httpx
+from supabase import create_client
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PENDING_THRESHOLD = 30
+DAYS_SINCE_LAST_RUN = 7
+MAX_CORPUS_ROWS = 200
+CORPUS_LOOKBACK_DAYS = 90
+
+DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
+DEFAULT_ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+MAX_TOKENS = 4000
+DEFAULT_TIMEOUT = 60.0
+
+# Max outputs per category — keeps the response within token budget and review
+# burden manageable per ADR-0003 (≤20 per Dreamer run).
+MAX_NEW_CANDIDATES = 5
+MAX_MERGE_PROPOSALS = 5
+
+
+DREAMER_SYSTEM_PROMPT = """You are analyzing a corpus of feedback memories from a personal AI agent's long-term memory store.
+
+Your task: identify cross-corpus insights that are worth capturing as new memories, AND identify groups of near-duplicate or overlapping memories that should be merged.
+
+## New candidates
+
+Identify patterns, connections, or important facts that emerge from looking at the corpus as a whole but aren't explicitly captured in any single memory. Examples:
+- A recurring theme or preference across multiple interactions
+- A project-specific pattern the agent should remember
+- A general insight about how the user works
+
+Each new candidate needs:
+- name (snake_case identifier)
+- type (one of: user, project, decision, feedback, reference — choose the most appropriate)
+- project: "jarvis" for project-specific insights; null for universal/user insights
+- description (one sentence summary)
+- content (full detail)
+- tags (relevant tags, include "dreamer")
+- reasoning (why this insight emerges from the corpus)
+
+## Merge proposals
+
+Identify groups of 2+ memories that refer to the same underlying fact and would serve better as a single unified memory. Only propose a merge if the unified version would be strictly better than keeping the parts separate.
+
+Each merge proposal needs:
+- name (snake_case identifier)
+- type (the most appropriate type for the merged result)
+- project: same as the memories being merged (or null if global)
+- description (one sentence summary)
+- content (full merged content — synthesize from all source memories)
+- tags (union of relevant tags, include "dreamer")
+- merge_targets: array of UUIDs of memories to supersede
+- reasoning (why these should be merged and how the new version improves on the parts)
+
+## Rules
+- Be conservative. Prefer fewer, high-quality outputs over many speculative ones.
+- A new candidate must represent information NOT already captured in the corpus as a single memory. If the corpus already contains the fact, don't repeat it.
+- Merge proposals should only reference UUIDs that appear in the corpus below.
+- Max 5 new candidates + 5 merge proposals per run.
+- When in doubt, emit nothing. Empty arrays are valid.
+
+Output strict JSON matching this schema, nothing else. No prose before or after.
+
+{
+  "new_candidates": [
+    {
+      "name": "snake_case_name",
+      "type": "user|project|decision|feedback|reference",
+      "project": "jarvis | null",
+      "description": "one sentence summary",
+      "content": "full content",
+      "tags": ["tag1", "tag2"],
+      "reasoning": "why this insight emerges"
+    }
+  ],
+  "merge_proposals": [
+    {
+      "name": "snake_case_name",
+      "type": "user|project|decision|feedback|reference",
+      "project": "jarvis | null",
+      "description": "one sentence summary",
+      "content": "full merged content",
+      "tags": ["tag1", "tag2"],
+      "merge_targets": ["uuid1", "uuid2"],
+      "reasoning": "why these should be merged"
+    }
+  ]
+}"""
+
+
+# ---------------------------------------------------------------------------
+# LLM configuration
+# ---------------------------------------------------------------------------
+
+
+def _llm_config() -> tuple[str, str, str]:
+    """Return (api_key, api_url, model) for the LLM call.
+
+    Resolution order:
+      1. ``DREAMER_API_KEY`` / ``DREAMER_API_URL`` / ``DREAMER_MODEL`` — alt
+         provider (Ollama, DeepSeek). The URL must be a ``/v1/messages``-
+         compatible endpoint matching the Anthropic Messages schema.
+      2. ``ANTHROPIC_API_KEY`` — default key; URL and model are the Anthropic
+         defaults.
+    """
+    api_key = os.environ.get("DREAMER_API_KEY") or os.environ.get("ANTHROPIC_API_KEY") or ""
+    api_url = os.environ.get("DREAMER_API_URL") or DEFAULT_ANTHROPIC_URL
+    model = os.environ.get("DREAMER_MODEL") or DEFAULT_ANTHROPIC_MODEL
+    return api_key, api_url, model
+
+
+# ---------------------------------------------------------------------------
+# Trigger logic
+# ---------------------------------------------------------------------------
+
+
+def fetch_pending_count(client) -> int:
+    """Count memories with ``requires_review=true`` (unreviewed candidates)."""
+    rows = (
+        client.table("memories")
+        .select("id", count="exact")
+        .eq("requires_review", True)
+        .is_("deleted_at", "null")
+        .execute()
+    )
+    return rows.count if hasattr(rows, "count") and rows.count is not None else 0
+
+
+def fetch_days_since_last_run(client) -> int | None:
+    """Return days since the last ``dreamer_run`` event, or None if no prior run."""
+    rows = (
+        client.table("events")
+        .select("created_at")
+        .eq("event_type", "dreamer_run")
+        .order("created_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    data = rows.data or []
+    if not data:
+        return None
+    last_ts = data[0].get("created_at")
+    if not last_ts:
+        return None
+    try:
+        last = datetime.fromisoformat(str(last_ts).replace("Z", "+00:00"))
+        return (datetime.now(timezone.utc) - last).days
+    except (TypeError, ValueError):
+        return None
+
+
+def check_trigger(client) -> tuple[bool, str]:
+    """Return (should_run: bool, reason: str).
+
+    Fires when ``pending_count >= PENDING_THRESHOLD`` OR
+    ``days_since >= DAYS_SINCE_LAST_RUN`` (or no prior run exists).
+    """
+    pending = fetch_pending_count(client)
+    if pending >= PENDING_THRESHOLD:
+        return True, f"pending_candidate_count={pending} >= threshold={PENDING_THRESHOLD}"
+
+    days = fetch_days_since_last_run(client)
+    if days is None:
+        return True, "no prior dreamer_run found — first run"
+    if days >= DAYS_SINCE_LAST_RUN:
+        return True, f"days_since_last_run={days} >= threshold={DAYS_SINCE_LAST_RUN}"
+
+    return False, (
+        f"pending_candidate_count={pending} < {PENDING_THRESHOLD} AND "
+        f"days_since_last_run={days} < {DAYS_SINCE_LAST_RUN}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corpus fetching
+# ---------------------------------------------------------------------------
+
+
+def fetch_corpus(client, *, max_rows: int = MAX_CORPUS_ROWS) -> list[dict]:
+    """Read pending + accepted ``feedback`` memories from the last 90 days.
+
+    Ordered by ``created_at`` descending; capped at ``max_rows`` (oldest
+    rows dropped first when over the limit).
+    """
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=CORPUS_LOOKBACK_DAYS)).isoformat()
+    rows = (
+        client.table("memories")
+        .select("id, name, type, description, content, tags, project, created_at, updated_at, requires_review")
+        .eq("type", "feedback")
+        .gte("created_at", cutoff)
+        .is_("deleted_at", "null")
+        .order("created_at", desc=True)
+        .limit(max_rows)
+        .execute()
+    )
+    return rows.data or []
+
+
+# ---------------------------------------------------------------------------
+# Pure consolidate function
+# ---------------------------------------------------------------------------
+
+
+def _build_corpus_prompt(corpus: list[dict]) -> str:
+    """Format the corpus as a text block for the LLM."""
+    lines = [
+        f"CORPUS: {len(corpus)} feedback memories (last {CORPUS_LOOKBACK_DAYS} days)",
+        "",
+    ]
+    for i, m in enumerate(corpus, 1):
+        block = [
+            f"MEMORY {i}:",
+            f"  id: {m.get('id', '?')}",
+            f"  name: {m.get('name', '?')}",
+            f"  project: {m.get('project', 'null')}",
+            f"  requires_review: {m.get('requires_review', False)}",
+            f"  created_at: {m.get('created_at', '?')}",
+        ]
+        if m.get("tags"):
+            block.append(f"  tags: {', '.join(m['tags'])}")
+        if m.get("description"):
+            block.append(f"  description: {m['description']}")
+        if m.get("content"):
+            # Truncate long content to keep prompt within budget
+            content = m["content"]
+            if len(content) > 800:
+                content = content[:800] + "…"
+            block.append(f"  content: {content}")
+        lines.append("\n".join(block))
+
+    lines.append(
+        "\n---\n"
+        "Analyze the above corpus and output strict JSON with "
+        "new_candidates and/or merge_proposals. "
+        "Empty arrays are valid — only emit when there is a genuine insight."
+    )
+    return "\n".join(lines)
+
+
+def _parse_response(text: str, corpus_ids: set[str]) -> tuple[list[dict], list[dict]] | None:
+    """Parse LLM JSON response.
+
+    Returns ``(new_candidates, merge_proposals)`` or ``None`` on
+    unrecoverable parse failure. Invalid entries are silently dropped
+    rather than failing the entire response.
+
+    Corpus-level validation:
+      - ``merge_targets`` must reference UUIDs present in ``corpus_ids``.
+      - Duplicate names within each category are dropped (keep first).
+    """
+    if not text:
+        return None
+    first = text.find("{")
+    last = text.rfind("}")
+    if first < 0 or last <= first:
+        return None
+    try:
+        data = json.loads(text[first : last + 1])
+    except json.JSONDecodeError:
+        return None
+
+    raw_candidates = data.get("new_candidates") or []
+    raw_proposals = data.get("merge_proposals") or []
+
+    if not isinstance(raw_candidates, list) or not isinstance(raw_proposals, list):
+        return None
+
+    # Validate new candidates
+    seen_names: set[str] = set()
+    new_candidates: list[dict] = []
+    for c in raw_candidates:
+        if not isinstance(c, dict):
+            continue
+        name = c.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if name in seen_names:
+            continue
+        mtype = c.get("type")
+        if mtype not in ("user", "project", "decision", "feedback", "reference"):
+            continue
+        c.setdefault("description", "")
+        c.setdefault("content", "")
+        c.setdefault("tags", [])
+        c.setdefault("reasoning", "")
+        # Strip merge_targets if LLM incorrectly set them on a new candidate
+        c.pop("merge_targets", None)
+        seen_names.add(name)
+        new_candidates.append(c)
+
+    # Validate merge proposals
+    seen_names_p: set[str] = set()
+    merge_proposals: list[dict] = []
+    for p in raw_proposals:
+        if not isinstance(p, dict):
+            continue
+        name = p.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if name in seen_names_p:
+            continue
+        mtype = p.get("type")
+        if mtype not in ("user", "project", "decision", "feedback", "reference"):
+            continue
+        mt = p.get("merge_targets")
+        if not isinstance(mt, list) or len(mt) < 2:
+            continue
+        # Filter to known corpus UUIDs
+        valid_mt = [u for u in mt if isinstance(u, str) and u in corpus_ids]
+        if len(valid_mt) < 2:
+            continue
+        p.setdefault("description", "")
+        p.setdefault("content", "")
+        p.setdefault("tags", [])
+        p.setdefault("reasoning", "")
+        p["merge_targets"] = valid_mt
+        seen_names_p.add(name)
+        merge_proposals.append(p)
+
+    return (new_candidates, merge_proposals)
+
+
+def _fallback_empty(why: str) -> tuple[list[dict], list[dict]]:
+    """Return empty results when the LLM call or parse fails."""
+    print(f"  ! consolidate fallback: {why}", file=sys.stderr)
+    return ([], [])
+
+
+def consolidate(
+    corpus: list[dict],
+    *,
+    api_key: str,
+    api_url: str | None = None,
+    model: str = DEFAULT_ANTHROPIC_MODEL,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> tuple[list[dict], list[dict]]:
+    """Pure consolidation function — the Dreamer's core.
+
+    Takes a corpus of ``feedback`` memory dicts, calls the configured LLM,
+    and returns ``(new_candidates, merge_proposals)``. Both lists may be
+    empty when the corpus is sparse or the LLM finds nothing worth emitting.
+
+    ``api_url`` defaults to the Anthropic Messages API. Compatible with
+    any ``/v1/messages`` endpoint (Ollama, DeepSeek) that accepts the
+    Anthropic schema.
+    """
+    if not api_key:
+        return _fallback_empty("no API key configured")
+    if not corpus:
+        return ([], [])
+
+    resolved_url = api_url or DEFAULT_ANTHROPIC_URL
+    corpus_ids = {m["id"] for m in corpus if isinstance(m.get("id"), str)}
+    user_message = _build_corpus_prompt(corpus)
+
+    body = {
+        "model": model,
+        "max_tokens": MAX_TOKENS,
+        "system": DREAMER_SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": user_message}],
+    }
+
+    try:
+        with httpx.Client(timeout=timeout) as http:
+            resp = http.post(
+                resolved_url,
+                headers={
+                    "x-api-key": api_key,
+                    "anthropic-version": ANTHROPIC_VERSION,
+                    "content-type": "application/json",
+                },
+                json=body,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+    except httpx.HTTPError as e:
+        return _fallback_empty(f"http_error: {type(e).__name__}")
+    except ValueError:
+        return _fallback_empty("invalid_json_payload")
+
+    blocks = payload.get("content", [])
+    text = ""
+    for b in blocks:
+        if isinstance(b, dict) and b.get("type") == "text":
+            text = b.get("text", "")
+            break
+
+    parsed = _parse_response(text, corpus_ids)
+    if parsed is None:
+        return _fallback_empty("unparseable_response")
+
+    candidates, proposals = parsed
+
+    # Enforce per-category caps
+    candidates = candidates[:MAX_NEW_CANDIDATES]
+    proposals = proposals[:MAX_MERGE_PROPOSALS]
+
+    return (candidates, proposals)
+
+
+# ---------------------------------------------------------------------------
+# DB writers
+# ---------------------------------------------------------------------------
+
+VALID_TYPES = ("user", "project", "decision", "feedback", "reference")
+
+
+def _row_for_memory(
+    item: dict,
+    run_id: str,
+    *,
+    merge_targets: list[str] | None = None,
+) -> dict:
+    """Build a DB row dict from a candidate or proposal."""
+    mtype = item.get("type", "project")
+    if mtype not in VALID_TYPES:
+        mtype = "project"
+    row: dict = {
+        "project": item.get("project"),
+        "name": item["name"].strip(),
+        "type": mtype,
+        "description": (item.get("description") or "").strip()[:500],
+        "content": (item.get("content") or "").strip(),
+        "tags": [t.strip() for t in (item.get("tags") or []) if isinstance(t, str) and t.strip()],
+        "requires_review": True,
+        "source_provenance": f"dreamer:{run_id}",
+        "derivation_run_id": run_id,
+    }
+    if merge_targets is not None:
+        row["merge_targets"] = merge_targets
+    return row
+
+
+def insert_candidates(client, candidates: list[dict], run_id: str) -> list[str]:
+    """Insert new candidate memories. Returns list of inserted IDs."""
+    ids: list[str] = []
+    for c in candidates:
+        row = _row_for_memory(c, run_id)
+        try:
+            resp = client.table("memories").insert(row).execute()
+            data = resp.data or []
+            if data and data[0].get("id"):
+                ids.append(data[0]["id"])
+        except Exception as e:
+            print(f"  ! candidate insert failed ({c.get('name')}): {e}", file=sys.stderr)
+    return ids
+
+
+def insert_merge_proposals(client, proposals: list[dict], run_id: str) -> list[str]:
+    """Insert merge proposal memories. Returns list of inserted IDs."""
+    ids: list[str] = []
+    for p in proposals:
+        row = _row_for_memory(p, run_id, merge_targets=p["merge_targets"])
+        try:
+            resp = client.table("memories").insert(row).execute()
+            data = resp.data or []
+            if data and data[0].get("id"):
+                ids.append(data[0]["id"])
+        except Exception as e:
+            print(f"  ! merge_proposal insert failed ({p.get('name')}): {e}", file=sys.stderr)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Event emitter
+# ---------------------------------------------------------------------------
+
+
+def write_event(
+    client,
+    *,
+    run_id: str,
+    status: str,
+    title: str,
+    payload: dict,
+) -> str | None:
+    """Insert one ``dreamer_run`` row into events. Best-effort."""
+    try:
+        resp = (
+            client.table("events")
+            .insert(
+                {
+                    "event_type": "dreamer_run",
+                    "severity": "info" if status == "ok" else "medium",
+                    "repo": "Osasuwu/jarvis",
+                    "source": "scheduled_task",
+                    "title": title,
+                    "payload": payload,
+                }
+            )
+            .execute()
+        )
+        data = resp.data or []
+        return data[0]["id"] if data else None
+    except Exception as e:
+        print(f"! event insert failed: {e}", file=sys.stderr)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip the trigger check (pending-count >= 30 OR >= 7d since last run). "
+        "Use for ad-hoc runs and smoke tests.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run the pipeline but skip all DB writes (inserts + event). "
+        "Prints what would be written to stderr.",
+    )
+    p.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Override the LLM model (overrides DREAMER_MODEL and ANTHROPIC defaults).",
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help=f"LLM API timeout in seconds (default {DEFAULT_TIMEOUT})",
+    )
+    args = p.parse_args()
+
+    sb_url = os.environ.get("SUPABASE_URL")
+    sb_key = os.environ.get("SUPABASE_KEY")
+    if not sb_url or not sb_key:
+        print("SUPABASE_URL / SUPABASE_KEY missing from env", file=sys.stderr)
+        return 2
+
+    api_key, api_url, model = _llm_config()
+    if args.model:
+        model = args.model
+    if not api_key:
+        print(
+            "No LLM API key found. Set DREAMER_API_KEY or ANTHROPIC_API_KEY.",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = create_client(sb_url, sb_key)
+    run_id = str(uuid.uuid4())
+    started_at = datetime.now(timezone.utc).isoformat()
+
+    # ---- Trigger check ---------------------------------------------------
+    if not args.force:
+        should_run, reason = check_trigger(client)
+        if not should_run:
+            recap = {
+                "status": "skipped",
+                "reason": reason,
+                "run_id": run_id,
+                "started_at": started_at,
+            }
+            print(json.dumps(recap, indent=2, default=str))
+            return 0
+        print(f"Trigger fired: {reason}", file=sys.stderr)
+    else:
+        print("--force: trigger check skipped", file=sys.stderr)
+
+    # ---- Corpus fetch ----------------------------------------------------
+    corpus = fetch_corpus(client)
+    print(f"Corpus: {len(corpus)} feedback memory/ies", file=sys.stderr)
+
+    if not corpus:
+        recap = {
+            "status": "ok",
+            "reason": "corpus_empty",
+            "run_id": run_id,
+            "started_at": started_at,
+            "corpus_size": 0,
+            "new_candidates": 0,
+            "merge_proposals": 0,
+        }
+        event_id = write_event(
+            client,
+            run_id=run_id,
+            status="ok",
+            title="Dreamer run — corpus empty, no output",
+            payload={**recap, "event_id": None},
+        )
+        recap["event_id"] = event_id
+        print(json.dumps(recap, indent=2, default=str))
+        return 0
+
+    # ---- Consolidate -----------------------------------------------------
+    t0 = time.monotonic()
+    new_candidates, merge_proposals = consolidate(
+        corpus, api_key=api_key, api_url=api_url, model=model, timeout=args.timeout
+    )
+    duration = time.monotonic() - t0
+
+    print(
+        f"Consolidation: {len(new_candidates)} candidate(s), "
+        f"{len(merge_proposals)} merge proposal(s) in {duration:.1f}s",
+        file=sys.stderr,
+    )
+
+    # ---- Write results ---------------------------------------------------
+    candidate_ids: list[str] = []
+    proposal_ids: list[str] = []
+
+    if not args.dry_run:
+        if new_candidates:
+            candidate_ids = insert_candidates(client, new_candidates, run_id)
+            print(
+                f"  Inserted {len(candidate_ids)}/{len(new_candidates)} candidates",
+                file=sys.stderr,
+            )
+        if merge_proposals:
+            proposal_ids = insert_merge_proposals(client, merge_proposals, run_id)
+            print(
+                f"  Inserted {len(proposal_ids)}/{len(merge_proposals)} merge proposals",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            f"  --dry-run: would insert {len(new_candidates)} candidate(s), "
+            f"{len(merge_proposals)} merge proposal(s)",
+            file=sys.stderr,
+        )
+        # Still report IDs for recap
+        candidate_ids = [f"(dry-run) {c.get('name', '?')}" for c in new_candidates]
+        proposal_ids = [f"(dry-run) {p.get('name', '?')}" for p in merge_proposals]
+
+    # ---- Event -----------------------------------------------------------
+    payload = {
+        "run_id": run_id,
+        "started_at": started_at,
+        "duration_s": round(duration, 2),
+        "corpus_size": len(corpus),
+        "new_candidates": len(new_candidates),
+        "candidate_inserted": len(candidate_ids),
+        "merge_proposals": len(merge_proposals),
+        "proposal_inserted": len(proposal_ids),
+        "model": model,
+        "dry_run": args.dry_run,
+        "force": args.force,
+    }
+    total = len(new_candidates) + len(merge_proposals)
+    total_inserted = len(candidate_ids) + len(proposal_ids)
+    title_status = "dry-run" if args.dry_run else "ok"
+    title = (
+        f"Dreamer run ({title_status}) — {len(new_candidates)} candidates, "
+        f"{len(merge_proposals)} merge proposals "
+        f"(corpus {len(corpus)}, {duration:.1f}s)"
+    )
+    event_id = write_event(
+        client,
+        run_id=run_id,
+        status=title_status,
+        title=title,
+        payload=payload,
+    )
+
+    recap = {
+        "status": title_status,
+        "event_id": event_id,
+        "run_id": run_id,
+        "title": title,
+        "started_at": started_at,
+        "duration_s": round(duration, 2),
+        "corpus_size": len(corpus),
+        "new_candidates": len(new_candidates),
+        "merge_proposals": len(merge_proposals),
+        "candidate_ids": candidate_ids,
+        "proposal_ids": proposal_ids,
+        "dry_run": args.dry_run,
+        "needs_review": total_inserted > 0,
+    }
+    print(json.dumps(recap, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -1,0 +1,614 @@
+"""Unit tests for scripts/dreamer-run.py — S4 Dreamer consolidation pipeline.
+
+Covers:
+  - ``consolidate()`` pure function with controlled LLM responses
+  - ``_parse_response()`` JSON extraction and validation
+  - Trigger logic (pending-count / days-since thresholds)
+  - ``fetch_corpus()`` filtering and cap
+
+Network + DB are stubbed via ``unittest.mock``. The ``consolidate()`` tests
+mock ``httpx.Client`` to control LLM output. Trigger and corpus tests operate
+on the pure logic / stubbed DB patterns so they don't need a real Supabase.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub httpx / supabase / dotenv if not installed so the module import works
+# in minimal CI (same pattern as test_consolidation_review.py).
+for name in ("httpx", "supabase", "dotenv"):
+    try:
+        __import__(name)
+    except ImportError:
+        mod = types.ModuleType(name)
+        if name == "supabase":
+            mod.create_client = lambda *a, **k: None  # type: ignore[attr-defined]
+        if name == "dotenv":
+            mod.load_dotenv = lambda *a, **k: None  # type: ignore[attr-defined]
+        sys.modules[name] = mod
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "dreamer-run.py"
+
+spec = importlib.util.spec_from_file_location("dreamer_run", SCRIPT_PATH)
+assert spec and spec.loader
+dreamer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(dreamer)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_corpus_memory(
+    *,
+    idx: int = 1,
+    name: str = "",
+    content: str = "Test feedback content",
+    project: str | None = "jarvis",
+    tags: list[str] | None = None,
+) -> dict:
+    uid = str(uuid.uuid4())
+    return {
+        "id": uid,
+        "name": name or f"test_feedback_{idx}",
+        "type": "feedback",
+        "project": project,
+        "description": f"Test feedback #{idx}",
+        "content": content,
+        "tags": tags or ["feedback", "test"],
+        "requires_review": False,
+        "created_at": f"2026-05-{10+idx:02d}T00:00:00Z",
+        "updated_at": f"2026-05-{10+idx:02d}T00:00:00Z",
+    }
+
+
+def _make_llm_response(
+    new_candidates: list[dict] | None = None,
+    merge_proposals: list[dict] | None = None,
+) -> MagicMock:
+    """Return a mocked httpx response with controlled JSON body.
+
+    The returned mock has ``.json()`` returning the Anthropic Messages
+    payload shape containing the given candidates/proposals as text content.
+    """
+    payload = {
+        "new_candidates": new_candidates or [],
+        "merge_proposals": merge_proposals or [],
+    }
+    resp = MagicMock()
+    resp.json.return_value = {
+        "content": [{"type": "text", "text": json.dumps(payload)}],
+    }
+    return resp
+
+
+def _make_mock_http(resp: MagicMock) -> MagicMock:
+    """Return a mock ``httpx.Client`` whose ``.post`` returns ``resp``."""
+    http = MagicMock()
+    http.post.return_value = resp
+    return http
+
+
+# ---------------------------------------------------------------------------
+# _parse_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseResponse:
+    def test_empty_text_returns_none(self):
+        assert dreamer._parse_response("", set()) is None
+        assert dreamer._parse_response("   ", set()) is None
+
+    def test_no_json_returns_none(self):
+        assert dreamer._parse_response("just prose", set()) is None
+
+    def test_valid_empty_output(self):
+        text = '{"new_candidates": [], "merge_proposals": []}'
+        result = dreamer._parse_response(text, set())
+        assert result is not None
+        candidates, proposals = result
+        assert candidates == []
+        assert proposals == []
+
+    def test_new_candidate_with_valid_type(self):
+        text = json.dumps({
+            "new_candidates": [
+                {
+                    "name": "test_insight",
+                    "type": "project",
+                    "project": "jarvis",
+                    "description": "A test insight",
+                    "content": "Test content here",
+                    "tags": ["dreamer", "test"],
+                    "reasoning": "This is a test",
+                }
+            ],
+            "merge_proposals": [],
+        })
+        result = dreamer._parse_response(text, set())
+        assert result is not None
+        candidates, proposals = result
+        assert len(candidates) == 1
+        assert candidates[0]["name"] == "test_insight"
+        assert candidates[0]["type"] == "project"
+        assert candidates[0]["project"] == "jarvis"
+
+    def test_new_candidate_invalid_type_is_dropped(self):
+        text = json.dumps({
+            "new_candidates": [
+                {
+                    "name": "bad_type",
+                    "type": "invalid_type",
+                    "description": "bad",
+                    "content": "bad",
+                }
+            ],
+            "merge_proposals": [],
+        })
+        result = dreamer._parse_response(text, set())
+        assert result is not None
+        candidates, _ = result
+        assert len(candidates) == 0
+
+    def test_merge_proposal_requires_two_or_more_targets(self):
+        corpus_ids = {"id-1", "id-2", "id-3"}
+        text = json.dumps({
+            "new_candidates": [],
+            "merge_proposals": [
+                {
+                    "name": "valid_merge",
+                    "type": "feedback",
+                    "description": "Merged feedback",
+                    "content": "Merged content",
+                    "tags": ["dreamer"],
+                    "merge_targets": ["id-1", "id-2"],
+                    "reasoning": "These overlap",
+                },
+                {
+                    "name": "single_target",
+                    "type": "feedback",
+                    "description": "Only one target",
+                    "content": "Content",
+                    "tags": ["dreamer"],
+                    "merge_targets": ["id-1"],
+                    "reasoning": "Only one",
+                },
+                {
+                    "name": "nonexistent_target",
+                    "type": "feedback",
+                    "description": "Target not in corpus",
+                    "content": "Content",
+                    "tags": ["dreamer"],
+                    "merge_targets": ["id-1", "no-such-id"],
+                    "reasoning": "Bad target",
+                },
+            ],
+        })
+        result = dreamer._parse_response(text, corpus_ids)
+        assert result is not None
+        _, proposals = result
+        # Only the first proposal has both targets in corpus_ids
+        assert len(proposals) == 1
+        assert proposals[0]["name"] == "valid_merge"
+
+    def test_merge_proposal_targets_filtered_to_corpus_ids(self):
+        corpus_ids = {"real-uuid-1", "real-uuid-2"}
+        text = json.dumps({
+            "new_candidates": [],
+            "merge_proposals": [
+                {
+                    "name": "partial_filter",
+                    "type": "feedback",
+                    "description": "One real, one fake",
+                    "content": "Content",
+                    "tags": ["dreamer"],
+                    "merge_targets": ["real-uuid-1", "fake-uuid", "real-uuid-2"],
+                    "reasoning": "Mixed targets",
+                },
+            ],
+        })
+        result = dreamer._parse_response(text, corpus_ids)
+        assert result is not None
+        _, proposals = result
+        # fake-uuid is filtered out, but real-uuid-1 and real-uuid-2 remain
+        assert len(proposals) == 1
+        assert set(proposals[0]["merge_targets"]) == {"real-uuid-1", "real-uuid-2"}
+
+    def test_new_candidate_strips_merge_targets(self):
+        """New candidates should not carry merge_targets even if LLM emits them."""
+        text = json.dumps({
+            "new_candidates": [
+                {
+                    "name": "should_not_have_targets",
+                    "type": "project",
+                    "description": "A candidate",
+                    "content": "Content",
+                    "merge_targets": ["some-uuid"],
+                }
+            ],
+            "merge_proposals": [],
+        })
+        result = dreamer._parse_response(text, {"some-uuid"})
+        assert result is not None
+        candidates, _ = result
+        assert len(candidates) == 1
+        assert "merge_targets" not in candidates[0]
+
+    def test_duplicate_names_deduplicated(self):
+        text = json.dumps({
+            "new_candidates": [
+                {
+                    "name": "duplicate_name",
+                    "type": "project",
+                    "description": "First",
+                    "content": "First content",
+                },
+                {
+                    "name": "duplicate_name",
+                    "type": "project",
+                    "description": "Second (duplicate)",
+                    "content": "Second content",
+                },
+            ],
+            "merge_proposals": [],
+        })
+        result = dreamer._parse_response(text, set())
+        assert result is not None
+        candidates, _ = result
+        assert len(candidates) == 1
+        assert candidates[0]["description"] == "First"
+
+    def test_prose_prefix_and_suffix(self):
+        """LLM sometimes adds prose around the JSON. Parser must ignore it."""
+        text = (
+            "Here is my analysis:\n\n"
+            '{\n  "new_candidates": [],\n  "merge_proposals": []\n}\n\n'
+            "Hope this helps!"
+        )
+        result = dreamer._parse_response(text, set())
+        assert result is not None
+        candidates, proposals = result
+        assert candidates == []
+        assert proposals == []
+
+
+# ---------------------------------------------------------------------------
+# consolidate() — pure function with mocked httpx
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidate:
+    """Tests the core ``consolidate(corpus)`` pure function.
+
+    httpx.Client is mocked to return controlled LLM responses.
+    """
+
+    def test_sparse_corpus_returns_empty(self):
+        """AC: given a sparse corpus, consolidate runs without error
+        and returns empty lists."""
+        corpus = []
+        candidates, proposals = dreamer.consolidate(
+            corpus, api_key="test-key"
+        )
+        assert candidates == []
+        assert proposals == []
+
+    def test_no_api_key_returns_empty(self):
+        corpus = [_make_corpus_memory(idx=1)]
+        candidates, proposals = dreamer.consolidate(corpus, api_key="")
+        assert candidates == []
+        assert proposals == []
+
+    def test_llm_http_error_returns_empty(self):
+        corpus = [_make_corpus_memory(idx=1)]
+        http = MagicMock()
+        http.post.side_effect = dreamer.httpx.HTTPError("connection failed")
+
+        with patch.object(dreamer.httpx, "Client") as mock_cls:
+            mock_cls.return_value.__enter__.return_value = http
+            candidates, proposals = dreamer.consolidate(
+                corpus, api_key="test-key"
+            )
+
+        assert candidates == []
+        assert proposals == []
+
+    def test_near_duplicate_corpus_returns_merge_proposal(self):
+        """AC: given a corpus with two near-duplicate accepted feedback
+        memories, consolidate returns at least one merge proposal whose
+        merge_targets contains both UUIDs."""
+        mem1 = _make_corpus_memory(idx=1, content="User prefers async workflows for code review")
+        mem2 = _make_corpus_memory(idx=2, content="User strongly prefers async code review workflows")
+        corpus = [mem1, mem2]
+
+        merge_proposals = [
+            {
+                "name": "async_review_preference",
+                "type": "user",
+                "project": None,
+                "description": "User prefers async code review workflows",
+                "content": "User consistently prefers async workflows for code review, "
+                "as seen in multiple feedback entries.",
+                "tags": ["dreamer", "workflow", "code-review"],
+                "merge_targets": [mem1["id"], mem2["id"]],
+                "reasoning": "Both entries describe the same user preference for async code review",
+            }
+        ]
+        llm_resp = _make_llm_response(merge_proposals=merge_proposals)
+        http = _make_mock_http(llm_resp)
+
+        with patch.object(dreamer.httpx, "Client") as mock_cls:
+            mock_cls.return_value.__enter__.return_value = http
+            candidates, proposals = dreamer.consolidate(
+                corpus, api_key="test-key"
+            )
+
+        assert len(proposals) >= 1
+        found = any(
+            mem1["id"] in p["merge_targets"] and mem2["id"] in p["merge_targets"]
+            for p in proposals
+        )
+        assert found, (
+            f"Expected a merge proposal referencing both {mem1['id']} "
+            f"and {mem2['id']}, got: {proposals}"
+        )
+
+    def test_unparseable_llm_response_returns_empty(self):
+        corpus = [_make_corpus_memory(idx=1)]
+        resp = MagicMock()
+        resp.json.return_value = {
+            "content": [{"type": "text", "text": "not json at all"}],
+        }
+        http = _make_mock_http(resp)
+
+        with patch.object(dreamer.httpx, "Client") as mock_cls:
+            mock_cls.return_value.__enter__.return_value = http
+            candidates, proposals = dreamer.consolidate(
+                corpus, api_key="test-key"
+            )
+
+        assert candidates == []
+        assert proposals == []
+
+    def test_response_capped_at_max(self):
+        """Enforce per-category caps (MAX_NEW_CANDIDATES, MAX_MERGE_PROPOSALS)."""
+        corpus = [_make_corpus_memory(idx=i) for i in range(10)]
+        many_candidates = [
+            {
+                "name": f"insight_{i}",
+                "type": "project",
+                "project": "jarvis",
+                "description": f"Insight #{i}",
+                "content": f"Content {i}",
+                "tags": ["dreamer"],
+                "reasoning": "Test",
+            }
+            for i in range(20)
+        ]
+        llm_resp = _make_llm_response(new_candidates=many_candidates)
+        http = _make_mock_http(llm_resp)
+
+        with patch.object(dreamer.httpx, "Client") as mock_cls:
+            mock_cls.return_value.__enter__.return_value = http
+            candidates, proposals = dreamer.consolidate(
+                corpus, api_key="test-key"
+            )
+
+        assert len(candidates) <= dreamer.MAX_NEW_CANDIDATES
+
+
+# ---------------------------------------------------------------------------
+# Trigger logic
+# ---------------------------------------------------------------------------
+
+
+class TestTrigger:
+    """Tests the trigger-check logic with a mocked client."""
+
+    @staticmethod
+    def _mock_client_with_pending(count: int) -> MagicMock:
+        """Build a client mock returning ``count`` pending candidates.
+
+        Builds a proper chain so that::
+            client.table("memories").select().eq().is_().execute()
+        returns a resp with ``.count = count``.
+        """
+        client = MagicMock()
+        exec_resp = MagicMock()
+        exec_resp.count = count
+
+        execute_mock = MagicMock()
+        execute_mock.execute.return_value = exec_resp
+
+        is_mock = MagicMock()
+        is_mock.is_.return_value = execute_mock
+
+        eq_mock = MagicMock()
+        eq_mock.eq.return_value = is_mock
+
+        select_mock = MagicMock()
+        select_mock.select.return_value = eq_mock
+
+        client.table.return_value = select_mock
+        return client
+
+    @staticmethod
+    def _mock_client_with_events(
+        client: MagicMock, last_event_dt: str | None
+    ) -> MagicMock:
+        """Add events-table mocks to an existing client stub.
+
+        Builds a chain::
+            client.table("events").select().eq().order().limit().execute()
+        returns a resp with ``.data`` containing (or not) the last event.
+        """
+        rows = [{"created_at": last_event_dt}] if last_event_dt else []
+
+        exec_resp = MagicMock()
+        exec_resp.data = rows
+
+        limit_mock = MagicMock()
+        limit_mock.limit.return_value.execute.return_value = exec_resp
+
+        order_mock = MagicMock()
+        order_mock.order.return_value = limit_mock
+
+        eq_mock = MagicMock()
+        eq_mock.eq.return_value = order_mock
+
+        select_mock = MagicMock()
+        select_mock.select.return_value = eq_mock
+
+        def _table_side_effect(name: str):
+            if name == "memories":
+                return client.table.return_value
+            elif name == "events":
+                return select_mock
+            return MagicMock()
+
+        client.table.side_effect = _table_side_effect
+        return client
+
+    def test_pending_above_threshold_fires(self):
+        client = self._mock_client_with_pending(dreamer.PENDING_THRESHOLD + 5)
+        should_run, reason = dreamer.check_trigger(client)
+        assert should_run
+        assert "pending_candidate_count" in reason
+
+    def test_pending_below_threshold_and_recent_run_skips(self):
+        client = self._mock_client_with_pending(5)
+        client = self._mock_client_with_events(client, "2026-05-18T12:00:00Z")
+        should_run, reason = dreamer.check_trigger(client)
+        assert not should_run
+        assert "pending_candidate_count=5" in reason
+
+    def test_no_prior_run_fires(self):
+        """If there has never been a Dreamer run, trigger fires unconditionally."""
+        client = self._mock_client_with_pending(5)
+        client = self._mock_client_with_events(client, None)
+        should_run, reason = dreamer.check_trigger(client)
+        assert should_run
+        assert "no prior" in reason
+
+    def test_days_since_above_threshold_fires(self):
+        client = self._mock_client_with_pending(5)
+        client = self._mock_client_with_events(client, "2026-05-10T12:00:00Z")
+        should_run, reason = dreamer.check_trigger(client)
+        # Should fire because 10 >= 7 days
+        assert should_run
+        assert "days_since_last_run" in reason
+
+
+# ---------------------------------------------------------------------------
+# Corpus fetching (pure logic test via fetch_corpus client stub)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCorpus:
+    def test_respects_max_rows(self):
+        """Corpus fetch caps at MAX_CORPUS_ROWS."""
+        client = MagicMock()
+        execute_resp = MagicMock()
+        execute_resp.data = [_make_corpus_memory(idx=i) for i in range(250)]
+        query_mock = MagicMock()
+        query_mock.execute.return_value = execute_resp
+
+        (
+            client.table("memories")
+            .select()
+            .eq()
+            .gte()
+            .is_()
+            .order()
+            .limit()
+        ).return_value = query_mock
+
+        corpus = dreamer.fetch_corpus(client)
+        assert len(corpus) <= dreamer.MAX_CORPUS_ROWS
+
+    def test_filters_to_feedback_type(self):
+        """Only feedback-type memories are returned."""
+        client = MagicMock()
+        execute_resp = MagicMock()
+        execute_resp.data = [_make_corpus_memory(idx=1)]
+
+        # Track what eq filter was applied
+        table_mock = MagicMock()
+        select_mock = MagicMock()
+        eq_mock = MagicMock()
+        gte_mock = MagicMock()
+        is__mock = MagicMock()
+        order_mock = MagicMock()
+        limit_mock = MagicMock()
+
+        client.table.return_value = table_mock
+        table_mock.select.return_value = eq_mock
+        eq_mock.eq.return_value = gte_mock
+        gte_mock.gte.return_value = is__mock
+        is__mock.is_.return_value = order_mock
+        order_mock.order.return_value = limit_mock
+        limit_mock.limit.return_value = execute_resp
+
+        corpus = dreamer.fetch_corpus(client)
+        # Verify eq("type", "feedback") was called
+        eq_mock.eq.assert_called_once_with("type", "feedback")
+
+
+# ---------------------------------------------------------------------------
+# Integration-style: _row_for_memory output shape
+# ---------------------------------------------------------------------------
+
+
+class TestRowForMemory:
+    def test_candidate_row_has_correct_shape(self):
+        run_id = str(uuid.uuid4())
+        item = {
+            "name": "test_insight",
+            "type": "project",
+            "project": "jarvis",
+            "description": "Test description",
+            "content": "Test content",
+            "tags": ["dreamer", "test"],
+            "reasoning": "Test reasoning",
+        }
+        row = dreamer._row_for_memory(item, run_id)
+        assert row["name"] == "test_insight"
+        assert row["type"] == "project"
+        assert row["project"] == "jarvis"
+        assert row["requires_review"] is True
+        assert row["source_provenance"] == f"dreamer:{run_id}"
+        assert row["derivation_run_id"] == run_id
+        assert "merge_targets" not in row
+
+    def test_merge_proposal_row_has_merge_targets(self):
+        run_id = str(uuid.uuid4())
+        item = {
+            "name": "merged_insight",
+            "type": "feedback",
+            "project": None,
+            "description": "Merged description",
+            "content": "Merged content",
+            "tags": ["dreamer", "merge"],
+            "merge_targets": ["uuid-1", "uuid-2"],
+        }
+        row = dreamer._row_for_memory(item, run_id, merge_targets=item["merge_targets"])
+        assert row["requires_review"] is True
+        assert row["source_provenance"] == f"dreamer:{run_id}"
+        assert row["merge_targets"] == ["uuid-1", "uuid-2"]
+
+    def test_invalid_type_falls_back_to_project(self):
+        row = dreamer._row_for_memory(
+            {"name": "test", "type": "nope", "description": "", "content": ""},
+            run_id=str(uuid.uuid4()),
+        )
+        assert row["type"] == "project"

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -30,6 +30,20 @@ for name in ("httpx", "supabase", "dotenv"):
         __import__(name)
     except ImportError:
         mod = types.ModuleType(name)
+        if name == "httpx":
+            mod.HTTPError = type("HTTPError", (Exception,), {})  # type: ignore[attr-defined]
+
+            class _StubClient:
+                def __init__(self, *a, **k):
+                    pass
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *a):
+                    pass
+
+            mod.Client = _StubClient  # type: ignore[attr-defined]
         if name == "supabase":
             mod.create_client = lambda *a, **k: None  # type: ignore[attr-defined]
         if name == "dotenv":
@@ -420,18 +434,18 @@ class TestTrigger:
         """Build a client mock returning ``count`` pending candidates.
 
         Builds a proper chain so that::
-            client.table("memories").select().eq().is_().execute()
+            client.table("memories").select().eq().is_().limit().execute()
         returns a resp with ``.count = count``.
         """
         client = MagicMock()
         exec_resp = MagicMock()
         exec_resp.count = count
 
-        execute_mock = MagicMock()
-        execute_mock.execute.return_value = exec_resp
+        limit_result = MagicMock()
+        limit_result.execute.return_value = exec_resp
 
         is_mock = MagicMock()
-        is_mock.is_.return_value = execute_mock
+        is_mock.is_.return_value.limit.return_value = limit_result
 
         eq_mock = MagicMock()
         eq_mock.eq.return_value = is_mock
@@ -516,25 +530,33 @@ class TestTrigger:
 
 class TestFetchCorpus:
     def test_respects_max_rows(self):
-        """Corpus fetch caps at MAX_CORPUS_ROWS."""
+        """Corpus fetch passes MAX_CORPUS_ROWS to .limit()."""
         client = MagicMock()
+        expected_rows = [_make_corpus_memory(idx=i) for i in range(dreamer.MAX_CORPUS_ROWS)]
         execute_resp = MagicMock()
-        execute_resp.data = [_make_corpus_memory(idx=i) for i in range(250)]
-        query_mock = MagicMock()
-        query_mock.execute.return_value = execute_resp
+        execute_resp.data = expected_rows
 
-        (
-            client.table("memories")
-            .select()
-            .eq()
-            .gte()
-            .is_()
-            .order()
-            .limit()
-        ).return_value = query_mock
+        table_mock = MagicMock()
+        select_mock = MagicMock()
+        eq_mock = MagicMock()
+        gte_mock = MagicMock()
+        is__mock = MagicMock()
+        order_mock = MagicMock()
+        limit_result = MagicMock()
+        limit_result.execute.return_value = execute_resp
+
+        client.table.return_value = table_mock
+        table_mock.select.return_value = select_mock
+        select_mock.eq.return_value = eq_mock
+        eq_mock.gte.return_value = gte_mock
+        gte_mock.is_.return_value = is__mock
+        is__mock.order.return_value = order_mock
+        order_mock.limit.return_value = limit_result
 
         corpus = dreamer.fetch_corpus(client)
-        assert len(corpus) <= dreamer.MAX_CORPUS_ROWS
+
+        order_mock.limit.assert_called_once_with(dreamer.MAX_CORPUS_ROWS)
+        assert corpus == expected_rows
 
     def test_filters_to_feedback_type(self):
         """Only feedback-type memories are returned."""
@@ -550,6 +572,8 @@ class TestFetchCorpus:
         is__mock = MagicMock()
         order_mock = MagicMock()
         limit_mock = MagicMock()
+        limit_result = MagicMock()
+        limit_result.execute.return_value = execute_resp
 
         client.table.return_value = table_mock
         table_mock.select.return_value = eq_mock
@@ -557,11 +581,12 @@ class TestFetchCorpus:
         gte_mock.gte.return_value = is__mock
         is__mock.is_.return_value = order_mock
         order_mock.order.return_value = limit_mock
-        limit_mock.limit.return_value = execute_resp
+        limit_mock.limit.return_value = limit_result
 
         corpus = dreamer.fetch_corpus(client)
         # Verify eq("type", "feedback") was called
         eq_mock.eq.assert_called_once_with("type", "feedback")
+        assert corpus == execute_resp.data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -18,10 +18,9 @@ import json
 import sys
 import types
 import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 # Stub httpx / supabase / dotenv if not installed so the module import works
 # in minimal CI (same pattern as test_consolidation_review.py).
@@ -81,8 +80,8 @@ def _make_corpus_memory(
         "content": content,
         "tags": tags or ["feedback", "test"],
         "requires_review": False,
-        "created_at": f"2026-05-{10+idx:02d}T00:00:00Z",
-        "updated_at": f"2026-05-{10+idx:02d}T00:00:00Z",
+        "created_at": f"2026-05-{10 + idx:02d}T00:00:00Z",
+        "updated_at": f"2026-05-{10 + idx:02d}T00:00:00Z",
     }
 
 
@@ -135,20 +134,22 @@ class TestParseResponse:
         assert proposals == []
 
     def test_new_candidate_with_valid_type(self):
-        text = json.dumps({
-            "new_candidates": [
-                {
-                    "name": "test_insight",
-                    "type": "project",
-                    "project": "jarvis",
-                    "description": "A test insight",
-                    "content": "Test content here",
-                    "tags": ["dreamer", "test"],
-                    "reasoning": "This is a test",
-                }
-            ],
-            "merge_proposals": [],
-        })
+        text = json.dumps(
+            {
+                "new_candidates": [
+                    {
+                        "name": "test_insight",
+                        "type": "project",
+                        "project": "jarvis",
+                        "description": "A test insight",
+                        "content": "Test content here",
+                        "tags": ["dreamer", "test"],
+                        "reasoning": "This is a test",
+                    }
+                ],
+                "merge_proposals": [],
+            }
+        )
         result = dreamer._parse_response(text, set())
         assert result is not None
         candidates, proposals = result
@@ -158,17 +159,19 @@ class TestParseResponse:
         assert candidates[0]["project"] == "jarvis"
 
     def test_new_candidate_invalid_type_is_dropped(self):
-        text = json.dumps({
-            "new_candidates": [
-                {
-                    "name": "bad_type",
-                    "type": "invalid_type",
-                    "description": "bad",
-                    "content": "bad",
-                }
-            ],
-            "merge_proposals": [],
-        })
+        text = json.dumps(
+            {
+                "new_candidates": [
+                    {
+                        "name": "bad_type",
+                        "type": "invalid_type",
+                        "description": "bad",
+                        "content": "bad",
+                    }
+                ],
+                "merge_proposals": [],
+            }
+        )
         result = dreamer._parse_response(text, set())
         assert result is not None
         candidates, _ = result
@@ -176,38 +179,40 @@ class TestParseResponse:
 
     def test_merge_proposal_requires_two_or_more_targets(self):
         corpus_ids = {"id-1", "id-2", "id-3"}
-        text = json.dumps({
-            "new_candidates": [],
-            "merge_proposals": [
-                {
-                    "name": "valid_merge",
-                    "type": "feedback",
-                    "description": "Merged feedback",
-                    "content": "Merged content",
-                    "tags": ["dreamer"],
-                    "merge_targets": ["id-1", "id-2"],
-                    "reasoning": "These overlap",
-                },
-                {
-                    "name": "single_target",
-                    "type": "feedback",
-                    "description": "Only one target",
-                    "content": "Content",
-                    "tags": ["dreamer"],
-                    "merge_targets": ["id-1"],
-                    "reasoning": "Only one",
-                },
-                {
-                    "name": "nonexistent_target",
-                    "type": "feedback",
-                    "description": "Target not in corpus",
-                    "content": "Content",
-                    "tags": ["dreamer"],
-                    "merge_targets": ["id-1", "no-such-id"],
-                    "reasoning": "Bad target",
-                },
-            ],
-        })
+        text = json.dumps(
+            {
+                "new_candidates": [],
+                "merge_proposals": [
+                    {
+                        "name": "valid_merge",
+                        "type": "feedback",
+                        "description": "Merged feedback",
+                        "content": "Merged content",
+                        "tags": ["dreamer"],
+                        "merge_targets": ["id-1", "id-2"],
+                        "reasoning": "These overlap",
+                    },
+                    {
+                        "name": "single_target",
+                        "type": "feedback",
+                        "description": "Only one target",
+                        "content": "Content",
+                        "tags": ["dreamer"],
+                        "merge_targets": ["id-1"],
+                        "reasoning": "Only one",
+                    },
+                    {
+                        "name": "nonexistent_target",
+                        "type": "feedback",
+                        "description": "Target not in corpus",
+                        "content": "Content",
+                        "tags": ["dreamer"],
+                        "merge_targets": ["id-1", "no-such-id"],
+                        "reasoning": "Bad target",
+                    },
+                ],
+            }
+        )
         result = dreamer._parse_response(text, corpus_ids)
         assert result is not None
         _, proposals = result
@@ -217,20 +222,22 @@ class TestParseResponse:
 
     def test_merge_proposal_targets_filtered_to_corpus_ids(self):
         corpus_ids = {"real-uuid-1", "real-uuid-2"}
-        text = json.dumps({
-            "new_candidates": [],
-            "merge_proposals": [
-                {
-                    "name": "partial_filter",
-                    "type": "feedback",
-                    "description": "One real, one fake",
-                    "content": "Content",
-                    "tags": ["dreamer"],
-                    "merge_targets": ["real-uuid-1", "fake-uuid", "real-uuid-2"],
-                    "reasoning": "Mixed targets",
-                },
-            ],
-        })
+        text = json.dumps(
+            {
+                "new_candidates": [],
+                "merge_proposals": [
+                    {
+                        "name": "partial_filter",
+                        "type": "feedback",
+                        "description": "One real, one fake",
+                        "content": "Content",
+                        "tags": ["dreamer"],
+                        "merge_targets": ["real-uuid-1", "fake-uuid", "real-uuid-2"],
+                        "reasoning": "Mixed targets",
+                    },
+                ],
+            }
+        )
         result = dreamer._parse_response(text, corpus_ids)
         assert result is not None
         _, proposals = result
@@ -240,18 +247,20 @@ class TestParseResponse:
 
     def test_new_candidate_strips_merge_targets(self):
         """New candidates should not carry merge_targets even if LLM emits them."""
-        text = json.dumps({
-            "new_candidates": [
-                {
-                    "name": "should_not_have_targets",
-                    "type": "project",
-                    "description": "A candidate",
-                    "content": "Content",
-                    "merge_targets": ["some-uuid"],
-                }
-            ],
-            "merge_proposals": [],
-        })
+        text = json.dumps(
+            {
+                "new_candidates": [
+                    {
+                        "name": "should_not_have_targets",
+                        "type": "project",
+                        "description": "A candidate",
+                        "content": "Content",
+                        "merge_targets": ["some-uuid"],
+                    }
+                ],
+                "merge_proposals": [],
+            }
+        )
         result = dreamer._parse_response(text, {"some-uuid"})
         assert result is not None
         candidates, _ = result
@@ -259,23 +268,25 @@ class TestParseResponse:
         assert "merge_targets" not in candidates[0]
 
     def test_duplicate_names_deduplicated(self):
-        text = json.dumps({
-            "new_candidates": [
-                {
-                    "name": "duplicate_name",
-                    "type": "project",
-                    "description": "First",
-                    "content": "First content",
-                },
-                {
-                    "name": "duplicate_name",
-                    "type": "project",
-                    "description": "Second (duplicate)",
-                    "content": "Second content",
-                },
-            ],
-            "merge_proposals": [],
-        })
+        text = json.dumps(
+            {
+                "new_candidates": [
+                    {
+                        "name": "duplicate_name",
+                        "type": "project",
+                        "description": "First",
+                        "content": "First content",
+                    },
+                    {
+                        "name": "duplicate_name",
+                        "type": "project",
+                        "description": "Second (duplicate)",
+                        "content": "Second content",
+                    },
+                ],
+                "merge_proposals": [],
+            }
+        )
         result = dreamer._parse_response(text, set())
         assert result is not None
         candidates, _ = result
@@ -311,9 +322,7 @@ class TestConsolidate:
         """AC: given a sparse corpus, consolidate runs without error
         and returns empty lists."""
         corpus = []
-        candidates, proposals = dreamer.consolidate(
-            corpus, api_key="test-key"
-        )
+        candidates, proposals = dreamer.consolidate(corpus, api_key="test-key")
         assert candidates == []
         assert proposals == []
 
@@ -330,9 +339,7 @@ class TestConsolidate:
 
         with patch.object(dreamer.httpx, "Client") as mock_cls:
             mock_cls.return_value.__enter__.return_value = http
-            candidates, proposals = dreamer.consolidate(
-                corpus, api_key="test-key"
-            )
+            candidates, proposals = dreamer.consolidate(corpus, api_key="test-key")
 
         assert candidates == []
         assert proposals == []
@@ -342,7 +349,9 @@ class TestConsolidate:
         memories, consolidate returns at least one merge proposal whose
         merge_targets contains both UUIDs."""
         mem1 = _make_corpus_memory(idx=1, content="User prefers async workflows for code review")
-        mem2 = _make_corpus_memory(idx=2, content="User strongly prefers async code review workflows")
+        mem2 = _make_corpus_memory(
+            idx=2, content="User strongly prefers async code review workflows"
+        )
         corpus = [mem1, mem2]
 
         merge_proposals = [
@@ -363,14 +372,11 @@ class TestConsolidate:
 
         with patch.object(dreamer.httpx, "Client") as mock_cls:
             mock_cls.return_value.__enter__.return_value = http
-            candidates, proposals = dreamer.consolidate(
-                corpus, api_key="test-key"
-            )
+            candidates, proposals = dreamer.consolidate(corpus, api_key="test-key")
 
         assert len(proposals) >= 1
         found = any(
-            mem1["id"] in p["merge_targets"] and mem2["id"] in p["merge_targets"]
-            for p in proposals
+            mem1["id"] in p["merge_targets"] and mem2["id"] in p["merge_targets"] for p in proposals
         )
         assert found, (
             f"Expected a merge proposal referencing both {mem1['id']} "
@@ -387,9 +393,7 @@ class TestConsolidate:
 
         with patch.object(dreamer.httpx, "Client") as mock_cls:
             mock_cls.return_value.__enter__.return_value = http
-            candidates, proposals = dreamer.consolidate(
-                corpus, api_key="test-key"
-            )
+            candidates, proposals = dreamer.consolidate(corpus, api_key="test-key")
 
         assert candidates == []
         assert proposals == []
@@ -414,9 +418,7 @@ class TestConsolidate:
 
         with patch.object(dreamer.httpx, "Client") as mock_cls:
             mock_cls.return_value.__enter__.return_value = http
-            candidates, proposals = dreamer.consolidate(
-                corpus, api_key="test-key"
-            )
+            candidates, proposals = dreamer.consolidate(corpus, api_key="test-key")
 
         assert len(candidates) <= dreamer.MAX_NEW_CANDIDATES
 
@@ -434,8 +436,10 @@ class TestTrigger:
         """Build a client mock returning ``count`` pending candidates.
 
         Builds a proper chain so that::
-            client.table("memories").select().eq().is_().limit().execute()
+            client.table("memories").select().eq().eq().is_().limit().execute()
         returns a resp with ``.count = count``.
+        The double eq() reflects fetch_pending_count's two filters:
+        eq("requires_review", True) then eq("type", "feedback").
         """
         client = MagicMock()
         exec_resp = MagicMock()
@@ -447,8 +451,11 @@ class TestTrigger:
         is_mock = MagicMock()
         is_mock.is_.return_value.limit.return_value = limit_result
 
+        type_eq_mock = MagicMock()
+        type_eq_mock.eq.return_value = is_mock  # second eq("type", "feedback") → is_mock
+
         eq_mock = MagicMock()
-        eq_mock.eq.return_value = is_mock
+        eq_mock.eq.return_value = type_eq_mock  # first eq("requires_review", True) → type_eq_mock
 
         select_mock = MagicMock()
         select_mock.select.return_value = eq_mock
@@ -457,9 +464,7 @@ class TestTrigger:
         return client
 
     @staticmethod
-    def _mock_client_with_events(
-        client: MagicMock, last_event_dt: str | None
-    ) -> MagicMock:
+    def _mock_client_with_events(client: MagicMock, last_event_dt: str | None) -> MagicMock:
         """Add events-table mocks to an existing client stub.
 
         Builds a chain::
@@ -501,7 +506,8 @@ class TestTrigger:
 
     def test_pending_below_threshold_and_recent_run_skips(self):
         client = self._mock_client_with_pending(5)
-        client = self._mock_client_with_events(client, "2026-05-18T12:00:00Z")
+        recent = (datetime.now(timezone.utc) - timedelta(days=4)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        client = self._mock_client_with_events(client, recent)
         should_run, reason = dreamer.check_trigger(client)
         assert not should_run
         assert "pending_candidate_count=5" in reason
@@ -566,7 +572,6 @@ class TestFetchCorpus:
 
         # Track what eq filter was applied
         table_mock = MagicMock()
-        select_mock = MagicMock()
         eq_mock = MagicMock()
         gte_mock = MagicMock()
         is__mock = MagicMock()


### PR DESCRIPTION
## Summary

Implements the Dreamer producer per ADR-0003 — a scheduled cross-corpus consolidation pass that reads pending + accepted `feedback` memories from the last 90 days (cap 200), invokes an LLM (Anthropic default, configurable for Ollama/DeepSeek), and emits two output kinds:

- **New candidates** — cross-cutting insights that emerge from looking at the corpus as a whole
- **Merge proposals** — candidates with non-empty `merge_targets` referencing live-memory UUIDs to supersede

### Pipeline

1. Trigger check: fires when pending-candidate count >= 30 OR >= 7 days since last run
2. Corpus fetch: `type=feedback` memories from last 90 days, cap 200 rows
3. `consolidate(corpus)` — pure function returning `(new_candidates, merge_proposals)`
4. DB writes: all rows set `requires_review=true`, `source_provenance='dreamer:<run-id>'`
5. Event: `dreamer_run` emitted to `events` table

### Configuration

| Env var | Purpose | Default |
|---|---|---|
| `DREAMER_API_KEY` | LLM API key (falls back to `ANTHROPIC_API_KEY`) | — |
| `DREAMER_API_URL` | LLM endpoint URL | Anthropic `/v1/messages` |
| `DREAMER_MODEL` | Model name | `claude-sonnet-4-6` |

### AC checklist

- [x] Scheduled task fires on (≥30 pending OR ≥7d since last run); both conditions independently exercised in tests
- [x] `consolidate(corpus)` returns `(new_candidates, merge_proposals)`; both may be empty
- [x] Inserted rows have `requires_review=true` and `source_provenance='dreamer:<run-id>'`
- [x] Merge proposals have non-empty `merge_targets` containing valid live-memory UUIDs
- [x] New candidates have `merge_targets IS NULL`
- [x] Fixture test: near-duplicate corpus → merge proposal with both UUIDs
- [x] Fixture test: sparse corpus → runs without error, returns empty lists
- [x] `memory_review_decide(action='merge')` — existing RPC from #681, not re-implemented
- [x] 200-row corpus cap; >200 rows truncate cleanly (newest kept)

## Test plan

- [x] `python3 -m pytest tests/test_dreamer.py -v` — 25 tests pass (parse, consolidate, trigger, corpus, row shape)
- [x] Syntax check: both new files compile cleanly

Closes #684

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>