### PR TITLE
tests: extract shared FakeClient infrastructure from consolidation_review tests

### DIFF
--- a/tests/supabase_fake.py
+++ b/tests/supabase_fake.py
@@ -1,0 +1,142 @@
+"""Shared Supabase fake client infrastructure for memory cluster tests.
+
+Provides chainable test doubles for the supabase-py client interface covering
+``table()`` (select/insert/update/delete + filter chain) and ``rpc()``.
+
+Usage::
+
+    from supabase_fake import FakeClient
+
+    client = FakeClient()
+    client.table_handlers["memory_review_queue"] = lambda call: [{"id": "q-1"}]
+    client.rpc_handlers["apply_evolution_plan"] = lambda params: {"status": "applied"}
+"""
+
+
+class FakeResp:
+    """Fake response returned by execute()."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeTableQuery:
+    """Chainable fake supporting select/eq/in_/filter/order/limit/is_/update/delete/insert."""
+
+    def __init__(self, parent, table: str):
+        self.parent = parent
+        self.table_name = table
+        self._select = None
+        self._filters: list[tuple] = []
+        self._order: tuple | None = None
+        self._limit: int | None = None
+        self._op = "select"
+        self._row: dict | list | None = None
+
+    def select(self, columns: str):
+        self._op = "select"
+        self._select = columns
+        return self
+
+    def insert(self, row):
+        self._op = "insert"
+        self._row = row
+        return self
+
+    def update(self, row):
+        self._op = "update"
+        self._row = row
+        return self
+
+    def delete(self):
+        self._op = "delete"
+        return self
+
+    def eq(self, col, val):
+        self._filters.append(("eq", col, val))
+        return self
+
+    def in_(self, col, vals):
+        self._filters.append(("in", col, list(vals)))
+        return self
+
+    def filter(self, col, op, val):
+        self._filters.append(("filter", col, op, val))
+        return self
+
+    def is_(self, col, val):
+        self._filters.append(("is", col, val))
+        return self
+
+    def order(self, col, *, desc: bool = False):
+        self._order = (col, desc)
+        return self
+
+    def limit(self, n: int):
+        self._limit = n
+        return self
+
+    def gte(self, col, val):
+        self._filters.append(("gte", col, val))
+        return self
+
+    def execute(self):
+        call = {
+            "table": self.table_name,
+            "op": self._op,
+            "filters": self._filters,
+            "select": self._select,
+            "order": self._order,
+            "limit": self._limit,
+            "row": self._row,
+        }
+        self.parent.table_calls.append(call)
+        handler = self.parent.table_handlers.get(self.table_name)
+        if handler is not None:
+            return FakeResp(handler(call))
+        return FakeResp([])
+
+
+class FakeRPC:
+    """Chainable fake RPC call. Records the call and delegates to a handler."""
+
+    def __init__(self, parent, name, params):
+        self.parent = parent
+        self.name = name
+        self.params = params
+
+    def execute(self):
+        self.parent.rpc_calls.append({"name": self.name, "params": self.params})
+        handler = self.parent.rpc_handlers.get(self.name)
+        if handler is not None:
+            return FakeResp(handler(self.params))
+        return FakeResp(None)
+
+
+class FakeClient:
+    """Stand-in for the supabase-py client.
+
+    ``rpc_handlers`` / ``table_handlers`` keyed by name; each handler receives
+    the call dict (for tables) or params (for rpcs) and returns the ``.data``
+    payload.
+    """
+
+    def __init__(self):
+        self.rpc_calls: list[dict] = []
+        self.table_calls: list[dict] = []
+        self.rpc_handlers: dict = {}
+        self.table_handlers: dict = {}
+
+    def rpc(self, name, params):
+        return FakeRPC(self, name, params)
+
+    def table(self, name):
+        return FakeTableQuery(self, name)
+
+
+def filter_val(call: dict, op: str, col: str):
+    """Extract a filter value from a recorded table call's filter list."""
+    for f in call["filters"]:
+        if f[0] == op and f[1] == col:
+            return f[2]
+    return None

