### PR TITLE
docs(design): reconcile redesign doc and sibling files for no-resident-process model (Closes #742)

### DIFF
--- a/docs/design/afk-system-night-flow.mmd
+++ b/docs/design/afk-system-night-flow.mmd
@@ -1,20 +1,19 @@
 sequenceDiagram
     autonumber
     participant Cron as Cron / Task Scheduler
-    participant W as Watcher daemon<br/>(Workshop, polls 30-60s)
     participant Probe as Quota probe<br/>(claude -p /usage, 30min)
     participant SC as Sandcastle<br/>(parallel containers, DeepSeek)
     participant GH as GitHub<br/>(repo + API + repo vars)
     participant GA as GH Actions<br/>(code-review, event-dispatch)
     participant Mem as Memory<br/>(Supabase events_canonical)
-    participant Orch as Orchestrator session<br/>(claude -p, on-demand)
+    participant Orch as Orchestrator session<br/>(event-woken cold boot)
     participant TG as Telegram
     participant P as Principal
 
     Note over Mem: PRE-NIGHT — issues status:ready, goals active, outcome history loaded, CLAUDE_QUOTA_PRESSURE=false
 
     rect rgba(220,220,255,0.25)
-    Note over Probe,Mem: ACT 0 — quota housekeeping (continuous)
+    Note over Probe,Mem: ACT 0 — quota housekeeping (scheduled task)
     Probe->>Probe: every 30 min: claude -p /usage
     Probe->>Probe: parse weekly%, cache ~/.jarvis/orchestrator/usage.json
     alt weekly >= 80%
@@ -48,12 +47,13 @@ sequenceDiagram
     end
 
     rect rgba(230,255,220,0.25)
-    Note over W,Mem: ACT 3 — programmatic watcher reacts (within 30-60s of event)
-    W->>Mem: poll: SELECT FROM events_canonical WHERE processed=false
-    W->>W: gate check — quota_cache.weekly < 80%, else skip
-    W->>Mem: per-PR lock check — outcome_records pattern_tags pr-N in_flight 2h
+    Note over Orch,Mem: ACT 3 — event-woken rework orchestrator (no persistent watcher)
+    Note over Mem: review_negative event lands in events_canonical
+    Mem->>Orch: event-woken cold boot via scheduled-task check (5min slack) or pg LISTEN/NOTIFY
+    Orch->>Mem: SELECT FROM events_canonical WHERE processed=false AND event_type='review_negative'
+    Orch->>Orch: gate check — quota_cache.weekly < 80%, else skip
+    Orch->>Mem: per-PR lock check — outcome_records pattern_tags pr-N in_flight 2h
     alt no in-flight rework for this PR
-        W->>Orch: spawn claude -p /rework 631
         Orch->>GH: gh pr view 631 — fetch latest body + reviews + statusCheck
         Orch->>SC: dispatch with SANDCASTLE_TARGET_PR=631
         Note over SC: separate container, parallel with other sandcastles
@@ -63,13 +63,15 @@ sequenceDiagram
         SC->>GH: add PR label status:rework-in-progress
         Orch->>Mem: events_mark_processed
         Orch->>Mem: record_decision (rework dispatched, rationale)
+        Orch->>Orch: session dies — no persistent process
     else in-flight exists
-        W->>Mem: events_mark_processed (subsumed by in-flight container)
+        Orch->>Mem: events_mark_processed (subsumed by in-flight container)
+        Orch->>Orch: session dies — no persistent process
     end
     end
 
     rect rgba(255,220,220,0.2)
-    Note over W,P: LOOP-STOP triggers (any one fires escalate)
+    Note over GH,Mem: LOOP-STOP triggers (any one fires escalate)
     alt attempts >= 3
         SC->>Mem: events_canonical (rework_stuck, severity=medium)
     else scope-creep — LOC delta > 50% OR files outside initial diff

--- a/docs/design/jarvis-v2-redesign.md
+++ b/docs/design/jarvis-v2-redesign.md
@@ -69,6 +69,7 @@ Jarvis covers the work of an entire software development team, leaving the princ
 - Impersonating the principal — Jarvis drafts; principal sends
 - Telegram as a primary interface (chat-only role at most, see L1)
 - Designing for other developers / multi-tenancy (separate project)
+- Persistent always-on process — Jarvis operates via event-woken cold boot, not a resident daemon. Persistent BEHAVIOR ≠ persistent PROCESS (resolved 2026-05-20 — see `pm_dispatch_v1_superseded_by_persistent_agents`).
 
 **Future feature backlog** (1.x, not separately versioned): TTS/STT, broader personal-data access, cross-platform search/curation, personal-life management, open-source framework split. Captured in memory + GitHub issues, surfaced via 1.x release planning when each becomes ready. Not "v3" — semver discipline reserves v2 for cardinal paradigm shifts.
 

--- a/docs/design/sandcastle-integration.md
+++ b/docs/design/sandcastle-integration.md
@@ -2,7 +2,7 @@
 
 **Purpose.** This document is the queryable architectural narrative for the Sandcastle subsystem. It points at the load-bearing decisions; rationale lives in the `decision_made` episodes referenced by UUID. When a future session asks "why does sandcastle work this way?" — `memory_get` the cited episode.
 
-**Scope.** Docker-isolated AFK coding-agent loop that picks `sandcastle`-labelled issues, works one at a time on local Ollama inside a sterile container, and opens PRs without ever merging. Production target is the always-on Workshop PC.
+**Scope.** Docker-isolated AFK coding-agent loop that picks `sandcastle`-labelled issues, works one at a time on local Ollama inside a sterile container, and opens PRs without ever merging. Production target is the Workshop PC (always-on physical host; AFK loop runs inside safe-hours window — no persistent software daemon).
 
 **Read order.** `CONTEXT.md` glossary (Sandcastle / Watchdog / Safe-hours window / Threat-model duality) → this doc → cited decision episodes for rationale.
 
@@ -32,7 +32,7 @@ These are the non-negotiable invariants that shape every other slice. Each commi
 6. **Failure modes are observable, not silenced.** Every iteration writes an `outcome_record` row (success / partial / failure). Telegram fires only when infrastructure cannot come up — not for agent failures, which are signal, not noise.
    - Decision: `0c3017c6-01ec-4392-86a1-6a1522e4c5ef` (Failure modes).
 
-7. **Workshop PC is the production target; Main PC is the dev/test bench.** The always-on Workshop host runs the safe-hours-bound AFK loop; the developer bench reproduces the runtime for iteration without touching prod data.
+7. **Workshop PC is the production target; Main PC is the dev/test bench.** The Workshop host (always-on physical machine; no persistent software daemon) runs the safe-hours-bound AFK loop; the developer bench reproduces the runtime for iteration without touching prod data.
    - Decision: `4890aa35-07ae-4e4c-8c4b-ec37e749d751` (Deployment shape).
 
 8. **Model escalation chain, Ollama-first.** Default model is local Ollama; the escalation chain (per-iteration retry on a stronger model on parse/hard-failure, with API/Sonnet as the final escape hatch) preserves the cost profile of the AFK loop while keeping a path through hard issues.


### PR DESCRIPTION
## Summary

- Added "Persistent always-on process" as explicit non-goal in `jarvis-v2-redesign.md` L0 section, with cross-reference to the `pm_dispatch_v1_superseded_by_persistent_agents` decision
- Removed "Watcher daemon" participant from `afk-system-night-flow.mmd`; replaced with event-woken cold-boot orchestrator; polling loop replaced with event-triggered activation
- Clarified "always-on" language in `sandcastle-integration.md` — refers to physical host availability, not a persistent software daemon
- SVG (`afk-system-night-flow.svg`) is a generated artifact from `.mmd` source — needs regeneration by someone with the mermaid CLI

Closes #742

## Verification

- [x] No remaining "always-on watcher daemon" language in any design doc under `docs/design/`
- [x] No "final"/"final version" labelling introduced (latest-only policy respected)
- [x] `jarvis-v2-redesign.md` L0 non-goals now explicitly state the no-resident-process model
- [x] `afk-system-night-flow.mmd` participant list no longer has a watcher daemon
- [x] `sandcastle-integration.md` disambiguates "always-on" host vs daemon
- [x] SVG regeneration deferred — generated artifact from `.mmd`