### PR TITLE
fix(sandcastle): clamp Quota-Probe duration to P9999D + admin pre-check

### DIFF
--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -144,6 +144,15 @@ if (-not $Force -and $currentDevice -ne $expectedDevice) {
     throw "Refusing to register on '$currentDevice' -- sandcastle production target is '$expectedDevice'. Pass -Force for dev rehearsal."
 }
 
+# Admin check up front -- Register-ScheduledTask with an S4U principal needs
+# elevation. If we don't check here, the idempotent "unregister existing first"
+# block below wipes the old task and then the Register call fails with
+# "Access is denied", leaving the device with NO task at all.
+$isAdmin = ([Security.Principal.WindowsPrincipal]([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin -and -not $WhatIfOnly) {
+    throw "Register-SandcastleTask must run from an elevated PowerShell. Re-launch as Administrator and retry."
+}
+
 # ---------------------------------------------------------------------------
 # Quota-probe mode (#635)
 # ---------------------------------------------------------------------------
@@ -193,13 +202,13 @@ if ($QuotaProbe) {
     # set on New-ScheduledTaskTrigger, which builds the MSFT_TaskRepetitionPattern
     # CIM instance internally.
     #
-    # [timespan]::MaxValue (~10.6M days) overflows Task Scheduler's COM layer
-    # (max ~49,710 days from Int32 seconds) -> COMException at register time or a
-    # silent wrap that stops the repetition immediately (C8). 100 years is well
-    # within range and is effectively indefinite for a self-retriggered task.
+    # Duration cap: Task Scheduler XML rejects durations exceeding PT24H × 9999
+    # (P36500D = 100 years tripped this — Register-ScheduledTask error
+    # "(10,29):Duration:P36500D"). 9999 days (~27 years) is the documented max and
+    # is effectively indefinite for a self-retriggered task.
     $trigger = New-ScheduledTaskTrigger -Once -At $startDt `
         -RepetitionInterval ([timespan]::FromMinutes($QuotaProbeInterval)) `
-        -RepetitionDuration (New-TimeSpan -Days 36500)
+        -RepetitionDuration ([timespan]::FromDays(9999))
 
     # S4U: run whether or not the user is logged on, and fire even when the screen
     # is locked (m1: LogonType Interactive skips the run on a locked workstation).


### PR DESCRIPTION
## Summary

Two regressions surfaced after [#793](https://github.com/Osasuwu/jarvis/pull/793) merged today (Quota-Probe registration path, M41 chain — issue [#635](https://github.com/Osasuwu/jarvis/issues/635)):

- **`P36500D` duration rejected by Task Scheduler XML.** `New-TimeSpan -Days 36500` (100 years) exceeds the `PT24H × 9999` cap. The comment in [Register-SandcastleTask.ps1:196-199](scripts/sandcastle/Register-SandcastleTask.ps1) was wrong about COM-layer Int32 being the binding limit — XML schema validation rejects it first. Clamped to `[timespan]::FromDays(9999)` (`P9999D`, ~27 years).
- **Non-admin runs wipe state.** The script `Unregister-ScheduledTask`s the existing entry *before* the `Register-ScheduledTask` call. S4U principal needs admin; failure leaves the device with no task at all. Reproduced today on Workshop — `Quota-Probe` is currently missing as a result. Added an `IsInRole(Administrator)` pre-check above the unregister; non-admin runs now throw cleanly without touching state. `-WhatIfOnly` deliberately bypasses the check.

Third bug in this script's registration logic (after [#792](https://github.com/Osasuwu/jarvis/issues/792) and [#793](https://github.com/Osasuwu/jarvis/pull/793)) — registration helper deserves a unit test in `tests/ci/` (deferred, separate slice).

## Test plan

- [x] `-WhatIfOnly` runs without elevation, prints planned task, no state change
- [x] Non-admin invocation refuses with clear error before unregistering
- [ ] Elevated run on Workshop registers `Quota-Probe` with a 30-min trigger
- [ ] `Get-ScheduledTask -TaskName Quota-Probe | Select -Expand Triggers` shows correct `RepetitionInterval`/`RepetitionDuration`
- [ ] `Start-ScheduledTask -TaskName Quota-Probe` runs one-shot; `~/.jarvis/orchestrator/usage.json` materialises (or logs reason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)