### PR TITLE
docs(autonomous-loop): mark SUPERSEDED + remove cron registration

### DIFF
--- a/.claude-userlevel/skills/autonomous-loop/SKILL.md
+++ b/.claude-userlevel/skills/autonomous-loop/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: autonomous-loop
-description: "Autonomous orchestrator: perceive events, evaluate against goals, decide and act within safety bounds. Runs daily via scheduled task or manual invocation."
+description: "[SUPERSEDED 2026-05-26 — pre-M44 catch-up baseline ONLY; do not invoke for new flows.] Legacy autonomous orchestrator: perceive events, evaluate against goals, decide and act within safety bounds. Cron entry removed; opt-in manual invocation only."
 version: 1.2.0
 ---
 
 # Autonomous Loop Orchestrator
+
+> ⚠ **SUPERSEDED 2026-05-26** (decision `a70c4460`). This skill is the pre-M44 cron-based catch-up baseline. **Do not invoke for new flows. Do not reference it in routing as if alive.** New AFK paths route through the reactive-core orchestrator (M44 `wake_driver` + event-driven `task_queue`). When M44 ships, this skill file is deleted entirely.
+>
+> Cron registration is no longer bootstrapped by `/setup-tasks`. Existing cron jobs on prior devices must be unregistered manually. Skill is retained on disk only so that a manual `/autonomous-loop` invocation still works if owner needs a one-off catch-up sweep pre-M44.
 
 Daily orchestrator that perceives events and perception outputs (goals, risks, research findings), evaluates them against active goals, decides actions within safety bounds, and executes them autonomously. Batches multiple Low-risk actions per run; limits Medium-risk to one.
 
@@ -12,9 +16,9 @@ Implements the perceive→evaluate→decide→act→record loop from the Autonom
 
 ## Usage
 
-- `/autonomous-loop` — manual invocation (full run)
-- Scheduled: daily 09:00 (after morning-brief)
-- Part of: Jarvis Autonomous Work Loop pillar
+- `/autonomous-loop` — manual opt-in invocation (full run). Owner-initiated only post-2026-05-26.
+- ~~Scheduled: daily 09:00 (after morning-brief)~~ — removed 2026-05-26.
+- Part of: Jarvis Autonomous Work Loop pillar (legacy; superseded by reactive-core M44).
 
 ## Architecture
 

--- a/.claude-userlevel/skills/setup-tasks/SKILL.md
+++ b/.claude-userlevel/skills/setup-tasks/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 
 # Setup Tasks
 
-Bootstrap all 6 scheduled tasks on a new device in one command.
+Bootstrap all 5 scheduled tasks on a new device in one command.
 
 ## Usage
 
@@ -19,7 +19,7 @@ This skill idempotently registers all scheduled tasks. If a task already exists,
 1. Call `list_scheduled_tasks` to see what's already registered
 2. **Deregister obsolete tasks** before adding new ones:
    - If `morning-brief` exists → call `delete_scheduled_task` (or the MCP equivalent). On success, count it under `removed`. **On failure, do NOT count it as removed** — print `warn: failed to remove morning-brief (<error>) — check manually` instead. A silent-fail would leave both `morning-brief` (07:43) and `status-record` (07:00) firing, defeating the migration.
-3. For each of the 6 required tasks:
+3. For each of the 5 required tasks:
    - If exists with matching name → skip ("already registered")
    - If missing → `create_scheduled_task` with cron + prompt
 4. Print summary: N created, N skipped, N removed.
@@ -31,9 +31,10 @@ This skill idempotently registers all scheduled tasks. If a task already exists,
 | nightly-research | `17 7 * * *` | Run `/research` — no topic argument; the skill auto-selects discovery mode from arg shape. |
 | status-record | `0 7 * * *` | Run `/status-record` — write daily snapshot of repo/CI/PR/issue/milestone state to memory under tag `status-snapshot`. |
 | risk-radar | `7 9,14,19 * * *` | Quick risk scan: check CI status, stale issues, security alerts across repos in `config/repos.conf` |
-| autonomous-loop | `3 9 * * *` | Run `/autonomous-loop` |
 | intel | `12 10 * * 1` | Weekly tech intelligence: search for new Claude Code features, MCP servers, AI agent patterns. Save findings to memory. |
 | verify | `47 16 * * 5` | Run `/verify` — verify pending outcomes, detect patterns, save lessons. |
