### PR TITLE
chore(ci): fail code-review check on findings to gate auto-merge

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -60,3 +60,42 @@ jobs:
             (not available in this runner). This is plugin invocation only.
           claude_args: |
             --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*)"
+
+      # Auto-merge gate: the plugin emits a structured comment beginning with
+      # `### Code review` and either "No issues found." (clean) or
+      # "Found N issues:" (findings ≥80 confidence). Without this step the
+      # `review` check is SUCCESS as long as the bot ran — auto-merge can't
+      # distinguish "ran cleanly" from "found CRITICAL bugs". Failing the
+      # job on findings turns the `review` check into a real verdict.
+      - name: Verify review verdict
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          body=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" --paginate \
+            --jq 'map(select(.body | startswith("### Code review"))) | .[-1].body // ""')
+
+          if [ -z "$body" ]; then
+            # Plugin skipped (draft / closed / already reviewed / not-eligible).
+            # No new verdict — leave merge gating to the eligibility logic upstream.
+            echo "::notice::No /code-review comment present; plugin likely skipped. Treating as pass."
+            exit 0
+          fi
+
+          if grep -qE '^No issues found\.?\s*$' <<<"$body"; then
+            echo "::notice::Code review clean."
+            exit 0
+          fi
+
+          if grep -qE 'Found [0-9]+ issues?:' <<<"$body"; then
+            count=$(grep -oE 'Found [0-9]+ issues?:' <<<"$body" | head -1 | grep -oE '[0-9]+')
+            echo "::error::Code review found $count issue(s); blocking auto-merge until addressed."
+            exit 1
+          fi
+
+          # Unexpected format — fail conservatively so a malformed comment
+          # can't slip past auto-merge.
+          echo "::warning::Could not parse /code-review verdict from last comment. Failing for safety."
+          exit 1


### PR DESCRIPTION
## Summary

The `review` workflow check today only signals "did the bot run successfully?", not "is the PR clean?". Plugin findings land as PR comments, but the check itself stays SUCCESS regardless. With auto-merge disabled this is a harmless manual-readonly signal; once auto-merge is enabled it becomes a foot-gun — PRs with real findings would auto-ship because all required checks show green.

This PR adds a post-step in `code-review.yml` that fails the job when the plugin's last comment indicates findings.

## How it works

The plugin emits a deterministic preamble (`### Code review`) followed by exactly one of:
- `No issues found.` (clean)
- `Found N issues:` (N ≥ 1 findings, all confidence ≥80 per plugin rubric)

The new step fetches the latest comment matching the preamble and:
- `No issues found.` → exit 0, `review` = SUCCESS
- `Found N issues:` → exit 1, `review` = FAILURE
- no comment present → exit 0 (plugin skipped: draft / closed / already-reviewed)
- body parses to neither → exit 1 (conservative safety)

No severity tiering is needed — the plugin already drops findings below 80-confidence per its `commands/code-review.md` rubric, so anything posted is a real-bug-hits-in-practice signal.

## Why now

Prerequisite for enabling repo-level auto-merge. Path A of the reactive-core M44 loop (`open → CI → review → automerge → rework → escalate`) requires the `review` check to actually reflect verdict, not just "bot ran". Follow-up PRs will enable auto-merge in repo settings + add an `owner-queue` guard.

## Note on this PR's own review check

`anthropics/claude-code-action@v1` refuses to run on PRs that modify the code-review workflow file itself (documented behavior — the error message says "this is normal and you should ignore this error"). The `review` check on this PR therefore fails on `Workflow validation failed`, NOT on the new verdict logic. Once merged, subsequent PRs that don't touch `code-review.yml` exercise the new step correctly.

## Test plan

- [x] Workflow YAML syntactically valid
- [x] Bash `set -euo pipefail` + grep patterns checked locally against canonical preamble samples
- [ ] Real-world exercise: lands once the new logic runs on a non-self-modifying PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[no-issue] — drive-by tooling change per #428; reversible single-file workflow edit, no parent feature/bug issue.