### PR TITLE
feat(skills): S2 /learn skill — classifier queue drain + review renderer + volume watcher

### DIFF
--- a/.claude-userlevel/skills/learn/SKILL.md
+++ b/.claude-userlevel/skills/learn/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: learn
+description: "Drain the memory review queue: review pending classifier decisions, candidates, and merge proposals one-by-one. Use when the owner says /learn, or on the weekly cron."
+---
+
+# /learn — memory review queue drain
+
+Drains `memory_review_list` in f2 order (merges → candidates → classifier).
+This slice exercises only the **classifier** branch; merges and candidates
+are counted but rendered as no-op.
+
+## Quick start
+
+```
+/learn                     # drain pending classifier queue (cap 20)
+/learn --status            # peek at pending counts, no mutations
+```
+
+## How it works
+
+1. **Fetch** — call `memory_review_list(queue='classifier')` to get up to
+   20 pending classifier-provenance rows from `memories`.
+
+2. **Render** — for each row, call the renderer module to produce a
+   display block. Classifier UPDATE rows show a before/after diff of the
+   target memory (context fetched by name). ADD / DELETE / NOOP show a
+   compact card.
+
+3. **Present + act** — show each row to the owner, prompt for action:
+
+   - `approve` — calls `memory_review_decide(action='approve')`,
+     removes the row from the review queue.
+   - `reject` — calls `memory_review_decide(action='reject_classifier')`
+     with the owner's free-text reject reason.
+   - `skip` — leave row pending, move to next.
+
+4. **Finalize** — emit one `outcome_record` with:
+   ```
+   {
+     accepted: N,
+     rejected: N,
+     merged: 0,          # reserved for future slices
+     classifier_drained: N,
+     top_reject_reasons: ["..."],
+     pending_remaining: N,
+     duration_s: N
+   }
+   ```
+   Always emitted, even for zero-row runs.
+
+## --status mode
+
+```
+/learn --status
+```
+
+Prints per-queue pending counts from `memory_review_list` without
+mutating any row:
+
+- Pending classifier items
+- Pending candidates (future)
+- Pending merge proposals (future)
+
+No interactions, no writes, no `outcome_record`.
+
+## Safety rules
+
+- **Hard cap**: process at most 20 rows per `/learn` run (the
+  `limit_count` parameter of `memory_review_list`). Remaining rows stay
+  pending for the next run.
+- **Fail-stop**: if `memory_review_decide` errors mid-run, stop
+  immediately and report the error. Already-processed rows are committed;
+  the remaining rows stay pending.
+- **No defer**: the current slice does not support `defer`. If the owner
+  wants to skip a row, use `skip` (leaves it pending for next run).
+- **No blanket actions**: no `accept_all` or `reject_all`. Each row is
+  reviewed individually.
+- **Rollback safety**: rejected rows are marked `requires_review=false`
+  with `reject_reason` populated — not deleted. Recovery is a manual
+  DB update to flip `reject_reason = null, requires_review = true`.
+
+## Implementation notes
+
+The renderer lives at `mcp-memory/review_render.py` — import via
+`importlib` (hyphen in parent directory name):
+
+```python
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "review_render",
+    Path("mcp-memory") / "review_render.py",
+)
+render_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(render_mod)
+```
+
+For each classifier row that looks like an UPDATE (has a same-named
+live memory in the DB), pre-fetch the current memory as the
+`before_snapshot` before calling `render_mod.render_proposal(row, ctx)`.
+
+RPCs (`memory_review_list`, `memory_review_decide`) are called via
+`execute_sql` or direct supabase client — whichever is available in the
+current context.

--- a/.claude-userlevel/skills/learn/SKILL.md
+++ b/.claude-userlevel/skills/learn/SKILL.md
@@ -34,19 +34,31 @@ are counted but rendered as no-op.
      with the owner's free-text reject reason.
    - `skip` — leave row pending, move to next.
 
-4. **Finalize** — emit one `outcome_record` with:
-   ```
-   {
-     accepted: N,
-     rejected: N,
-     merged: 0,          # reserved for future slices
-     classifier_drained: N,
-     top_reject_reasons: ["..."],
-     pending_remaining: N,
-     duration_s: N
-   }
-   ```
-   Always emitted, even for zero-row runs.
+4. **Finalize** — in order:
+
+   a. **Emit `learn_run` event** into the `events` table to close the
+      debounce loop (prevents watcher re-firing within 24 h):
+      ```sql
+      INSERT INTO events (event_type, severity, repo, source, title, payload)
+      VALUES ('learn_run', 'info', 'Osasuwu/jarvis', 'learn_skill',
+              '/learn session complete', '{}');
+      ```
+      Use the `execute_sql` MCP tool or the Supabase client. **Always
+      emitted** — even for zero-row runs — so the watcher debounce is
+      set after every `/learn` invocation, not only watcher-triggered ones.
+
+   b. Emit one `outcome_record` with:
+      ```
+      {
+        accepted: N,
+        rejected: N,
+        merged: 0,          # reserved for future slices
+        classifier_drained: N,
+        top_reject_reasons: ["..."],
+        pending_remaining: N,
+        duration_s: N
+      }
+      ```
 
 ## --status mode
 
