### PR TITLE
feat(routines): Workshop = sole routine host; drop nightly-research+risk-radar

### DIFF
--- a/.claude-userlevel/skills/setup-tasks/SKILL.md
+++ b/.claude-userlevel/skills/setup-tasks/SKILL.md
@@ -1,53 +1,75 @@
 ---
 name: setup-tasks
 description: "Bootstrap all scheduled tasks on a new device. Idempotent — safe to re-run."
-version: 1.0.0
+version: 2.0.0
 ---
 
 # Setup Tasks
 
-Bootstrap all 5 scheduled tasks on a new device in one command.
+Bootstrap Jarvis's scheduled tasks on a device. Idempotent.
+
+## Routine host policy (2026-05-26)
+
+**Workshop PC is the sole routine host.** All `create_scheduled_task` MCP routines and Workshop-only Task Scheduler entries register **only** when `config/device.json` reports `name == "VividFormsPC4Workshop"`. On any other device the skill refuses with a message pointing here.
+
+Rationale: removes per-device cron-dedup complexity, eliminates double-dispatch risk (two devices firing the same job seconds apart), centralises observability (one log surface), and aligns routines with the 24/7 sandcastle/orchestrator infra already living on Workshop. SPOF tradeoff accepted — Workshop offline = routines pause until restart; status-record gap on next SessionStart is the canary.
+
+Decision: `1b7ff8d1-bbca-4207-a7e4-4c1edddef67e`.
 
 ## Usage
 
 `/setup-tasks`
 
-This skill idempotently registers all scheduled tasks. If a task already exists, it's skipped. Safe to re-run on the same device.
-
 ## Implementation
 
-1. Call `list_scheduled_tasks` to see what's already registered
-2. **Deregister obsolete tasks** before adding new ones:
-   - If `morning-brief` exists → call `delete_scheduled_task` (or the MCP equivalent). On success, count it under `removed`. **On failure, do NOT count it as removed** — print `warn: failed to remove morning-brief (<error>) — check manually` instead. A silent-fail would leave both `morning-brief` (07:43) and `status-record` (07:00) firing, defeating the migration.
-3. For each of the 5 required tasks:
-   - If exists with matching name → skip ("already registered")
-   - If missing → `create_scheduled_task` with cron + prompt
-4. Print summary: N created, N skipped, N removed.
+1. Read `config/device.json`. If `name != "VividFormsPC4Workshop"` → print:
+   ```
+   refused: routines are Workshop-only as of 2026-05-26.
+   To clean up legacy entries on this device, run:
+     /setup-tasks --cleanup
+   ```
+   and exit. The `--cleanup` flag (separate path below) deletes any MCP scheduled tasks this skill previously registered here.
+2. On Workshop: call `list_scheduled_tasks` to see what's already registered.
+3. **Deregister obsolete tasks** before adding new ones. For each entry in the *Obsolete* table below:
+   - If present → call `delete_scheduled_task`. On success count under `removed`. On failure print `warn: failed to remove <taskId> (<error>) — check manually` and DO NOT count it.
+4. For each task in the *Routines (MCP)* table:
+   - If exists with matching name → skip ("already registered").
+   - If missing → `create_scheduled_task` with cron + prompt.
+5. Run the Workshop Task Scheduler registration commands in the *Workshop Task Scheduler* section below (each script is itself idempotent).
+6. Print summary: `N created, N skipped, N removed, N task-scheduler-entries`.
 
-## Tasks to Register
+### `--cleanup` mode (non-Workshop devices)
+
+Pure removal. For each task in *Routines (MCP)* + *Obsolete*:
+- If present → `delete_scheduled_task`.
+Print summary: `N removed`.
+
+Use after migrating off a device that previously hosted these routines.
+
+## Routines (MCP) — Workshop-only
+
+Registered via `create_scheduled_task` MCP. All run on Workshop with full local MCP access (Supabase, memory, ccd_session, scheduled-tasks).
 
 | Task ID | Cron | Prompt |
-|---------|------|--------|
-| nightly-research | `17 7 * * *` | Run `/research` — no topic argument; the skill auto-selects discovery mode from arg shape. |
+|---|---|---|
 | status-record | `0 7 * * *` | Run `/status-record` — write daily snapshot of repo/CI/PR/issue/milestone state to memory under tag `status-snapshot`. |
