### PR TITLE
feat(task_queue): reshape table — drop approval cols, add priority/assignee, new FSM

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -16,5 +16,6 @@ __all__ = [
     "safety",
     "scheduler",
     "supabase_client",
+    "task_queue",
     "usage_probe",
 ]

--- a/agents/task_queue.py
+++ b/agents/task_queue.py
@@ -1,0 +1,216 @@
+"""Task queue interface — enqueue, claim_next, transition.
+
+Built on the reshaped ``task_queue`` table (issue #740):
+- FSM: ``pending → claimed → running → done | failed | parked``
+- Priority-ordered claiming (highest first, FIFO for ties)
+- Idempotency-key dedup (colliding key on enqueue is a silent no-op)
+
+Usage::
+
+    from agents.task_queue import claim_next, enqueue, transition
+
+    row = enqueue(goal="fix: tighten error path",
+                  priority=10,
+                  idempotency_key=sha256(...))
+    if row is None:
+        ...  # colliding key
+
+    claimed = claim_next()
+    if claimed is None:
+        ...  # queue empty
+
+    transition(claimed["id"], "running")
+    transition(claimed["id"], "done")
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from supabase import Client
+
+from agents.supabase_client import get_client
+
+# -- FSM -------------------------------------------------------------------
+
+_VALID_TRANSITIONS: dict[str, frozenset[str]] = {
+    "pending": frozenset({"claimed"}),
+    "claimed": frozenset({"running"}),
+    "running": frozenset({"done", "failed", "parked"}),
+}
+
+_TERMINAL_STATES: frozenset[str] = frozenset({"done", "failed", "parked"})
+
+
+# -- Public API ------------------------------------------------------------
+
+
+def enqueue(
+    *,
+    goal: str,
+    priority: int = 0,
+    assignee: str | None = None,
+    idempotency_key: str,
+    scope_files: list[str] | None = None,
+    client: Client | None = None,
+) -> dict[str, Any] | None:
+    """Insert a task into the queue.
+
+    **Idempotent:** a colliding ``idempotency_key`` silently returns
+    ``None`` instead of raising. Callers that need to detect collision
+    should check the return value.
+
+    Returns the inserted row, or ``None`` if the key already existed.
+    """
+    cli = client or get_client()
+    row: dict[str, Any] = {
+        "goal": goal,
+        "priority": priority,
+        "idempotency_key": idempotency_key,
+        "status": "pending",
+    }
+    if assignee is not None:
+        row["assignee"] = assignee
+    if scope_files:
+        row["scope_files"] = scope_files
+
+    result = cli.table("task_queue").insert(row).execute()
+    data = result.data or []
+    return data[0] if data else None
+
+
+def claim_next(
+    client: Client | None = None,
+) -> dict[str, Any] | None:
+    """Claim the highest-priority pending task (priority desc, FIFO ties).
+
+    Returns the claimed row with status updated to ``claimed``, or
+    ``None`` if the queue is empty or another worker claimed the task
+    first (optimistic lock).
+
+    The returned dict includes the full row as it looked after the update,
+    including ``id``, ``status``, ``claimed_at``, etc.
+    """
+    cli = client or get_client()
+
+    # Read the highest-priority pending task
+    rows = (
+        cli.table("task_queue")
+        .select("*")
+        .eq("status", "pending")
+        .order("priority", desc=True)
+        .order("created_at", desc=False)
+        .limit(1)
+        .execute()
+    ).data or []
+
+    if not rows:
+        return None
+
+    task = rows[0]
+
+    # Optimistic-lock claim: only succeeds if row is still pending
+    now = datetime.now(timezone.utc).isoformat()
+    result = (
+        cli.table("task_queue")
+        .update({"status": "claimed", "claimed_at": now})
+        .eq("id", task["id"])
+        .eq("status", "pending")
+        .execute()
+    )
+
+    updated = result.data or []
+    return updated[0] if updated else None
+
+
+def transition(
+    task_id: str,
+    to_status: str,
+    *,
+    reason: str | None = None,
+    client: Client | None = None,
+) -> dict[str, Any]:
+    """Transition a task to a new status, validating the FSM.
+
+    Parameters
+    ----------
+    task_id
+        UUID of the task to transition.
+    to_status
+        Target FSM state. Must be a legal transition from the current
+        state of the task.
+    reason
+        Optional reason attached to ``escalated_reason`` (useful for
+        ``failed`` transitions to document the failure cause).
+
+    Returns the updated row.
+
+    Raises
+    ------
+    ValueError
+        The transition is not allowed by the FSM (e.g. ``pending → done``
+        without going through ``claimed → running``).
+    RuntimeError
+        The task does not exist, or another worker modified it between
+        our read and write (optimistic lock failure).
+    """
+    cli = client or get_client()
+
+    # Read current state
+    rows = (
+        cli.table("task_queue")
+        .select("status")
+        .eq("id", task_id)
+        .limit(1)
+        .execute()
+    ).data or []
+
+    if not rows:
+        raise RuntimeError(f"Task not found: {task_id}")
+
+    current_status = rows[0]["status"]
+
+    if current_status in _TERMINAL_STATES:
+        raise ValueError(
+            f"Cannot transition from terminal state {current_status!r}"
+        )
+
+    allowed = _VALID_TRANSITIONS.get(current_status, frozenset())
+    if to_status not in allowed:
+        raise ValueError(
+            f"Illegal transition: {current_status!r} → {to_status!r}. "
+            f"Allowed targets from {current_status!r}: "
+            f"{sorted(allowed)}"
+        )
+
+    # Build update payload
+    now = datetime.now(timezone.utc).isoformat()
+    update: dict[str, Any] = {"status": to_status}
+
+    if to_status == "claimed":
+        update["claimed_at"] = now
+    elif to_status in ("done", "failed"):
+        update["completed_at"] = now
+
+    if reason is not None:
+        update["escalated_reason"] = reason
+
+    # Optimistic lock: only succeeds if status hasn't changed since our read
+    result = (
+        cli.table("task_queue")
+        .update(update)
+        .eq("id", task_id)
+        .eq("status", current_status)
+        .execute()
+    )
+
+    updated = result.data or []
+    if not updated:
+        raise RuntimeError(
+            f"Transition {current_status!r} → {to_status!r} failed: "
+            f"task {task_id} was modified by another worker"
+        )
+
+    return updated[0]

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2407,22 +2407,19 @@ $$;
 
 
 -- =========================================================================
--- Pillar 7 Sprint 2: task_queue — dispatcher input surface (issue #296, S2-1)
+-- Issue #740: Reshaped task_queue — drop approval columns, add
+-- priority/assignee, new FSM.
 --
--- Owner inserts approved tasks; the task-dispatcher agent (S2-3) scans
--- status='pending' and transitions rows through the FSM below, logging
--- each transition to audit_log via the safety gate (agents/safety.py).
+-- FSM transitions (enforced in the interface; DB check guards the enum):
+--   pending  -> claimed
+--   claimed  -> running
+--   running  -> done | failed | parked
+--   done     -> (terminal)
+--   failed   -> (terminal)
+--   parked   -> (terminal)
 --
--- FSM transitions (enforced in the dispatcher; DB check guards the enum):
---   pending    -> dispatched | escalated | rejected
---   dispatched -> done | escalated
---   escalated  -> pending      (owner re-approves)
---   done       -> (terminal)
---   rejected   -> (terminal)
---
--- Drift detection uses `approved_scope_hash` + `scope_files`: if the repo
--- state at dispatch time disagrees with the approval-time hash/globs, the
--- dispatcher flips the row to `escalated` instead of firing.
+-- Interface: agents/task_queue.py exposes enqueue(), claim_next()
+-- (priority-ordered), and transition().
 -- =========================================================================
 
 create table if not exists task_queue (
@@ -2432,21 +2429,19 @@ create table if not exists task_queue (
   goal text not null,
   scope_files text[] not null default '{}',
 
-  -- Approval (inputs for drift detection + auto-dispatch gating)
-  approved_at timestamptz not null default now(),
-  approved_by text not null,
-  approved_scope_hash text not null,
-  auto_dispatch boolean not null default false,
+  -- Priority (higher = claimed first; FIFO ties) + optional worker assignee
+  priority int not null default 0,
+  assignee text,
 
   -- Lifecycle
   status text not null default 'pending'
-    check (status in ('pending', 'dispatched', 'done', 'escalated', 'rejected')),
-  dispatched_at timestamptz,
+    check (status in ('pending', 'claimed', 'running', 'done', 'failed', 'parked')),
+  claimed_at timestamptz,
   completed_at timestamptz,
   escalated_reason text,
 
-  -- Dedup. Matches the safety-gate idempotency_key shape (sha256 hex, 64
-  -- chars). Unique so a retrying dispatcher cannot double-enqueue.
+  -- Dedup. sha256 hex (64 chars). Unique so a retrying worker cannot
+  -- double-enqueue.
   idempotency_key text not null unique,
 
   -- Timestamps
@@ -2454,11 +2449,10 @@ create table if not exists task_queue (
   updated_at timestamptz not null default now()
 );
 
--- Dispatcher scan: oldest approved pending first. Also covers 'dispatched'
--- so a restarted dispatcher can find in-flight rows to reconcile.
+-- Dispatcher scan: highest-priority pending first, FIFO for ties.
 create index if not exists idx_task_queue_pending_scan
-  on task_queue(status, approved_at)
-  where status in ('pending', 'dispatched');
+  on task_queue(priority desc, created_at asc)
+  where status = 'pending';
 
 -- Dedicated updated_at trigger. The memories-shared update_updated_at()
 -- references last_accessed_at/fts/project_key -- columns task_queue does
@@ -2477,7 +2471,7 @@ create trigger task_queue_updated_at
   for each row execute function update_task_queue_updated_at();
 
 -- RLS -- matches the Pillar 7 convention (allow-all under service/anon
--- key; app-layer gatekeeping is the safety gate + dispatcher). Hardening
+-- key; app-layer gatekeeping is the interface functions). Hardening
 -- to per-role policies is its own sweep.
 alter table task_queue enable row level security;
 

--- a/supabase/migrations/20260521131547_reshape_task_queue.sql
+++ b/supabase/migrations/20260521131547_reshape_task_queue.sql
@@ -1,0 +1,40 @@
+-- Issue #740: Reshape task_queue — drop approval columns, add priority/assignee, new FSM
+-- Paired with mcp-memory/schema.sql.
+-- CI gate (#289) requires a migration file whenever schema.sql changes.
+
+-- FSM transitions (enforced in the interface; DB check guards the enum):
+--   pending  -> claimed
+--   claimed  -> running
+--   running  -> done | failed | parked
+--   done     -> (terminal)
+--   failed   -> (terminal)
+--   parked   -> (terminal)
+
+-- Drop old partial index (references old status values + approved_at)
+drop index if exists idx_task_queue_pending_scan;
+
+-- Drop approval-gated columns
+alter table task_queue drop column approved_at;
+alter table task_queue drop column approved_by;
+alter table task_queue drop column approved_scope_hash;
+alter table task_queue drop column auto_dispatch;
+
+-- Rename dispatched_at to claimed_at for new FSM semantics
+alter table task_queue rename column dispatched_at to claimed_at;
+
+-- Add priority (for claim_next ordering) and assignee (for worker routing)
+alter table task_queue add column priority int not null default 0;
+alter table task_queue add column assignee text;
+
+-- Remove smoke/test rows — no real data to preserve (per issue #740 spec)
+delete from task_queue;
+
+-- Replace status check constraint with new FSM
+alter table task_queue drop constraint task_queue_status_check;
+alter table task_queue add constraint task_queue_status_check
+  check (status in ('pending', 'claimed', 'running', 'done', 'failed', 'parked'));
+
+-- Partial index: highest-priority pending tasks first, FIFO for ties
+create index if not exists idx_task_queue_pending_scan
+  on task_queue(priority desc, created_at asc)
+  where status = 'pending';

--- a/tests/test_agents_task_queue.py
+++ b/tests/test_agents_task_queue.py
@@ -1,0 +1,414 @@
+"""Tests for agents/task_queue.py — enqueue, claim_next, transition.
+
+Uses a stub Supabase client. No live DB.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from agents.task_queue import (
+    _TERMINAL_STATES,
+    _VALID_TRANSITIONS,
+    claim_next,
+    enqueue,
+    transition,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub — minimal Supabase client emulation for task_queue operations
+# ---------------------------------------------------------------------------
+
+
+class _StubResponse:
+    def __init__(self, data: list[dict[str, Any]]) -> None:
+        self.data = data
+
+
+class _StubSelect:
+    def __init__(self, parent: _StubTable, rows: list[dict[str, Any]]) -> None:
+        self._parent = parent
+        self._rows = list(rows)
+        self._filters: list[tuple[str, Any]] = []
+        self._order: list[tuple[str, bool]] = []
+        self._limit_n: int | None = None
+
+    def eq(self, col: str, val: Any) -> _StubSelect:
+        self._filters.append((col, val))
+        return self
+
+    def order(self, col: str, *, desc: bool = False, **kwargs: Any) -> _StubSelect:
+        self._order.append((col, desc))
+        return self
+
+    def limit(self, n: int) -> _StubSelect:
+        self._limit_n = n
+        return self
+
+    def execute(self) -> _StubResponse:
+        rows = list(self._rows)
+        for col, val in self._filters:
+            rows = [r for r in rows if r.get(col) == val]
+        for col, desc in reversed(self._order):
+            rows.sort(
+                key=lambda r: (r.get(col) is None, r.get(col)),
+                reverse=desc,
+            )
+        if self._limit_n is not None:
+            rows = rows[: self._limit_n]
+        self._parent.calls.append(("select", dict(self._filters)))
+        return _StubResponse(data=rows)
+
+
+class _StubUpdate:
+    def __init__(self, parent: _StubTable, rows: list[dict[str, Any]],
+                 payload: dict[str, Any]) -> None:
+        self._parent = parent
+        self._rows = rows
+        self._payload = payload
+        self._eq_filters: list[tuple[str, Any]] = []
+
+    def eq(self, col: str, val: Any) -> _StubUpdate:
+        self._eq_filters.append((col, val))
+        return self
+
+    def execute(self) -> _StubResponse:
+        matched: list[dict[str, Any]] = []
+        for row in self._rows:
+            if all(row.get(c) == v for c, v in self._eq_filters):
+                row.update(self._payload)
+                matched.append(dict(row))
+        self._parent.calls.append(("update", dict(self._eq_filters)))
+        return _StubResponse(data=matched)
+
+
+class _StubInsert:
+    def __init__(self, parent: _StubTable, rows: list[dict[str, Any]],
+                 payload: dict[str, Any]) -> None:
+        self._parent = parent
+        self._rows = rows
+        self._payload = payload
+
+    def execute(self) -> _StubResponse:
+        for existing in self._rows:
+            if existing.get("idempotency_key") == self._payload.get("idempotency_key"):
+                return _StubResponse(data=[])
+        stored = {
+            **self._payload,
+            "id": f"tq-{len(self._rows) + 1}",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._rows.append(stored)
+        self._parent.calls.append(("insert", self._payload.get("idempotency_key", "")))
+        return _StubResponse(data=[stored])
+
+
+class _StubTable:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self.calls: list[Any] = []
+
+    def select(self, *args: Any, **kwargs: Any) -> _StubSelect:
+        return _StubSelect(self, self._rows)
+
+    def insert(self, payload: dict[str, Any]) -> _StubInsert:
+        return _StubInsert(self, self._rows, payload)
+
+    def update(self, payload: dict[str, Any]) -> _StubUpdate:
+        return _StubUpdate(self, self._rows, payload)
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self._tables: dict[str, _StubTable] = {}
+
+    def table(self, name: str) -> _StubTable:
+        if name not in self._tables:
+            self._tables[name] = _StubTable([])
+        return self._tables[name]
+
+    def seed(self, table: str, rows: list[dict[str, Any]]) -> None:
+        self.table(table)._rows.extend(rows)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client() -> _StubClient:
+    return _StubClient()
+
+
+def _pending(**kw: Any) -> dict[str, Any]:
+    base = {
+        "id": "tq-pending",
+        "goal": "test task",
+        "priority": 0,
+        "status": "pending",
+        "claimed_at": None,
+        "completed_at": None,
+        "escalated_reason": None,
+        "idempotency_key": "key-pending",
+        "scope_files": [],
+        "created_at": "2026-05-21T00:00:00",
+        "updated_at": "2026-05-21T00:00:00",
+    }
+    base.update(kw)
+    return base
+
+
+def _claimed(**kw: Any) -> dict[str, Any]:
+    base = _pending(id="tq-claimed", status="claimed", idempotency_key="key-claimed",
+                    claimed_at="2026-05-21T01:00:00")
+    base.update(kw)
+    return base
+
+
+def _running(**kw: Any) -> dict[str, Any]:
+    base = _claimed(id="tq-running", status="running", idempotency_key="key-running",
+                    claimed_at="2026-05-21T01:00:00")
+    base.update(kw)
+    return base
+
+
+# ===========================================================================
+# enqueue
+# ===========================================================================
+
+
+class TestEnqueue:
+    def test_inserts_row(self, client: _StubClient) -> None:
+        row = enqueue(
+            goal="test task",
+            priority=5,
+            idempotency_key="key-1",
+            client=client,
+        )
+        assert row is not None
+        assert row["goal"] == "test task"
+        assert row["priority"] == 5
+        assert row["status"] == "pending"
+        assert row["idempotency_key"] == "key-1"
+
+    def test_with_assignee_and_scope(self, client: _StubClient) -> None:
+        row = enqueue(
+            goal="scoped task",
+            priority=3,
+            assignee="worker-a",
+            idempotency_key="key-2",
+            scope_files=["src/main.py"],
+            client=client,
+        )
+        assert row is not None
+        assert row["assignee"] == "worker-a"
+        assert row["scope_files"] == ["src/main.py"]
+
+    def test_idempotency_key_collision(self, client: _StubClient) -> None:
+        client.seed("task_queue", [
+            _pending(idempotency_key="dup-key"),
+        ])
+        row = enqueue(
+            goal="duplicate",
+            priority=0,
+            idempotency_key="dup-key",
+            client=client,
+        )
+        assert row is None
+
+    def test_default_priority_zero(self, client: _StubClient) -> None:
+        row = enqueue(
+            goal="default priority",
+            idempotency_key="key-default",
+            client=client,
+        )
+        assert row is not None
+        assert row["priority"] == 0
+
+
+# ===========================================================================
+# claim_next
+# ===========================================================================
+
+
+class TestClaimNext:
+    def test_claims_highest_priority(self, client: _StubClient) -> None:
+        client.seed("task_queue", [
+            _pending(id="low", priority=1, idempotency_key="key-low"),
+            _pending(id="high", priority=10, idempotency_key="key-high"),
+            _pending(id="medium", priority=5, idempotency_key="key-med"),
+        ])
+        row = claim_next(client=client)
+        assert row is not None
+        assert row["id"] == "high"
+        assert row["status"] == "claimed"
+        assert row["claimed_at"] is not None
+
+    def test_fifo_for_tie(self, client: _StubClient) -> None:
+        client.seed("task_queue", [
+            _pending(id="first", priority=5, idempotency_key="key-a",
+                     created_at="2026-05-21T00:00:00"),
+            _pending(id="second", priority=5, idempotency_key="key-b",
+                     created_at="2026-05-21T01:00:00"),
+        ])
+        row = claim_next(client=client)
+        assert row is not None
+        assert row["id"] == "first"
+
+    def test_returns_none_when_empty(self, client: _StubClient) -> None:
+        row = claim_next(client=client)
+        assert row is None
+
+    def test_ignores_non_pending_status(self, client: _StubClient) -> None:
+        client.seed("task_queue", [
+            _claimed(id="claimed-task"),
+            _running(id="running-task"),
+        ])
+        row = claim_next(client=client)
+        assert row is None
+
+    def test_optimistic_lock_race(self, client: _StubClient) -> None:
+        """Another worker claimed the task between our read and update."""
+        client.seed("task_queue", [
+            _pending(id="race", idempotency_key="key-race"),
+        ])
+
+        # First claim succeeds
+        first = claim_next(client=client)
+        assert first is not None
+        assert first["id"] == "race"
+
+        # Second claim on same task fails (already claimed)
+        second = claim_next(client=client)
+        assert second is None
+
+
+# ===========================================================================
+# transition
+# ===========================================================================
+
+
+class TestTransition:
+    def test_pending_to_claimed(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_pending()])
+        row = transition("tq-pending", "claimed", client=client)
+        assert row["status"] == "claimed"
+        assert row["claimed_at"] is not None
+
+    def test_claimed_to_running(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_claimed()])
+        row = transition("tq-claimed", "running", client=client)
+        assert row["status"] == "running"
+
+    def test_running_to_done(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_running()])
+        row = transition("tq-running", "done", client=client)
+        assert row["status"] == "done"
+        assert row["completed_at"] is not None
+
+    def test_running_to_failed(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_running()])
+        row = transition("tq-running", "failed", reason="timeout", client=client)
+        assert row["status"] == "failed"
+        assert row["completed_at"] is not None
+        assert row["escalated_reason"] == "timeout"
+
+    def test_running_to_parked(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_running()])
+        row = transition("tq-running", "parked", client=client)
+        assert row["status"] == "parked"
+
+    def test_full_lifecycle(self, client: _StubClient) -> None:
+        """pending → claimed → running → done"""
+        client.seed("task_queue", [_pending(id="lifecycle")])
+
+        r1 = transition("lifecycle", "claimed", client=client)
+        assert r1["status"] == "claimed"
+
+        r2 = transition("lifecycle", "running", client=client)
+        assert r2["status"] == "running"
+
+        r3 = transition("lifecycle", "done", client=client)
+        assert r3["status"] == "done"
+
+    # -- Error cases -------------------------------------------------------
+
+    def test_illegal_transition(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_pending()])
+        with pytest.raises(ValueError, match="Illegal transition"):
+            transition("tq-pending", "done", client=client)
+
+    def test_illegal_transition_from_claimed(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_claimed()])
+        with pytest.raises(ValueError, match="Illegal transition"):
+            transition("tq-claimed", "done", client=client)
+
+    def test_transition_from_terminal_state(self, client: _StubClient) -> None:
+        for terminal in ("done", "failed", "parked"):
+            rows = [_running(id=f"tq-{terminal}", status=terminal)]
+            c = _StubClient()
+            c.seed("task_queue", rows)
+            with pytest.raises(ValueError, match="terminal state"):
+                transition(f"tq-{terminal}", "claimed", client=c)
+
+    def test_task_not_found(self, client: _StubClient) -> None:
+        with pytest.raises(RuntimeError, match="Task not found"):
+            transition("nonexistent-id", "claimed", client=client)
+
+    def test_uses_optimistic_lock(self, client: _StubClient) -> None:
+        """Update always includes both id and status for race safety."""
+        client.seed("task_queue", [_pending()])
+        transition("tq-pending", "claimed", client=client)
+        tq_calls = client.table("task_queue").calls
+        update_calls = [c for c in tq_calls if c[0] == "update"]
+        assert len(update_calls) >= 1
+        filters = update_calls[0][1]
+        assert "id" in filters
+        assert "status" in filters
+
+    def test_claimed_updated_by_another_worker(self, client: _StubClient) -> None:
+        """Transition from a task already moved by another worker fails."""
+        client.seed("task_queue", [_claimed()])
+        transition("tq-claimed", "running", client=client)
+        # A second call sees "running" -> "running" is not in FSM
+        with pytest.raises(ValueError, match="Illegal transition"):
+            transition("tq-claimed", "running", client=client)
+
+
+# ===========================================================================
+# FSM table integrity
+# ===========================================================================
+
+
+class TestFSMDefinition:
+    """Validate the FSM transition table covers every non-terminal state."""
+
+    def test_all_non_terminal_states_defined(self) -> None:
+        all_states = {"pending", "claimed", "running", "done", "failed", "parked"}
+        non_terminal = all_states - _TERMINAL_STATES
+        defined = set(_VALID_TRANSITIONS.keys())
+        assert defined == non_terminal, (
+            f"Missing transition rules for: {non_terminal - defined}"
+        )
+
+    def test_no_transition_from_terminal_states(self) -> None:
+        for state in _TERMINAL_STATES:
+            assert state not in _VALID_TRANSITIONS
+
+    def test_no_self_loops(self) -> None:
+        for state, targets in _VALID_TRANSITIONS.items():
+            assert state not in targets, f"Self-loop in {state}"
+
+    def test_all_targets_are_valid_states(self) -> None:
+        all_states = {"pending", "claimed", "running", "done", "failed", "parked"}
+        for state, targets in _VALID_TRANSITIONS.items():
+            for target in targets:
+                assert target in all_states, (
+                    f"Transition {state} -> {target}: {target!r} is not a valid state"
+                )


### PR DESCRIPTION
## Summary

Reshape the `task_queue` table for the reactive-core milestone (#44):

- **Migration drops** `approved_by`, `approved_at`, `approved_scope_hash`, `auto_dispatch` columns
- **Adds** `priority int NOT NULL DEFAULT 0` and `assignee text`
- **Renames** `dispatched_at` → `claimed_at`
- **New FSM:** `pending → claimed → running → done | failed | parked`
- **Deletes** 3 disposable smoke rows
- **Updates** partial scan index to `(priority DESC, created_at ASC) WHERE status = 'pending'`

New `agents/task_queue.py` interface module:
- `enqueue()` — insert with idempotency-key dedup
- `claim_next()` — highest priority first, FIFO ties, optimistic lock
- `transition()` — FSM-validated with optimistic locking

## Acceptance criteria covered

- [x] Migration drops `approved_*` / `auto_dispatch`; adds `priority int`, `assignee text`; keeps `idempotency_key` unique
- [x] 3 smoke rows deleted in the migration
- [x] `enqueue` / `claim_next` (priority-ordered) / `transition` implemented
- [x] FSM tests: every legal transition passes, illegal transitions rejected
- [x] Idempotency test: a colliding `idempotency_key` does not double-enqueue

Closes #740