### PR TITLE
chore(ci): owner-queue-guard workflow + cross-project auto-merge policy

### DIFF
--- a/.claude-userlevel/CLAUDE.md
+++ b/.claude-userlevel/CLAUDE.md
@@ -77,3 +77,46 @@ Memory records can be wrong:
 ### Decisions belong in memory, not in issue/PR bodies
 
 Architectural resolutions go to `record_decision`. Issue bodies, PR bodies, PRD prose all decay; the queryable decision log doesn't. Skills that produce issues (`/to-prd`, `/to-issues`) reference `decision_uuids[]` rather than restating the *why* — see each skill for the section template.
+
+## Repo policy — auto-merge & merge gates
+
+Applies to every owned repo (`Osasuwu/jarvis`, `SergazyNarynov/redrobot`, and any future personal project). Foreign-owner repos are exempt — they have their own protection rules.
+
+**Goal:** AFK Path A loop closes by itself — `open → CI → review → automerge → rework → escalate`. Subagent opens a PR, Jarvis flips it to ready, GitHub merges when every gate is green. No human in the merge step *unless* a gate fires.
+
+### The four gates
+
+Every owned repo enforces the same set via **branch protection on the default branch** + repo-level `allow_auto_merge=true`:
+
+1. **`review` (Claude code-review plugin)** — the workflow runs `/code-review`, posts findings as a structured comment, **and a post-step (`Verify review verdict`) fails the job on `Found N issues:`**. Without the post-step the check signals "bot ran" not "PR is clean" — auto-merge would happily ship PRs with CRITICAL findings. Plugin already drops findings below 80-confidence per its rubric, so any surfaced finding is real.
+2. **`owner-queue-guard`** — fails the job when the PR carries the `status:owner-queue` label. That label is the manual "park this for me" signal; the guard turns it into a hard merge block instead of a hope-Jarvis-honors-it convention. Triggered on `opened / synchronize / labeled / unlabeled` so the gate is re-evaluated whenever label state changes.
+3. **`require-linked-issue`** — PR body must reference `Closes #NNN`, OR carry the `priority:critical` label (hotfix bypass), OR contain the `[no-issue]` marker (drive-by fix-inline per jarvis#428), OR use a `refactor:` / `refactor(scope):` title prefix.
+4. **Project-specific test gates** — `pytest`, `meta-tests`, `Detect secrets with gitleaks` in jarvis; the equivalents in any other repo. These come from the repo's own CI surface.
+
+### Drafts are the manual hold
+
+A PR stays in **draft** while owner attention is owed (waiting on design feedback, intentional batching, etc.). Drafts never auto-merge — that's GitHub's default and it's the right one. Once flipped to ready, the four gates above are the merge gate.
+
+Use `status:owner-queue` for the rarer case: PR is content-complete (so it can pass review) but owner still wants to eyeball it before it ships. The label keeps it ready-but-blocked. Don't reach for the label when draft already covers the case.
+
+### Required files per repo
+
+- `.github/workflows/code-review.yml` — final step `Verify review verdict` parses the latest `### Code review` comment, exits 1 on `Found N issues:` / 0 on `No issues found.` / 0 on no comment (plugin skipped).
+- `.github/workflows/owner-queue-guard.yml` — single job named `owner-queue-guard`, triggers on `opened, synchronize, labeled, unlabeled`, fails on the label.
+
+The check name `owner-queue-guard` is what branch protection references — rename in lockstep with the protection rule or the gate silently disappears (cf. jarvis#326 meta-test rule: path-filtered guards need a fixture test pinning the canonical name).
+
+### Repo-settings checklist (one-time per repo)
+
+```
+gh api -X PATCH /repos/<owner>/<repo> -F allow_auto_merge=true -F delete_branch_on_merge=true
+gh api -X PUT /repos/<owner>/<repo>/branches/<default>/protection -F required_status_checks='{"strict":true,"contexts":["review","owner-queue-guard","require-linked-issue", ...repo-specific...]}' -F enforce_admins=false -F required_pull_request_reviews=null -F restrictions=null
+```
+
+`enforce_admins=false` keeps escape-hatch open for the owner (admin-merge when a gate is broken). `required_pull_request_reviews=null` because the `review` check already encodes the AI review verdict — adding a required human review would defeat AFK Path A.
+
+### When to break the rules
+
+- **Gate is broken, blocking real work**: admin-merge (`gh pr merge --admin`) is fine. Note in the PR comment which gate you bypassed and why.
+- **A PR modifies `code-review.yml` itself**: `anthropics/claude-code-action@v1` refuses to run on self-modifying PRs ("Workflow validation failed" — documented behavior). The `review` check fails as expected; admin-merge.
+- **Self-hosted runner is down (redrobot)**: review/CI can't run. Verify locally, admin-merge per `redrobot_billing_blocked_manual_merge_protocol` precedent.

--- a/.github/workflows/owner-queue-guard.yml
+++ b/.github/workflows/owner-queue-guard.yml
@@ -1,0 +1,36 @@
+name: Owner Queue Guard
+
+# Fails when a PR carries the `status:owner-queue` label — that label is the
+# explicit "wait for the owner to look at this" signal. Without this guard,
+# auto-merge would happily ship a PR the owner had specifically parked.
+#
+# Triggers cover the four ways the label state changes:
+#   labeled / unlabeled — label add/remove
+#   opened              — PR opens with the label already attached
+#   synchronize         — re-check on every push so a stale guard state
+#                         doesn't outlive a label removal followed by
+#                         an unrelated push
+#
+# The check name (`owner-queue-guard`) is what branch protection requires.
+# If you rename it, update the required-checks list in repo settings.
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+jobs:
+  guard:
+    name: owner-queue-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for status:owner-queue label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          if echo "$LABELS" | grep -q '"status:owner-queue"'; then
+            echo "::error::PR is labelled status:owner-queue — owner review required before merge."
+            echo "Remove the label to clear the guard once the PR is ready to ship."
+            exit 1
+          fi
+          echo "::notice::No status:owner-queue label present."


### PR DESCRIPTION
## Summary

Two pieces of the AFK Path A loop landing together because they only make sense as a pair.

### `.github/workflows/owner-queue-guard.yml` (new)

Fails the `owner-queue-guard` job when a PR carries the `status:owner-queue` label. That label has been a Jarvis-honored convention; this workflow turns it into a real merge gate so auto-merge can't ship past it. Triggers cover the four ways label state changes: `opened, synchronize, labeled, unlabeled` — so the gate re-evaluates whenever the label state shifts (no stale-state outlives a removal).

### `.claude-userlevel/CLAUDE.md` (new section: "Repo policy — auto-merge & merge gates")

Documents the cross-project policy:
- Four required gates per owned repo: `review`, `owner-queue-guard`, `require-linked-issue`, project-specific test gates (pytest/meta-tests/gitleaks in jarvis).
- Draft = manual hold (no auto-merge). `status:owner-queue` label = ready-but-eyeballing (used rarer; ride-along block for content-complete PRs).
- One-time `gh api` snippets for `allow_auto_merge=true` + branch protection.
- Documented escape hatches: admin-merge on broken gates, self-modifying `code-review.yml` PRs (`anthropics/claude-code-action@v1` refuses by design), self-hosted runner outages per `redrobot_billing_blocked_manual_merge_protocol` precedent.

## Why this PR is the right shape

#809 made the `review` check actually reflect verdict (was just "did bot run?"). This PR adds the second required-check (owner-queue) and writes the policy down so:
- Future personal repos can adopt the same shape without re-deriving.
- The redrobot mirror knows exactly what to copy (workflow + verdict step).
- The escape hatches are recorded — when (not if) a gate breaks, the bypass route is documented, not improvised.

Repo settings (`allow_auto_merge` + branch protection with the required-checks list) land via `gh api` after this and the redrobot mirror are on their default branches. They don't need PRs.

## Test plan

- [x] Workflow YAML syntactically valid (single job, single step, deterministic exit).
- [x] Trigger list (`opened, synchronize, labeled, unlabeled`) covers state changes; `synchronize` re-runs on each push so a stale "passed" doesn't outlive a quiet unlabel→push.
- [ ] Real-world exercise on this PR's own run — without the label, guard passes; manual label-and-watch test after merge to confirm the failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[no-issue] — drive-by tooling change per #428; reversible workflow add + documentation, no parent feature/bug issue.