-| risk-radar | `7 9,14,19 * * *` | Quick risk scan: check CI status, stale issues, security alerts across repos in `config/repos.conf` |
 | intel | `12 10 * * 1` | Weekly tech intelligence: search for new Claude Code features, MCP servers, AI agent patterns. Save findings to memory. |
 | verify | `47 16 * * 5` | Run `/verify` — verify pending outcomes, detect patterns, save lessons. |
+| memory-consolidation-weekly | `1 10 * * 0` | Run `/memory-consolidation-weekly` — weekly A-MEM Phase 5.1d-α consolidation apply (`scripts/consolidation-run.py`). |
+| memory-evolve-weekly | `0 11 * * 0` | Run `/memory-evolve-weekly` — weekly A-MEM Phase 5.2-γ neighbor-evolve apply (`scripts/evolve-run.py`, one hour after consolidation). |
 
-> `autonomous-loop` cron entry was removed 2026-05-26 (decision `a70c4460`). The skill itself is retained as opt-in pre-M44 catch-up baseline but is not bootstrapped on new devices. Existing cron jobs on prior devices must be unregistered manually (`Unregister-ScheduledTask -TaskName "jarvis-autonomous-loop"` on Windows, `crontab -e` on Linux/Mac).
+## Obsolete (deregister)
 
