### PR TITLE
Consolidate _hash_scope_files into single source of truth

### DIFF
--- a/agents/executor.py
+++ b/agents/executor.py
@@ -21,13 +21,14 @@ must never inherit API-billing keys.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 import shutil
 import subprocess
 from datetime import UTC, datetime
 from typing import Any
+
+from agents.scope_hash import _hash_scope_files  # re-export — see issue #773
 
 logger = logging.getLogger(__name__)
 
@@ -159,16 +160,6 @@ def _sanitize_env(env: dict[str, str] | None = None) -> dict[str, str]:
     """
     source = env if env is not None else os.environ
     return {k: v for k, v in source.items() if k not in _SENSITIVE_ENV_KEYS}
-
-
-def _hash_scope_files(scope_files: list[str] | tuple[str, ...]) -> str:
-    """Deterministic scope-files hash for drift detection.
-
-    Sort the list so "files reordered" doesn't read as "files changed";
-    newline-join so a glob that grew by one file produces different hashes.
-    """
-    normalized = "\n".join(sorted(scope_files or []))
-    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
 def _now_iso() -> str:

--- a/agents/perception_github.py
+++ b/agents/perception_github.py
@@ -37,6 +37,7 @@ from typing import Any
 from supabase import Client
 
 from agents import supabase_client
+from agents.scope_hash import _hash_scope_files  # re-export — see issue #773
 
 logger = logging.getLogger(__name__)
 
@@ -85,16 +86,6 @@ def _parse_scope_files(body: str) -> list[str]:
             files.add(match)
 
     return sorted(files)
-
-
-def _hash_scope_files(scope_files: list[str]) -> str:
-    """Deterministic scope-files hash.
-
-    Matches dispatcher._hash_scope_files: sort + newline-join + sha256.
-    Used for approved_scope_hash and idempotency key computation.
-    """
-    normalized = "\n".join(sorted(scope_files or []))
-    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
 def _idempotency_key(repo: str, issue_number: int, labels: list[str]) -> str:

--- a/agents/scope_hash.py
+++ b/agents/scope_hash.py
@@ -1,0 +1,25 @@
+"""Deterministic scope-files hash — single source of truth for drift detection.
+
+Consolidated from copies previously living in ``executor.py``,
+``perception_github.py``, and ``scripts/dispatcher_smoke_live.py`` (issue
+#773). Kept in its own module so callers like ``morning_check.py`` don't
+import a hash utility from ``agents/executor.py`` (a subprocess-spawning
+module).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def _hash_scope_files(scope_files: list[str] | tuple[str, ...]) -> str:
+    """Deterministic scope-files hash for drift detection.
+
+    Matches the approval-time hashing convention S2-1 expects. Sort the
+    list so "files reordered" doesn't read as "files changed"; newline-join
+    so a glob that grew by one file ``['a']`` vs ``['a', 'b']`` produces
+    different hashes (concatenation ``'ab'`` vs ``'a'`` would too, but
+    a separator makes the invariant human-readable).
+    """
+    normalized = "\n".join(sorted(scope_files or []))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()

--- a/scripts/dispatcher_smoke_live.py
+++ b/scripts/dispatcher_smoke_live.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from agents.scope_hash import _hash_scope_files
+
 STATE_FILE = Path(__file__).parent / ".dispatcher_smoke_state.json"
 MARKER_DIR = Path(__file__).parent / ".smoke-markers"
 
@@ -46,7 +48,7 @@ def seed() -> int:
     )
 
     scope_files: list[str] = []
-    scope_hash = hashlib.sha256("\n".join(sorted(scope_files)).encode("utf-8")).hexdigest()
+    scope_hash = _hash_scope_files(scope_files)
     idem_key = hashlib.sha256(f"dispatcher-smoke-live-{marker}".encode("utf-8")).hexdigest()
 
     cli = get_client()

--- a/scripts/observability/morning_check.py
+++ b/scripts/observability/morning_check.py
@@ -20,7 +20,8 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from agents.executor import _hash_scope_files, _now_iso
+from agents.executor import _now_iso
+from agents.scope_hash import _hash_scope_files
 from agents.supabase_client import get_client
 
 # Alarm categories for stable idempotency key generation

--- a/tests/test_scope_hash.py
+++ b/tests/test_scope_hash.py
@@ -1,0 +1,45 @@
+"""Direct tests for ``agents.scope_hash._hash_scope_files`` (issue #773).
+
+Covers the three consolidation invariants:
+- stable output across calls (same input → same hash)
+- sensitivity to file *content* change (different file names → different hash)
+- sensitivity to file *set* change (added/removed file → different hash)
+"""
+
+from __future__ import annotations
+
+from agents.scope_hash import _hash_scope_files
+
+
+def test_stable_across_calls() -> None:
+    """Same input produces same hash on repeated calls."""
+    files = ["a.py", "b.py", "c.py"]
+    assert _hash_scope_files(files) == _hash_scope_files(files)
+
+
+def test_order_independent() -> None:
+    """Hash is order-independent (sort normalisation)."""
+    assert _hash_scope_files(["b.py", "a.py"]) == _hash_scope_files(["a.py", "b.py"])
+
+
+def test_sensitivity_to_file_name() -> None:
+    """Different file names produce different hashes."""
+    assert _hash_scope_files(["a.py"]) != _hash_scope_files(["b.py"])
+
+
+def test_sensitivity_to_added_file() -> None:
+    """Adding a file changes the hash."""
+    assert _hash_scope_files(["a.py"]) != _hash_scope_files(["a.py", "b.py"])
+
+
+def test_sensitivity_to_removed_file() -> None:
+    """Removing a file changes the hash."""
+    assert _hash_scope_files(["a.py", "b.py"]) != _hash_scope_files(["a.py"])
+
+
+def test_empty_list_is_stable() -> None:
+    """Empty file list produces consistent sha256 hex digest."""
+    first = _hash_scope_files([])
+    second = _hash_scope_files([])
+    assert first == second
+    assert len(first) == 64  # sha256 hex


### PR DESCRIPTION
Closes #773

Extract the deterministic scope-files hash function into its own module
`agents/scope_hash.py` so the three identical copies are replaced by
imports. The new home avoids the odd coupling of `morning_check.py`
importing a hash utility from `agents/dispatcher.py` (a subprocess-spawning
module).

**Changes:**
- `agents/scope_hash.py` — canonical `_hash_scope_files` (single `def`)
- `agents/dispatcher.py` — imports from `agents.scope_hash` (re-exports)
- `agents/perception_github.py` — imports from `agents.scope_hash` (re-exports)
- `scripts/dispatcher_smoke_live.py` — uses imported function instead of inline
- `scripts/observability/morning_check.py` — imports from `agents.scope_hash`
- `tests/test_scope_hash.py` — dedicated test (stable output, order independence,
  sensitivity to file name, added/removed files, empty list stability)

**Verification:**
- `grep 'def _hash_scope_files' -r` → 1 hit (agents/scope_hash.py)
- All 6 hash behavior tests pass
- Syntax check on all modified files passes
- Existing tests continue to import via re-export from original modules

**Size:** S — pure refactor, behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)