### PR TITLE
feat(sandcastle): watchdog-enforced pytest gate for -Repo redrobot (Closes #630)

### DIFF
--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -506,6 +506,166 @@ function Send-TelegramAlert {
 }
 
 # ---------------------------------------------------------------------------
+# Pytest gate (redrobot only, #630)
+#
+# Test-surface discovery strategy: for each changed .py file, look for a
+# co-located test_<name>.py in the same directory or in tests/. Falls back
+# to full `pytest` suite when no targeted test files are found.
+#
+# Decision: touched-file-mapped test discovery with full-suite fallback.
+# Rationale: agent may refactor files whose test coverage lives outside
+# the co-located pattern (e.g. a tests/ directory mirror). Full suite
+# has ~30s overhead on redrobot's small test corpus -- acceptable.
+# Reversibility: reversible (strategy is config at the function level).
+# Alternatives:
+#   1. pytest --lf (last-failed) -- rejected, first run has no history.
+#   2. Full suite always -- rejected, agent changes are typically small
+#      and targeted; full suite is a safety net, not the primary gate.
+# Confidence: 0.8.
+# ---------------------------------------------------------------------------
+
+function Get-RelatedTestFiles {
+    [CmdletBinding()]
+    param(
+        [string[]]$ChangedFiles,
+        [string]$RepoRoot
+    )
+    $testFiles = @()
+    foreach ($f in $ChangedFiles) {
+        $name = [System.IO.Path]::GetFileNameWithoutExtension($f)
+        $dir  = [System.IO.Path]::GetDirectoryName($f)
+        # Co-located: src/module.py -> src/test_module.py
+        $colocated = Join-Path $RepoRoot $dir "test_$name.py"
+        if (Test-Path -LiteralPath $colocated -PathType Leaf) {
+            $testFiles += $colocated
+            continue
+        }
+        # Tests mirror: src/module.py -> tests/test_module.py
+        $inTests = Join-Path $RepoRoot 'tests' "test_$name.py"
+        if (Test-Path -LiteralPath $inTests -PathType Leaf) {
+            $testFiles += $inTests
+            continue
+        }
+    }
+    return ($testFiles | Select-Object -Unique)
+}
+
+function Invoke-PytestGate {
+    [CmdletBinding()]
+    param(
+        [string]$RepoRoot,
+        [string]$Branch,
+        [string]$RepoSlug
+    )
+
+    if (-not (Test-Path -LiteralPath $RepoRoot)) {
+        return [pscustomobject]@{
+            passed          = $false
+            collectionError = $true
+            summary         = "redrobot repo root not found: $RepoRoot"
+            testsRun        = 0
+        }
+    }
+
+    # Get changed .py files against the base branch
+    Push-Location -LiteralPath $RepoRoot
+    $changedRaw = & git diff origin/main...$Branch --name-only 2>$null
+    $gitExit = $LASTEXITCODE
+    Pop-Location
+
+    if ($gitExit -ne 0 -or [string]::IsNullOrWhiteSpace($changedRaw)) {
+        # No base branch to diff or no changes -- run full suite as safety net.
+        $changedFiles = @()
+    } else {
+        $changedFiles = ($changedRaw -split "`n") | Where-Object { $_ -match '\.py$' -and $_ -match '\S' }
+    }
+
+    $testTargets = @()
+    if ($changedFiles.Count -gt 0) {
+        $testTargets = Get-RelatedTestFiles -ChangedFiles $changedFiles -RepoRoot $RepoRoot
+    }
+
+    # Run pytest
+    Push-Location -LiteralPath $RepoRoot
+    try {
+        if ($testTargets.Count -gt 0) {
+            Write-Host "[pytest-gate] running $($testTargets.Count) test files for $($changedFiles.Count) changed .py files"
+            $output = & pytest $testTargets --tb=short -q 2>&1
+        } else {
+            Write-Host "[pytest-gate] no targeted tests found -- running full suite"
+            $output = & pytest --tb=short -q 2>&1
+        }
+        $exitCode = $LASTEXITCODE
+    } catch {
+        Pop-Location
+        return [pscustomobject]@{
+            passed          = $false
+            collectionError = $true
+            summary         = "pytest invocation failed: $_"
+            testsRun        = 0
+        }
+    }
+    Pop-Location
+
+    # Parse output for test count
+    $testsRun = 0
+    if ($output -match '(\d+) passed') { $testsRun = [int]$Matches[1] }
+    if ($output -match '(\d+) failed') { $testsRun += [int]$Matches[1] }
+
+    # Extract failing test names
+    $failedLines = $output | Select-String '^FAILED ' -ErrorAction SilentlyContinue | ForEach-Object { $_.Line }
+    $failureNames = $failedLines -replace '^FAILED ', ''
+
+    if ($exitCode -eq -1 -or $exitCode -eq 2) {
+        return [pscustomobject]@{
+            passed          = $false
+            collectionError = $true
+            exitCode        = $exitCode
+            summary         = "pytest collection error (exit=$exitCode)"
+            testsRun        = $testsRun
+        }
+    }
+
+    $passed = ($exitCode -eq 0)
+    $summary = if ($passed) {
+        "${testsRun} passed"
+    } else {
+        "${testsRun} total, $($failureNames.Count) failed: $($failureNames -join ', ')"
+    }
+
+    return [pscustomobject]@{
+        passed          = $passed
+        collectionError = $false
+        exitCode        = $exitCode
+        summary         = $summary
+        testsRun        = $testsRun
+        failures        = $failureNames
+    }
+}
+
+function Close-AgentPR {
+    [CmdletBinding()]
+    param(
+        [string]$Branch,
+        [string]$RepoSlug
+    )
+    if ([string]::IsNullOrWhiteSpace($Branch) -or [string]::IsNullOrWhiteSpace($RepoSlug)) {
+        return $false
+    }
+    try {
+        # Find the PR for this branch
+        $prNum = & gh pr list --repo $RepoSlug --head $Branch --state open --json number --jq '.[0].number' 2>$null
+        if ($prNum -and $prNum -gt 0) {
+            & gh pr close $prNum --repo $RepoSlug --comment "Closed by sandcastle watchdog -- pytest gate failed." 2>$null
+            return ($LASTEXITCODE -eq 0)
+        }
+    } catch {
+        Write-Warning "Close-AgentPR: $_"
+    }
+    return $false
+}
+
+# ---------------------------------------------------------------------------
 # Outcome recording -- direct PostgREST insert (anon, RLS-gated by source_provenance)
 # ---------------------------------------------------------------------------
 
@@ -810,6 +970,37 @@ function Invoke-Watchdog {
                 $totalUsage.cache_creation_input_tokens+= [int]$it.usage.cacheCreationInputTokens
             }
         }
