### PR TITLE
tests: replace deep mock chain with FakeSupabaseClient in pretooluse_recall tests

### DIFF
--- a/tests/test_events_canonical_writer.py
+++ b/tests/test_events_canonical_writer.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,6 +25,64 @@ from events_canonical import (  # noqa: E402
 )
 from trace_context import new_trace, with_trace  # noqa: E402
 
+# ---------------------------------------------------------------------------
+# RecordingClient — Supabase-shaped test double
+# ---------------------------------------------------------------------------
+
+
+class _RecordingResponse:
+    """Fake response returned by RecordingClient.execute()."""
+
+    def __init__(self, data: list[dict]) -> None:
+        self.data = data
+
+
+class RecordingClient:
+    """Supabase-shaped test double that records inserted rows.
+
+    Captures all rows passed to insert() so tests can assert on
+    values directly instead of mock call-chain inspection.
+
+    Usage::
+
+        client = RecordingClient()
+        client.table("events_canonical").insert(row).execute()
+        assert client.inserts == [row]
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_on_insert: bool = False,
+        return_data: list[dict] | None = None,
+    ) -> None:
+        self.inserts: list[dict] = []
+        self.tables: list[str] = []
+        self._fail_on_insert = fail_on_insert
+        self._return_data = return_data
+
+    def table(self, name: str) -> RecordingClient:
+        self.tables.append(name)
+        return self
+
+    def insert(self, row: dict) -> RecordingClient:
+        if self._fail_on_insert:
+            raise RuntimeError("simulated failure")
+        self.inserts.append(row)
+        return self
+
+    def execute(self) -> _RecordingResponse:
+        if self._return_data is not None:
+            return _RecordingResponse(self._return_data)
+        return _RecordingResponse(
+            [{"event_id": "stub-event-id", "trace_id": "stub-trace-id"}]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Buffer isolation per test
+# ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def _isolate_buffer() -> None:
@@ -35,49 +92,14 @@ def _isolate_buffer() -> None:
     _buffer_clear_for_test()
 
 
-def _stub_client(
-    *,
-    insert_returns: list[dict] | None = None,
-    insert_raises: Exception | None = None,
-) -> MagicMock:
-    """Minimal Supabase-shaped stub.
-
-    Returns a MagicMock whose ``.table(name).insert(row).execute()``
-    chain mirrors the real client. ``insert_returns`` controls the
-    payload of every successful insert; ``insert_raises`` makes
-    ``insert(...)`` raise when set.
-    """
-    client = MagicMock()
-    table = MagicMock()
-    insert = MagicMock()
-    execute = MagicMock()
-
-    if insert_raises is not None:
-        insert.side_effect = insert_raises
-        client.table.return_value.insert = insert
-    else:
-        # Explicit `is None` so passing `insert_returns=[]` produces an
-        # empty data response (used to verify defensive empty-result path).
-        if insert_returns is None:
-            data = [{"event_id": "stub-event-id", "trace_id": "stub-trace-id"}]
-        else:
-            data = insert_returns
-        execute.return_value = MagicMock(data=data)
-        insert.return_value = MagicMock(execute=execute)
-        table.insert = insert
-        client.table.return_value = table
-
-    return client
-
-
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
 
 
 def test_emit_event_inserts_and_returns_row() -> None:
-    client = _stub_client(
-        insert_returns=[{"event_id": "abc", "trace_id": "xyz"}]
+    client = RecordingClient(
+        return_data=[{"event_id": "abc", "trace_id": "xyz"}]
     )
     result = emit_event(
         client,
@@ -87,12 +109,12 @@ def test_emit_event_inserts_and_returns_row() -> None:
         outcome="success",
     )
     assert result == {"event_id": "abc", "trace_id": "xyz"}
-    client.table.assert_called_with("events_canonical")
+    assert "events_canonical" in client.tables
 
 
 def test_emit_event_uses_context_trace_id() -> None:
     """When context is set, writer picks it up automatically."""
-    client = _stub_client()
+    client = RecordingClient()
     tid = new_trace()
     with with_trace(tid):
         emit_event(
@@ -100,21 +122,21 @@ def test_emit_event_uses_context_trace_id() -> None:
             actor="skill:test",
             action="memory_recall",
         )
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert inserted["trace_id"] == tid
 
 
 def test_emit_event_synthesizes_trace_when_context_missing() -> None:
     """No ContextVar set → writer mints a fresh trace_id, doesn't crash."""