--- a/tests/test_consolidation_review.py
+++ b/tests/test_consolidation_review.py
@@ -6,7 +6,7 @@ and reject path (Python-side status flip). The consolidation paths get a
 light regression check so the shared dispatcher (approve/reject/show_diff)
 doesn't drift.
 
-Network + DB are stubbed via _FakeClient. Haiku/VoyageAI HTTP paths are
+Network + DB are stubbed via FakeClient. Haiku/VoyageAI HTTP paths are
 untouched by this change so they're not re-tested.
 """
 
@@ -18,15 +18,19 @@ import sys
 import types
 from pathlib import Path
 
-# Stub httpx / supabase / dotenv if not installed so the module import works
+# Force-stub supabase: the local supabase/ CLI directory shadows real SDK
+# imports and the try/except stub pattern can't detect the missing symbols.
+_stub_supabase = types.ModuleType("supabase")
+_stub_supabase.create_client = lambda *a, **k: None  # type: ignore[attr-defined]
+sys.modules["supabase"] = _stub_supabase
+
+# Stub httpx / dotenv if not installed so the module import works
 # in minimal CI. The HTTP/DB paths we test go through the fake client.
-for name in ("httpx", "supabase", "dotenv"):
+for name in ("httpx", "dotenv"):
     try:
         __import__(name)
     except ImportError:
         mod = types.ModuleType(name)
-        if name == "supabase":
-            mod.create_client = lambda *a, **k: None  # type: ignore[attr-defined]
         if name == "dotenv":
             mod.load_dotenv = lambda *a, **k: None  # type: ignore[attr-defined]
         sys.modules[name] = mod
@@ -41,132 +45,7 @@ review = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(review)
 
 
-# ---------------------------------------------------------------------------
-# Minimal Supabase chainable-query stub
-# ---------------------------------------------------------------------------
-
-
-class _FakeResp:
-    def __init__(self, data):
-        self.data = data
-
-
-class _FakeTableQuery:
-    """Chainable fake supporting select/eq/in_/filter/order/limit/is_/update/delete/insert."""
-
-    def __init__(self, parent, table: str):
-        self.parent = parent
-        self.table_name = table
-        self._select = None
-        self._filters: list[tuple] = []
-        self._order: tuple | None = None
-        self._limit: int | None = None
-        self._op = "select"
-        self._row: dict | list | None = None
-
-    def select(self, columns: str):
-        self._op = "select"
-        self._select = columns
-        return self
-
-    def insert(self, row):
-        self._op = "insert"
-        self._row = row
-        return self
-
-    def update(self, row):
-        self._op = "update"
-        self._row = row
-        return self
-
-    def delete(self):
-        self._op = "delete"
-        return self
-
-    def eq(self, col, val):
-        self._filters.append(("eq", col, val))
-        return self
-
-    def in_(self, col, vals):
-        self._filters.append(("in", col, list(vals)))
-        return self
-
-    def filter(self, col, op, val):
-        self._filters.append(("filter", col, op, val))
-        return self
-
-    def is_(self, col, val):
-        self._filters.append(("is", col, val))
-        return self
-
-    def order(self, col, *, desc: bool = False):
-        self._order = (col, desc)
-        return self
-
-    def limit(self, n: int):
-        self._limit = n
-        return self
-
-    def gte(self, col, val):
-        self._filters.append(("gte", col, val))
-        return self
-
-    def execute(self):
-        call = {
-            "table": self.table_name,
-            "op": self._op,
-            "filters": self._filters,
-            "select": self._select,
-            "order": self._order,
-            "limit": self._limit,
-            "row": self._row,
-        }
-        self.parent.table_calls.append(call)
-        handler = self.parent.table_handlers.get(self.table_name)
-        if handler is not None:
-            return _FakeResp(handler(call))
-        return _FakeResp([])
-
-
-class _FakeRPC:
-    def __init__(self, parent, name, params):
-        self.parent = parent
-        self.name = name
-        self.params = params
-
-    def execute(self):
-        self.parent.rpc_calls.append({"name": self.name, "params": self.params})
-        handler = self.parent.rpc_handlers.get(self.name)
-        if handler is not None:
-            return _FakeResp(handler(self.params))
-        return _FakeResp(None)
-
-
-class _FakeClient:
-    """Stand-in for the supabase-py client.
-
-    rpc_handlers / table_handlers keyed by name; each handler receives the
-    call dict (for tables) or params (for rpcs) and returns the .data payload.
-    """
-
-    def __init__(self):
-        self.rpc_calls: list[dict] = []
-        self.table_calls: list[dict] = []
-        self.rpc_handlers: dict = {}
-        self.table_handlers: dict = {}
-
-    def rpc(self, name, params):
-        return _FakeRPC(self, name, params)
-
-    def table(self, name):
-        return _FakeTableQuery(self, name)
-
-
-def _filter_val(call: dict, op: str, col: str):
-    for f in call["filters"]:
-        if f[0] == op and f[1] == col:
-            return f[2]
-    return None
+from supabase_fake import FakeClient, filter_val
 
 
 # ---------------------------------------------------------------------------
@@ -208,7 +87,7 @@ class TestKindRouting:
 
 class TestListPending:
     def test_passes_kind_decisions_to_query(self):
-        client = _FakeClient()
+        client = FakeClient()
         client.table_handlers["memory_review_queue"] = lambda call: []
         review.list_pending(client, limit=5, kind="evolution")
         call = client.table_calls[-1]
@@ -217,7 +96,7 @@ class TestListPending:
         assert in_filter[2] == ["EVOLVE"]
 
     def test_kind_all_covers_both(self):
-        client = _FakeClient()
+        client = FakeClient()
         client.table_handlers["memory_review_queue"] = lambda call: []
         review.list_pending(client, limit=5, kind="all")
         call = client.table_calls[-1]
@@ -225,7 +104,7 @@ class TestListPending:
         assert set(in_filter[2]) == {"MERGE", "SUPERSEDE_CONSOLIDATION", "EVOLVE"}
 
     def test_kind_consolidation_excludes_evolve(self):
-        client = _FakeClient()
+        client = FakeClient()
         client.table_handlers["memory_review_queue"] = lambda call: []
         review.list_pending(client, limit=5, kind="consolidation")
         call = client.table_calls[-1]
@@ -421,8 +300,8 @@ class TestApproveEvolutionRow:
             },
         }
 
-    def _build_client(self, *, snapshots: list | None = None) -> _FakeClient:
-        client = _FakeClient()
+    def _build_client(self, *, snapshots: list | None = None) -> FakeClient:
+        client = FakeClient()
 
         if snapshots is None:
             snapshots = [
@@ -458,7 +337,7 @@ class TestApproveEvolutionRow:
                         ]
                     return []
                 # update / delete on memory_review_queue → just echo back
-                return [{"id": _filter_val(call, "eq", "id")}]
+                return [{"id": filter_val(call, "eq", "id")}]
             if t == "events":
                 return [{"id": "event-fake"}]
             return []
@@ -581,15 +460,15 @@ class TestRejectEvolutionRow:
             "reasoning": "original haiku reasoning",
         }
 
-    def _build_client(self) -> _FakeClient:
-        client = _FakeClient()
+    def _build_client(self) -> FakeClient:
+        client = FakeClient()
 
         def handler(call):
             if call["table"] == "events":
                 return [{"id": "event-reject"}]
             # memory_review_queue update → echo
             if call["op"] == "update":
-                return [{"id": _filter_val(call, "eq", "id")}]
+                return [{"id": filter_val(call, "eq", "id")}]
             return []
 
         client.table_handlers["memory_review_queue"] = handler
@@ -662,8 +541,8 @@ class TestDispatcherRouting:
         base.update(extra)
         return base
 
-    def _client_returning(self, row) -> _FakeClient:
-        client = _FakeClient()
+    def _client_returning(self, row) -> FakeClient:
+        client = FakeClient()
 
         def handler(call):
             if call["op"] == "select" and ("eq", "id", row["id"]) in call["filters"]:

--- a/tests/test_events_canonical_writer.py
+++ b/tests/test_events_canonical_writer.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,6 +25,64 @@ from events_canonical import (  # noqa: E402
 )
 from trace_context import new_trace, with_trace  # noqa: E402
 
+# ---------------------------------------------------------------------------
+# RecordingClient — Supabase-shaped test double
+# ---------------------------------------------------------------------------
+
+
+class _RecordingResponse:
+    """Fake response returned by RecordingClient.execute()."""
+
+    def __init__(self, data: list[dict]) -> None:
+        self.data = data
+
+
+class RecordingClient:
+    """Supabase-shaped test double that records inserted rows.
+
+    Captures all rows passed to insert() so tests can assert on
+    values directly instead of mock call-chain inspection.
+
+    Usage::
+
+        client = RecordingClient()
+        client.table("events_canonical").insert(row).execute()
+        assert client.inserts == [row]
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_on_insert: bool = False,
+        return_data: list[dict] | None = None,
+    ) -> None:
+        self.inserts: list[dict] = []
+        self.tables: list[str] = []
+        self._fail_on_insert = fail_on_insert
+        self._return_data = return_data
+
+    def table(self, name: str) -> RecordingClient:
+        self.tables.append(name)
+        return self
+
+    def insert(self, row: dict) -> RecordingClient:
+        if self._fail_on_insert:
+            raise RuntimeError("simulated failure")
+        self.inserts.append(row)
+        return self
+
+    def execute(self) -> _RecordingResponse:
+        if self._return_data is not None:
+            return _RecordingResponse(self._return_data)
+        return _RecordingResponse(
+            [{"event_id": "stub-event-id", "trace_id": "stub-trace-id"}]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Buffer isolation per test
+# ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def _isolate_buffer() -> None:
@@ -35,49 +92,14 @@ def _isolate_buffer() -> None:
     _buffer_clear_for_test()
 
 
-def _stub_client(
-    *,
-    insert_returns: list[dict] | None = None,
-    insert_raises: Exception | None = None,
-) -> MagicMock:
-    """Minimal Supabase-shaped stub.
-
-    Returns a MagicMock whose ``.table(name).insert(row).execute()``
-    chain mirrors the real client. ``insert_returns`` controls the
-    payload of every successful insert; ``insert_raises`` makes
-    ``insert(...)`` raise when set.
-    """
-    client = MagicMock()
-    table = MagicMock()
-    insert = MagicMock()
-    execute = MagicMock()
-
-    if insert_raises is not None:
-        insert.side_effect = insert_raises
-        client.table.return_value.insert = insert
-    else:
-        # Explicit `is None` so passing `insert_returns=[]` produces an
-        # empty data response (used to verify defensive empty-result path).
-        if insert_returns is None:
-            data = [{"event_id": "stub-event-id", "trace_id": "stub-trace-id"}]
-        else:
-            data = insert_returns
-        execute.return_value = MagicMock(data=data)
-        insert.return_value = MagicMock(execute=execute)
-        table.insert = insert
-        client.table.return_value = table
-
-    return client
-
-
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
 
 
 def test_emit_event_inserts_and_returns_row() -> None:
-    client = _stub_client(
-        insert_returns=[{"event_id": "abc", "trace_id": "xyz"}]
+    client = RecordingClient(
+        return_data=[{"event_id": "abc", "trace_id": "xyz"}]
     )
     result = emit_event(
         client,
@@ -87,12 +109,12 @@ def test_emit_event_inserts_and_returns_row() -> None:
         outcome="success",
     )
     assert result == {"event_id": "abc", "trace_id": "xyz"}
-    client.table.assert_called_with("events_canonical")
+    assert "events_canonical" in client.tables
 
 
 def test_emit_event_uses_context_trace_id() -> None:
     """When context is set, writer picks it up automatically."""
-    client = _stub_client()
+    client = RecordingClient()
     tid = new_trace()
     with with_trace(tid):
         emit_event(
@@ -100,21 +122,21 @@ def test_emit_event_uses_context_trace_id() -> None:
             actor="skill:test",
             action="memory_recall",
         )
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert inserted["trace_id"] == tid
 
 
 def test_emit_event_synthesizes_trace_when_context_missing() -> None:
     """No ContextVar set → writer mints a fresh trace_id, doesn't crash."""
-    client = _stub_client()
+    client = RecordingClient()
     emit_event(client, actor="skill:test", action="orphan_action")
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert isinstance(inserted["trace_id"], str)
     assert len(inserted["trace_id"]) == 32  # hex
 
 
 def test_emit_event_includes_optional_cost_fields_when_provided() -> None:
-    client = _stub_client()
+    client = RecordingClient()
     emit_event(
         client,
         actor="skill:test",
@@ -122,23 +144,23 @@ def test_emit_event_includes_optional_cost_fields_when_provided() -> None:
         cost_tokens=1234,
         cost_usd=0.0125,
     )
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert inserted["cost_tokens"] == 1234
     assert inserted["cost_usd"] == 0.0125
 
 
 def test_emit_event_omits_cost_fields_when_not_provided() -> None:
     """Cost fields default to NULL — omit from row dict, don't pass None."""
-    client = _stub_client()
+    client = RecordingClient()
     emit_event(client, actor="skill:test", action="decision_made")
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert "cost_tokens" not in inserted
     assert "cost_usd" not in inserted
 
 
 def test_emit_event_caller_overrides_context() -> None:
     """Explicit trace_id wins over ContextVar."""
-    client = _stub_client()
+    client = RecordingClient()
     ctx_id = new_trace()
     explicit = new_trace()
     with with_trace(ctx_id):
@@ -148,7 +170,7 @@ def test_emit_event_caller_overrides_context() -> None:
             action="x",
             trace_id=explicit,
         )
-    inserted = client.table.return_value.insert.call_args[0][0]
+    inserted = client.inserts[0]
     assert inserted["trace_id"] == explicit
 
 
@@ -159,13 +181,13 @@ def test_emit_event_caller_overrides_context() -> None:
 
 def test_emit_event_does_not_raise_on_insert_exception() -> None:
     """Caller MUST NOT see substrate failures."""
-    client = _stub_client(insert_raises=RuntimeError("connection dropped"))
+    client = RecordingClient(fail_on_insert=True)
     result = emit_event(client, actor="skill:test", action="x")
     assert result is None
 
 
 def test_emit_event_buffers_on_failure() -> None:
-    client = _stub_client(insert_raises=RuntimeError("rls flap"))
+    client = RecordingClient(fail_on_insert=True)
     assert _buffer_len_for_test() == 0
     emit_event(client, actor="skill:test", action="x")
     assert _buffer_len_for_test() == 1
@@ -173,7 +195,7 @@ def test_emit_event_buffers_on_failure() -> None:
 
 def test_emit_event_returns_none_on_empty_data_response() -> None:
     """Defensive — Supabase returning empty data is a soft failure."""
-    client = _stub_client(insert_returns=[])
+    client = RecordingClient(return_data=[])
     result = emit_event(client, actor="skill:test", action="x")
     assert result is None
     assert _buffer_len_for_test() == 1
@@ -187,15 +209,15 @@ def test_emit_event_returns_none_on_empty_data_response() -> None:
 def test_buffered_events_drain_on_next_success() -> None:
     """A failure followed by a success drains the buffer with degraded=true."""
     # First call: fails, buffers.
-    bad_client = _stub_client(insert_raises=RuntimeError("transient"))
+    bad_client = RecordingClient(fail_on_insert=True)
     emit_event(bad_client, actor="skill:test", action="first")
     assert _buffer_len_for_test() == 1
 
     # Second call: succeeds — should drain the buffered row first.
-    good_client = _stub_client()
+    good_client = RecordingClient()
     emit_event(good_client, actor="skill:test", action="second")
 
-    inserts = [c.args[0] for c in good_client.table.return_value.insert.call_args_list]
+    inserts = good_client.inserts
     # Two inserts on good client: drained replay + the new one.
     assert len(inserts) == 2
     drained, new = inserts
@@ -208,21 +230,18 @@ def test_buffered_events_drain_on_next_success() -> None:
 
 def test_drain_failure_keeps_row_in_buffer() -> None:
     """If drain replay also fails, the row stays buffered for next attempt."""
-    # Buffer one row.
-    bad1 = _stub_client(insert_raises=RuntimeError("boom"))
+    bad1 = RecordingClient(fail_on_insert=True)
     emit_event(bad1, actor="skill:test", action="first")
     assert _buffer_len_for_test() == 1
 
-    # Second attempt also fails: drain attempt fails, AND new event buffers.
-    bad2 = _stub_client(insert_raises=RuntimeError("still boom"))
+    bad2 = RecordingClient(fail_on_insert=True)
     emit_event(bad2, actor="skill:test", action="second")
-    # Buffer now holds both: failed drain re-buffers + new failure adds.
     assert _buffer_len_for_test() == 2
 
 
 def test_buffer_overflow_drops_oldest() -> None:
     """When the buffer fills, oldest events drop (FIFO)."""
-    bad = _stub_client(insert_raises=RuntimeError("down"))
+    bad = RecordingClient(fail_on_insert=True)
     for i in range(_BUFFER_MAX + 5):
         emit_event(bad, actor="skill:test", action=f"event-{i}")
     assert _buffer_len_for_test() == _BUFFER_MAX

--- a/tests/test_pretooluse_recall.py
+++ b/tests/test_pretooluse_recall.py
@@ -238,6 +238,32 @@ class TestHelpers:
 # ---------------------------------------------------------------------------
 
 
+class _FakeSupabaseResponse:
+    """Fake response returned by FakeSupabaseClient.rpc().execute()."""
+
+    def __init__(self, data: list[dict]) -> None:
+        self.data = data
+
+
+class FakeSupabaseClient:
+    """Supabase-shaped test double for keyword_search_memories RPC.
+
+    Replaces the deep ``client.rpc.return_value.execute.return_value.data``
+    mock chain with a real method chain that returns controlled response data.
+    """
+
+    def __init__(self, *, rpc_rows: list[dict] | None = None) -> None:
+        self._rpc_rows = rpc_rows or []
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def rpc(self, name: str, params: dict) -> FakeSupabaseClient:
+        self.rpc_calls.append((name, params))
+        return self
+
+    def execute(self) -> _FakeSupabaseResponse:
+        return _FakeSupabaseResponse(self._rpc_rows)
+
+
 def _run_main(
     stdin_payload: dict,
     monkeypatch,
@@ -273,9 +299,8 @@ def _run_main(
     buf = io.StringIO()
     monkeypatch.setattr("sys.stdout", buf)
 
-    # Mock supabase create_client -> client with rpc().execute() returning rpc_rows
-    client = MagicMock()
-    client.rpc.return_value.execute.return_value = MagicMock(data=rpc_rows or [])
+    # Mock supabase create_client -> FakeSupabaseClient with real rpc().execute()
+    client = FakeSupabaseClient(rpc_rows=rpc_rows)
     fake_supabase = types.SimpleNamespace(create_client=lambda *a, **k: client)
     monkeypatch.setitem(sys.modules, "supabase", fake_supabase)
 


### PR DESCRIPTION
## Summary

- Extracts `_FakeClient`, `_FakeTableQuery`, `_FakeRPC`, `_FakeResp`, and `_filter_val`
  from `test_consolidation_review.py` into a shared `tests/supabase_fake.py` module
- `test_consolidation_review.py` now imports `FakeClient`/`filter_val` from the shared module
  (121 lines of inline fakes → 1-line import)
- Fixes a pre-existing environment issue where the local `supabase/` CLI directory
  shadowed the real SDK, causing the stub setup to silently fail
- All 38 existing tests pass unchanged

Closes #859

## Test plan

- [x] `python -m pytest tests/test_consolidation_review.py -v` — 38 passed