### PR TITLE
feat(sandcastle): append rework history to PR body on terminal state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ yarn-error.log*
 .sandcastle/.env
 .sandcastle/runtime/
 .sandcastle/worktrees/
+.sandcastle/hfcache/
 docs/research/
 
 # Logs

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -31,6 +31,12 @@ const agentAuthToken = process.env.SANDCASTLE_AGENT_AUTH_TOKEN ?? "ollama";
 // it sets SANDCASTLE_TARGET_ISSUE so prompt.md can pin the agent to that
 // issue instead of picking afresh from the queue.
 const targetIssue = process.env.SANDCASTLE_TARGET_ISSUE ?? "";
+
+// Rework mode: when SANDCASTLE_TARGET_PR=<N> is set, the container runs
+// /rework on the existing PR branch instead of a fresh pick+implement cycle.
+// The env var is forwarded into the container; prompt.md branches on its
+// presence (see issue #637, decision 69b7eddb).
+const targetPr = process.env.SANDCASTLE_TARGET_PR ?? "";
 const ghToken = process.env.GH_TOKEN;
 if (!ghToken) {
   throw new Error(
@@ -92,6 +98,9 @@ const result = await run({
       // Forced-target issue for slice-5 escalation retries. Empty string =
       // free pick from queue (default behavior).
       SANDCASTLE_TARGET_ISSUE: targetIssue,
+      // Rework mode: when non-empty, the container branches into rework path
+      // on this PR number instead of the fresh pick+implement cycle (#637).
+      SANDCASTLE_TARGET_PR: targetPr,
     },
   }),
   agent: claudeCode(agentModel),

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -110,6 +110,24 @@ this section replaces it entirely.
      Add `status:needs-human` label via
      `gh issue edit $SANDCASTLE_TARGET_PR --add-label status:needs-human`.
      Remove `status:rework-in-progress` label.
+   - **Both paths — final action before exit**: append a rework history entry to
+     the PR body. Use the exact verdict name (`converged`, `stuck_attempts`,
+     `stuck_scope`, `stuck_no_convergence`, or `stuck_conflict`) in the header.
+     Procedure:
+     a. Fetch fresh body — `gh pr view $SANDCASTLE_TARGET_PR --json body |
+        jq -r '.body'` so any owner edits between AFK runs survive.
+     b. Write the body + new entry to a temp file via the Write tool (avoids shell
+        quoting issues). Determine attempt number N by counting existing
+        `### Attempt` headers in the body + 1; if none exist, N=1.
+     c. If `## Rework history` section already exists in the body, append:
+        ```
+        ### Attempt N (<UTC_YYYY-MM-DD HH:MM>) — <verdict>
+        <1-2 lines: what changed, what's still outstanding>
+        ```
+        under the existing section. If it does NOT exist, create it at the end of
+        the body separated by `\n\n---\n\n`.
+     d. Update PR body — `gh pr edit $SANDCASTLE_TARGET_PR --body "$(cat <tempfile>)"`
+     e. Container exits after this step (no further actions).
 7. **Do NOT touch**: PR title, `Closes` line in body, or any label other than
    `status:rework-in-progress` and `status:needs-human`.
 8. **Record iteration outcome** — one `outcome_record` (separate from the lock)

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -4,6 +4,10 @@
 
 !`if [ -n "$SANDCASTLE_TARGET_ISSUE" ]; then echo "**Tier escalation retry — pinned to issue #$SANDCASTLE_TARGET_ISSUE.** Skip the pick step below; resume work on this exact issue (claim if not already claimed by you, otherwise continue on its branch)."; else echo "(no forced target — free pick)"; fi`
 
+## Rework mode (forced PR target)
+
+!`if [ -n "$SANDCASTLE_TARGET_PR" ]; then echo "**Rework mode — pinned to PR #$SANDCASTLE_TARGET_PR.** Follow the §Rework workflow below instead of the standard workflow."; else echo "(no rework target — free pick)"; fi`
+
 ## Open issues in the AFK queue
 
 !`gh issue list --repo Osasuwu/jarvis --label "sandcastle" --state open --limit 20 2>&1 || echo "(gh failed)"`
@@ -13,6 +17,13 @@
 !`git log --oneline --grep="^feat\|^fix" -10`
 
 # Task
+
+**If the §Rework mode section at the top shows an active target PR** — skip the
+"Workflow per iteration" below and follow the **§Rework workflow** section
+instead. The standard workflow would create a duplicate PR, which is incorrect
+for rework mode.
+
+Otherwise, follow the standard workflow below.
 
 You are a Jarvis coding subagent running in a sandcastle Docker container on
 local Ollama. You work through GitHub issues one at a time, **opening PRs but
@@ -56,6 +67,57 @@ issues**, not to the prompt-level context blocks.
    the most valuable signal for the orchestrator review.
 9. **Stop on this issue** — do NOT merge. The orchestrator (live Claude Code
    session) reviews and merges separately.
+
+## Rework workflow
+
+Follow this when `SANDCASTLE_TARGET_PR=<N>` is present (shown in §Rework mode
+at the top). **Do NOT** follow the standard "Workflow per iteration" above —
+this section replaces it entirely.
+
+1. **Fetch PR info** — `gh pr view $SANDCASTLE_TARGET_PR --json headRefName,state,headRepository,baseRefName`
+   - If this fails (PR closed / branch deleted / response is empty) → call
+     `outcome_record` with `outcome_status="unknown"`,
+     `pattern_tags=['pr-$SANDCASTLE_TARGET_PR', 'rework', 'skipped']`,
+     `task_description="Rework skipped — unable to fetch PR #$SANDCASTLE_TARGET_PR"`.
+     Then **stop** (exit cleanly — no lock, no label, no rework attempt). Do NOT
+     delete any existing lock — a stale lock is a deliberate anomaly signal.
+2. **Checkout the PR branch** — `git fetch origin <headRefName>` then
+   `git checkout <headRefName>`. This is the PR author's branch; push fix commits
+   directly to it. Do NOT create a new branch or PR.
+3. **Write per-PR lock** — call `outcome_record` with:
+   - `task_type="fix"`
+   - `task_description="Rework sandcastle agent processing PR #$SANDCASTLE_TARGET_PR"`
+   - `outcome_status="pending"`
+   - `pattern_tags=['pr-$SANDCASTLE_TARGET_PR', 'rework', 'in_flight']`
+   - `project="jarvis"`
+   - provenance per §Memory provenance below
+   Capture the returned outcome UUID — you need it for the terminal update.
+   If you encounter a stale lock (>2h with `in_flight` pattern tag for this PR),
+   flag it in a PR comment but proceed with rework (do NOT auto-release).
+4. **Label the PR** — `gh issue edit $SANDCASTLE_TARGET_PR --add-label status:rework-in-progress`
+5. **Invoke rework skill** — run `/rework $SANDCASTLE_TARGET_PR`. This executes
+   the rework loop (apply review fixes per CRITICAL/MAJOR findings, push, verify
+   CI). Wait for its completion or terminal verdict.
+6. **On terminal state**:
+   - **Converged** (all findings resolved): push any remaining commits. Update the
+     lock outcome record via `outcome_update` with `outcome_status="success"`,
+     `outcome_summary="Rework converged — all findings resolved"`.
+     Remove `status:rework-in-progress` label via
+     `gh issue edit $SANDCASTLE_TARGET_PR --remove-label status:rework-in-progress`.
+   - **Stuck** (unresolvable findings): update the lock via `outcome_update` with
+     `outcome_status="failure"`,
+     `outcome_summary="Rework stuck — <brief reason>"`.
+     Add `status:needs-human` label via
+     `gh issue edit $SANDCASTLE_TARGET_PR --add-label status:needs-human`.
+     Remove `status:rework-in-progress` label.
+7. **Do NOT touch**: PR title, `Closes` line in body, or any label other than
+   `status:rework-in-progress` and `status:needs-human`.
+8. **Record iteration outcome** — one `outcome_record` (separate from the lock)
+   with `task_type="fix"`, `outcome_status` matching the rework result
+   (success/partial/failure), `pattern_tags=['pr-$SANDCASTLE_TARGET_PR', 'rework',
+   'iteration']`. This is the sandcastle iteration record for orchestrator
+   tracking — distinct from the per-PR lock.
+9. **Stop** — do NOT merge. The orchestrator reviews and merges separately.
 
 ## Memory provenance (mandatory on every memory write)
 


### PR DESCRIPTION
## Summary

- Extend the rework workflow's terminal-state handler in `.sandcastle/prompt.md` to append a `## Rework history` entry to the PR body as the final action before container exit
- Entry format: `### Attempt N (UTC timestamp) — <verdict>` with 1-2 line summary
- Fresh `gh pr view` before each append so owner edits between AFK runs survive
- Section created on first attempt (`---` separator), appended on subsequent ones

Closes #638

## Acceptance criteria covered

- [x] Append occurs only on terminal state (converged or `stuck_*`). No body update on `continue` verdicts.
- [x] Body update is the final action before container exit (explicit step (e))
- [x] First attempt creates `## Rework history` + `### Attempt 1`; subsequent adds `### Attempt N+1`
- [x] Fresh `gh pr view --json body` before each append — owner edits survive
- [x] Timestamp in UTC `YYYY-MM-DD HH:MM` format
- [x] Verdict string matches policy module names exactly (`converged`, `stuck_attempts`, etc.)
- [x] Blocked by #637 — branch stacks on #637's changes

## Rework history

This is the first PR for this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)