-    client = _stub_client()
+    client = RecordingClient()
     emit_event(client, actor="skill:test", action="orphan_action")
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert isinstance(inserted["trace_id"], str)
     assert len(inserted["trace_id"]) == 32  # hex
 
 
 def test_emit_event_includes_optional_cost_fields_when_provided() -> None:
-    client = _stub_client()
+    client = RecordingClient()
     emit_event(
         client,
         actor="skill:test",
@@ -122,23 +144,23 @@ def test_emit_event_includes_optional_cost_fields_when_provided() -> None:
         cost_tokens=1234,
         cost_usd=0.0125,
     )
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert inserted["cost_tokens"] == 1234
     assert inserted["cost_usd"] == 0.0125
 
 
 def test_emit_event_omits_cost_fields_when_not_provided() -> None:
     """Cost fields default to NULL — omit from row dict, don't pass None."""
-    client = _stub_client()
+    client = RecordingClient()
     emit_event(client, actor="skill:test", action="decision_made")
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert "cost_tokens" not in inserted
     assert "cost_usd" not in inserted
 
 
 def test_emit_event_caller_overrides_context() -> None:
     """Explicit trace_id wins over ContextVar."""
-    client = _stub_client()
+    client = RecordingClient()
     ctx_id = new_trace()
     explicit = new_trace()
     with with_trace(ctx_id):
@@ -148,7 +170,7 @@ def test_emit_event_caller_overrides_context() -> None:
             action="x",
             trace_id=explicit,
         )
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert inserted["trace_id"] == explicit
 
 
@@ -159,13 +181,13 @@ def test_emit_event_caller_overrides_context() -> None:
 
 def test_emit_event_does_not_raise_on_insert_exception() -> None:
     """Caller MUST NOT see substrate failures."""
-    client = _stub_client(insert_raises=RuntimeError("connection dropped"))
+    client = RecordingClient(fail_on_insert=True)
     result = emit_event(client, actor="skill:test", action="x")
     assert result is None
 
 
 def test_emit_event_buffers_on_failure() -> None:
-    client = _stub_client(insert_raises=RuntimeError("rls flap"))
+    client = RecordingClient(fail_on_insert=True)
     assert _buffer_len_for_test() == 0
     emit_event(client, actor="skill:test", action="x")
     assert _buffer_len_for_test() == 1
@@ -173,7 +195,7 @@ def test_emit_event_buffers_on_failure() -> None:
 
 def test_emit_event_returns_none_on_empty_data_response() -> None:
     """Defensive — Supabase returning empty data is a soft failure."""
-    client = _stub_client(insert_returns=[])
+    client = RecordingClient(return_data=[])
     result = emit_event(client, actor="skill:test", action="x")
     assert result is None
     assert _buffer_len_for_test() == 1
@@ -187,15 +209,15 @@ def test_emit_event_returns_none_on_empty_data_response() -> None:
 def test_buffered_events_drain_on_next_success() -> None:
     """A failure followed by a success drains the buffer with degraded=true."""
     # First call: fails, buffers.
-    bad_client = _stub_client(insert_raises=RuntimeError("transient"))
+    bad_client = RecordingClient(fail_on_insert=True)
     emit_event(bad_client, actor="skill:test", action="first")
     assert _buffer_len_for_test() == 1
 
     # Second call: succeeds — should drain the buffered row first.
