### PR TITLE
ci: auto-enable squash auto-merge on ready PRs (Closes #891)

### DIFF
--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -1,0 +1,26 @@
+# Closes the AFK Path A merge-enable gap (#891): the repo allows auto-merge,
+# but nothing was turning it on per-PR, so green PRs never merged on their own.
+# This enables squash auto-merge the moment a PR is open-and-ready (non-draft);
+# GitHub then merges it once every required gate (review / pytest / meta-tests /
+# gitleaks / require-linked-issue / owner-queue-guard) is green. Owner holds a PR
+# by keeping it a draft or applying status:owner-queue (owner-queue-guard stays red).
+name: auto-merge-enable
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable:
+    # Skip drafts — a draft is the manual "owner attention owed" hold.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --auto --squash


### PR DESCRIPTION
Closes #891

## Summary

Adds `.github/workflows/auto-merge-enable.yml` — on `pull_request` [opened, ready_for_review], for non-draft PRs, runs `gh pr merge --auto --squash`. Closes the layer-1 gap behind the "green PRs pile up unmerged" problem: the repo allowed auto-merge but nothing ever enabled it per-PR.

## How the gates still hold

- **Drafts skipped** (`if: draft == false`) — draft remains the manual owner-hold.
- **`status:owner-queue`** PRs: auto-merge can be enabled but won't complete because the `owner-queue-guard` required check stays red.
- All four merge gates (review / pytest / meta-tests / gitleaks / require-linked-issue / owner-queue-guard) remain the merge condition — this workflow only flips the switch GitHub already gates.

## Token

Uses `GITHUB_TOKEN` with `pull-requests: write` + `contents: write`. Enabling auto-merge doesn't require a PAT; the actual merge is performed by GitHub when checks pass.

## Known residual (tracked in #891, not this PR)

Under strict mode without a merge queue, a large simultaneous batch still serializes (auto-merge enabled but BEHIND until branch-updated one at a time). A push-triggered train-updater or a GitHub merge queue is the fuller fix; deferred unless it recurs.

## Decision

`b278c75a-4064-4536-b174-f6b65cab003f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)