-> `status-record` supersedes the old `morning-brief`/`/status` slot — the skill records state only, owner reads inline via `memory_recall(query="status-snapshot")`. Decisions/actions on findings belong to the sandcastle orchestrator (#531).
+| Task ID | Why removed |
+|---|---|
+| morning-brief | superseded by `status-record` (2026-04 migration). |
+| autonomous-loop | superseded 2026-05-26 by reactive-core M44 (`wake_driver` + `task_queue`); cron pacing replaced by event-trigger (decision `a70c4460`). Skill file retained as pre-M44 catch-up baseline; cron entry removed. |
+| nightly-research | removed 2026-05-26 — `/research` is a user-driven flow, scheduled blind discovery produced low-value noise. |
+| risk-radar | removed 2026-05-26 — overlapped with `status-record` + sandcastle-orchestrator gating; signal-to-noise was poor. |
 
-## Notes
+## Workshop Task Scheduler entries
 
-- All tasks run locally with full MCP access
-- Times are in local timezone (not UTC)
-- Cron dedup via Supabase memory: scheduled tasks check `*_last_run` markers to prevent duplicate runs across devices
-- Prompts reference skill files so updates to skills automatically update scheduled task behavior
-
-## Workshop-only: Windows Task Scheduler entries
-
-When invoked on the Workshop PC (`config/device.json` name = `VividFormsPC4Workshop`), `/setup-tasks` also registers the Task Scheduler entries below. Different infra from the five tasks above (those use `create_scheduled_task` MCP; these use `Register-ScheduledTask`).
+Different infra from the MCP routines above (these use `Register-ScheduledTask` via PowerShell). All also Workshop-only.
 
 ### Sandcastle AFK loops
 
@@ -56,9 +78,7 @@ When invoked on the Workshop PC (`config/device.json` name = `VividFormsPC4Works
 | `Sandcastle-Jarvis` | Daily 18:00 | 01:00 | [#545](https://github.com/Osasuwu/jarvis/issues/545) |
 | `Sandcastle-Redrobot` | Daily 01:00 | 08:00 | [#546](https://github.com/Osasuwu/jarvis/issues/546) |
 
-Non-overlapping by design. (The earlier 22:00/02:00 start times were driven by Ollama VRAM contention; that constraint was relaxed in [#711](https://github.com/Osasuwu/jarvis/issues/711), and the script defaults moved to 18:00/01:00 — these are the source of truth.)
-
-Implementation: invoke the registration script directly (idempotent, replaces existing entry):
+Non-overlapping by design (#711 relaxed the earlier Ollama-VRAM constraint).
 
 ```powershell
 .\scripts\sandcastle\Register-SandcastleTask.ps1 -Repo jarvis
@@ -71,14 +91,38 @@ Implementation: invoke the registration script directly (idempotent, replaces ex
 |---|---|---|
 | `Quota-Probe` | Daily (repeating) | Every 30 min |
 
-Polls `claude -p "/usage"` and broadcasts the `CLAUDE_QUOTA_PRESSURE` repo variable with hysteresis (trip ≥80%, release <70%), and writes a `quota_pressure` row to the `events` table so the #327 telegram escalation hook can notify the owner. See issue #635.
+Polls `claude -p "/usage"`, broadcasts `CLAUDE_QUOTA_PRESSURE` repo variable with hysteresis (trip ≥80%, release <70%), writes `quota_pressure` events for telegram escalation (#327).
 
-**Prerequisite:** `.sandcastle/.env` must carry `SUPABASE_URL` + `SUPABASE_KEY` (the probe reads it via `-DotEnvPath`, default `.sandcastle/.env`) — without them the `events` write is skipped and a pressure trip never reaches Telegram. The `gh variable` broadcast still works (uses the gh auth, not the .env).
+**Prerequisite:** `.sandcastle/.env` carries `SUPABASE_URL` + `SUPABASE_KEY` (read via `-DotEnvPath`, default `.sandcastle/.env`).
 
 ```powershell
 .\scripts\sandcastle\Register-SandcastleTask.ps1 -QuotaProbe
 ```
 
-On non-Workshop devices the script refuses unless `-Force` (dev rehearsal). Full setup + troubleshooting: [`docs/agents/sandcastle-setup.md`](../../../docs/agents/sandcastle-setup.md).
+### Orchestrator watcher daemon (M41/#639)
 
-Decisions: `4890aa35` (Workshop = prod), `0c3017c6` (failure modes), `f8e27d53` (escalation), `58670ea5` (model tier), `46830b4e` (80/70 hysteresis, SUPERSEDES `d5b3fdd3` initial 90% gate).
+| Task name | Schedule | Notes |
+|---|---|---|
+| `Orchestrator-Watcher` | At Workshop startup, restart on failure | Continuous poll (45s) of `events` table for `review_negative`; dispatches `claude -p "/rework <N>"` on hit. Gated by quota probe cache. |
+
+**Registration script:** **NOT YET WRITTEN** — tracked as a follow-up to the routine-cleanup migration. Manual registration in the interim:
+
+```powershell
+$action = New-ScheduledTaskAction -Execute "python" -Argument "C:\Users\<user>\GitHub\jarvis\scripts\orchestrator\watcher.py" -WorkingDirectory "C:\Users\<user>\GitHub\jarvis"
+$trigger = New-ScheduledTaskTrigger -AtStartup
+$settings = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 5)
+Register-ScheduledTask -TaskName "Orchestrator-Watcher" -Action $action -Trigger $trigger -Settings $settings -RunLevel Highest
+```
+
+Prerequisites for the watcher to actually dispatch:
+- `SUPABASE_URL` + `SUPABASE_KEY` in the watcher's environment
+- `~/.jarvis/orchestrator/usage.json` present and fresh (written by Quota-Probe)
+- `/rework` skill installed (`install.ps1 -Apply`)
+
+## Notes
+
+- All routine times are local timezone (Asia/Almaty on Workshop).
+- Prompts reference skill files; skill updates take effect on next run.
+- Source of truth for this file: `.claude-userlevel/skills/setup-tasks/SKILL.md`. Live mirror at `~/.claude/skills/setup-tasks/SKILL.md` is propagated by `install.ps1 -Apply`.
+
+Decisions: `4890aa35` (Workshop = prod), `0c3017c6` (failure modes), `f8e27d53` (escalation), `58670ea5` (model tier), `46830b4e` (80/70 hysteresis), `a70c4460` (autonomous-loop superseded), `1b7ff8d1` (Workshop = sole routine host).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Use skills — don't reinvent with raw tools.
 | "исследуй", "research", "сравни" | `/research` |
 | "улучши себя", self-improvement | `/self-improve` |
 | "цели", "приоритеты" | `/goals` |
-| New device bootstrap, "scheduled tasks setup" | `/setup-tasks` |
+| New device bootstrap, "scheduled tasks setup" | `/setup-tasks` (Workshop-only as of 2026-05-26 per `1b7ff8d1`; refuses on other devices, offers `--cleanup` for legacy entries) |
 | ~~Daily scheduled tick~~ | ~~`/autonomous-loop`~~ — **SUPERSEDED**, pre-M44 catch-up baseline only. **Do not invoke for new flows.** No live cron registration since Medium-scope cleanup 2026-05-26. Will be deleted when reactive-core M44 (`wake_driver` + `orchestrator`) ships. |
 | "end" / "end quick" | `/end` (full) / `/end --quick` (fast) |
 | Vague intuition (no written plan yet) / "у меня ощущение что", "может быть лучше но не знаю как", "обсудим концепт"; subsumes /research for in-debate factual grounding | `/reason` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,7 +116,7 @@ Where load-bearing rules live, in order of preference:
 ### Devices & paths
 
 - **3 devices** — owner runs Jarvis on Lenovo laptop, desktop, MacBook. Different usernames, different paths. Anything device-pinned is a bug.
-- **Workshop PC = AFK orchestrator host.** Robot connection became network-mediated, so Workshop is no longer pinned to mid-day robot work — runs 24/7 as the residency for the orchestrator watcher daemon and sandcastle launches. Other devices can run sandcastle ad-hoc but the watcher lives only on Workshop (single source of dispatch truth, no double-fire across devices).
+- **Workshop PC = sole routine host.** Robot connection became network-mediated, so Workshop runs 24/7 as the residency for **all** Jarvis routines: orchestrator watcher daemon, sandcastle AFK launches, quota probe, and all `create_scheduled_task` MCP routines (status-record, intel, verify, memory-consolidation-weekly, memory-evolve-weekly). Other devices can run sandcastle ad-hoc but no routine is registered there — `/setup-tasks` refuses on non-Workshop. Removes per-device cron-dedup, eliminates double-dispatch, centralises observability. SPOF tradeoff: Workshop offline = routines pause; `status-record` gap on next SessionStart is the canary. Decision `1b7ff8d1` (2026-05-26).
 - **JARVIS_HOME** — env var resolved at install time to the absolute repo root. Use this in templated configs, never hardcode `C:\Users\...`.
 - **`~/.claude/`** — user-level mirror of `.claude-userlevel/`. **Do not edit directly** — edit canonical source in `.claude-userlevel/` and run `install.ps1 -Apply`.
 


### PR DESCRIPTION
## Summary

- `/setup-tasks` skill rewritten: Workshop-only enforcement + `--cleanup` mode for legacy devices
- Two routines deleted from spec: `nightly-research` (user-driven flow, scheduled noise), `risk-radar` (overlap with status-record + orchestrator gating)
- Two routines added to spec (were missing): `memory-consolidation-weekly`, `memory-evolve-weekly`
- Orchestrator watcher (M41/#639) registration documented (script helper deferred)
- `CONTEXT.md` Workshop entry extended; `CLAUDE.md` skill-routing row annotated

Closes #790

## Decision basis

`1b7ff8d1-bbca-4207-a7e4-4c1edddef67e` — Workshop = sole routine host (reversible, confidence 0.75).

Alternatives considered: any-device cron-dedup (status quo, kept dedup complexity), mixed model (kept routing-rule confusion), cloud routines (limited by MCP-write needs per `cloud_vs_local_scheduled_tasks_routing`). SPOF tradeoff accepted in exchange for eliminating double-dispatch risk and per-task dedup complexity.

## Migration execution

This PR is the spec change. Actual rollout (Workshop bootstrap + Main/MacBook cleanup) tracked in #790. After merge:

1. Workshop: `git pull` → `install.ps1 -Apply` → `/setup-tasks`
2. Main PC: `/setup-tasks --cleanup` to delete the 3 currently-active routines (status-record, memory-consolidation-weekly, memory-evolve-weekly)

## Test plan

- [x] Skill body documents refusal behavior on non-Workshop devices
- [x] Decision UUID referenced in skill body, CLAUDE.md routing row, CONTEXT.md glossary entry
- [x] Obsolete routines (`morning-brief`, `autonomous-loop`, `nightly-research`, `risk-radar`) listed with deregistration rationale
- [ ] Workshop bootstrap verified after merge (in #790)
- [ ] Main PC cleanup verified post-Workshop (in #790)

🤖 Generated with [Claude Code](https://claude.com/claude-code)