### PR TITLE
feat(orchestrator): watcher daemon -- poll, gate, lock, dispatch (Closes #639)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ yarn-error.log*
 .sandcastle/.env
 .sandcastle/runtime/
 .sandcastle/worktrees/
+.sandcastle/hfcache/
 docs/research/
 
 # Logs

--- a/scripts/orchestrator/__init__.py
+++ b/scripts/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+# Orchestrator package — watcher daemon + supporting modules.

--- a/scripts/orchestrator/register-watcher.ps1
+++ b/scripts/orchestrator/register-watcher.ps1
@@ -1,0 +1,165 @@
+<#
+.SYNOPSIS
+    Register (or re-register) a Windows Task Scheduler entry for the
+    orchestrator watcher daemon. Idempotent.
+
+.DESCRIPTION
+    Registers a task that runs scripts/orchestrator/watcher.py as a continuous
+    daemon (poll loop). The task starts at user logon and restarts on failure.
+
+    Device guard: only registers on Workshop PC (config/device.json "name"
+    == "VividFormsPC4Workshop") unless -Force is passed.
+
+.PARAMETER PollInterval
+    Seconds between ticks (default: 45). Passed through to --poll-interval.
+
+.PARAMETER PythonExe
+    Path to the Python interpreter. Defaults to the first `python3` on PATH.
+
+.PARAMETER RepoRoot
+    Repository root. Defaults to the repo containing this script.
+
+.PARAMETER WhatIf
+    Print the planned scheduled task XML without registering.
+
+.PARAMETER Force
+    Allow registration on non-Workshop devices (dev rehearsal).
+
+.EXAMPLE
+    .\register-watcher.ps1
+    # Registers Orchestrator-Watcher to run at user logon.
+
+.EXAMPLE
+    .\register-watcher.ps1 -PollInterval 60
+    # Registers with a 60-second poll interval.
+#>
+
+[CmdletBinding()]
+param(
+    [int]$PollInterval = 45,
+
+    [string]$PythonExe,
+
+    [string]$RepoRoot,
+
+    [switch]$WhatIfOnly,
+
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Device guard -- Workshop only per decision e6441d77.
+# ---------------------------------------------------------------------------
+
+$expectedDevice = 'VividFormsPC4Workshop'
+$deviceJson     = Join-Path $PSScriptRoot '..\..\config\device.json'
+$currentDevice  = $null
+if (Test-Path $deviceJson) {
+    try {
+        $currentDevice = (Get-Content $deviceJson -Raw | ConvertFrom-Json).name
+    } catch {
+        Write-Warning "config/device.json present but unparsable: $($_.Exception.Message)"
+    }
+}
+
+if (-not $Force -and $currentDevice -ne $expectedDevice) {
+    throw "Refusing to register on '$currentDevice' -- orchestrator watcher production target is '$expectedDevice'. Pass -Force for dev rehearsal."
+}
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+}
+
+if (-not (Test-Path $RepoRoot)) {
+    throw "RepoRoot '$RepoRoot' does not exist."
+}
+
+$watcherScript = Join-Path $RepoRoot 'scripts\orchestrator\watcher.py'
+if (-not (Test-Path $watcherScript)) {
+    throw "Watcher script not found at '$watcherScript'. Is the repo root correct?"
+}
+
+if (-not $PythonExe) {
+    $cmd = Get-Command python3 -ErrorAction SilentlyContinue
+    if (-not $cmd) { $cmd = Get-Command python -ErrorAction Stop }
+    $PythonExe = $cmd.Source
+}
+
+# ---------------------------------------------------------------------------
+# Task identity
+# ---------------------------------------------------------------------------
+
+$taskName = 'Orchestrator-Watcher'
+
+# ---------------------------------------------------------------------------
+# Build the action -- continuous daemon, not one-shot.
+# ---------------------------------------------------------------------------
+
+$argParts = @(
+    "`"$watcherScript`"",
+    "--poll-interval", "$PollInterval"
+)
+
+$action = New-ScheduledTaskAction -Execute $PythonExe `
+    -Argument ($argParts -join ' ') `
+    -WorkingDirectory $RepoRoot
+
+# ---------------------------------------------------------------------------
+# Trigger -- start at user logon, keep running.
+# ---------------------------------------------------------------------------
+
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+
+# ---------------------------------------------------------------------------
+# Principal + settings -- restart on crash.
+# ---------------------------------------------------------------------------
+
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -MultipleInstances IgnoreNew `
+    -RestartCount 5 `
+    -RestartInterval ([timespan]::FromMinutes(1))
+
+# ---------------------------------------------------------------------------
+# Register (idempotent)
+# ---------------------------------------------------------------------------
+
+$existing = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+
+if ($WhatIfOnly) {
+    Write-Host "[whatif] Would register task '$taskName'"
+    Write-Host "         Execute   : $PythonExe"
+    Write-Host "         Arguments : $($argParts -join ' ')"
+    Write-Host "         WorkingDir: $RepoRoot"
+    Write-Host "         Trigger   : AtLogOn (continuous, restart on crash)"
+    Write-Host "         Existing  : $(if ($existing) { 'YES (would be replaced)' } else { 'no' })"
+    return
+}
+
+if ($existing) {
+    Write-Host "[register] Unregistering existing '$taskName' (idempotent)"
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+}
+
+$description = "Orchestrator watcher daemon -- poll events, gate on quota, dispatch /rework. Poll interval: ${PollInterval}s. Decision e6441d77."
+
+Register-ScheduledTask -TaskName $taskName `
+    -Action $action -Trigger $trigger `
+    -Principal $principal -Settings $settings `
+    -Description $description | Out-Null
+
+Write-Host "[register] '$taskName' registered (continuous daemon, poll interval ${PollInterval}s)."
+Write-Host "           Script: $watcherScript"
+Write-Host "           Python : $PythonExe"
+Write-Host "           Inspect: Get-ScheduledTask -TaskName '$taskName'"
+Write-Host "           Invoke : Start-ScheduledTask -TaskName '$taskName'"

--- a/scripts/orchestrator/watcher.py
+++ b/scripts/orchestrator/watcher.py
@@ -1,0 +1,515 @@
+"""Orchestrator watcher daemon — poll events, gate on quota, dispatch /rework.
+
+Tick interface (the deep module's only contract)::
+
+    tick(now, events_client, locks_client, spawner) -> TickResult
+
+Per-poll (every 30-60s):
+1. Poll the events table for ``event_type ∈ {review_negative}`` AND
+   ``processed=false``.
+2. Gate on quota cache. If ``weekly_pct >= 80``, skip dispatch entirely and
+   do NOT mark events processed (next poll re-evaluates).
+3. Group by PR number. Per-PR lock check via ``outcome_records``
+   (pattern_tags includes ``pr-<N>`` + ``rework`` + ``in_flight``, TTL 2h).
+   If lock exists, mark events processed (subsumed) without dispatch.
+4. Otherwise acquire lock and spawn ``claude -p "/rework <N>"``.
+   On spawn success: mark events processed. On spawn failure: leave events
+   unprocessed (next poll retries).
+
+Daemon usage::
+
+    python scripts/orchestrator/watcher.py [--poll-interval 45]
+
+Environment:
+    SUPABASE_URL  — Supabase project URL
+    SUPABASE_KEY  — Supabase anon key
+
+Realizes decision ``e6441d77-457b-451a-ac48-06830c1d9a8a`` (Q3 — orchestrator
+architecture, AFK PR-rework loop).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.handlers
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_POLL_INTERVAL_SECONDS = 45
+LOCK_TTL_MINUTES = 120
+QUOTA_WEEKLY_THRESHOLD_PCT = 80
+EVENT_TYPES: list[str] = ["review_negative"]
+
+_LOG_DIR = Path.home() / ".jarvis" / "orchestrator"
+QUOTA_CACHE_DEFAULT = _LOG_DIR / "usage.json"
+LOG_PATH_DEFAULT = _LOG_DIR / "watcher.log"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EventRow:
+    """A single row from the events table."""
+
+    event_id: str
+    event_type: str
+    payload: dict
+    repo: str
+
+
+@dataclass
+class TickResult:
+    """Summary of one tick cycle."""
+
+    events_processed: int = 0
+    events_skipped_quota: int = 0
+    events_skipped_lock: int = 0
+    spawns_attempted: int = 0
+    spawns_succeeded: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Abstract interfaces (injected dependencies — swap for tests)
+# ---------------------------------------------------------------------------
+
+
+class EventsClient:
+    """Interface for reading / writing the events table.
+
+    Production: :class:`SupabaseEventsClient`.
+    Tests: provide a fake that records method calls.
+    """
+
+    def fetch_unprocessed(self, event_types: list[str]) -> list[EventRow]:
+        """Return all unprocessed rows whose event_type is in *event_types*."""
+        raise NotImplementedError
+
+    def mark_processed(self, event_id: str) -> None:
+        """Mark a single event as processed."""
+        raise NotImplementedError
+
+    def mark_many_processed(self, event_ids: list[str]) -> None:
+        """Mark multiple events as processed (batch)."""
+        raise NotImplementedError
+
+
+class LocksClient:
+    """Interface for per-PR rework locks via ``outcome_records``.
+
+    A "lock" is a ``task_outcomes`` row with::
+
+        pattern_tags @> ARRAY['pr-<N>', 'rework', 'in_flight']
+
+    with ``created_at`` within the TTL window (default 2h).
+
+    Production: :class:`SupabaseLocksClient`.
+    Tests: provide a fake that records method calls.
+    """
+
+    def exists(self, pr_number: int) -> bool:
+        """Return True if an active in_flight lock exists for this PR."""
+        raise NotImplementedError
+
+    def acquire(self, pr_number: int) -> bool:
+        """Try to acquire a lock. Returns False if already held or insert failed."""
+        raise NotImplementedError
+
+
+Spawner = Callable[[int], None]
+"""Callable that takes a PR number and spawns ``claude -p "/rework <N>"``.
+
+Must raise on failure — the tick function catches the exception and leaves
+the event row unprocessed so the next poll retries.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Quota check (pure function)
+# ---------------------------------------------------------------------------
+
+
+def check_quota(cache_path: Path = QUOTA_CACHE_DEFAULT) -> bool:
+    """Return True if dispatch is allowed (weekly usage < 80%).
+
+    Returns False (fail-closed) when the cache file:
+    - does not exist
+    - contains malformed JSON
+    - is missing the ``weekly_pct`` key
+    - has ``weekly_pct >= 80``
+    """
+    if not cache_path.exists():
+        return False
+    try:
+        data = json.loads(cache_path.read_text())
+        weekly_pct = data.get("weekly_pct")
+        if weekly_pct is None:
+            return False
+        return weekly_pct < QUOTA_WEEKLY_THRESHOLD_PCT
+    except (json.JSONDecodeError, OSError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tick implementation
+# ---------------------------------------------------------------------------
+
+
+def _extract_pr_number(payload: dict) -> Optional[int]:
+    """Extract a PR number from an event payload.
+
+    Checks ``pr_number`` then ``pull_request_number`` (legacy keys).
+    Returns None when neither key is present.
+    """
+    pr = payload.get("pr_number") or payload.get("pull_request_number")
+    if pr is not None:
+        return int(pr)
+    return None
+
+
+def tick(
+    now: datetime,  # noqa: ARG001 — reserved for future time-window checks
+    events_client: EventsClient,
+    locks_client: LocksClient,
+    spawner: Spawner,
+    quota_cache_path: Path = QUOTA_CACHE_DEFAULT,
+) -> TickResult:
+    """One poll-gate-lock-dispatch cycle.
+
+    Steps:
+    1. Fetch unprocessed events of configured types from the events table.
+    2. Gate on quota — if weekly usage >= 80%, skip entirely (no marks).
+    3. Group rows by PR number (deduplicates within a single tick).
+    4. For each PR with a lock active → mark rows processed (subsumed).
+    5. For each PR without a lock → acquire lock, spawn ``/rework``.
+       - Spawn succeeds → mark rows processed.
+       - Spawn raises → leave rows unprocessed (next tick retries).
+    """
+    result = TickResult()
+
+    # 1. Fetch
+    rows = events_client.fetch_unprocessed(EVENT_TYPES)
+    if not rows:
+        return result
+
+    # 2. Quota gate
+    if not check_quota(quota_cache_path):
+        result.events_skipped_quota = len(rows)
+        return result
+
+    # 3. Group by PR number
+    by_pr: dict[int, list[EventRow]] = {}
+    for row in rows:
+        pr = _extract_pr_number(row.payload)
+        if pr is None:
+            # Can't determine PR — mark processed to avoid re-polling garbage
+            events_client.mark_processed(row.event_id)
+            result.events_processed += 1
+            continue
+        by_pr.setdefault(pr, []).append(row)
+
+    # 4. Dispatch per PR
+    for pr_number, pr_rows in by_pr.items():
+        event_ids = [r.event_id for r in pr_rows]
+
+        # 4a. Check existing lock
+        if locks_client.exists(pr_number):
+            events_client.mark_many_processed(event_ids)
+            result.events_skipped_lock += len(event_ids)
+            result.events_processed += len(event_ids)
+            continue
+
+        # 4b. Try to acquire lock
+        if not locks_client.acquire(pr_number):
+            # Another process got there first
+            events_client.mark_many_processed(event_ids)
+            result.events_skipped_lock += len(event_ids)
+            result.events_processed += len(event_ids)
+            continue
+
+        # 4c. Dispatch
+        result.spawns_attempted += 1
+        try:
+            spawner(pr_number)
+            events_client.mark_many_processed(event_ids)
+            result.events_processed += len(event_ids)
+            result.spawns_succeeded += 1
+        except Exception as exc:
+            # Spawn failed — do NOT mark processed; next poll retries
+            result.errors.append(f"PR #{pr_number}: {exc}")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Production implementations (Supabase)
+# ---------------------------------------------------------------------------
+
+
+def _supabase_client():
+    """Lazy-import and return a Supabase client.
+
+    The ``supabase`` package is heavy and only needed by the production
+    implementations — tests provide their own fakes.
+    """
+    from supabase import create_client
+
+    return create_client
+
+
+class SupabaseEventsClient(EventsClient):
+    """EventsClient backed by the legacy ``events`` table.
+
+    The ``events`` table has ``event_type``, ``processed``, and ``payload``
+    columns needed by the watcher. When ``events_canonical`` gains these
+    columns (#739), a new implementation can be swapped in without changing
+    the tick function.
+    """
+
+    def __init__(self, url: str, key: str):
+        self._table = _supabase_client()(url, key).table("events")
+
+    def fetch_unprocessed(self, event_types: list[str]) -> list[EventRow]:
+        resp = (
+            self._table.select("id, event_type, payload, repo")
+            .in_("event_type", event_types)
+            .eq("processed", False)
+            .execute()
+        )
+        rows: list[EventRow] = []
+        for r in getattr(resp, "data", []) or []:
+            rows.append(
+                EventRow(
+                    event_id=r["id"],
+                    event_type=r.get("event_type", ""),
+                    payload=r.get("payload", {}),
+                    repo=r.get("repo", ""),
+                )
+            )
+        return rows
+
+    def mark_processed(self, event_id: str) -> None:
+        self._table.update({"processed": True}).eq("id", event_id).execute()
+
+    def mark_many_processed(self, event_ids: list[str]) -> None:
+        if not event_ids:
+            return
+        self._table.update({"processed": True}).in_("id", event_ids).execute()
+
+
+class SupabaseLocksClient(LocksClient):
+    """LocksClient backed by ``task_outcomes`` table (pattern_tags convention).
+
+    Lock = a ``task_outcomes`` row with::
+
+        pattern_tags @> ARRAY['pr-<N>', 'rework', 'in_flight']
+        AND created_at > now() - TTL
+
+    The lock is both a mutual-exclusion primitive and an audit trail — it
+    persists across container restarts, so even if the watcher crashes, the
+    lock survives to prevent double-dispatch from a new watcher instance.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        key: str,
+        ttl_minutes: int = LOCK_TTL_MINUTES,
+    ):
+        self._table = _supabase_client()(url, key).table("task_outcomes")
+        self._ttl = timedelta(minutes=ttl_minutes)
+
+    def _lock_tags(self, pr_number: int) -> list[str]:
+        return [f"pr-{pr_number}", "rework", "in_flight"]
+
+    def exists(self, pr_number: int) -> bool:
+        cutoff = (datetime.now(timezone.utc) - self._ttl).isoformat()
+        resp = (
+            self._table.select("id")
+            .contains("pattern_tags", self._lock_tags(pr_number))
+            .gte("created_at", cutoff)
+            .limit(1)
+            .execute()
+        )
+        data = getattr(resp, "data", []) or []
+        return len(data) > 0
+
+    def acquire(self, pr_number: int) -> bool:
+        if self.exists(pr_number):
+            return False
+        try:
+            self._table.insert(
+                {
+                    "task_type": "autonomous",
+                    "task_description": f"rework lock for PR #{pr_number}",
+                    "outcome_status": "pending",
+                    "project": "jarvis",
+                    "pattern_tags": self._lock_tags(pr_number),
+                    "source_provenance": f"sandcastle:watcher:lock:{pr_number}",
+                }
+            ).execute()
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+
+def process_spawner(pr_number: int) -> None:
+    """Spawn a Claude Code session to run ``/rework <N>``.
+
+    The spawned process is intentionally *not* waited on for status beyond
+    exit code — all judgement happens inside the on-demand session.
+    """
+    cmd = ["claude", "-p", f"/rework {pr_number}"]
+    result = subprocess.run(  # noqa: S603 — claude is a first-party binary
+        cmd,
+        capture_output=False,
+        timeout=3600,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude -p '/rework {pr_number}' exited {result.returncode}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Daemon loop
+# ---------------------------------------------------------------------------
+
+
+def _setup_logging(log_path: Path = LOG_PATH_DEFAULT) -> logging.Logger:
+    """Configure rotating file logger + stderr console handler."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger("watcher")
+    logger.setLevel(logging.INFO)
+
+    # Avoid duplicate handlers on re-entry (testing)
+    if logger.handlers:
+        return logger
+
+    fmt = logging.Formatter(
+        "%(asctime)s  %(levelname)s  %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z",
+    )
+
+    fh = logging.handlers.RotatingFileHandler(
+        log_path, maxBytes=5 * 1024 * 1024, backupCount=3
+    )
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+
+    ch = logging.StreamHandler(sys.stderr)
+    ch.setFormatter(fmt)
+    logger.addHandler(ch)
+
+    return logger
+
+
+def run_daemon(
+    poll_interval: int = DEFAULT_POLL_INTERVAL_SECONDS,
+    quota_cache_path: Path = QUOTA_CACHE_DEFAULT,
+    log_path: Path = LOG_PATH_DEFAULT,
+) -> None:
+    """Enter the watcher's main poll loop.
+
+    The daemon never exits on a transient error — each tick failure is logged
+    and the loop continues. This is intentional: the daemon should only be
+    stopped by Task Scheduler / OS signals, never by an event-processing crash.
+    """
+    logger = _setup_logging(log_path)
+    logger.info("Watcher daemon starting (poll_interval=%ds)", poll_interval)
+
+    supabase_url = os.environ.get("SUPABASE_URL", "")
+    supabase_key = os.environ.get("SUPABASE_KEY", "")
+    if not supabase_url or not supabase_key:
+        logger.error("SUPABASE_URL and SUPABASE_KEY must be set")
+        sys.exit(1)
+
+    events_client: EventsClient = SupabaseEventsClient(supabase_url, supabase_key)
+    locks_client: LocksClient = SupabaseLocksClient(supabase_url, supabase_key)
+
+    logger.info("Watcher initialized, entering poll loop")
+
+    while True:
+        tick_start = time.monotonic()
+        try:
+            result = tick(
+                now=datetime.now(timezone.utc),
+                events_client=events_client,
+                locks_client=locks_client,
+                spawner=process_spawner,
+                quota_cache_path=quota_cache_path,
+            )
+            if result.spawns_succeeded > 0 or result.errors:
+                logger.info(
+                    "Tick: %d spawned, %d processed, "
+                    "%d quota-skipped, %d lock-skipped, %d errors",
+                    result.spawns_succeeded,
+                    result.events_processed,
+                    result.events_skipped_quota,
+                    result.events_skipped_lock,
+                    len(result.errors),
+                )
+                for err in result.errors:
+                    logger.error("Tick error: %s", err)
+        except Exception:  # noqa: BLE001
+            logger.exception("Tick crashed (daemon continues)")
+
+        elapsed = time.monotonic() - tick_start
+        sleep_for = max(1, poll_interval - int(elapsed))
+        time.sleep(sleep_for)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Orchestrator watcher daemon — poll, gate, lock, dispatch"
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=DEFAULT_POLL_INTERVAL_SECONDS,
+        help="Seconds between ticks (default: %d)" % DEFAULT_POLL_INTERVAL_SECONDS,
+    )
+    parser.add_argument(
+        "--quota-cache",
+        type=str,
+        default=str(QUOTA_CACHE_DEFAULT),
+        help="Path to quota cache JSON file",
+    )
+    parser.add_argument(
+        "--log-path",
+        type=str,
+        default=str(LOG_PATH_DEFAULT),
+        help="Path to watcher log file",
+    )
+    args = parser.parse_args()
+
+    run_daemon(
+        poll_interval=args.poll_interval,
+        quota_cache_path=Path(args.quota_cache),
+        log_path=Path(args.log_path),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_orchestrator_watcher.py
+++ b/tests/test_orchestrator_watcher.py
@@ -1,0 +1,422 @@
+"""Unit tests for orchestrator watcher tick function (#639).
+
+All tests use fakes for EventsClient, LocksClient, and Spawner — no live
+Supabase or Claude session is required.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+import pytest
+
+from orchestrator.watcher import (
+    EventRow,
+    EventsClient,
+    LocksClient,
+    TickResult,
+    check_quota,
+    tick,
+)
+
+
+# ============================================================================
+# Fakes
+# ============================================================================
+
+
+@dataclass
+class FakeEventsClient(EventsClient):
+    """In-memory events store. Records method calls for assertion."""
+
+    rows: list[EventRow] = field(default_factory=list)
+    processed: set[str] = field(default_factory=set)
+    mark_calls: list[str] = field(default_factory=list)
+
+    def fetch_unprocessed(self, event_types: list[str]) -> list[EventRow]:
+        return [
+            r
+            for r in self.rows
+            if r.event_type in event_types and r.event_id not in self.processed
+        ]
+
+    def mark_processed(self, event_id: str) -> None:
+        self.mark_calls.append(event_id)
+        self.processed.add(event_id)
+
+    def mark_many_processed(self, event_ids: list[str]) -> None:
+        self.mark_calls.extend(event_ids)
+        self.processed.update(event_ids)
+
+
+@dataclass
+class FakeLocksClient(LocksClient):
+    """In-memory lock store. Records method calls for assertion."""
+
+    locks: set[int] = field(default_factory=set)
+    exists_calls: list[int] = field(default_factory=list)
+    acquire_calls: list[int] = field(default_factory=list)
+    _acquire_result: bool | None = None  # None = use default logic
+
+    def exists(self, pr_number: int) -> bool:
+        self.exists_calls.append(pr_number)
+        return pr_number in self.locks
+
+    def acquire(self, pr_number: int) -> bool:
+        self.acquire_calls.append(pr_number)
+        if self._acquire_result is not None:
+            return self._acquire_result
+        if pr_number in self.locks:
+            return False
+        self.locks.add(pr_number)
+        return True
+
+
+@dataclass
+class FakeSpawner:
+    """Records spawn calls. Can be configured to raise."""
+
+    calls: list[int] = field(default_factory=list)
+    raise_on: int | None = None  # PR number that should cause a raise
+
+    def __call__(self, pr_number: int) -> None:
+        self.calls.append(pr_number)
+        if self.raise_on is not None and pr_number == self.raise_on:
+            raise RuntimeError(f"spawn failed for PR #{pr_number}")
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def make_row(
+    event_id: str,
+    event_type: str = "review_negative",
+    pr_number: int = 42,
+    repo: str = "Osasuwu/jarvis",
+) -> EventRow:
+    return EventRow(
+        event_id=event_id,
+        event_type=event_type,
+        payload={"pr_number": pr_number},
+        repo=repo,
+    )
+
+
+def now() -> datetime:
+    return datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def quota_file(tmp_path: Path) -> Path:
+    """Create a temporary quota cache file with 50% usage (under threshold)."""
+    path = tmp_path / "usage.json"
+    path.write_text(json.dumps({"weekly_pct": 50}))
+    return path
+
+
+# ============================================================================
+# AC: check_quota (pure function)
+# ============================================================================
+
+
+class TestCheckQuota:
+    def test_under_threshold_allows(self, tmp_path: Path) -> None:
+        path = tmp_path / "usage.json"
+        path.write_text(json.dumps({"weekly_pct": 50}))
+        assert check_quota(path) is True
+
+    def test_at_threshold_blocks(self, tmp_path: Path) -> None:
+        path = tmp_path / "usage.json"
+        path.write_text(json.dumps({"weekly_pct": 80}))
+        assert check_quota(path) is False
+
+    def test_over_threshold_blocks(self, tmp_path: Path) -> None:
+        path = tmp_path / "usage.json"
+        path.write_text(json.dumps({"weekly_pct": 85}))
+        assert check_quota(path) is False
+
+    def test_missing_file_fails_closed(self, tmp_path: Path) -> None:
+        path = tmp_path / "nonexistent.json"
+        assert check_quota(path) is False
+
+    def test_malformed_json_fails_closed(self, tmp_path: Path) -> None:
+        path = tmp_path / "usage.json"
+        path.write_text("not json")
+        assert check_quota(path) is False
+
+    def test_missing_weekly_pct_key_fails_closed(self, tmp_path: Path) -> None:
+        path = tmp_path / "usage.json"
+        path.write_text(json.dumps({"other": "data"}))
+        assert check_quota(path) is False
+
+
+# ============================================================================
+# AC: Tick — empty queue
+# ============================================================================
+
+
+class TestTickEmptyQueue:
+    """Empty queue → no spawn, no marks."""
+
+    def test_no_events(self, quota_file: Path) -> None:
+        events = FakeEventsClient()  # no rows
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.events_processed == 0
+        assert result.spawns_attempted == 0
+        assert result.spawns_succeeded == 0
+        assert result.errors == []
+        assert spawner.calls == []
+
+    def test_wrong_event_type_filtered(self, quota_file: Path) -> None:
+        events = FakeEventsClient(rows=[make_row("e1", event_type="ci_failure")])
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.events_processed == 0
+        assert spawner.calls == []
+
+
+# ============================================================================
+# AC: Tick — one review_negative row, quota OK, no lock
+# ============================================================================
+
+
+class TestTickNormalDispatch:
+    """One review_negative row, quota OK, no lock → exactly one spawner call with
+    correct args; row marked processed."""
+
+    def test_dispatch_and_mark(self, quota_file: Path) -> None:
+        events = FakeEventsClient(rows=[make_row("e1", pr_number=42)])
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.spawns_attempted == 1
+        assert result.spawns_succeeded == 1
+        assert result.events_processed == 1
+        assert spawner.calls == [42]
+        assert "e1" in events.processed
+
+
+# ============================================================================
+# AC: Tick — quota blocks dispatch
+# ============================================================================
+
+
+class TestTickQuotaGate:
+    """Quota cache shows 85% → no spawner call, row NOT marked."""
+
+    def test_quota_blocks(self, tmp_path: Path) -> None:
+        quota = tmp_path / "usage.json"
+        quota.write_text(json.dumps({"weekly_pct": 85}))
+        events = FakeEventsClient(rows=[make_row("e1", pr_number=42)])
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota)
+
+        assert result.events_skipped_quota == 1
+        assert result.spawns_attempted == 0
+        assert spawner.calls == []
+        assert "e1" not in events.processed
+
+    def test_quota_missing_file_fails_closed(self, tmp_path: Path) -> None:
+        quota = tmp_path / "nonexistent.json"
+        events = FakeEventsClient(rows=[make_row("e1", pr_number=42)])
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota)
+
+        assert result.events_skipped_quota == 1
+        assert result.spawns_attempted == 0
+        assert spawner.calls == []
+
+    def test_quota_ok_then_below_threshold_dispatches(self, quota_file: Path) -> None:
+        events = FakeEventsClient(rows=[make_row("e1", pr_number=42)])
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.spawns_succeeded == 1
+        assert spawner.calls == [42]
+
+
+# ============================================================================
+# AC: Tick — in-flight lock subsumes
+# ============================================================================
+
+
+class TestTickLockSubsumes:
+    """In-flight lock present for PR N → row marked processed, no spawner call."""
+
+    def test_lock_prevents_dispatch(self, quota_file: Path) -> None:
+        events = FakeEventsClient(rows=[make_row("e1", pr_number=42)])
+        locks = FakeLocksClient(locks={42})  # lock already held
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.events_skipped_lock == 1
+        assert result.events_processed == 1
+        assert result.spawns_attempted == 0
+        assert spawner.calls == []
+        assert "e1" in events.processed
+
+
+# ============================================================================
+# AC: Tick — spawner raises → row stays unprocessed
+# ============================================================================
+
+
+class TestTickSpawnFailure:
+    """Spawner raises → row stays processed=false, no lock written."""
+
+    def test_spawn_error_leaves_row(self, quota_file: Path) -> None:
+        events = FakeEventsClient(rows=[make_row("e1", pr_number=42)])
+        locks = FakeLocksClient()
+        spawner = FakeSpawner(raise_on=42)
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.spawns_attempted == 1
+        assert result.spawns_succeeded == 0
+        assert result.events_processed == 0
+        assert len(result.errors) == 1
+        assert "42" in result.errors[0]
+        assert spawner.calls == [42]
+        assert "e1" not in events.processed
+
+
+# ============================================================================
+# AC: Tick — dedup within tick
+# ============================================================================
+
+
+class TestTickDedup:
+    """Two rows for the same PR in one tick → exactly one spawner call,
+    both rows marked processed."""
+
+    def test_same_pr_dedup(self, quota_file: Path) -> None:
+        events = FakeEventsClient(
+            rows=[
+                make_row("e1", pr_number=42),
+                make_row("e2", pr_number=42),
+            ]
+        )
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.spawns_attempted == 1
+        assert result.spawns_succeeded == 1
+        assert result.events_processed == 2
+        assert spawner.calls == [42]
+        assert "e1" in events.processed
+        assert "e2" in events.processed
+
+    def test_different_prs_separate_spawns(self, quota_file: Path) -> None:
+        events = FakeEventsClient(
+            rows=[
+                make_row("e1", pr_number=42),
+                make_row("e2", pr_number=100),
+            ]
+        )
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.spawns_attempted == 2
+        assert result.spawns_succeeded == 2
+        assert result.events_processed == 2
+        assert spawner.calls == [42, 100]
+
+    def test_same_pr_different_events_one_lock_subsumes_all(
+        self, quota_file: Path
+    ) -> None:
+        events = FakeEventsClient(
+            rows=[
+                make_row("e1", pr_number=42),
+                make_row("e2", pr_number=42),
+            ]
+        )
+        locks = FakeLocksClient(locks={42})
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.spawns_attempted == 0
+        assert result.events_processed == 2
+        assert result.events_skipped_lock == 2
+        assert spawner.calls == []
+
+
+# ============================================================================
+# AC: Tick — event without PR number
+# ============================================================================
+
+
+class TestTickNoPrNumber:
+    """Events without a PR number are marked processed without dispatch."""
+
+    def test_missing_pr_number(self, quota_file: Path) -> None:
+        events = FakeEventsClient(
+            rows=[
+                EventRow(
+                    event_id="e1",
+                    event_type="review_negative",
+                    payload={},  # no pr_number
+                    repo="Osasuwu/jarvis",
+                )
+            ]
+        )
+        locks = FakeLocksClient()
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.events_processed == 1
+        assert result.spawns_attempted == 0
+        assert spawner.calls == []
+        assert "e1" in events.processed
+
+
+# ============================================================================
+# AC: Tick — lock acquire race
+# ============================================================================
+
+
+class TestTickLockRace:
+    """Lock acquire returns False (race with another process)."""
+
+    def test_acquire_race(self, quota_file: Path) -> None:
+        events = FakeEventsClient(rows=[make_row("e1", pr_number=42)])
+        locks = FakeLocksClient()
+        locks._acquire_result = False  # race: another process got lock
+        spawner = FakeSpawner()
+
+        result = tick(now(), events, locks, spawner, quota_cache_path=quota_file)
+
+        assert result.spawns_attempted == 0
+        assert result.events_processed == 1
+        assert result.events_skipped_lock == 1
+        assert spawner.calls == []
+        assert "e1" in events.processed


### PR DESCRIPTION
## Summary

Implements Module 2 of the AFK PR-rework loop (milestone #41). The orchestrator watcher daemon polls the events table every 45s for review_negative events, gates on quota cache, applies per-PR lock checks via task_outcomes, and dispatches claude -p "/rework <N>".

## Architecture

The tick function is a pure-ish module with injected dependencies:

tick(now, events_client, locks_client, spawner) -> TickResult

Three injected interfaces (EventsClient, LocksClient, Spawner) make the entire core logic unit-testable without live Supabase or Claude. Production implementations target the legacy events table (has processed + event_type) — when events_canonical gains these columns (#739), a new client implementation can be swapped in without touching the tick function.

## Files

- scripts/orchestrator/watcher.py — Tick function + Supabase clients + daemon loop
- scripts/orchestrator/register-watcher.ps1 — Task Scheduler registration (Workshop only)
- tests/test_orchestrator_watcher.py — 19 unit tests with fakes

## Test plan

- 19/19 unit tests pass (verified in sandcastle CI)
- All ACs covered by fakes: empty queue, normal dispatch, quota gate (85% blocks, missing file fail-closed, 50% allows), lock subsumption, spawn failure leaves row unprocessed, same-PR dedup, cross-PR parallel dispatch, missing PR number, lock race
- Manual E2E on Workshop is blocked — depends on #633 (review_negative event emission), #635 (quota probe), #636 (/rework skill)

## Verification

memory_recall queried before implementation. Relevant memories reviewed: workshop cold-boot latency bounds (#738), workshop scheduler deployment lessons, event-driven perception v1, autonomous loop v1 architecture.

Realizes decision e6441d77 (Q3 orchestrator architecture).

Closes #639