@@ -86,11 +98,17 @@ The renderer lives at `mcp-memory/review_render.py` — import via
 
 ```python
 import importlib.util
+import subprocess
 from pathlib import Path
 
+_repo_root = Path(
+    subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+    .decode()
+    .strip()
+)
 spec = importlib.util.spec_from_file_location(
     "review_render",
-    Path("mcp-memory") / "review_render.py",
+    _repo_root / "mcp-memory" / "review_render.py",
 )
 render_mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(render_mod)
@@ -98,7 +116,10 @@ spec.loader.exec_module(render_mod)
 
 For each classifier row that looks like an UPDATE (has a same-named
 live memory in the DB), pre-fetch the current memory as the
-`before_snapshot` before calling `render_mod.render_proposal(row, ctx)`.
+`before_snapshot` and set `ctx['decision'] = 'UPDATE'` **before** calling
+`render_mod.render_proposal(row, ctx)`. Without the explicit `'UPDATE'`
+key the diff branch never fires — the row renders as a compact card
+instead of a before/after diff.
 
 RPCs (`memory_review_list`, `memory_review_decide`) are called via
 `execute_sql` or direct supabase client — whichever is available in the

--- a/.claude-userlevel/skills/setup-tasks/SKILL.md
+++ b/.claude-userlevel/skills/setup-tasks/SKILL.md
@@ -74,6 +74,7 @@ Registered via `create_scheduled_task` MCP. All run on Workshop with full local 
 | verify | `47 16 * * 5` | Run `/verify` — verify pending outcomes, detect patterns, save lessons. |
 | memory-consolidation-weekly | `1 10 * * 0` | Run `/memory-consolidation-weekly` — weekly A-MEM Phase 5.1d-α consolidation apply (`scripts/consolidation-run.py`). |
 | memory-evolve-weekly | `0 11 * * 0` | Run `/memory-evolve-weekly` — weekly A-MEM Phase 5.2-γ neighbor-evolve apply (`scripts/evolve-run.py`, one hour after consolidation). |
+| learn | `0 10 * * 0` | Run `/learn` — drain the pending memory review queue (classifier, candidates, merge proposals). Weekly owner review cadence per ADR-0003. |
 
 ## Obsolete (disable)
 

--- a/mcp-memory/review_render.py
+++ b/mcp-memory/review_render.py
@@ -16,7 +16,6 @@ Display formats per row type:
 from __future__ import annotations
 
 import difflib
-from typing import Any
 
 
 def render_proposal(row: dict, context: dict | None = None) -> str:
@@ -40,7 +39,7 @@ def render_proposal(row: dict, context: dict | None = None) -> str:
           ``content``, ``tags`` keys at minimum.
         - ``reasoning`` (``str``) — classifier reasoning to display.
     """
-    source_prov = (row.get("source_provenance") or "")
+    source_prov = row.get("source_provenance") or ""
     is_classifier = source_prov.startswith("classifier:")
     has_merge_targets = bool(row.get("merge_targets"))
 
@@ -208,8 +207,9 @@ def _simple_diff(before: str, after: str, context: str = "") -> str:
     if not diff:
         return ""
 
-    # Skip --- and +++ header lines — they're noise in a compact card
-    body_lines = [l for l in diff[2:] if not l.startswith("@@" )]
+    # Skip --- and +++ header lines; keep @@ hunk headers so multi-hunk diffs
+    # don't silently concatenate disjoint sections.
+    body_lines = list(diff[2:])
     body = "".join(body_lines).strip()
     return f"```diff\n{body}\n```" if body else ""
 

--- a/mcp-memory/review_render.py
+++ b/mcp-memory/review_render.py
@@ -234,6 +234,11 @@ def render_proposal_list(
     if contexts is None:
         contexts = [None] * len(rows)
 
+    if len(contexts) != len(rows):
+        raise ValueError(
+            f"render_proposal_list: contexts length {len(contexts)} != rows length {len(rows)}"
+        )
+
     blocks: list[str] = []
     for i, (row, ctx) in enumerate(zip(rows, contexts)):
         blocks.append(render_proposal(row, ctx))

--- a/mcp-memory/review_render.py
+++ b/mcp-memory/review_render.py
@@ -1,0 +1,240 @@
+"""Pure-function renderer for memory review queue rows.
+
+Takes a row from ``memory_review_list`` (or ``memory_review_queue``) plus
+optional pre-fetched context and returns a formatted Markdown display block.
+No DB calls inside — every input is passed as argument.
+
+Display formats per row type:
+
+  - **classifier UPDATE** — before/after diff (requires ``context`` with
+    ``before_snapshot`` and ``decision='UPDATE'``).
+  - **classifier ADD / DELETE / NOOP** — compact card.
+  - **candidate** (not classifier) — compact card.
+  - **merge proposal** — merge card showing target count.
+"""
+
+from __future__ import annotations
+
+import difflib
+from typing import Any
+
+
+def render_proposal(row: dict, context: dict | None = None) -> str:
+    """Render one review-queue row as a Markdown display block.
+
+    Parameters
+    ----------
+    row:
+        A dict from ``memory_review_list`` or ``memory_review_queue``.
+        Expected keys: ``id``, ``name``, ``type``, ``description``,
+        ``content``, ``tags``, ``source_provenance``, ``requires_review``,
+        ``merge_targets``, ``reject_reason``, ``created_at``.
+    context:
+        Optional pre-fetched context. Supported keys:
+
+        - ``decision`` (``'UPDATE'`` | ``'ADD'`` | ``'DELETE'`` |
+          ``'NOOP'``) — classifier decision type. When ``'UPDATE'`` and
+          ``before_snapshot`` is present, renders a diff.
+        - ``before_snapshot`` (``dict``) — snapshot of the target memory
+          *before* the proposed change. Must have ``description``,
+          ``content``, ``tags`` keys at minimum.
+        - ``reasoning`` (``str``) — classifier reasoning to display.
+    """
+    source_prov = (row.get("source_provenance") or "")
+    is_classifier = source_prov.startswith("classifier:")
+    has_merge_targets = bool(row.get("merge_targets"))
+
+    decision = (context or {}).get("decision", "")
+    before = (context or {}).get("before_snapshot")
+
+    if is_classifier and decision == "UPDATE" and before:
+        return _render_diff_block(row, before, context)
+    if is_classifier:
+        return _render_compact(row, label=decision or "classifier", context=context)
+    if has_merge_targets:
+        return _render_merge(row)
+    return _render_compact(row, label="candidate", context=context)
+
+
+# ---------------------------------------------------------------------------
+# UPDATE diff
+# ---------------------------------------------------------------------------
+
+
+def _render_diff_block(row: dict, before: dict, context: dict | None = None) -> str:
+    """Render before/after diff for a classifier UPDATE proposal."""
+    name = row.get("name", "?")
+    mtype = row.get("type", "?")
+
+    before_desc = (before.get("description") or "").strip()
+    after_desc = (row.get("description") or "").strip()
+    before_content = (before.get("content") or "").strip()
+    after_content = (row.get("content") or "").strip()
+    before_tags = set(before.get("tags") or [])
+    after_tags = set(row.get("tags") or [])
+
+    lines = [f"### {name} ({mtype}) — UPDATE"]
+
+    # Description diff
+    if before_desc != after_desc:
+        lines.append("")
+        lines.append("**Description:**")
+        d = _simple_diff(before_desc, after_desc, "description")
+        if d:
+            lines.append(d)
+
+    # Content diff
+    if before_content != after_content:
+        lines.append("")
+        lines.append("**Content:**")
+        d = _simple_diff(before_content, after_content, "content")
+        if d:
+            lines.append(d)
+
+    # Tag diff
+    added = after_tags - before_tags
+    removed = before_tags - after_tags
+    if added or removed:
+        lines.append("")
+        lines.append("**Tags:**")
+        if added:
+            lines.append(f"  + {', '.join(sorted(added))}")
+        if removed:
+            lines.append(f"  - {', '.join(sorted(removed))}")
+
+    reasoning = (context or {}).get("reasoning", "")
+    if reasoning:
+        lines.append("")
+        lines.append(f"**Reasoning:** {reasoning[:500]}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Compact card (ADD / DELETE / NOOP / candidate / merge)
+# ---------------------------------------------------------------------------
+
+
+def _render_compact(row: dict, label: str, context: dict | None = None) -> str:
+    """Render a compact card."""
+    name = row.get("name", "?")
+    mtype = row.get("type", "?")
+    desc = (row.get("description") or "").strip()
+    content = (row.get("content") or "").strip()
+    tags = row.get("tags") or []
+
+    header_label = label.upper() if label else "ITEM"
+    lines = [f"### {name} ({mtype}) — {header_label}"]
+
+    reject = row.get("reject_reason")
+    if reject:
+        lines.append("")
+        lines.append(f"*Previously rejected: {reject[:300]}*")
+
+    reasoning = (context or {}).get("reasoning", "")
+    if reasoning:
+        lines.append("")
+        lines.append(f"**Reasoning:** {reasoning[:500]}")
+
+    if desc:
+        lines.append("")
+        lines.append(f"**Description:** {desc}")
+
+    if content:
+        lines.append("")
+        lines.append(f"**Content:** {content[:600]}{'…' if len(content) > 600 else ''}")
+
+    if tags:
+        lines.append("")
+        lines.append(f"**Tags:** {', '.join(tags)}")
+
+    lines.append("")
+    lines.append(f"**Provenance:** {row.get('source_provenance', '—')}")
+    lines.append(f"**ID:** `{row.get('id', '?')}`")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Merge proposal
+# ---------------------------------------------------------------------------
+
+
+def _render_merge(row: dict) -> str:
+    """Render a merge proposal card."""
+    name = row.get("name", "?")
+    targets = row.get("merge_targets") or []
+    desc = (row.get("description") or "").strip()
+    lines = [f"### {name} — MERGE ({len(targets)} targets)"]
+
+    if desc:
+        lines.append("")
+        lines.append(f"**Description:** {desc}")
+
+    lines.append("")
+    lines.append("**Merge targets:**")
+    for t in targets:
+        lines.append(f"  - `{t}`")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Diff utility
+# ---------------------------------------------------------------------------
+
+
+def _simple_diff(before: str, after: str, context: str = "") -> str:
+    """Compute a concise unified diff between two strings.
+
+    Returns a Markdown ``diff`` code block, or empty string if the strings
+    are identical (ignoring leading/trailing whitespace).
+    """
+    if before.strip() == after.strip():
+        return ""
+
+    before_lines = before.splitlines(keepends=True)
+    after_lines = after.splitlines(keepends=True)
+
+    diff = list(
+        difflib.unified_diff(
+            before_lines,
+            after_lines,
+            fromfile=f"before/{context}",
+            tofile=f"after/{context}",
+            n=2,
+        )
+    )
+    if not diff:
+        return ""
+
+    # Skip --- and +++ header lines — they're noise in a compact card
+    body_lines = [l for l in diff[2:] if not l.startswith("@@" )]
+    body = "".join(body_lines).strip()
+    return f"```diff\n{body}\n```" if body else ""
+
+
+# ---------------------------------------------------------------------------
+# Convenience: render a list of proposals
+# ---------------------------------------------------------------------------
+
+
+def render_proposal_list(
+    rows: list[dict],
+    contexts: list[dict | None] | None = None,
+) -> str:
+    """Render multiple proposals as a single display block.
+
+    Each row is separated by ``---``. If ``contexts`` is provided it must
+    be parallel to ``rows``.
+    """
+    if not rows:
+        return "_No pending proposals to review._"
+
+    if contexts is None:
+        contexts = [None] * len(rows)
+
+    blocks: list[str] = []
+    for i, (row, ctx) in enumerate(zip(rows, contexts)):
+        blocks.append(render_proposal(row, ctx))
+    return "\n\n---\n\n".join(blocks)

--- a/mcp-memory/review_render.py
+++ b/mcp-memory/review_render.py
@@ -46,12 +46,17 @@ def render_proposal(row: dict, context: dict | None = None) -> str:
     decision = (context or {}).get("decision", "")
     before = (context or {}).get("before_snapshot")
 
+    # merge_targets is a meta-row property — when present, the consolidation
+    # intent is the most important thing for the reviewer to see, regardless
+    # of whether the row also carries a classifier:* provenance. Route to the
+    # merge card before any classifier short-circuit so compound rows
+    # (e.g. classifier:add:* with merge_targets) don't silently drop the targets.
+    if has_merge_targets:
+        return _render_merge(row)
     if is_classifier and decision == "UPDATE" and before:
         return _render_diff_block(row, before, context)
     if is_classifier:
         return _render_compact(row, label=decision or "classifier", context=context)
-    if has_merge_targets:
-        return _render_merge(row)
     return _render_compact(row, label="candidate", context=context)
 
 

--- a/scripts/pending-volume-watcher.py
+++ b/scripts/pending-volume-watcher.py
@@ -1,0 +1,236 @@
+"""Volume-event watcher for the pending-review queue.
+
+Checks the count of pending memories (``requires_review=true``) and emits
+a ``candidates_pending`` event when it crosses the fire threshold (>= 10),
+with hysteresis to avoid flapping (re-arms when count drops below 8).
+
+Also debounces: skips firing if a ``/learn`` run completed in the last 24
+hours (``event_type='learn_run'`` in the ``events`` table).
+
+Designed for the orchestrator-watcher's polling loop. Can be called as a
+standalone script or imported as a module.
+
+Usage::
+
+    python scripts/pending-volume-watcher.py            # check + maybe emit
+    python scripts/pending-volume-watcher.py --dry-run   # check only, no event
+
+Env: SUPABASE_URL, SUPABASE_KEY. ``.env`` auto-loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+try:
+    from dotenv import load_dotenv
+
+    here = Path(__file__).resolve().parent
+    for c in (here.parent / ".env", here.parent.parent / ".env"):
+        if c.exists():
+            load_dotenv(c, override=True)
+            break
+except ImportError:
+    pass
+
+from supabase import create_client
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FIRE_THRESHOLD = 10
+REARM_THRESHOLD = 8
+DEBOUNCE_HOURS = 24
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+
+def count_pending(client) -> int:
+    """Count memories with ``requires_review=true`` and not deleted."""
+    rows = (
+        client.table("memories")
+        .select("id", count="exact")
+        .eq("requires_review", True)
+        .is_("deleted_at", "null")
+        .execute()
+    )
+    return rows.count if hasattr(rows, "count") and rows.count is not None else 0
+
+
+def last_candidates_pending_event(client) -> dict | None:
+    """Return the most recent ``candidates_pending`` event, or None."""
+    rows = (
+        client.table("events")
+        .select("created_at, payload")
+        .eq("event_type", "candidates_pending")
+        .order("created_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    data = rows.data or []
+    return data[0] if data else None
+
+
+def last_learn_run(client) -> dict | None:
+    """Return the most recent ``learn_run`` event, or None."""
+    rows = (
+        client.table("events")
+        .select("created_at")
+        .eq("event_type", "learn_run")
+        .order("created_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    data = rows.data or []
+    return data[0] if data else None
+
+
+def emit_event(client, *, pending_count: int, dry_run: bool = False) -> str | None:
+    """Emit a ``candidates_pending`` event. Best-effort."""
+    if dry_run:
+        return None
+    try:
+        resp = (
+            client.table("events")
+            .insert(
+                {
+                    "event_type": "candidates_pending",
+                    "severity": "medium",
+                    "repo": "Osasuwu/jarvis",
+                    "source": "volume_watcher",
+                    "title": f"Pending review queue: {pending_count} items",
+                    "payload": {
+                        "pending_count": pending_count,
+                        "state": "fired",
+                    },
+                }
+            )
+            .execute()
+        )
+        data = resp.data or []
+        return data[0]["id"] if data else None
+    except Exception as e:
+        print(f"! event insert failed: {e}", file=sys.stderr)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Watcher logic
+# ---------------------------------------------------------------------------
+
+
+def check_and_fire(client, *, dry_run: bool = False) -> dict:
+    """Run the volume watcher predicate.
+
+    Returns a dict with the decision and metadata.
+
+    Logic::
+
+        1. Count pending. If < FIRE_THRESHOLD → no action.
+        2. Check if already fired (last ``candidates_pending`` event has
+           ``payload.state='fired'`` and count >= REARM_THRESHOLD).
+           If still in the "fired" band → no action.
+        3. Check if a ``/learn`` run happened in the last
+           ``DEBOUNCE_HOURS`` → no action.
+        4. Otherwise → emit ``candidates_pending`` event.
+    """
+    pending = count_pending(client)
+
+    if pending < FIRE_THRESHOLD:
+        return {
+            "action": "none",
+            "reason": f"pending={pending} < fire={FIRE_THRESHOLD}",
+            "pending_count": pending,
+        }
+
+    # Check last fired event
+    last_event = last_candidates_pending_event(client)
+    if last_event:
+        payload = last_event.get("payload") or {}
+        last_state = payload.get("state", "rearmed")
+        if last_state == "fired" and pending >= REARM_THRESHOLD:
+            return {
+                "action": "none",
+                "reason": (
+                    f"already fired (pending={pending} >= rearm={REARM_THRESHOLD}), "
+                    f"still in hysteresis band"
+                ),
+                "pending_count": pending,
+            }
+
+    # Check 24h debounce
+    last_learn = last_learn_run(client)
+    if last_learn:
+        created = last_learn.get("created_at")
+        if created:
+            try:
+                last_ts = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
+                age = datetime.now(timezone.utc) - last_ts
+                if age < timedelta(hours=DEBOUNCE_HOURS):
+                    return {
+                        "action": "none",
+                        "reason": (
+                            f"/learn ran {age.total_seconds() / 3600:.1f}h ago, "
+                            f"within {DEBOUNCE_HOURS}h debounce"
+                        ),
+                        "pending_count": pending,
+                    }
+            except (TypeError, ValueError):
+                pass
+
+    # Fire!
+    event_id = emit_event(client, pending_count=pending, dry_run=dry_run)
+    return {
+        "action": "fired" if not dry_run else "would_fire",
+        "event_id": event_id,
+        "pending_count": pending,
+        "fire_threshold": FIRE_THRESHOLD,
+        "rearm_threshold": REARM_THRESHOLD,
+        "dry_run": dry_run,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Check only, do not emit any event.",
+    )
+    args = p.parse_args()
+
+    sb_url = os.environ.get("SUPABASE_URL")
+    sb_key = os.environ.get("SUPABASE_KEY")
+    if not sb_url or not sb_key:
+        print("SUPABASE_URL / SUPABASE_KEY missing from env", file=sys.stderr)
+        return 2
+
+    client = create_client(sb_url, sb_key)
+    result = check_and_fire(client, dry_run=args.dry_run)
+    print(json.dumps(result, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pending-volume-watcher.py
+++ b/scripts/pending-volume-watcher.py
@@ -62,12 +62,13 @@ DEBOUNCE_HOURS = 24
 
 
 def count_pending(client) -> int:
-    """Count memories with ``requires_review=true`` and not deleted."""
+    """Count memories with ``requires_review=true`` and not deleted or superseded."""
     rows = (
         client.table("memories")
         .select("id", count="exact")
         .eq("requires_review", True)
         .is_("deleted_at", "null")
+        .is_("superseded_by", "null")
         .execute()
     )
     return rows.count if hasattr(rows, "count") and rows.count is not None else 0
@@ -101,7 +102,7 @@ def last_learn_run(client) -> dict | None:
     return data[0] if data else None
 
 
-def emit_event(client, *, pending_count: int, dry_run: bool = False) -> str | None:
+def emit_event(client, *, pending_count: int, state: str = "fired", dry_run: bool = False) -> str | None:
     """Emit a ``candidates_pending`` event. Best-effort."""
     if dry_run:
         return None
@@ -117,7 +118,7 @@ def emit_event(client, *, pending_count: int, dry_run: bool = False) -> str | No
                     "title": f"Pending review queue: {pending_count} items",
                     "payload": {
                         "pending_count": pending_count,
-                        "state": "fired",
+                        "state": state,
                     },
                 }
             )
@@ -130,49 +131,83 @@ def emit_event(client, *, pending_count: int, dry_run: bool = False) -> str | No
         return None
 
 
+def emit_learn_run(client) -> None:
+    """Emit a ``learn_run`` event to self-debounce subsequent watcher invocations."""
+    try:
+        client.table("events").insert(
+            {
+                "event_type": "learn_run",
+                "severity": "info",
+                "repo": "Osasuwu/jarvis",
+                "source": "volume_watcher",
+                "title": "Volume watcher fired — learn_run debounce marker",
+                "payload": {},
+            }
+        ).execute()
+    except Exception as e:
+        print(f"! learn_run event insert failed: {e}", file=sys.stderr)
+
+
 # ---------------------------------------------------------------------------
 # Watcher logic
 # ---------------------------------------------------------------------------
 
 
-def check_and_fire(client, *, dry_run: bool = False) -> dict:
+def check_and_fire(client, *, dry_run: bool = False, _now=None) -> dict:
     """Run the volume watcher predicate.
 
     Returns a dict with the decision and metadata.
 
     Logic::
 
-        1. Count pending. If < FIRE_THRESHOLD → no action.
-        2. Check if already fired (last ``candidates_pending`` event has
-           ``payload.state='fired'`` and count >= REARM_THRESHOLD).
-           If still in the "fired" band → no action.
-        3. Check if a ``/learn`` run happened in the last
-           ``DEBOUNCE_HOURS`` → no action.
-        4. Otherwise → emit ``candidates_pending`` event.
+        1. Count pending.
+        2. Fetch last ``candidates_pending`` event (needed for hysteresis).
+        3. Re-arm: if state was ``fired`` and count dropped below
+           REARM_THRESHOLD, emit a ``rearmed`` event (resets the gate).
+        4. If pending < FIRE_THRESHOLD → no action.
+        5. If still in hysteresis band (state=fired, count >= REARM) → skip.
+        6. Check 24h debounce (``learn_run`` event) → skip if recent.
+        7. Otherwise → emit ``candidates_pending`` event + ``learn_run`` marker.
     """
+    if _now is None:
+        _now = lambda: datetime.now(timezone.utc)
+
     pending = count_pending(client)
 
+    # Fetch last event BEFORE fire-threshold early-exit so re-arm can run.
+    last_event = last_candidates_pending_event(client)
+    last_state = "rearmed"
+    if last_event:
+        payload = last_event.get("payload") or {}
+        last_state = payload.get("state", "rearmed")
+
+    # Re-arm: fired state but count dropped below rearm threshold.
+    rearmed = False
+    if last_state == "fired" and pending < REARM_THRESHOLD:
+        emit_event(client, pending_count=pending, state="rearmed", dry_run=dry_run)
+        last_state = "rearmed"
+        rearmed = True
+
     if pending < FIRE_THRESHOLD:
-        return {
+        result: dict = {
             "action": "none",
             "reason": f"pending={pending} < fire={FIRE_THRESHOLD}",
             "pending_count": pending,
         }
+        if rearmed:
+            result["rearmed"] = True
+        return result
 
-    # Check last fired event
-    last_event = last_candidates_pending_event(client)
-    if last_event:
-        payload = last_event.get("payload") or {}
-        last_state = payload.get("state", "rearmed")
-        if last_state == "fired" and pending >= REARM_THRESHOLD:
-            return {
-                "action": "none",
-                "reason": (
-                    f"already fired (pending={pending} >= rearm={REARM_THRESHOLD}), "
-                    f"still in hysteresis band"
-                ),
-                "pending_count": pending,
-            }
+    # Hysteresis: already fired, count still in band.
+    if last_state == "fired" and pending >= REARM_THRESHOLD:
+        return {
+            "action": "none",
+            "reason": (
+                f"already fired (pending={pending} >= rearm={REARM_THRESHOLD}), "
+                f"still in hysteresis band"
+            ),
+            "pending_count": pending,
+        }
 
     # Check 24h debounce
     last_learn = last_learn_run(client)
@@ -181,7 +216,7 @@ def check_and_fire(client, *, dry_run: bool = False) -> dict:
         if created:
             try:
                 last_ts = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
-                age = datetime.now(timezone.utc) - last_ts
+                age = _now() - last_ts
                 if age < timedelta(hours=DEBOUNCE_HOURS):
                     return {
                         "action": "none",
@@ -195,7 +230,9 @@ def check_and_fire(client, *, dry_run: bool = False) -> dict:
                 pass
 
     # Fire!
-    event_id = emit_event(client, pending_count=pending, dry_run=dry_run)
+    event_id = emit_event(client, pending_count=pending, state="fired", dry_run=dry_run)
+    if not dry_run:
+        emit_learn_run(client)
     return {
         "action": "fired" if not dry_run else "would_fire",
         "event_id": event_id,

--- a/scripts/pending-volume-watcher.py
+++ b/scripts/pending-volume-watcher.py
@@ -102,7 +102,9 @@ def last_learn_run(client) -> dict | None:
     return data[0] if data else None
 
 
-def emit_event(client, *, pending_count: int, state: str = "fired", dry_run: bool = False) -> str | None:
+def emit_event(
+    client, *, pending_count: int, state: str = "fired", dry_run: bool = False
+) -> str | None:
     """Emit a ``candidates_pending`` event. Best-effort."""
     if dry_run:
         return None
@@ -170,7 +172,9 @@ def check_and_fire(client, *, dry_run: bool = False, _now=None) -> dict:
         7. Otherwise → emit ``candidates_pending`` event + ``learn_run`` marker.
     """
     if _now is None:
-        _now = lambda: datetime.now(timezone.utc)
+
+        def _now():
+            return datetime.now(timezone.utc)
 
     pending = count_pending(client)
 
@@ -179,7 +183,7 @@ def check_and_fire(client, *, dry_run: bool = False, _now=None) -> dict:
     last_state = "rearmed"
     if last_event:
         payload = last_event.get("payload") or {}
-        last_state = payload.get("state", "rearmed")
+        last_state = payload.get("state", "fired")
 
     # Re-arm: fired state but count dropped below rearm threshold.
     rearmed = False
@@ -231,7 +235,7 @@ def check_and_fire(client, *, dry_run: bool = False, _now=None) -> dict:
 
     # Fire!
     event_id = emit_event(client, pending_count=pending, state="fired", dry_run=dry_run)
-    if not dry_run:
+    if not dry_run and event_id is not None:
         emit_learn_run(client)
     return {
         "action": "fired" if not dry_run else "would_fire",

--- a/scripts/pending-volume-watcher.py
+++ b/scripts/pending-volume-watcher.py
@@ -102,10 +102,20 @@ def last_learn_run(client) -> dict | None:
     return data[0] if data else None
 
 
+NO_ID_SENTINEL = "<no-id>"
+
+
 def emit_event(
     client, *, pending_count: int, state: str = "fired", dry_run: bool = False
 ) -> str | None:
-    """Emit a ``candidates_pending`` event. Best-effort."""
+    """Emit a ``candidates_pending`` event.
+
+    Returns the inserted row's ``id`` when PostgREST returns it in
+    ``resp.data`` (default). When ``Prefer: return=minimal`` or RLS hide the
+    row, returns ``NO_ID_SENTINEL`` to mark **success-without-id** so the
+    caller can still write the debounce marker. Returns ``None`` only when
+    the INSERT itself failed (exception caught).
+    """
     if dry_run:
         return None
     try:
@@ -127,14 +137,19 @@ def emit_event(
             .execute()
         )
         data = resp.data or []
-        return data[0]["id"] if data else None
+        return data[0]["id"] if data else NO_ID_SENTINEL
     except Exception as e:
         print(f"! event insert failed: {e}", file=sys.stderr)
         return None
 
 
-def emit_learn_run(client) -> None:
-    """Emit a ``learn_run`` event to self-debounce subsequent watcher invocations."""
+def emit_learn_run(client) -> bool:
+    """Emit a ``learn_run`` event to self-debounce subsequent watcher invocations.
+
+    Returns ``True`` if the marker was written, ``False`` on insert failure.
+    The caller surfaces this in the result dict so a transient DB error
+    doesn't silently produce a double-fire on the next queue oscillation.
+    """
     try:
         client.table("events").insert(
             {
@@ -146,8 +161,10 @@ def emit_learn_run(client) -> None:
                 "payload": {},
             }
         ).execute()
+        return True
     except Exception as e:
         print(f"! learn_run event insert failed: {e}", file=sys.stderr)
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -183,7 +200,9 @@ def check_and_fire(client, *, dry_run: bool = False, _now=None) -> dict:
     last_state = "rearmed"
     if last_event:
         payload = last_event.get("payload") or {}
-        last_state = payload.get("state", "fired")
+        # Fail open: a missing "state" key (manually-inserted event, alt emitter,
+        # future payload schema) must not lock the hysteresis guard permanently.
+        last_state = payload.get("state", "rearmed")
 
     # Re-arm: fired state but count dropped below rearm threshold.
     rearmed = False
@@ -235,11 +254,13 @@ def check_and_fire(client, *, dry_run: bool = False, _now=None) -> dict:
 
     # Fire!
     event_id = emit_event(client, pending_count=pending, state="fired", dry_run=dry_run)
+    debounce_marker_written: bool | None = None
     if not dry_run and event_id is not None:
-        emit_learn_run(client)
+        debounce_marker_written = emit_learn_run(client)
     return {
         "action": "fired" if not dry_run else "would_fire",
         "event_id": event_id,
+        "debounce_marker_written": debounce_marker_written,
         "pending_count": pending,
         "fire_threshold": FIRE_THRESHOLD,
         "rearm_threshold": REARM_THRESHOLD,

--- a/tests/test_pending_volume_watcher.py
+++ b/tests/test_pending_volume_watcher.py
@@ -7,7 +7,6 @@ client. See ``test_dreamer.py`` for same-pattern mock chain construction.
 from __future__ import annotations
 
 import importlib.util
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -52,6 +51,7 @@ def _mock_events(client: MagicMock, events_by_type: dict[str, list[dict]]):
     empty result.  Call this *after* ``_mock_pending_count`` so the memories
     mock (stored in ``client.table.return_value``) is already in place.
     """
+
     def _make_chain(rows: list[dict]) -> MagicMock:
         exec_resp = MagicMock()
         exec_resp.data = rows
@@ -107,12 +107,17 @@ class TestHysteresis:
         """Still in fired state and count >= rearm threshold → skip."""
         client = MagicMock()
         _mock_pending_count(client, 10)
-        _mock_events(client, {"candidates_pending": [
+        _mock_events(
+            client,
             {
-                "created_at": "2026-05-20T10:00:00Z",
-                "payload": {"state": "fired", "pending_count": 15},
-            }
-        ]})
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-20T10:00:00Z",
+                        "payload": {"state": "fired", "pending_count": 15},
+                    }
+                ]
+            },
+        )
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "none"
@@ -122,12 +127,17 @@ class TestHysteresis:
         """After re-arm (<8), crossing >=10 fires again."""
         client = MagicMock()
         _mock_pending_count(client, 12)
-        _mock_events(client, {"candidates_pending": [
+        _mock_events(
+            client,
             {
-                "created_at": "2026-05-19T10:00:00Z",
-                "payload": {"state": "rearmed", "pending_count": 7},
-            }
-        ]})
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-19T10:00:00Z",
+                        "payload": {"state": "rearmed", "pending_count": 7},
+                    }
+                ]
+            },
+        )
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "would_fire"
@@ -137,12 +147,17 @@ class TestHysteresis:
         """pending=9 is in the hysteresis band (8..9), no re-fire when last was fired."""
         client = MagicMock()
         _mock_pending_count(client, 9)
-        _mock_events(client, {"candidates_pending": [
+        _mock_events(
+            client,
             {
-                "created_at": "2026-05-20T10:00:00Z",
-                "payload": {"state": "fired", "pending_count": 15},
-            }
-        ]})
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-20T10:00:00Z",
+                        "payload": {"state": "fired", "pending_count": 15},
+                    }
+                ]
+            },
+        )
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "none"
@@ -159,9 +174,18 @@ class TestHysteresis:
         # Phase 2: pending=6, last state=fired → re-arms, returns none (below FIRE)
         c2 = MagicMock()
         _mock_pending_count(c2, 6)
-        _mock_events(c2, {"candidates_pending": [
-            {"created_at": "2026-05-24T10:00:00Z", "payload": {"state": "fired", "pending_count": 12}}
-        ], "learn_run": []})
+        _mock_events(
+            c2,
+            {
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-24T10:00:00Z",
+                        "payload": {"state": "fired", "pending_count": 12},
+                    }
+                ],
+                "learn_run": [],
+            },
+        )
         r2 = watcher.check_and_fire(c2, dry_run=True, _now=lambda: FROZEN_NOW)
         assert r2["action"] == "none"
         assert r2.get("rearmed") is True
@@ -169,9 +193,18 @@ class TestHysteresis:
         # Phase 3: pending=11, last state=rearmed → fires again
         c3 = MagicMock()
         _mock_pending_count(c3, 11)
-        _mock_events(c3, {"candidates_pending": [
-            {"created_at": "2026-05-24T11:00:00Z", "payload": {"state": "rearmed", "pending_count": 6}}
-        ], "learn_run": []})
+        _mock_events(
+            c3,
+            {
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-24T11:00:00Z",
+                        "payload": {"state": "rearmed", "pending_count": 6},
+                    }
+                ],
+                "learn_run": [],
+            },
+        )
         r3 = watcher.check_and_fire(c3, dry_run=True, _now=lambda: FROZEN_NOW)
         assert r3["action"] == "would_fire"
 
@@ -182,17 +215,20 @@ class TestDebounce:
     def test_recent_learn_skips_fire(self):
         client = MagicMock()
         _mock_pending_count(client, 15)
-        _mock_events(client, {
-            "candidates_pending": [
-                {
-                    "created_at": "2026-05-23T12:00:00Z",
-                    "payload": {"state": "rearmed", "pending_count": 5},
-                }
-            ],
-            "learn_run": [
-                {"created_at": "2026-05-24T11:00:00Z"},  # 1h before FROZEN_NOW
-            ],
-        })
+        _mock_events(
+            client,
+            {
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-23T12:00:00Z",
+                        "payload": {"state": "rearmed", "pending_count": 5},
+                    }
+                ],
+                "learn_run": [
+                    {"created_at": "2026-05-24T11:00:00Z"},  # 1h before FROZEN_NOW
+                ],
+            },
+        )
 
         result = watcher.check_and_fire(client, dry_run=True, _now=lambda: FROZEN_NOW)
         assert result["action"] == "none"
@@ -201,17 +237,20 @@ class TestDebounce:
     def test_old_learn_allows_fire(self):
         client = MagicMock()
         _mock_pending_count(client, 15)
-        _mock_events(client, {
-            "candidates_pending": [
-                {
-                    "created_at": "2026-05-22T12:00:00Z",
-                    "payload": {"state": "rearmed", "pending_count": 5},
-                }
-            ],
-            "learn_run": [
-                {"created_at": "2026-05-22T12:00:00Z"},  # 48h before FROZEN_NOW
-            ],
-        })
+        _mock_events(
+            client,
+            {
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-22T12:00:00Z",
+                        "payload": {"state": "rearmed", "pending_count": 5},
+                    }
+                ],
+                "learn_run": [
+                    {"created_at": "2026-05-22T12:00:00Z"},  # 48h before FROZEN_NOW
+                ],
+            },
+        )
 
         result = watcher.check_and_fire(client, dry_run=True, _now=lambda: FROZEN_NOW)
         assert result["action"] == "would_fire"
@@ -220,18 +259,76 @@ class TestDebounce:
         """After watcher fires, re-invocation within 24h is suppressed via learn_run marker."""
         client = MagicMock()
         _mock_pending_count(client, 15)
-        _mock_events(client, {
-            "candidates_pending": [
-                {"created_at": "2026-05-24T11:55:00Z", "payload": {"state": "rearmed"}}
-            ],
-            "learn_run": [
-                {"created_at": "2026-05-24T11:59:00Z"},  # 1 min before FROZEN_NOW
-            ],
-        })
+        _mock_events(
+            client,
+            {
+                "candidates_pending": [
+                    {"created_at": "2026-05-24T11:55:00Z", "payload": {"state": "rearmed"}}
+                ],
+                "learn_run": [
+                    {"created_at": "2026-05-24T11:59:00Z"},  # 1 min before FROZEN_NOW
+                ],
+            },
+        )
 
         result = watcher.check_and_fire(client, dry_run=True, _now=lambda: FROZEN_NOW)
         assert result["action"] == "none"
         assert "debounce" in result["reason"]
+
+
+class TestEmitLearnRunGuard:
+    """Tests the guard: emit_learn_run must not fire when emit_event fails (#2)."""
+
+    def test_no_debounce_marker_when_emit_event_fails(self):
+        """emit_learn_run must NOT be called when emit_event returns None (DB error)."""
+        from unittest.mock import patch
+
+        client = MagicMock()
+        _mock_pending_count(client, 15)
+        _mock_events(client, {"candidates_pending": [], "learn_run": []})
+
+        with (
+            patch.object(watcher, "emit_event", return_value=None),
+            patch.object(watcher, "emit_learn_run") as mock_learn_run,
+        ):
+            result = watcher.check_and_fire(client, dry_run=False)
+
+        mock_learn_run.assert_not_called()
+        assert result.get("event_id") is None
+
+    def test_debounce_marker_written_when_emit_event_succeeds(self):
+        """emit_learn_run IS called when emit_event returns a valid event_id."""
+        from unittest.mock import patch
+
+        client = MagicMock()
+        _mock_pending_count(client, 15)
+        _mock_events(client, {"candidates_pending": [], "learn_run": []})
+
+        with (
+            patch.object(watcher, "emit_event", return_value="event-uuid-123"),
+            patch.object(watcher, "emit_learn_run") as mock_learn_run,
+        ):
+            result = watcher.check_and_fire(client, dry_run=False)
+
+        mock_learn_run.assert_called_once_with(client)
+        assert result["action"] == "fired"
+
+
+class TestLearnRunContract:
+    """Verify SKILL.md closes the /learn → learn_run event loop (#1)."""
+
+    def test_skill_md_contains_learn_run_emit_instruction(self):
+        """SKILL.md must instruct the skill to emit a learn_run event."""
+        skill_path = (
+            Path(__file__).resolve().parent.parent
+            / ".claude-userlevel"
+            / "skills"
+            / "learn"
+            / "SKILL.md"
+        )
+        content = skill_path.read_text(encoding="utf-8")
+        assert "learn_run" in content, "SKILL.md must instruct emitting learn_run event"
+        assert "learn_skill" in content, "SKILL.md must identify the source as learn_skill"
 
 
 class TestDryRun:

--- a/tests/test_pending_volume_watcher.py
+++ b/tests/test_pending_volume_watcher.py
@@ -143,8 +143,14 @@ class TestHysteresis:
         assert result["action"] == "would_fire"
         assert result["pending_count"] == 12
 
-    def test_hysteresis_band_does_not_refire(self):
-        """pending=9 is in the hysteresis band (8..9), no re-fire when last was fired."""
+    def test_pending_below_fire_with_prior_fired_no_action(self):
+        """pending=9 + prior fired → 'none' via the below-fire early-exit (step 4).
+
+        Note: this does NOT exercise the step-5 hysteresis guard — pending < FIRE
+        returns early at step 4. The reason-string assertion pins the path so a
+        reorder of steps 4 and 5 cannot pass silently.
+        See test_hysteresis_guard_blocks_for_already_fired for the step-5 case.
+        """
         client = MagicMock()
         _mock_pending_count(client, 9)
         _mock_events(
@@ -161,6 +167,54 @@ class TestHysteresis:
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "none"
+        assert "pending=9 < fire=10" in result["reason"]
+
+    def test_hysteresis_guard_blocks_for_already_fired(self):
+        """pending well above FIRE + prior fired → step-5 hysteresis guard fires."""
+        client = MagicMock()
+        _mock_pending_count(client, 15)  # well above FIRE_THRESHOLD=10
+        _mock_events(
+            client,
+            {
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-24T10:00:00Z",
+                        "payload": {"state": "fired", "pending_count": 12},
+                    }
+                ],
+                "learn_run": [],
+            },
+        )
+
+        result = watcher.check_and_fire(client, dry_run=True, _now=lambda: FROZEN_NOW)
+        assert result["action"] == "none"
+        assert "already fired" in result["reason"]
+        assert "hysteresis band" in result["reason"]
+
+    def test_missing_state_in_payload_fails_open(self):
+        """A `candidates_pending` event without 'state' in payload must not lock the guard.
+
+        Regression: round-2 default of 'fired' caused a permanent hysteresis lock
+        whenever a payload was missing the state key (manually inserted, alt
+        emitter, future schema). Default must be 'rearmed' (fail open).
+        """
+        client = MagicMock()
+        _mock_pending_count(client, 12)
+        _mock_events(
+            client,
+            {
+                "candidates_pending": [
+                    {
+                        "created_at": "2026-05-20T10:00:00Z",
+                        "payload": {"pending_count": 12},  # state missing
+                    }
+                ],
+                "learn_run": [],
+            },
+        )
+
+        result = watcher.check_and_fire(client, dry_run=True, _now=lambda: FROZEN_NOW)
+        assert result["action"] == "would_fire"
 
     def test_fire_drop_rerise_refires(self):
         """fire → drop below REARM_THRESHOLD → rise above FIRE_THRESHOLD → re-fires."""
@@ -306,12 +360,58 @@ class TestEmitLearnRunGuard:
 
         with (
             patch.object(watcher, "emit_event", return_value="event-uuid-123"),
-            patch.object(watcher, "emit_learn_run") as mock_learn_run,
+            patch.object(watcher, "emit_learn_run", return_value=True) as mock_learn_run,
         ):
             result = watcher.check_and_fire(client, dry_run=False)
 
         mock_learn_run.assert_called_once_with(client)
         assert result["action"] == "fired"
+        assert result["debounce_marker_written"] is True
+
+    def test_debounce_marker_written_when_emit_event_returns_no_id_sentinel(self):
+        """emit_learn_run IS called even when emit_event returns the NO_ID_SENTINEL.
+
+        Regression: round-2 conflated 'INSERT succeeded with empty resp.data'
+        (PostgREST return=minimal, RLS hiding the row) with 'INSERT failed',
+        so the debounce marker was never written and the watcher double-fired
+        on the next queue oscillation.
+        """
+        from unittest.mock import patch
+
+        client = MagicMock()
+        _mock_pending_count(client, 15)
+        _mock_events(client, {"candidates_pending": [], "learn_run": []})
+
+        with (
+            patch.object(watcher, "emit_event", return_value=watcher.NO_ID_SENTINEL),
+            patch.object(watcher, "emit_learn_run", return_value=True) as mock_learn_run,
+        ):
+            result = watcher.check_and_fire(client, dry_run=False)
+
+        mock_learn_run.assert_called_once_with(client)
+        assert result["event_id"] == watcher.NO_ID_SENTINEL
+        assert result["debounce_marker_written"] is True
+
+    def test_emit_learn_run_failure_surfaced_in_result(self):
+        """emit_learn_run insert failure (returns False) must appear in result.
+
+        Regression: round-2 swallowed the exception and returned action='fired'
+        with no signal that the debounce marker was lost — the watcher would
+        double-fire on the next oscillation without any visible error.
+        """
+        from unittest.mock import patch
+
+        client = MagicMock()
+        _mock_pending_count(client, 15)
+        _mock_events(client, {"candidates_pending": [], "learn_run": []})
+
+        with (
+            patch.object(watcher, "emit_event", return_value="event-uuid-123"),
+            patch.object(watcher, "emit_learn_run", return_value=False),
+        ):
+            result = watcher.check_and_fire(client, dry_run=False)
+
+        assert result["debounce_marker_written"] is False
 
 
 class TestLearnRunContract:

--- a/tests/test_pending_volume_watcher.py
+++ b/tests/test_pending_volume_watcher.py
@@ -1,0 +1,194 @@
+"""Unit tests for ``scripts/pending-volume-watcher.py``.
+
+Tests the hysteresis logic and debounce behavior with a mocked Supabase
+client. See ``test_dreamer.py`` for same-pattern mock chain construction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "pending-volume-watcher.py"
+_spec = importlib.util.spec_from_file_location("pending_volume_watcher", _SCRIPT_PATH)
+assert _spec and _spec.loader
+watcher = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(watcher)
+
+
+def _mock_pending_count(client: MagicMock, count: int):
+    """Set up the client stub to return ``count`` pending items."""
+    exec_resp = MagicMock()
+    exec_resp.count = count
+
+    execute_mock = MagicMock()
+    execute_mock.execute.return_value = exec_resp
+
+    is_mock = MagicMock()
+    is_mock.is_.return_value = execute_mock
+
+    eq_mock = MagicMock()
+    eq_mock.eq.return_value = is_mock
+
+    select_mock = MagicMock()
+    select_mock.select.return_value = eq_mock
+
+    client.table.return_value = select_mock
+
+
+def _mock_events(client: MagicMock, event_type: str, rows: list[dict]):
+    """Set up the client stub to return events rows."""
+    exec_resp = MagicMock()
+    exec_resp.data = rows
+
+    limit_mock = MagicMock()
+    limit_mock.limit.return_value.execute.return_value = exec_resp
+
+    order_mock = MagicMock()
+    order_mock.order.return_value = limit_mock
+
+    eq_mock = MagicMock()
+    eq_mock.eq.return_value = order_mock
+
+    select_mock = MagicMock()
+    select_mock.select.return_value = eq_mock
+
+    def _table_side_effect(name: str):
+        if name == "memories":
+            return client.table.return_value
+        elif name == "events":
+            return select_mock
+        return MagicMock()
+
+    client.table.side_effect = _table_side_effect
+
+
+class TestHysteresis:
+    """Tests the fire/re-arm hysteresis logic."""
+
+    def test_below_threshold_no_action(self):
+        client = MagicMock()
+        _mock_pending_count(client, 5)
+        _mock_events(client, "candidates_pending", [])
+
+        result = watcher.check_and_fire(client, dry_run=True)
+        assert result["action"] == "none"
+        assert "pending=5 < fire=10" in result["reason"]
+
+    def test_above_threshold_fires(self):
+        client = MagicMock()
+        _mock_pending_count(client, 12)
+        _mock_events(client, "candidates_pending", [])
+
+        result = watcher.check_and_fire(client, dry_run=True)
+        assert result["action"] == "would_fire"
+        assert result["pending_count"] == 12
+
+    def test_already_fired_no_rearm_skips(self):
+        """Still in fired state and count >= rearm threshold → skip."""
+        client = MagicMock()
+        _mock_pending_count(client, 10)
+        _mock_events(client, "candidates_pending", [
+            {
+                "created_at": "2026-05-20T10:00:00Z",
+                "payload": {"state": "fired", "pending_count": 15},
+            }
+        ])
+
+        result = watcher.check_and_fire(client, dry_run=True)
+        assert result["action"] == "none"
+        assert "already fired" in result["reason"]
+
+    def test_rearmed_then_crosses_threshold_fires_again(self):
+        """After re-arm (<8), crossing >=10 fires again."""
+        client = MagicMock()
+        _mock_pending_count(client, 12)
+        # Last event was a fired event from earlier, but count dropped below 8
+        # so re-arm happened. The last event's state is still 'fired' but
+        # pending_count is now 12 >= 8 rearm threshold... hmm.
+
+        # Actually, the logic is: if last state is 'fired' AND pending >= rearm,
+        # skip. So to re-fire, we need either:
+        # 1. Last state is 'rearmed' (from a re-arm event), or
+        # 2. pending < rearm threshold (wouldn't fire anyway)
+
+        # Let me simulate: after re-arm, the last event is 'rearmed'
+        _mock_events(client, "candidates_pending", [
+            {
+                "created_at": "2026-05-19T10:00:00Z",
+                "payload": {"state": "rearmed", "pending_count": 7},
+            }
+        ])
+
+        result = watcher.check_and_fire(client, dry_run=True)
+        assert result["action"] == "would_fire"
+        assert result["pending_count"] == 12
+
+    def test_hysteresis_band_does_not_refire(self):
+        """pending=9 is in the hysteresis band (8..9), no re-fire when last was fired."""
+        client = MagicMock()
+        _mock_pending_count(client, 9)
+        _mock_events(client, "candidates_pending", [
+            {
+                "created_at": "2026-05-20T10:00:00Z",
+                "payload": {"state": "fired", "pending_count": 15},
+            }
+        ])
+
+        result = watcher.check_and_fire(client, dry_run=True)
+        assert result["action"] == "none"
+        # Still in hysteresis band (pending=9 >= rearm=8, last state=fired)
+
+
+class TestDebounce:
+    """Tests the 24h debounce after /learn runs."""
+
+    def test_recent_learn_skips_fire(self):
+        client = MagicMock()
+        _mock_pending_count(client, 15)
+        # Last candidates_pending event is rearmed, so that gate passes
+        _mock_events(client, "candidates_pending", [
+            {
+                "created_at": "2026-05-19T10:00:00Z",
+                "payload": {"state": "rearmed", "pending_count": 5},
+            }
+        ])
+        # But a /learn ran 2 hours ago
+        _mock_events(client, "learn_run", [
+            {"created_at": "2026-05-20T10:00:00Z"},
+        ])
+
+        result = watcher.check_and_fire(client, dry_run=True)
+        assert result["action"] == "none"
+        assert "debounce" in result["reason"]
+
+    def test_old_learn_allows_fire(self):
+        client = MagicMock()
+        _mock_pending_count(client, 15)
+        # Last candidates_pending is rearmed
+        _mock_events(client, "candidates_pending", [
+            {
+                "created_at": "2026-05-19T10:00:00Z",
+                "payload": {"state": "rearmed", "pending_count": 5},
+            }
+        ])
+        # But /learn ran 48 hours ago - outside debounce window
+        _mock_events(client, "learn_run", [
+            {"created_at": "2026-05-18T10:00:00Z"},
+        ])
+
+        result = watcher.check_and_fire(client, dry_run=True)
+        assert result["action"] == "would_fire"
+
+
+class TestDryRun:
+    def test_dry_run_no_event_emitted(self):
+        client = MagicMock()
+        _mock_pending_count(client, 15)
+        _mock_events(client, "candidates_pending", [])
+
+        result = watcher.check_and_fire(client, dry_run=True)
+        assert result["action"] == "would_fire"
+        assert result["dry_run"] is True

--- a/tests/test_pending_volume_watcher.py
+++ b/tests/test_pending_volume_watcher.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -16,6 +17,8 @@ _spec = importlib.util.spec_from_file_location("pending_volume_watcher", _SCRIPT
 assert _spec and _spec.loader
 watcher = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(watcher)
+
+FROZEN_NOW = datetime(2026, 5, 24, 12, 0, 0, tzinfo=timezone.utc)
 
 
 def _mock_pending_count(client: MagicMock, count: int):
@@ -26,11 +29,14 @@ def _mock_pending_count(client: MagicMock, count: int):
     execute_mock = MagicMock()
     execute_mock.execute.return_value = exec_resp
 
-    is_mock = MagicMock()
-    is_mock.is_.return_value = execute_mock
+    is_superseded_mock = MagicMock()
+    is_superseded_mock.is_.return_value = execute_mock
+
+    is_deleted_mock = MagicMock()
+    is_deleted_mock.is_.return_value = is_superseded_mock
 
     eq_mock = MagicMock()
-    eq_mock.eq.return_value = is_mock
+    eq_mock.eq.return_value = is_deleted_mock
 
     select_mock = MagicMock()
     select_mock.select.return_value = eq_mock
@@ -38,19 +44,30 @@ def _mock_pending_count(client: MagicMock, count: int):
     client.table.return_value = select_mock
 
 
-def _mock_events(client: MagicMock, event_type: str, rows: list[dict]):
-    """Set up the client stub to return events rows."""
-    exec_resp = MagicMock()
-    exec_resp.data = rows
+def _mock_events(client: MagicMock, events_by_type: dict[str, list[dict]]):
+    """Set up the client stub to return event rows keyed by event_type.
 
-    limit_mock = MagicMock()
-    limit_mock.limit.return_value.execute.return_value = exec_resp
+    Each key maps to the rows that queries with
+    ``.eq("event_type", key)`` should return.  Unknown event_types get an
+    empty result.  Call this *after* ``_mock_pending_count`` so the memories
+    mock (stored in ``client.table.return_value``) is already in place.
+    """
+    def _make_chain(rows: list[dict]) -> MagicMock:
+        exec_resp = MagicMock()
+        exec_resp.data = rows
+        limit_mock = MagicMock()
+        limit_mock.limit.return_value.execute.return_value = exec_resp
+        order_mock = MagicMock()
+        order_mock.order.return_value = limit_mock
+        return order_mock
 
-    order_mock = MagicMock()
-    order_mock.order.return_value = limit_mock
+    def _eq_side_effect(field: str, value):
+        if field == "event_type" and value in events_by_type:
+            return _make_chain(events_by_type[value])
+        return _make_chain([])
 
     eq_mock = MagicMock()
-    eq_mock.eq.return_value = order_mock
+    eq_mock.eq.side_effect = _eq_side_effect
 
     select_mock = MagicMock()
     select_mock.select.return_value = eq_mock
@@ -71,7 +88,7 @@ class TestHysteresis:
     def test_below_threshold_no_action(self):
         client = MagicMock()
         _mock_pending_count(client, 5)
-        _mock_events(client, "candidates_pending", [])
+        _mock_events(client, {"candidates_pending": []})
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "none"
@@ -80,7 +97,7 @@ class TestHysteresis:
     def test_above_threshold_fires(self):
         client = MagicMock()
         _mock_pending_count(client, 12)
-        _mock_events(client, "candidates_pending", [])
+        _mock_events(client, {"candidates_pending": []})
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "would_fire"
@@ -90,12 +107,12 @@ class TestHysteresis:
         """Still in fired state and count >= rearm threshold → skip."""
         client = MagicMock()
         _mock_pending_count(client, 10)
-        _mock_events(client, "candidates_pending", [
+        _mock_events(client, {"candidates_pending": [
             {
                 "created_at": "2026-05-20T10:00:00Z",
                 "payload": {"state": "fired", "pending_count": 15},
             }
-        ])
+        ]})
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "none"
@@ -105,22 +122,12 @@ class TestHysteresis:
         """After re-arm (<8), crossing >=10 fires again."""
         client = MagicMock()
         _mock_pending_count(client, 12)
-        # Last event was a fired event from earlier, but count dropped below 8
-        # so re-arm happened. The last event's state is still 'fired' but
-        # pending_count is now 12 >= 8 rearm threshold... hmm.
-
-        # Actually, the logic is: if last state is 'fired' AND pending >= rearm,
-        # skip. So to re-fire, we need either:
-        # 1. Last state is 'rearmed' (from a re-arm event), or
-        # 2. pending < rearm threshold (wouldn't fire anyway)
-
-        # Let me simulate: after re-arm, the last event is 'rearmed'
-        _mock_events(client, "candidates_pending", [
+        _mock_events(client, {"candidates_pending": [
             {
                 "created_at": "2026-05-19T10:00:00Z",
                 "payload": {"state": "rearmed", "pending_count": 7},
             }
-        ])
+        ]})
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "would_fire"
@@ -130,16 +137,43 @@ class TestHysteresis:
         """pending=9 is in the hysteresis band (8..9), no re-fire when last was fired."""
         client = MagicMock()
         _mock_pending_count(client, 9)
-        _mock_events(client, "candidates_pending", [
+        _mock_events(client, {"candidates_pending": [
             {
                 "created_at": "2026-05-20T10:00:00Z",
                 "payload": {"state": "fired", "pending_count": 15},
             }
-        ])
+        ]})
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "none"
-        # Still in hysteresis band (pending=9 >= rearm=8, last state=fired)
+
+    def test_fire_drop_rerise_refires(self):
+        """fire → drop below REARM_THRESHOLD → rise above FIRE_THRESHOLD → re-fires."""
+        # Phase 1: no prior event, pending=12 → fires
+        c1 = MagicMock()
+        _mock_pending_count(c1, 12)
+        _mock_events(c1, {"candidates_pending": [], "learn_run": []})
+        r1 = watcher.check_and_fire(c1, dry_run=True, _now=lambda: FROZEN_NOW)
+        assert r1["action"] == "would_fire"
+
+        # Phase 2: pending=6, last state=fired → re-arms, returns none (below FIRE)
+        c2 = MagicMock()
+        _mock_pending_count(c2, 6)
+        _mock_events(c2, {"candidates_pending": [
+            {"created_at": "2026-05-24T10:00:00Z", "payload": {"state": "fired", "pending_count": 12}}
+        ], "learn_run": []})
+        r2 = watcher.check_and_fire(c2, dry_run=True, _now=lambda: FROZEN_NOW)
+        assert r2["action"] == "none"
+        assert r2.get("rearmed") is True
+
+        # Phase 3: pending=11, last state=rearmed → fires again
+        c3 = MagicMock()
+        _mock_pending_count(c3, 11)
+        _mock_events(c3, {"candidates_pending": [
+            {"created_at": "2026-05-24T11:00:00Z", "payload": {"state": "rearmed", "pending_count": 6}}
+        ], "learn_run": []})
+        r3 = watcher.check_and_fire(c3, dry_run=True, _now=lambda: FROZEN_NOW)
+        assert r3["action"] == "would_fire"
 
 
 class TestDebounce:
@@ -148,46 +182,63 @@ class TestDebounce:
     def test_recent_learn_skips_fire(self):
         client = MagicMock()
         _mock_pending_count(client, 15)
-        # Last candidates_pending event is rearmed, so that gate passes
-        _mock_events(client, "candidates_pending", [
-            {
-                "created_at": "2026-05-19T10:00:00Z",
-                "payload": {"state": "rearmed", "pending_count": 5},
-            }
-        ])
-        # But a /learn ran 2 hours ago
-        _mock_events(client, "learn_run", [
-            {"created_at": "2026-05-20T10:00:00Z"},
-        ])
+        _mock_events(client, {
+            "candidates_pending": [
+                {
+                    "created_at": "2026-05-23T12:00:00Z",
+                    "payload": {"state": "rearmed", "pending_count": 5},
+                }
+            ],
+            "learn_run": [
+                {"created_at": "2026-05-24T11:00:00Z"},  # 1h before FROZEN_NOW
+            ],
+        })
 
-        result = watcher.check_and_fire(client, dry_run=True)
+        result = watcher.check_and_fire(client, dry_run=True, _now=lambda: FROZEN_NOW)
         assert result["action"] == "none"
         assert "debounce" in result["reason"]
 
     def test_old_learn_allows_fire(self):
         client = MagicMock()
         _mock_pending_count(client, 15)
-        # Last candidates_pending is rearmed
-        _mock_events(client, "candidates_pending", [
-            {
-                "created_at": "2026-05-19T10:00:00Z",
-                "payload": {"state": "rearmed", "pending_count": 5},
-            }
-        ])
-        # But /learn ran 48 hours ago - outside debounce window
-        _mock_events(client, "learn_run", [
-            {"created_at": "2026-05-18T10:00:00Z"},
-        ])
+        _mock_events(client, {
+            "candidates_pending": [
+                {
+                    "created_at": "2026-05-22T12:00:00Z",
+                    "payload": {"state": "rearmed", "pending_count": 5},
+                }
+            ],
+            "learn_run": [
+                {"created_at": "2026-05-22T12:00:00Z"},  # 48h before FROZEN_NOW
+            ],
+        })
 
-        result = watcher.check_and_fire(client, dry_run=True)
+        result = watcher.check_and_fire(client, dry_run=True, _now=lambda: FROZEN_NOW)
         assert result["action"] == "would_fire"
+
+    def test_second_invocation_within_debounce_suppressed(self):
+        """After watcher fires, re-invocation within 24h is suppressed via learn_run marker."""
+        client = MagicMock()
+        _mock_pending_count(client, 15)
+        _mock_events(client, {
+            "candidates_pending": [
+                {"created_at": "2026-05-24T11:55:00Z", "payload": {"state": "rearmed"}}
+            ],
+            "learn_run": [
+                {"created_at": "2026-05-24T11:59:00Z"},  # 1 min before FROZEN_NOW
+            ],
+        })
+
+        result = watcher.check_and_fire(client, dry_run=True, _now=lambda: FROZEN_NOW)
+        assert result["action"] == "none"
+        assert "debounce" in result["reason"]
 
 
 class TestDryRun:
     def test_dry_run_no_event_emitted(self):
         client = MagicMock()
         _mock_pending_count(client, 15)
-        _mock_events(client, "candidates_pending", [])
+        _mock_events(client, {"candidates_pending": []})
 
         result = watcher.check_and_fire(client, dry_run=True)
         assert result["action"] == "would_fire"

--- a/tests/test_review_render.py
+++ b/tests/test_review_render.py
@@ -12,7 +12,6 @@ the diff on every PR.
 from __future__ import annotations
 
 import importlib.util
-import sys
 import uuid
 from pathlib import Path
 
@@ -66,7 +65,11 @@ class TestClassifierUpdate:
             "content": "User prefers async workflows for code review.",
             "tags": ["workflow", "async"],
         }
-        ctx = {"decision": "UPDATE", "before_snapshot": before, "reasoning": "More specific preference detected"}
+        ctx = {
+            "decision": "UPDATE",
+            "before_snapshot": before,
+            "reasoning": "More specific preference detected",
+        }
         result = review_render.render_proposal(row, ctx)
         assert "### async_pref (feedback) — UPDATE" in result
         assert "Description:" in result
@@ -175,6 +178,27 @@ class TestMergeProposal:
         assert "uuid-b" in result
         assert "Consolidated feedback" in result
 
+    def test_classifier_with_merge_targets_renders_as_merge(self):
+        """Compound row (classifier:* provenance + non-empty merge_targets) must show targets.
+
+        Regression: round-2 routing checked `is_classifier` before `has_merge_targets`,
+        so a classifier:add:* row that also consolidates duplicates rendered as a
+        plain classifier compact card and the merge target UUIDs were silently
+        dropped from the reviewer's view.
+        """
+        row = _row(
+            name="consolidated_add",
+            description="New consolidated memory replacing duplicates",
+            merge_targets=["uuid-dup-1", "uuid-dup-2", "uuid-dup-3"],
+            source_provenance="classifier:add:2026-05-26",
+        )
+        ctx = {"decision": "ADD", "reasoning": "Consolidates 3 duplicates into one canonical"}
+        result = review_render.render_proposal(row, ctx)
+        assert "MERGE (3 targets)" in result
+        assert "uuid-dup-1" in result
+        assert "uuid-dup-2" in result
+        assert "uuid-dup-3" in result
+
 
 # ---------------------------------------------------------------------------
 # Candidate
@@ -237,6 +261,7 @@ class TestRenderList:
 
     def test_contexts_length_mismatch_raises(self):
         import pytest
+
         rows = [_row(name="only")]
         with pytest.raises(ValueError, match="contexts length"):
             review_render.render_proposal_list(rows, contexts=[None, None])

--- a/tests/test_review_render.py
+++ b/tests/test_review_render.py
@@ -234,3 +234,9 @@ class TestRenderList:
         assert "first" in result
         assert "second" in result
         assert "---" in result  # separator between items
+
+    def test_contexts_length_mismatch_raises(self):
+        import pytest
+        rows = [_row(name="only")]
+        with pytest.raises(ValueError, match="contexts length"):
+            review_render.render_proposal_list(rows, contexts=[None, None])

--- a/tests/test_review_render.py
+++ b/tests/test_review_render.py
@@ -1,0 +1,236 @@
+"""Golden-file fixture tests for ``mcp-memory/review_render.py``.
+
+Covers every row type the renderer accepts: classifier UPDATE (with diff),
+classifier ADD / DELETE / NOOP, merge proposal, candidate, empty list,
+and a previously-rejected item.
+
+All tests are pure — no network, no DB, no mocks. Input data is inline.
+Expected output is inline (golden strings) so fixture drift is visible in
+the diff on every PR.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+
+_THIS_DIR = Path(__file__).resolve().parent
+_WORKSPACE_ROOT = _THIS_DIR.parent
+_REVIEW_RENDER_PATH = _WORKSPACE_ROOT / "mcp-memory" / "review_render.py"
+
+# Hyphen in parent directory name → use spec_from_file_location.
+_spec = importlib.util.spec_from_file_location("review_render", _REVIEW_RENDER_PATH)
+assert _spec and _spec.loader
+review_render = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(review_render)
+
+
+def _row(**overrides: str | list | None) -> dict:
+    """Build a minimal ``memory_review_list``-shaped row."""
+    base = {
+        "id": str(uuid.uuid4()),
+        "name": "test_memory",
+        "type": "feedback",
+        "project": "jarvis",
+        "description": "Test description",
+        "content": "Test content body",
+        "tags": ["test", "fixture"],
+        "source_provenance": "classifier:test",
+        "requires_review": True,
+        "merge_targets": None,
+        "reject_reason": None,
+        "created_at": "2026-05-20T12:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# classifier UPDATE — with diff
+# ---------------------------------------------------------------------------
+
+
+class TestClassifierUpdate:
+    def test_content_diff(self):
+        row = _row(
+            name="async_pref",
+            description="User prefers async workflows",
+            content="User strongly prefers async code review workflows and "
+            "avoids synchronous meetings for code discussions.",
+            tags=["workflow", "async", "code-review"],
+        )
+        before = {
+            "description": "User likes async",
+            "content": "User prefers async workflows for code review.",
+            "tags": ["workflow", "async"],
+        }
+        ctx = {"decision": "UPDATE", "before_snapshot": before, "reasoning": "More specific preference detected"}
+        result = review_render.render_proposal(row, ctx)
+        assert "### async_pref (feedback) — UPDATE" in result
+        assert "Description:" in result
+        assert "Content:" in result
+        assert "+ code-review" in result
+        assert "More specific preference detected" in result
+        assert "```diff" in result
+
+    def test_no_diff_when_unchanged(self):
+        """When before and after are identical, no diff block is emitted."""
+        before = {"description": "Same", "content": "Same body", "tags": ["a"]}
+        row = _row(description="Same", content="Same body", tags=["a"])
+        ctx = {"decision": "UPDATE", "before_snapshot": before}
+        result = review_render.render_proposal(row, ctx)
+        assert "UPDATE" in result
+        assert "```diff" not in result
+        assert "Content:" not in result  # no section header when unchanged
+
+    def test_tag_changes_only(self):
+        before = {"description": "Desc", "content": "Body", "tags": ["old"]}
+        row = _row(description="Desc", content="Body", tags=["old", "new"])
+        ctx = {"decision": "UPDATE", "before_snapshot": before}
+        result = review_render.render_proposal(row, ctx)
+        assert "+ new" in result
+        assert "```diff" not in result  # content unchanged, no diff block
+
+    def test_missing_before_snapshot_falls_back_to_compact(self):
+        """UPDATE without before_snapshot renders as compact card."""
+        row = _row(source_provenance="classifier:update")
+        ctx = {"decision": "UPDATE"}  # no before_snapshot
+        result = review_render.render_proposal(row, ctx)
+        # Falls back to compact card
+        assert "UPDATE" in result or "CLASSIFIER" in result
+        assert "Provenance:" in result
+
+
+# ---------------------------------------------------------------------------
+# classifier ADD / DELETE / NOOP
+# ---------------------------------------------------------------------------
+
+
+class TestClassifierCompact:
+    def test_add(self):
+        row = _row(
+            name="new_insight",
+            source_provenance="classifier:add:2026-05-20",
+            description="A brand new insight",
+            content="This is a new memory proposed by the classifier.",
+            tags=["insight", "new"],
+        )
+        ctx = {"decision": "ADD", "reasoning": "New fact worth recording"}
+        result = review_render.render_proposal(row, ctx)
+        assert "new_insight" in result
+        assert "ADD" in result
+        assert "A brand new insight" in result
+        assert "This is a new memory" in result
+        assert "New fact worth recording" in result
+
+    def test_delete(self):
+        row = _row(
+            name="stale_memory",
+            source_provenance="classifier:delete:2026-05-20",
+            description="Stale memory to remove",
+        )
+        ctx = {"decision": "DELETE", "reasoning": "Superseded by newer entry"}
+        result = review_render.render_proposal(row, ctx)
+        assert "stale_memory" in result
+        assert "DELETE" in result
+        assert "Superseded by newer entry" in result
+
+    def test_noop(self):
+        row = _row(
+            name="already_captured",
+            source_provenance="classifier:noop:2026-05-20",
+        )
+        ctx = {"decision": "NOOP", "reasoning": "Already captured in existing memory"}
+        result = review_render.render_proposal(row, ctx)
+        assert "already_captured" in result
+        assert "NOOP" in result
+
+    def test_missing_decision_label(self):
+        """Classifier row without explicit decision in context still renders."""
+        row = _row(source_provenance="classifier:unknown")
+        result = review_render.render_proposal(row)
+        assert "CLASSIFIER" in result or "unknown" not in result
+        assert "Provenance:" in result
+
+
+# ---------------------------------------------------------------------------
+# Merge proposal
+# ---------------------------------------------------------------------------
+
+
+class TestMergeProposal:
+    def test_basic_merge(self):
+        row = _row(
+            name="merged_feedback",
+            description="Consolidated feedback about X",
+            merge_targets=["uuid-a", "uuid-b"],
+            source_provenance="dreamer:run-123",
+        )
+        result = review_render.render_proposal(row)
+        assert "merged_feedback" in result
+        assert "MERGE (2 targets)" in result
+        assert "uuid-a" in result
+        assert "uuid-b" in result
+        assert "Consolidated feedback" in result
+
+
+# ---------------------------------------------------------------------------
+# Candidate
+# ---------------------------------------------------------------------------
+
+
+class TestCandidate:
+    def test_basic_candidate(self):
+        row = _row(
+            name="derived_insight",
+            source_provenance="dreamer:run-123",
+            description="An insight derived from cross-corpus analysis",
+            content="The agent should remember this important pattern.",
+            tags=["dreamer", "insight"],
+        )
+        result = review_render.render_proposal(row)
+        assert "derived_insight" in result
+        assert "CANDIDATE" in result
+        assert "An insight derived" in result
+        assert "Provenance:" in result
+        assert "dreamer:run-123" in result
+
+
+# ---------------------------------------------------------------------------
+# Previously rejected
+# ---------------------------------------------------------------------------
+
+
+class TestRejectedItem:
+    def test_shows_reject_reason(self):
+        row = _row(
+            name="rejected_candidate",
+            reject_reason="Not actionable, vague scope",
+        )
+        result = review_render.render_proposal(row)
+        assert "rejected_candidate" in result
+        assert "Previously rejected" in result
+        assert "Not actionable" in result
+
+
+# ---------------------------------------------------------------------------
+# render_proposal_list
+# ---------------------------------------------------------------------------
+
+
+class TestRenderList:
+    def test_empty_list(self):
+        result = review_render.render_proposal_list([])
+        assert "No pending proposals" in result
+
+    def test_multiple_rows(self):
+        rows = [
+            _row(name="first", description="First item"),
+            _row(name="second", description="Second item"),
+        ]
+        result = review_render.render_proposal_list(rows)
+        assert "first" in result
+        assert "second" in result
+        assert "---" in result  # separator between items


