### PR TITLE
fix(install): wire /learn into install-manifest.yaml whitelist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Use skills — don't reinvent with raw tools.
 | PR rework needed / negative review received | `/rework` (skips grill-me checkbox; reactive TDD per CRITICAL finding, MAJOR fixes, loop-stop guard policy) |
 | "improve architecture", find shallow modules, refactoring opportunities | `/improve-codebase-architecture` |
 | "почисти память", "memory hygiene", /curate, after 2+ recall complaints | `/curate` (owner-invoked weekly; M45 S3 — host-only, deterministic surfacer, per-row owner confirm) |
+| "review memories", "drain queue", "проверь кандидаты", weekly memory-review, volume-event fire, /learn --status | `/learn` (M42 always-gate review surface; drains classifier + Deriver/Dreamer queues, hard cap 20, idempotent, no defer/accept_all) |
 | "last sprint report", "what did we ship", "milestone closeout", pre-sweep brief | `/last-work-report` (skeleton — #606) |
 | "zoom out", unfamiliar code area, need higher-level map | `/zoom-out` |
 | Issue triage / state machine / "ready for agent" | `/triage` |

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -116,6 +116,7 @@ groups:
           # AI Hero skills (Matt Pocock — github.com/mattpocock/skills, MIT).
           # See .claude-userlevel/skills/AIHERO_CREDIT.md for attribution + adaptations.
           - "caveman"
+          - "curate"
           - "diagnose"
           - "grill"
           - "improve-codebase-architecture"

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -105,6 +105,7 @@ groups:
           - "goals"
           - "implement"
           - "last-work-report"
+          - "learn"
           - "reflect"
           - "research"
           - "rework"


### PR DESCRIPTION
## Summary
- `/learn` skill (M42 deliverable, shipped via S2 #731) was missing from `install-manifest.yaml` whitelist
- Without this, `install.ps1 -Apply` skips the skill — `/learn` unavailable in `~/.claude/skills/` on every device
- Caught during M42 milestone-close AC verification (skill source present in `.claude-userlevel/skills/learn/`, but `ls ~/.claude/skills/learn/` was empty on Main PC)

Fix > track inline per CLAUDE.md (trivial reversible adjacent fix; `[no-issue]` in commit msg per `.pre-commit-config.yaml` regex).

## Test plan
- [ ] `install.ps1 -Apply` propagates `.claude-userlevel/skills/learn/` → `~/.claude/skills/learn/` on next install run
- [ ] `/learn` becomes a usable slash command on all 3 devices after next bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)