+
+> `autonomous-loop` cron entry was removed 2026-05-26 (decision `a70c4460`). The skill itself is retained as opt-in pre-M44 catch-up baseline but is not bootstrapped on new devices. Existing cron jobs on prior devices must be unregistered manually (`Unregister-ScheduledTask -TaskName "jarvis-autonomous-loop"` on Windows, `crontab -e` on Linux/Mac).
 
 > `status-record` supersedes the old `morning-brief`/`/status` slot — the skill records state only, owner reads inline via `memory_recall(query="status-snapshot")`. Decisions/actions on findings belong to the sandcastle orchestrator (#531).
 
@@ -46,7 +47,7 @@ This skill idempotently registers all scheduled tasks. If a task already exists,
 
 ## Workshop-only: Windows Task Scheduler entries
 
-When invoked on the Workshop PC (`config/device.json` name = `VividFormsPC4Workshop`), `/setup-tasks` also registers the Task Scheduler entries below. Different infra from the six tasks above (those use `create_scheduled_task` MCP; these use `Register-ScheduledTask`).
+When invoked on the Workshop PC (`config/device.json` name = `VividFormsPC4Workshop`), `/setup-tasks` also registers the Task Scheduler entries below. Different infra from the five tasks above (those use `create_scheduled_task` MCP; these use `Register-ScheduledTask`).
 
 ### Sandcastle AFK loops
 

--- a/.claude-userlevel/skills/verify/SKILL.md
+++ b/.claude-userlevel/skills/verify/SKILL.md
@@ -10,8 +10,8 @@ Closes the outcome tracking loop: did the work actually land?
 ## When to use
 
 - After delegations have had time to merge
-- As part of autonomous-loop (scheduled)
 - Manual: `/verify` to check all pending outcomes
+- (Pre-2026-05-26: scheduled inside `/autonomous-loop` — superseded.)
 
 ## Step 1 — Fetch pending outcomes
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -20,11 +20,12 @@ Only jarvis-project-specific Claude Code config:
   here if jarvis ever needs them. The federation-wide hooks live in
   `~/.claude/settings.json` (installed from `.claude-userlevel/settings.json`).
 
-Everything else (the 11 core skills — `implement`, `delegate`, `verify`,
+Everything else (the core skills — `implement`, `delegate`, `verify`,
 `status`, `reflect`, `end` (with `--quick`), `research`, `goals`,
-`self-improve`, `setup-tasks`, `autonomous-loop` — plus SOUL.md and
-`.mcp.json`) was removed in M5 (#340). They're still available in every
-session, just from `~/.claude/` now.
+`self-improve`, `setup-tasks` — plus SOUL.md and `.mcp.json`) was removed
+in M5 (#340). They're still available in every session, just from
+`~/.claude/` now. (`autonomous-loop` skill file is retained but SUPERSEDED
+2026-05-26 — pre-M44 baseline only, do not invoke for new flows.)
 
 ## Where to look next
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Use skills — don't reinvent with raw tools.
 | "улучши себя", self-improvement | `/self-improve` |
 | "цели", "приоритеты" | `/goals` |
 | New device bootstrap, "scheduled tasks setup" | `/setup-tasks` |
-| Daily scheduled tick, "запусти автономный цикл" | `/autonomous-loop` (legacy cron baseline; reactive-core M44 `wake_driver` + `orchestrator` replace this once shipped — see CONTEXT.md) |
+| ~~Daily scheduled tick~~ | ~~`/autonomous-loop`~~ — **SUPERSEDED**, pre-M44 catch-up baseline only. **Do not invoke for new flows.** No live cron registration since Medium-scope cleanup 2026-05-26. Will be deleted when reactive-core M44 (`wake_driver` + `orchestrator`) ships. |
 | "end" / "end quick" | `/end` (full) / `/end --quick` (fast) |
 | Vague intuition (no written plan yet) / "у меня ощущение что", "может быть лучше но не знаю как", "обсудим концепт"; subsumes /research for in-debate factual grounding | `/reason` |
 | Stress-test plan / "grill me" / before non-trivial implementation | `/grill` |
@@ -121,7 +121,7 @@ Boundaries:
 
 - **Orchestrator-emitted TASK rows carry the same AFK-fit/sandcastle semantics** as manually-triaged ones — `/to-issues`'s checklist applies regardless of who emits the task. An AFK-unsafe TASK row gets routed for owner attention (no auto-spawn), same as the `status:owner-queue` landing zone for `/delegate` refuses.
 - **The orchestrator is a router, not the principal.** It runs routing-policy only (no full SOUL load). Full SOUL is for interactive `/implement` and for the `claude -p` subagents the executor spawns — both are the principal in their lane (CONTEXT.md → *SOUL is shared across interactive + autonomous lanes*).
-- **`/autonomous-loop` (legacy)** is the cron-based catch-up baseline pre-M44 and will be retired when reactive-core ships. New AFK paths should route through events + orchestrator, not through new `/autonomous-loop` invocations.
+- **`/autonomous-loop` (SUPERSEDED 2026-05-26)** — cron entry removed from `setup-tasks` bootstrap; existing cron jobs on each device must be unregistered manually. The skill file is retained as an opt-in pre-M44 catch-up baseline ONLY. **Do not invoke for new flows; do not reference it in routing as if alive.** New AFK paths route through events + reactive-core orchestrator (M44). When M44 ships, the skill itself is deleted.
 
 ## Autonomous work
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ User-level Jarvis is seeded from `.claude-userlevel/` in this repo by
 | Component | Description |
 |-----------|-------------|
 | **Cross-device memory** | MCP server syncs memories, goals, events via Supabase. Vector search (Voyage AI) + keyword fallback |
-| **11 skills** | `/status`, `/implement`, `/delegate`, `/verify`, `/reflect`, `/research`, `/self-improve`, `/goals`, `/setup-tasks`, `/autonomous-loop`, `/end` (`--quick` for fast exit) |
+| **Core skills** | `/status`, `/implement`, `/delegate`, `/verify`, `/reflect`, `/research`, `/self-improve`, `/goals`, `/setup-tasks`, `/end` (`--quick` for fast exit). (`/autonomous-loop` is SUPERSEDED 2026-05-26 — pre-M44 baseline only.) |
 | **SOUL.md personality** | Auto-loaded every session via hook. Opinionated, direct, bilingual (RU/EN) |
 | **Goal-aware decisions** | Jarvis knows priorities and pushes back when a task conflicts with active goals |
 | **Delegation pipeline** | Issue -> branch -> coding agent -> PR, with verification |
@@ -85,7 +85,7 @@ User-level Jarvis is seeded from `.claude-userlevel/` in this repo by
 | `/self-improve` | "improve yourself" | Gap analysis -> ideation -> research -> implementation |
 | `/goals` | "goals", "priorities" | View, set, update strategic goals in Supabase |
 | `/setup-tasks` | New device bootstrap | Registers all scheduled tasks (idempotent) |
-| `/autonomous-loop` | Daily scheduled tick or manual | Perceives events, evaluates against goals, acts within safety bounds |
+| ~~`/autonomous-loop`~~ | **SUPERSEDED 2026-05-26** | Pre-M44 catch-up baseline only. No live cron. Do not invoke for new flows. |
 | `/end` | End of session | Behavioral reflection, decision log, memory save, commit. With `--quick`: checkpoint + commit only (~30 sec). |
 
 ## Memory System

--- a/config/pm-prompt.md
+++ b/config/pm-prompt.md
@@ -60,7 +60,7 @@ You can launch multiple coding agents in parallel if tasks are independent.
 
 ### Report (MUST do at end):
 
-Save a structured report to memory. This format is machine-readable — Jarvis and autonomous-loop parse it.
+Save a structured report to memory. This format is machine-readable — Jarvis (and the future reactive-core orchestrator) parse it. (Pre-2026-05-26 also consumed by `/autonomous-loop`, now superseded.)
 
 ```
 memory_store(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,7 @@ Installed to `~/.claude/` by `scripts/install/installer.py` (entry points `insta
 | Component | Source in repo | Installed to | Purpose |
 |-----------|----------------|--------------|---------|
 | Identity | `config/SOUL.md` | `~/.claude/SOUL.md` | Personality, tone, behavior rules (loaded by SessionStart) |
-| Universal skills | `.claude-userlevel/skills/*/SKILL.md` | `~/.claude/skills/*/SKILL.md` | 11 core slash commands: `implement`, `delegate`, `verify`, `status`, `reflect`, `end` (with `--quick` flag), `research`, `goals`, `self-improve`, `setup-tasks`, `autonomous-loop` |
+| Universal skills | `.claude-userlevel/skills/*/SKILL.md` | `~/.claude/skills/*/SKILL.md` | Core slash commands: `implement`, `delegate`, `verify`, `status`, `reflect`, `end` (with `--quick` flag), `research`, `goals`, `self-improve`, `setup-tasks`. (`autonomous-loop` retained on disk but SUPERSEDED 2026-05-26 — do not invoke for new flows.) |
 | Hooks | `.claude-userlevel/settings.json` | `~/.claude/settings.json` (deep-merged) | SessionStart, PreCompact, PreToolUse secret/dedup/protected-file scans, UserPromptSubmit memory recall |
 | MCP servers | `.claude-userlevel/.mcp.json` | `~/.claude/.mcp.json` (deep-merged) | memory, github, context7, etc. |
 | Version pin | — | `~/.claude/.jarvis-version` | Current applied jarvis SHA (for no-op detection) |
@@ -139,7 +139,7 @@ Universal skills live at `~/.claude/skills/` (source of truth: `.claude-userleve
 | `/goals` | View / set / update strategic goals |
 | `/self-improve` | Health check + gap analysis + auto-apply low-risk fixes |
 | `/setup-tasks` | Bootstrap scheduled tasks on a new device (idempotent) |
-| `/autonomous-loop` | Perceive → evaluate → decide → act (daily scheduled or manual) |
+| ~~`/autonomous-loop`~~ | **SUPERSEDED 2026-05-26.** No live cron. Retained as opt-in pre-M44 catch-up only; will be deleted when reactive-core M44 ships. |
 
 Project-specific skills stay under `<project>/.claude/skills/`. In this repo the only one is `/sprint-report` (redrobot release flow).
 
@@ -172,7 +172,7 @@ jarvis/
 ├── config/
 │   ├── SOUL.md              ← Jarvis personality (canonical; installed to ~/.claude/SOUL.md)
 │   ├── SETUP.md             ← First-time device setup
-│   └── repos.conf           ← Repos scanned by risk-radar / autonomous-loop
+│   └── repos.conf           ← Repos scanned by risk-radar (and historically by autonomous-loop, superseded)
 ├── .claude-userlevel/       ← SOURCE OF TRUTH for user-level install
 │   ├── settings.json        ← Hooks (installed to ~/.claude/settings.json)
 │   ├── .mcp.json            ← MCP servers (installed to ~/.claude/.mcp.json)


### PR DESCRIPTION
## Summary

Formalises the SUPERSEDED-2026-05-26 status of `/autonomous-loop` across docs and removes its cron registration from `/setup-tasks`.

**Decision:** `a70c4460-c75a-4281-8cf6-2b34a5c231f6` (reversible). Rationale: reactive-core M44 (`wake_driver` + `task_queue`) replaces the cron-based perceive→evaluate→decide→act loop. Even pre-M44, the daily cron is no longer the right pacing primitive — work is event-triggered, not time-triggered. Removing the cron now cuts spurious daily runs.

## Changes (8 files)

- `autonomous-loop/SKILL.md` — SUPERSEDED frontmatter + blockquote warning.
- `setup-tasks/SKILL.md` — drop `autonomous-loop` row from cron table; update counts (6 → 5); move blockquote past end of table (was breaking markdown render between `intel` and `verify` rows in the original stash apply).
- `verify/SKILL.md` — drop the "as part of autonomous-loop" usage line.
- `CLAUDE.md` — strike-through routing row + stronger SUPERSEDED note in orchestrator boundaries.
- `README.md` / `.claude/README.md` / `docs/architecture.md` — update skill counts + call out SUPERSEDED status.
- `config/pm-prompt.md` — report consumer reworded (reactive-core will parse; autonomous-loop superseded).

Skill file is **retained on disk** as opt-in pre-M44 catch-up baseline; deleted entirely when M44 ships.

## Test plan

- [x] All references to `87be311e` (fabricated decision SHA from original stash) replaced with real `a70c4460`.
- [x] `setup-tasks/SKILL.md` table renders correctly (blockquote no longer mid-table).
- [x] Counts of "6 / six tasks" updated to "5 / five" in 3 places.
- [ ] Existing devices: owner manually unregisters cron jobs (`Unregister-ScheduledTask -TaskName "jarvis-autonomous-loop"` on Windows / `crontab -e` on Linux/Mac). Instructions are in the new blockquote.

## Notes

This is the Theme A rescue from session 2026-05-26 stash-sweep. Theme B (heavy-skill frontmatter pins) shipped via #788. The original stash was blocked because it cited a decision SHA that did not exist; that SHA is now backed by a real `record_decision` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[no-issue]