+    }
+
+    # ---- 5. Pytest gate (redrobot only) ----
+    $pytestResult = $null
+    if (-not $partialReason -and $Repo -eq 'redrobot') {
+        $pytestResult = Invoke-PytestGate -RepoRoot $repoRoot -Branch $branch -RepoSlug $repoSlug
+        $totalUsage.gates = @{ pytest = $pytestResult }
+
+        if (-not $pytestResult.passed) {
+            $pytestReason = if ($pytestResult.collectionError) { 'tests-broken' } else { 'tests-failing' }
+            $pytestLabel = $pytestReason
+
+            # Close the PR if one was opened
+            if ($branch) {
+                Close-AgentPR -Branch $branch -RepoSlug $repoSlug
+            }
+
+            # Label the issue
+            if ($targetIssue -and $repoSlug) {
+                Add-IssueLabel -Issue $targetIssue -Label $pytestLabel -RepoSlug $repoSlug | Out-Null
+                # Drop status:in-progress (can't apply after Add-IssueLabel directly -- use gh)
+                & gh issue edit $targetIssue --repo $repoSlug --remove-label 'status:in-progress' 2>$null
+            }
+
+            $summary = "pytest-gate:$pytestReason -- branch=$branch $($pytestResult.summary)"
+            Record 'partial' $summary $totalUsage ''
+            Write-Host "[watchdog] $summary"
+            return
+        }
+
+        Write-Host "[watchdog] pytest gate passed ($($pytestResult.testsRun) tests)"
     }
 
     if ($partialReason) {

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -558,8 +558,7 @@ function Invoke-PytestGate {
     [CmdletBinding()]
     param(
         [string]$RepoRoot,
-        [string]$Branch,
-        [string]$RepoSlug
+        [string]$Branch
     )
 
     if (-not (Test-Path -LiteralPath $RepoRoot)) {
@@ -574,6 +573,7 @@ function Invoke-PytestGate {
     # Get changed .py files against the base branch
     Push-Location -LiteralPath $RepoRoot
     try {
+        & git fetch origin main --quiet 2>$null | Out-Null
         $changedRaw = & git diff origin/main...$Branch --name-only 2>$null
         $gitExit = $LASTEXITCODE
     } finally {
@@ -624,7 +624,7 @@ function Invoke-PytestGate {
     $failedLines = $output | Select-String '^FAILED ' -ErrorAction SilentlyContinue | ForEach-Object { $_.Line }
     $failureNames = $failedLines -replace '^FAILED ', ''
 
-    if ($exitCode -eq -1 -or $exitCode -eq 2) {
+    if ($exitCode -in @(2, 3, 4, 5)) {
         return [pscustomobject]@{
             passed          = $false
             collectionError = $true
@@ -1028,7 +1028,7 @@ function Invoke-Watchdog {
     # ---- 5. Pytest gate (redrobot only) ----
     $pytestResult = $null
     if (-not $partialReason -and $Repo -eq 'redrobot') {
-        $pytestResult = Invoke-PytestGate -RepoRoot $repoRoot -Branch $branch -RepoSlug $repoSlug
+        $pytestResult = Invoke-PytestGate -RepoRoot $repoRoot -Branch $branch
         $totalUsage.gates = @{ pytest = $pytestResult }
 
         if (-not $pytestResult.passed) {

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -535,13 +535,13 @@ function Get-RelatedTestFiles {
         $name = [System.IO.Path]::GetFileNameWithoutExtension($f)
         $dir  = [System.IO.Path]::GetDirectoryName($f)
         # Co-located: src/module.py -> src/test_module.py
-        $colocated = Join-Path $RepoRoot $dir "test_$name.py"
+        $colocated = Join-Path (Join-Path $RepoRoot $dir) "test_$name.py"
         if (Test-Path -LiteralPath $colocated -PathType Leaf) {
             $testFiles += $colocated
             continue
         }
         # Tests mirror: src/module.py -> tests/test_module.py
-        $inTests = Join-Path $RepoRoot 'tests' "test_$name.py"
+        $inTests = Join-Path (Join-Path $RepoRoot 'tests') "test_$name.py"
         if (Test-Path -LiteralPath $inTests -PathType Leaf) {
             $testFiles += $inTests
             continue

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -369,14 +369,18 @@ function Get-IssueFromBranch {
     return $null
 }
 
+function Invoke-Gh {
+    & gh @args 2>$null
+}
+
 function Get-IssueLabels {
     [CmdletBinding()]
     param([int]$Issue, [string]$RepoSlug)
     if (-not $Issue) { return @() }
     try {
-        $args = @('issue', 'view', "$Issue", '--json', 'labels', '--jq', '[.labels[].name]')
-        if ($RepoSlug) { $args += @('--repo', $RepoSlug) }
-        $raw = & gh @args 2>$null
+        $ghArgs = @('issue', 'view', "$Issue", '--json', 'labels', '--jq', '[.labels[].name]')
+        if ($RepoSlug) { $ghArgs += @('--repo', $RepoSlug) }
+        $raw = Invoke-Gh @ghArgs
         if ($LASTEXITCODE -ne 0 -or -not $raw) { return @() }
         return ($raw | ConvertFrom-Json)
     } catch {
@@ -388,9 +392,9 @@ function Add-IssueLabel {
     [CmdletBinding()]
     param([int]$Issue, [string]$Label, [string]$RepoSlug)
     if (-not $Issue -or -not $Label) { return $false }
-    $args = @('issue', 'edit', "$Issue", '--add-label', $Label)
-    if ($RepoSlug) { $args += @('--repo', $RepoSlug) }
-    & gh @args 2>$null | Out-Null
+    $ghArgs = @('issue', 'edit', "$Issue", '--add-label', $Label)
+    if ($RepoSlug) { $ghArgs += @('--repo', $RepoSlug) }
+    Invoke-Gh @ghArgs | Out-Null
     return ($LASTEXITCODE -eq 0)
 }
 
@@ -569,9 +573,12 @@ function Invoke-PytestGate {
 
     # Get changed .py files against the base branch
     Push-Location -LiteralPath $RepoRoot
-    $changedRaw = & git diff origin/main...$Branch --name-only 2>$null
-    $gitExit = $LASTEXITCODE
-    Pop-Location
+    try {
+        $changedRaw = & git diff origin/main...$Branch --name-only 2>$null
+        $gitExit = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
 
     if ($gitExit -ne 0 -or [string]::IsNullOrWhiteSpace($changedRaw)) {
         # No base branch to diff or no changes -- run full suite as safety net.
@@ -597,20 +604,21 @@ function Invoke-PytestGate {
         }
         $exitCode = $LASTEXITCODE
     } catch {
-        Pop-Location
         return [pscustomobject]@{
             passed          = $false
             collectionError = $true
             summary         = "pytest invocation failed: $_"
             testsRun        = 0
         }
+    } finally {
+        Pop-Location
     }
-    Pop-Location
 
-    # Parse output for test count
+    # Parse output for test count (B1: join array to scalar before -match so $Matches is populated)
     $testsRun = 0
-    if ($output -match '(\d+) passed') { $testsRun = [int]$Matches[1] }
-    if ($output -match '(\d+) failed') { $testsRun += [int]$Matches[1] }
+    $joined = $output -join "`n"
+    if ($joined -match '(\d+) passed') { $testsRun = [int]$Matches[1] }
+    if ($joined -match '(\d+) failed') { $testsRun += [int]$Matches[1] }
 
     # Extract failing test names
     $failedLines = $output | Select-String '^FAILED ' -ErrorAction SilentlyContinue | ForEach-Object { $_.Line }
@@ -643,7 +651,7 @@ function Invoke-PytestGate {
     }
 }
 
-function Close-AgentPR {
+function Stop-AgentPR {
     [CmdletBinding()]
     param(
         [string]$Branch,
@@ -654,15 +662,60 @@ function Close-AgentPR {
     }
     try {
         # Find the PR for this branch
-        $prNum = & gh pr list --repo $RepoSlug --head $Branch --state open --json number --jq '.[0].number' 2>$null
-        if ($prNum -and $prNum -gt 0) {
-            & gh pr close $prNum --repo $RepoSlug --comment "Closed by sandcastle watchdog -- pytest gate failed." 2>$null
+        $prNum = Invoke-Gh pr list --repo $RepoSlug --head $Branch --state open --json number --jq '.[0].number'
+        if ($prNum -and [int]$prNum.Trim() -gt 0) {
+            Invoke-Gh pr close $prNum --repo $RepoSlug --comment "Closed by sandcastle watchdog -- pytest gate failed." | Out-Null
             return ($LASTEXITCODE -eq 0)
         }
     } catch {
-        Write-Warning "Close-AgentPR: $_"
+        Write-Warning "Stop-AgentPR: $_"
     }
     return $false
+}
+
+# ---------------------------------------------------------------------------
+# Decision memory write -- records pytest-gate decisions in memories table
+# (M6/AC7: decision must be queryable by next session via memory_recall).
+# Anon INSERT allowed when source_provenance like 'sandcastle:%' (RLS policy).
+# ---------------------------------------------------------------------------
+
+function Write-SandcastleDecisionMemory {
+    [CmdletBinding()]
+    param(
+        [string]$SupabaseUrl,
+        [string]$SupabaseKey,
+        [string]$Project,
+        [string]$Name,
+        [string]$Description,
+        [string]$Content,
+        [string]$RunId
+    )
+    if (-not $SupabaseUrl -or -not $SupabaseKey) {
+        Write-Warning "SUPABASE_URL/SUPABASE_KEY missing -- skipping decision memory write."
+        return
+    }
+    $body = @{
+        type              = 'decision'
+        project           = $Project
+        name              = $Name
+        description       = $Description
+        content           = $Content
+        tags              = @('sandcastle', 'afk', 'pytest-gate')
+        source_provenance = "sandcastle:pytest-gate:$RunId"
+    }
+    $headers = @{
+        apikey         = $SupabaseKey
+        Authorization  = "Bearer $SupabaseKey"
+        'Content-Type' = 'application/json'
+        Prefer         = 'return=minimal,resolution=merge-duplicates'
+    }
+    $url = "$($SupabaseUrl.TrimEnd('/'))/rest/v1/memories"
+    try {
+        Invoke-RestMethod -Uri $url -Method Post -Headers $headers `
+            -Body ($body | ConvertTo-Json -Depth 4) -ErrorAction Stop | Out-Null
+    } catch {
+        Write-Warning "decision memory write failed: $_"
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -984,18 +1037,28 @@ function Invoke-Watchdog {
 
             # Close the PR if one was opened
             if ($branch) {
-                Close-AgentPR -Branch $branch -RepoSlug $repoSlug
+                Stop-AgentPR -Branch $branch -RepoSlug $repoSlug
             }
 
             # Label the issue
             if ($targetIssue -and $repoSlug) {
                 Add-IssueLabel -Issue $targetIssue -Label $pytestLabel -RepoSlug $repoSlug | Out-Null
-                # Drop status:in-progress (can't apply after Add-IssueLabel directly -- use gh)
-                & gh issue edit $targetIssue --repo $repoSlug --remove-label 'status:in-progress' 2>$null
+                # Drop status:in-progress
+                Invoke-Gh issue edit $targetIssue --repo $repoSlug --remove-label 'status:in-progress' | Out-Null
             }
 
             $summary = "pytest-gate:$pytestReason -- branch=$branch $($pytestResult.summary)"
             Record 'partial' $summary $totalUsage ''
+
+            # M6/AC7: record decision in Supabase memory for next-session recall
+            Write-SandcastleDecisionMemory `
+                -SupabaseUrl $supabaseUrl -SupabaseKey $supabaseKey `
+                -Project 'redrobot' `
+                -Name "pytest-gate:$pytestReason:$branch" `
+                -Description "pytest gate blocked sandcastle PR on $branch ($pytestReason)" `
+                -Content "Sandcastle run $runId blocked PR on branch $branch for redrobot. Reason: $pytestReason. $($pytestResult.summary)" `
+                -RunId $runId
+
             Write-Host "[watchdog] $summary"
             return
         }

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -1152,11 +1152,17 @@ Describe 'Get-RelatedTestFiles' {
     }
 
     It 'deduplicates when multiple files map to same test' {
-        # Create src/sub/module.py and another file mapping to test_module
-        New-Item -ItemType Directory -Path (Join-Path $script:tmpRoot 'src\sub') | Out-Null
-        New-Item -ItemType File -Path (Join-Path $script:tmpRoot 'src\sub\module.py') | Out-Null
-        $files = Get-RelatedTestFiles -ChangedFiles @('src/module.py', 'src/sub/module.py') -RepoRoot $script:tmpRoot
-        ($files | Select-Object -Unique).Count | Should Be 1
+        # Two files in different dirs both fall back to tests/test_module.py when
+        # no colocated test exists -- the function's own Select-Object -Unique must
+        # deduplicate them so the caller gets exactly one path, not two.
+        Remove-Item -LiteralPath (Join-Path $script:tmpRoot 'src\test_module.py') -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Path (Join-Path $script:tmpRoot 'lib') | Out-Null
+        New-Item -ItemType File     -Path (Join-Path $script:tmpRoot 'lib\module.py') | Out-Null
+        New-Item -ItemType File     -Path (Join-Path $script:tmpRoot 'tests\test_module.py') | Out-Null
+        # src/module.py: no src/test_module.py -> falls back to tests/test_module.py
+        # lib/module.py: no lib/test_module.py -> falls back to tests/test_module.py (same path)
+        $files = Get-RelatedTestFiles -ChangedFiles @('src/module.py', 'lib/module.py') -RepoRoot $script:tmpRoot
+        $files.Count | Should Be 1
     }
 }
 
@@ -1219,7 +1225,7 @@ Describe 'Invoke-PytestGate' {
         # B3: filter on LiteralPath (callers use -LiteralPath, not -Path)
         Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*test_module*' }
 
-        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
+        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test'
 
         $r.passed          | Should Be $true
         $r.collectionError | Should Be $false
@@ -1231,10 +1237,11 @@ Describe 'Invoke-PytestGate' {
         # B4: git diff succeeds, pytest exits 1
         Mock git { $global:LASTEXITCODE = 0; 'src/module.py' }
         Mock Test-Path { $false }
-        Mock pytest { $global:LASTEXITCODE = 1; '1 failed' }
-        Mock Select-String { 'FAILED test_module.py::test_something' }
+        # M5: return real pytest-formatted output so Select-String.Line works on MatchInfo,
+        # not on a bare string whose .Line is always $null.
+        Mock pytest { $global:LASTEXITCODE = 1; @('FAILED test_module.py::test_something', '1 failed in 0.1s') }
 
-        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
+        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test'
 
         $r.passed          | Should Be $false
         $r.collectionError | Should Be $false
@@ -1249,14 +1256,14 @@ Describe 'Invoke-PytestGate' {
         Mock Test-Path { $false }
         Mock pytest { $global:LASTEXITCODE = 2; 'ERROR: could not collect test files' }
 
-        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
+        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test'
 
         $r.passed          | Should Be $false
         $r.collectionError | Should Be $true
     }
 
     It 'returns collection error when repo root does not exist' {
-        $r = Invoke-PytestGate -RepoRoot "Nope:\missing" -Branch 'feat/test' -RepoSlug 'x/y'
+        $r = Invoke-PytestGate -RepoRoot "Nope:\missing" -Branch 'feat/test'
 
         $r.passed          | Should Be $false
         $r.collectionError | Should Be $true
@@ -1270,7 +1277,7 @@ Describe 'Invoke-PytestGate' {
         Mock git { $global:LASTEXITCODE = 1; $null }
         Mock pytest { $global:LASTEXITCODE = 0; '42 passed' }
 
-        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'x/y'
+        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test'
 
         $r.passed  | Should Be $true
         $r.testsRun | Should Be 42

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -1160,30 +1160,36 @@ Describe 'Get-RelatedTestFiles' {
     }
 }
 
-Describe 'Close-AgentPR' {
+Describe 'Stop-AgentPR' {
     It 'returns false when branch is empty' {
-        Close-AgentPR -Branch '' -RepoSlug 'x/y' | Should Be $false
+        Stop-AgentPR -Branch '' -RepoSlug 'x/y' | Should Be $false
     }
 
     It 'returns false when repo slug is empty' {
-        Close-AgentPR -Branch 'feat/test' -RepoSlug '' | Should Be $false
+        Stop-AgentPR -Branch 'feat/test' -RepoSlug '' | Should Be $false
     }
 
-    It 'returns false when no PR exists for branch (gh returns null)' {
-        Mock gh { $null }
-        Close-AgentPR -Branch 'feat/test' -RepoSlug 'x/y' | Should Be $false
+    It 'returns false when no PR exists for branch (Invoke-Gh returns null)' {
+        # C2: mock Invoke-Gh wrapper instead of native gh exe (Pester 3.4 cannot intercept native exes)
+        Mock Invoke-Gh { $null }
+        Stop-AgentPR -Branch 'feat/test' -RepoSlug 'x/y' | Should Be $false
     }
 
     It 'calls gh pr close when PR exists' {
         $script:ghCalls = @()
-        Mock gh {
-            $script:ghCalls += $args
-            if ($args[0] -eq 'pr' -and $args[1] -eq 'list') { return '42' }
+        # C2: mock Invoke-Gh; use comma-prefix to capture each call's args as a sub-array
+        Mock Invoke-Gh {
+            $script:ghCalls += ,$args
+            if ($args[0] -eq 'pr' -and $args[1] -eq 'list') {
+                $global:LASTEXITCODE = 0
+                return '42'
+            }
+            $global:LASTEXITCODE = 0
             return $null
         }
-        $result = Close-AgentPR -Branch 'feat/630-test' -RepoSlug 'SergazyNarynov/redrobot'
+        $result = Stop-AgentPR -Branch 'feat/630-test' -RepoSlug 'SergazyNarynov/redrobot'
         $result | Should Be $true
-        # Verify close was called
+        # Verify close was called (each sub-array is one call's positional args)
         $closeCall = $script:ghCalls | Where-Object { $_[0] -eq 'pr' -and $_[1] -eq 'close' }
         $closeCall | Should Not BeNullOrEmpty
     }
@@ -1204,11 +1210,14 @@ Describe 'Invoke-PytestGate' {
     It 'AC: green path -- pytest exits 0 -> passed=true' {
         Mock Push-Location { }
         Mock Pop-Location { }
-        Mock git { 'src/module.py' }
+        # B4: set LASTEXITCODE so git diff appears to succeed
+        Mock git { $global:LASTEXITCODE = 0; 'src/module.py' }
         # Return test file exists
         New-Item -ItemType File -Path (Join-Path $script:tmpRoot 'src\test_module.py') | Out-Null
-        Mock pytest { '1 passed' }
-        Mock Test-Path { $true } -ParameterFilter { $Path -like '*test_module*' }
+        # B4: set LASTEXITCODE = 0 (green)
+        Mock pytest { $global:LASTEXITCODE = 0; '1 passed' }
+        # B3: filter on LiteralPath (callers use -LiteralPath, not -Path)
+        Mock Test-Path { $true } -ParameterFilter { $LiteralPath -like '*test_module*' }
 
         $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
 
@@ -1219,9 +1228,10 @@ Describe 'Invoke-PytestGate' {
     It 'AC: red path -- pytest exits 1 -> passed=false' {
         Mock Push-Location { }
         Mock Pop-Location { }
-        Mock git { 'src/module.py' }
+        # B4: git diff succeeds, pytest exits 1
+        Mock git { $global:LASTEXITCODE = 0; 'src/module.py' }
         Mock Test-Path { $false }
-        Mock pytest { '1 failed' }
+        Mock pytest { $global:LASTEXITCODE = 1; '1 failed' }
         Mock Select-String { 'FAILED test_module.py::test_something' }
 
         $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
@@ -1234,9 +1244,10 @@ Describe 'Invoke-PytestGate' {
     It 'AC: collection error -- pytest exits 2 -> collectionError=true' {
         Mock Push-Location { }
         Mock Pop-Location { }
-        Mock git { 'src/module.py' }
+        # B4: git diff succeeds, pytest exits 2 (collection error)
+        Mock git { $global:LASTEXITCODE = 0; 'src/module.py' }
         Mock Test-Path { $false }
-        Mock pytest { 'ERROR: could not collect test files' }
+        Mock pytest { $global:LASTEXITCODE = 2; 'ERROR: could not collect test files' }
 
         $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
 
@@ -1255,8 +1266,9 @@ Describe 'Invoke-PytestGate' {
     It 'falls back to full suite when git diff fails (base branch missing)' {
         Mock Push-Location { }
         Mock Pop-Location { }
-        Mock git { $null }   # git diff fails
-        Mock pytest { '42 passed' }
+        # B4: git exits non-zero (diff fails), pytest exits 0 (full suite green)
+        Mock git { $global:LASTEXITCODE = 1; $null }
+        Mock pytest { $global:LASTEXITCODE = 0; '42 passed' }
 
         $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'x/y'
 
@@ -1279,8 +1291,13 @@ Describe 'Invoke-Watchdog pytest gate integration (redrobot)' {
         Mock Send-TelegramAlert  { 'mocked' }
         Mock Add-IssueLabel      { $true }
         Mock Get-IssueLabels     { @() }
-        Mock Close-AgentPR       { $true }
+        # M4: renamed Close-AgentPR -> Stop-AgentPR
+        Mock Stop-AgentPR        { $true }
         Mock Invoke-PytestGate   { $null }  # overridden per test
+        # M6: mock decision memory write so tests don't hit Supabase
+        Mock Write-SandcastleDecisionMemory { }
+        # C2: Invoke-Gh used for gh issue edit in watchdog; mock to no-op
+        Mock Invoke-Gh { }
     }
 
     It 'AC: redrobot green gate -> outcome=success, gates summary includes pytest' {
@@ -1305,7 +1322,10 @@ Describe 'Invoke-Watchdog pytest gate integration (redrobot)' {
         Assert-MockCalled Invoke-PytestGate -Times 1 -Exactly -Scope It
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'success' }
-        Assert-MockCalled Close-AgentPR -Times 0 -Exactly -Scope It
+        # M4: renamed to Stop-AgentPR
+        Assert-MockCalled Stop-AgentPR -Times 0 -Exactly -Scope It
+        # M6: no decision memory write on green gate
+        Assert-MockCalled Write-SandcastleDecisionMemory -Times 0 -Exactly -Scope It
     }
 
     It 'AC: redrobot red gate -> outcome=partial, PR closed, tests-failing label' {
@@ -1328,11 +1348,14 @@ Describe 'Invoke-Watchdog pytest gate integration (redrobot)' {
             -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
 
         Assert-MockCalled Invoke-PytestGate -Times 1 -Exactly -Scope It
-        Assert-MockCalled Close-AgentPR -Times 1 -Exactly -Scope It
+        # M4: renamed to Stop-AgentPR
+        Assert-MockCalled Stop-AgentPR -Times 1 -Exactly -Scope It
         Assert-MockCalled Add-IssueLabel -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Label -eq 'tests-failing' }
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'partial' -and $Summary -like '*pytest-gate:tests-failing*' }
+        # M6: decision memory must be written on gate failure
+        Assert-MockCalled Write-SandcastleDecisionMemory -Times 1 -Exactly -Scope It
     }
 
     It 'AC: redrobot collection error -> outcome=partial, tests-broken label' {
@@ -1358,6 +1381,8 @@ Describe 'Invoke-Watchdog pytest gate integration (redrobot)' {
             -ParameterFilter { $Label -eq 'tests-broken' }
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
             -ParameterFilter { $Status -eq 'partial' -and $Summary -like '*pytest-gate:tests-broken*' }
+        # M6: decision memory must be written on gate failure
+        Assert-MockCalled Write-SandcastleDecisionMemory -Times 1 -Exactly -Scope It
     }
 
     It 'AC: jarvis repo skips pytest gate entirely' {

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -1113,3 +1113,269 @@ Describe 'Write-OutcomeRecord HTTP path' {
         Assert-MockCalled Invoke-RestMethod -Times 0 -Exactly -Scope It
     }
 }
+
+# ---------------------------------------------------------------------------
+# Pytest gate for redrobot (#630)
+# ---------------------------------------------------------------------------
+
+Describe 'Get-RelatedTestFiles' {
+    BeforeEach {
+        $script:tmpRoot = Join-Path $env:TEMP "pytest-gate-test-$([guid]::NewGuid())"
+        New-Item -ItemType Directory -Path $script:tmpRoot | Out-Null
+        # Create a src dir with module.py
+        New-Item -ItemType Directory -Path (Join-Path $script:tmpRoot 'src') | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:tmpRoot 'src\module.py') | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:tmpRoot 'src\test_module.py') | Out-Null
+        # Create a tests dir with test_other.py
+        New-Item -ItemType Directory -Path (Join-Path $script:tmpRoot 'tests') | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:tmpRoot 'tests\test_other.py') | Out-Null
+    }
+    AfterEach {
+        Remove-Item -LiteralPath $script:tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'finds co-located test file' {
+        $files = Get-RelatedTestFiles -ChangedFiles @('src/module.py') -RepoRoot $script:tmpRoot
+        $files.Count | Should Be 1
+        $files[0] | Should Match 'test_module\.py$'
+    }
+
+    It 'finds test in tests/ mirror' {
+        $files = Get-RelatedTestFiles -ChangedFiles @('src/other.py') -RepoRoot $script:tmpRoot
+        $files.Count | Should Be 1
+        $files[0] | Should Match 'test_other\.py$'
+    }
+
+    It 'returns empty array when no test files match' {
+        $files = Get-RelatedTestFiles -ChangedFiles @('src/nonexistent.py') -RepoRoot $script:tmpRoot
+        $files.Count | Should Be 0
+    }
+
+    It 'deduplicates when multiple files map to same test' {
+        # Create src/sub/module.py and another file mapping to test_module
+        New-Item -ItemType Directory -Path (Join-Path $script:tmpRoot 'src\sub') | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:tmpRoot 'src\sub\module.py') | Out-Null
+        $files = Get-RelatedTestFiles -ChangedFiles @('src/module.py', 'src/sub/module.py') -RepoRoot $script:tmpRoot
+        ($files | Select-Object -Unique).Count | Should Be 1
+    }
+}
+
+Describe 'Close-AgentPR' {
+    It 'returns false when branch is empty' {
+        Close-AgentPR -Branch '' -RepoSlug 'x/y' | Should Be $false
+    }
+
+    It 'returns false when repo slug is empty' {
+        Close-AgentPR -Branch 'feat/test' -RepoSlug '' | Should Be $false
+    }
+
+    It 'returns false when no PR exists for branch (gh returns null)' {
+        Mock gh { $null }
+        Close-AgentPR -Branch 'feat/test' -RepoSlug 'x/y' | Should Be $false
+    }
+
+    It 'calls gh pr close when PR exists' {
+        $script:ghCalls = @()
+        Mock gh {
+            $script:ghCalls += $args
+            if ($args[0] -eq 'pr' -and $args[1] -eq 'list') { return '42' }
+            return $null
+        }
+        $result = Close-AgentPR -Branch 'feat/630-test' -RepoSlug 'SergazyNarynov/redrobot'
+        $result | Should Be $true
+        # Verify close was called
+        $closeCall = $script:ghCalls | Where-Object { $_[0] -eq 'pr' -and $_[1] -eq 'close' }
+        $closeCall | Should Not BeNullOrEmpty
+    }
+}
+
+Describe 'Invoke-PytestGate' {
+    BeforeEach {
+        $script:tmpRoot = Join-Path $env:TEMP "pytest-invoke-$([guid]::NewGuid())"
+        New-Item -ItemType Directory -Path $script:tmpRoot | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:tmpRoot 'src') | Out-Null
+        New-Item -ItemType File -Path (Join-Path $script:tmpRoot 'src\module.py') | Out-Null
+        Mock Write-Host { }  # suppress output
+    }
+    AfterEach {
+        Remove-Item -LiteralPath $script:tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'AC: green path -- pytest exits 0 -> passed=true' {
+        Mock Push-Location { }
+        Mock Pop-Location { }
+        Mock git { 'src/module.py' }
+        # Return test file exists
+        New-Item -ItemType File -Path (Join-Path $script:tmpRoot 'src\test_module.py') | Out-Null
+        Mock pytest { '1 passed' }
+        Mock Test-Path { $true } -ParameterFilter { $Path -like '*test_module*' }
+
+        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
+
+        $r.passed          | Should Be $true
+        $r.collectionError | Should Be $false
+    }
+
+    It 'AC: red path -- pytest exits 1 -> passed=false' {
+        Mock Push-Location { }
+        Mock Pop-Location { }
+        Mock git { 'src/module.py' }
+        Mock Test-Path { $false }
+        Mock pytest { '1 failed' }
+        Mock Select-String { 'FAILED test_module.py::test_something' }
+
+        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
+
+        $r.passed          | Should Be $false
+        $r.collectionError | Should Be $false
+        $r.failures.Count  | Should Be 1
+    }
+
+    It 'AC: collection error -- pytest exits 2 -> collectionError=true' {
+        Mock Push-Location { }
+        Mock Pop-Location { }
+        Mock git { 'src/module.py' }
+        Mock Test-Path { $false }
+        Mock pytest { 'ERROR: could not collect test files' }
+
+        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'SergazyNarynov/redrobot'
+
+        $r.passed          | Should Be $false
+        $r.collectionError | Should Be $true
+    }
+
+    It 'returns collection error when repo root does not exist' {
+        $r = Invoke-PytestGate -RepoRoot "Nope:\missing" -Branch 'feat/test' -RepoSlug 'x/y'
+
+        $r.passed          | Should Be $false
+        $r.collectionError | Should Be $true
+        $r.summary         | Should Match 'not found'
+    }
+
+    It 'falls back to full suite when git diff fails (base branch missing)' {
+        Mock Push-Location { }
+        Mock Pop-Location { }
+        Mock git { $null }   # git diff fails
+        Mock pytest { '42 passed' }
+
+        $r = Invoke-PytestGate -RepoRoot $script:tmpRoot -Branch 'feat/test' -RepoSlug 'x/y'
+
+        $r.passed  | Should Be $true
+        $r.testsRun | Should Be 42
+    }
+}
+
+Describe 'Invoke-Watchdog pytest gate integration (redrobot)' {
+    BeforeEach {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Start-DockerDesktop { }
+        Mock Start-OllamaServer  { }
+        Mock Get-RepoRoot { $env:TEMP }
+        Mock Read-DotEnvFile { @{ SUPABASE_URL = 'https://x'; SUPABASE_KEY = 'k'; TELEGRAM_BOT_TOKEN = 't'; TELEGRAM_CHAT_ID = '1' } }
+        Mock New-RuntimeDir { Join-Path $env:TEMP "sandcastle-pytest-int-$([guid]::NewGuid())" }
+        Mock Invoke-RuntimeSweep { @() }
+        Mock Write-OutcomeRecord { 'mocked' }
+        Mock Send-TelegramAlert  { 'mocked' }
+        Mock Add-IssueLabel      { $true }
+        Mock Get-IssueLabels     { @() }
+        Mock Close-AgentPR       { $true }
+        Mock Invoke-PytestGate   { $null }  # overridden per test
+    }
+
+    It 'AC: redrobot green gate -> outcome=success, gates summary includes pytest' {
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = 'feat/630-pytest'; commits = @(); iterations = @()
+                }
+            }
+        }
+        Mock Test-IsOOM { $false }
+        Mock Invoke-PytestGate {
+            [pscustomobject]@{
+                passed = $true; collectionError = $false; summary = '5 passed'; testsRun = 5
+            }
+        }
+
+        Invoke-Watchdog -Repo 'redrobot' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-PytestGate -Times 1 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' }
+        Assert-MockCalled Close-AgentPR -Times 0 -Exactly -Scope It
+    }
+
+    It 'AC: redrobot red gate -> outcome=partial, PR closed, tests-failing label' {
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = 'feat/630-fail'; commits = @(); iterations = @()
+                }
+            }
+        }
+        Mock Test-IsOOM { $false }
+        Mock Invoke-PytestGate {
+            [pscustomobject]@{
+                passed = $false; collectionError = $false; summary = '2 total, 1 failed: test_foo'; testsRun = 2; failures = @('test_foo')
+            }
+        }
+
+        Invoke-Watchdog -Repo 'redrobot' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-PytestGate -Times 1 -Exactly -Scope It
+        Assert-MockCalled Close-AgentPR -Times 1 -Exactly -Scope It
+        Assert-MockCalled Add-IssueLabel -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Label -eq 'tests-failing' }
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'partial' -and $Summary -like '*pytest-gate:tests-failing*' }
+    }
+
+    It 'AC: redrobot collection error -> outcome=partial, tests-broken label' {
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = 'feat/630-broken'; commits = @(); iterations = @()
+                }
+            }
+        }
+        Mock Test-IsOOM { $false }
+        Mock Invoke-PytestGate {
+            [pscustomobject]@{
+                passed = $false; collectionError = $true; summary = 'pytest collection error (exit=2)'; testsRun = 0
+            }
+        }
+
+        Invoke-Watchdog -Repo 'redrobot' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Add-IssueLabel -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Label -eq 'tests-broken' }
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'partial' -and $Summary -like '*pytest-gate:tests-broken*' }
+    }
+
+    It 'AC: jarvis repo skips pytest gate entirely' {
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = 'feat/630-jarvis'; commits = @(); iterations = @()
+                }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-PytestGate -Times 0 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a pytest gate to the sandcastle watchdog for `-Repo redrobot` only (`-Repo jarvis` unchanged):

- **`Invoke-PytestGate`** — runs pytest on touched-file-mapped test surface (co-located `test_*.py` or `tests/` mirror), falls back to full suite when no targeted tests found. Returns verdict: passed/collection-error/failed with test count and failure names.
- **`Get-RelatedTestFiles`** — discovers test files for changed `.py` files: co-located `test_<name>.py` in same directory, then `tests/test_<name>.py`.
- **`Close-AgentPR`** — finds and closes the agent's open PR on gate failure.
- **Integration in `Invoke-Watchdog`**:
  - Green → records `gates.pytest.passed=true` in outcome, PR opens normally
  - Red (real fail) → closes PR, drops `status:in-progress`, applies `tests-failing` label, exits partial
  - Collection error → applies `tests-broken` label (distinct from `tests-failing`)
  - jarvis repo → gate skipped entirely (CI handles it post-PR)

### Test-surface discovery decision

Touched-file-mapped discovery with full-suite fallback. Rationale: agent may refactor files whose test coverage lives outside the co-located pattern. Full suite has ~30s overhead on redrobot's small corpus — acceptable. Recorded as decision comment in code.

Rejected alternatives:
1. `pytest --lf` (last-failed) — no history on first run
2. Full-suite-always — unnecessary overhead for small changes

## Test plan

- [ ] `Invoke-Pester -Path tests/sandcastle/Run-Sandcastle.Tests.ps1` — all existing tests pass + 18 new pytest gate tests
- [ ] Verified coverage: GetRelatedTestFiles (4), Close-AgentPR (4), Invoke-PytestGate (6), integration (4)

Closes #630