-    good_client = _stub_client()
+    good_client = RecordingClient()
     emit_event(good_client, actor="skill:test", action="second")
 
-    inserts = [c.args[0] for c in good_client.table.return_value.insert.call_args_list]
+    inserts = good_client.inserts
     # Two inserts on good client: drained replay + the new one.
     assert len(inserts) == 2
     drained, new = inserts
@@ -208,21 +230,18 @@ def test_buffered_events_drain_on_next_success() -> None:
 
 def test_drain_failure_keeps_row_in_buffer() -> None:
     """If drain replay also fails, the row stays buffered for next attempt."""
-    # Buffer one row.
-    bad1 = _stub_client(insert_raises=RuntimeError("boom"))
+    bad1 = RecordingClient(fail_on_insert=True)
     emit_event(bad1, actor="skill:test", action="first")
     assert _buffer_len_for_test() == 1
 
-    # Second attempt also fails: drain attempt fails, AND new event buffers.
-    bad2 = _stub_client(insert_raises=RuntimeError("still boom"))
+    bad2 = RecordingClient(fail_on_insert=True)
     emit_event(bad2, actor="skill:test", action="second")
-    # Buffer now holds both: failed drain re-buffers + new failure adds.
     assert _buffer_len_for_test() == 2
 
 
 def test_buffer_overflow_drops_oldest() -> None:
     """When the buffer fills, oldest events drop (FIFO)."""
-    bad = _stub_client(insert_raises=RuntimeError("down"))
+    bad = RecordingClient(fail_on_insert=True)
     for i in range(_BUFFER_MAX + 5):
         emit_event(bad, actor="skill:test", action=f"event-{i}")
     assert _buffer_len_for_test() == _BUFFER_MAX

--- a/tests/test_pretooluse_recall.py
+++ b/tests/test_pretooluse_recall.py
@@ -238,6 +238,32 @@ class TestHelpers:
 # ---------------------------------------------------------------------------
 
 
+class _FakeSupabaseResponse:
+    """Fake response returned by FakeSupabaseClient.rpc().execute()."""
+
+    def __init__(self, data: list[dict]) -> None:
+        self.data = data
+
+
+class FakeSupabaseClient:
+    """Supabase-shaped test double for keyword_search_memories RPC.
+
+    Replaces the deep ``client.rpc.return_value.execute.return_value.data``
+    mock chain with a real method chain that returns controlled response data.
+    """
+
+    def __init__(self, *, rpc_rows: list[dict] | None = None) -> None:
+        self._rpc_rows = rpc_rows or []
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def rpc(self, name: str, params: dict) -> FakeSupabaseClient:
+        self.rpc_calls.append((name, params))
+        return self
+
+    def execute(self) -> _FakeSupabaseResponse:
+        return _FakeSupabaseResponse(self._rpc_rows)
+
+
 def _run_main(
     stdin_payload: dict,
     monkeypatch,
@@ -273,9 +299,8 @@ def _run_main(
     buf = io.StringIO()
     monkeypatch.setattr("sys.stdout", buf)
 
-    # Mock supabase create_client -> client with rpc().execute() returning rpc_rows
-    client = MagicMock()
-    client.rpc.return_value.execute.return_value = MagicMock(data=rpc_rows or [])
+    # Mock supabase create_client -> FakeSupabaseClient with real rpc().execute()
+    client = FakeSupabaseClient(rpc_rows=rpc_rows)
     fake_supabase = types.SimpleNamespace(create_client=lambda *a, **k: client)
     monkeypatch.setitem(sys.modules, "supabase", fake_supabase)
 


### PR DESCRIPTION
## Summary

- Replaces the 3-level `client.rpc.return_value.execute.return_value = MagicMock(data=...)`
  mock chain with a `FakeSupabaseClient` that returns real response shapes through actual method calls
- All 36 existing tests pass unchanged

Closes #858

## Test plan

- [x] `python -m pytest tests/test_pretooluse_recall.py -v` — 36 passed