### PR TITLE
fix(install): add /rework to skills whitelist

### DIFF
--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -107,6 +107,7 @@ groups:
           - "last-work-report"
           - "reflect"
           - "research"
+          - "rework"
           - "self-improve"
           - "setup-tasks"
           - "status-record"


### PR DESCRIPTION
## Summary

PR [#756](https://github.com/Osasuwu/jarvis/pull/756) (merged 2026-05-24) shipped `.claude-userlevel/skills/rework/SKILL.md` but did not update [`install-manifest.yaml`](install-manifest.yaml)'s explicit skills whitelist. As a result `install.ps1 -Apply` silently skipped the skill on every device — the Skill tool never saw `/rework`, blocking M41 [#640](https://github.com/Osasuwu/jarvis/issues/640)'s smoke-test path (no way to dispatch `/rework <PR>` to demonstrate the reactive-rework loop end-to-end).

One-line addition in alphabetical position. Reversible.

## Test plan

- [x] `git diff` shows the single insertion
- [ ] After merge, pull main on Workshop, run `install.ps1 -Apply`, verify `~/.claude/skills/rework/SKILL.md` lands
- [ ] Restart Claude Code session, confirm `/rework` shows up in skills list

Decision: `e262def9-2a3b-4a98-abc4-8a5316ef0b78`. `[no-issue]` per CLAUDE.md hotfix policy (priority:critical label set; PR Body Check honors it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)