### PR DESCRIPTION
## Summary

Implements the `/learn` skill for draining the memory review queue, per ADR-0003. This slice exercises the classifier branch of `memory_review_list`; merge proposals and candidates are counted but rendered as no-op stubs.

### Components

| File | Purpose |
|---|---|
| `mcp-memory/review_render.py` | Pure-function row renderer — takes a `memory_review_list` row + optional context, returns formatted Markdown. No DB calls inside. |
| `.claude-userlevel/skills/learn/SKILL.md` | `/learn` skill orchestration: list → render → prompt → decide → record outcome. |
| `.claude-userlevel/skills/setup-tasks/SKILL.md` | Adds weekly `/learn` cron entry (Sun 10:00). |
| `scripts/pending-volume-watcher.py` | Volume-event watcher with hysteresis (>=10 fire, <8 re-arm) and 24h debounce after `/learn` runs. |
| `tests/test_review_render.py` | 13 golden-file fixture tests covering UPDATE diff, ADD/DELETE/NOOP compact, merge, candidate, rejected items, empty list. |
| `tests/test_pending_volume_watcher.py` | 7 tests covering hysteresis states, debounce, and dry-run. |

### Renderer formats

- **classifier UPDATE**: before/after diff with description, content, and tag changes
- **classifier ADD / DELETE / NOOP**: compact card with reasoning, content, tags, provenance
- **Merge proposal**: summary with target count and UUIDs
- **Candidate**: compact card (placeholder for future slices)

### AC checklist

- [x] `/learn` invoked manually drains classifier queue rows up to cap 20
- [x] Each classifier UPDATE row displays before/after diff; ADD/DELETE/NOOP display compact form
- [x] `approve` action applies classifier decision; `reject` action drops row with free-text reason
- [x] One `outcome_record` row written per `/learn` run (zero-row runs included)
- [x] `/learn --status` prints per-queue pending counts without mutations
- [x] Row renderer is importable as a pure function with 13 fixture tests
- [x] Weekly Task Scheduler entry added to setup-tasks (Sun 10:00)
- [x] Volume-event watcher fires at >=10, hysteresis band 8-9, re-arms at <8
- [x] 24h debounce skips fire if `/learn` ran in last 24 hours
- [x] Fail-stop on `memory_review_decide` errors mid-run

## Test plan

- [x] `python3 -m pytest tests/test_review_render.py tests/test_pending_volume_watcher.py -v` — 21 tests pass
- [x] Syntax check: all 4 new files compile cleanly

Closes #682

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
