### PR TITLE
refactor(tests): extract shared fake client infrastructure into test_utils

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,9 @@ for _mod_name, _mod in [
 try:
     import supabase  # noqa: F401
 except ImportError:
-    sys.modules["supabase"] = types.ModuleType("supabase")
+    _supabase_mod = types.ModuleType("supabase")
+    _supabase_mod.create_client = MagicMock
+    sys.modules["supabase"] = _supabase_mod
 
 try:
     import httpx  # noqa: F401

--- a/tests/test_consolidation_review.py
+++ b/tests/test_consolidation_review.py
@@ -6,7 +6,7 @@ and reject path (Python-side status flip). The consolidation paths get a
 light regression check so the shared dispatcher (approve/reject/show_diff)
 doesn't drift.
 
-Network + DB are stubbed via _FakeClient. Haiku/VoyageAI HTTP paths are
+Network + DB are stubbed via FakeClient. Haiku/VoyageAI HTTP paths are
 untouched by this change so they're not re-tested.
 """
 
@@ -14,22 +14,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import sys
-import types
 from pathlib import Path
 
-# Stub httpx / supabase / dotenv if not installed so the module import works
-# in minimal CI. The HTTP/DB paths we test go through the fake client.
-for name in ("httpx", "supabase", "dotenv"):
-    try:
-        __import__(name)
-    except ImportError:
-        mod = types.ModuleType(name)
-        if name == "supabase":
-            mod.create_client = lambda *a, **k: None  # type: ignore[attr-defined]
-        if name == "dotenv":
-            mod.load_dotenv = lambda *a, **k: None  # type: ignore[attr-defined]
-        sys.modules[name] = mod
+from test_utils import FakeClient, FakeResp, filter_val
 
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "consolidation-review.py"
@@ -39,134 +26,6 @@ spec = importlib.util.spec_from_file_location("consolidation_review", SCRIPT_PAT
 assert spec and spec.loader
 review = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(review)
-
-
-# ---------------------------------------------------------------------------
-# Minimal Supabase chainable-query stub
-# ---------------------------------------------------------------------------
-
-
-class _FakeResp:
-    def __init__(self, data):
-        self.data = data
-
-
-class _FakeTableQuery:
-    """Chainable fake supporting select/eq/in_/filter/order/limit/is_/update/delete/insert."""
-
-    def __init__(self, parent, table: str):
-        self.parent = parent
-        self.table_name = table
-        self._select = None
-        self._filters: list[tuple] = []
-        self._order: tuple | None = None
-        self._limit: int | None = None
-        self._op = "select"
-        self._row: dict | list | None = None
-
-    def select(self, columns: str):
-        self._op = "select"
-        self._select = columns
-        return self
-
-    def insert(self, row):
-        self._op = "insert"
-        self._row = row
-        return self
-
-    def update(self, row):
-        self._op = "update"
-        self._row = row
-        return self
-
-    def delete(self):
-        self._op = "delete"
-        return self
-
-    def eq(self, col, val):
-        self._filters.append(("eq", col, val))
-        return self
-
-    def in_(self, col, vals):
-        self._filters.append(("in", col, list(vals)))
-        return self
-
-    def filter(self, col, op, val):
-        self._filters.append(("filter", col, op, val))
-        return self
-
-    def is_(self, col, val):
-        self._filters.append(("is", col, val))
-        return self
-
-    def order(self, col, *, desc: bool = False):
-        self._order = (col, desc)
-        return self
-
-    def limit(self, n: int):
-        self._limit = n
-        return self
-
-    def gte(self, col, val):
-        self._filters.append(("gte", col, val))
-        return self
-
-    def execute(self):
-        call = {
-            "table": self.table_name,
-            "op": self._op,
-            "filters": self._filters,
-            "select": self._select,
-            "order": self._order,
-            "limit": self._limit,
-            "row": self._row,
-        }
-        self.parent.table_calls.append(call)
-        handler = self.parent.table_handlers.get(self.table_name)
-        if handler is not None:
-            return _FakeResp(handler(call))
-        return _FakeResp([])
-
-
-class _FakeRPC:
-    def __init__(self, parent, name, params):
-        self.parent = parent
-        self.name = name
-        self.params = params
-
-    def execute(self):
-        self.parent.rpc_calls.append({"name": self.name, "params": self.params})
-        handler = self.parent.rpc_handlers.get(self.name)
-        if handler is not None:
-            return _FakeResp(handler(self.params))
-        return _FakeResp(None)
-
-
-class _FakeClient:
-    """Stand-in for the supabase-py client.
-
-    rpc_handlers / table_handlers keyed by name; each handler receives the
-    call dict (for tables) or params (for rpcs) and returns the .data payload.
-    """
-
-    def __init__(self):
-        self.rpc_calls: list[dict] = []
-        self.table_calls: list[dict] = []
-        self.rpc_handlers: dict = {}
-        self.table_handlers: dict = {}
-
-    def rpc(self, name, params):
-        return _FakeRPC(self, name, params)
-
-    def table(self, name):
-        return _FakeTableQuery(self, name)
-
-
-def _filter_val(call: dict, op: str, col: str):
-    for f in call["filters"]:
-        if f[0] == op and f[1] == col:
-            return f[2]
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -208,7 +67,7 @@ class TestKindRouting:
 
 class TestListPending:
     def test_passes_kind_decisions_to_query(self):
-        client = _FakeClient()
+        client = FakeClient()
         client.table_handlers["memory_review_queue"] = lambda call: []
         review.list_pending(client, limit=5, kind="evolution")
         call = client.table_calls[-1]
@@ -217,7 +76,7 @@ class TestListPending:
         assert in_filter[2] == ["EVOLVE"]
 
     def test_kind_all_covers_both(self):
-        client = _FakeClient()
+        client = FakeClient()
         client.table_handlers["memory_review_queue"] = lambda call: []
         review.list_pending(client, limit=5, kind="all")
         call = client.table_calls[-1]
@@ -225,7 +84,7 @@ class TestListPending:
         assert set(in_filter[2]) == {"MERGE", "SUPERSEDE_CONSOLIDATION", "EVOLVE"}
 
     def test_kind_consolidation_excludes_evolve(self):
-        client = _FakeClient()
+        client = FakeClient()
         client.table_handlers["memory_review_queue"] = lambda call: []
         review.list_pending(client, limit=5, kind="consolidation")
         call = client.table_calls[-1]
@@ -421,8 +280,8 @@ class TestApproveEvolutionRow:
             },
         }
 
-    def _build_client(self, *, snapshots: list | None = None) -> _FakeClient:
-        client = _FakeClient()
+    def _build_client(self, *, snapshots: list | None = None) -> FakeClient:
+        client = FakeClient()
 
         if snapshots is None:
             snapshots = [
@@ -458,7 +317,7 @@ class TestApproveEvolutionRow:
                         ]
                     return []
                 # update / delete on memory_review_queue → just echo back
-                return [{"id": _filter_val(call, "eq", "id")}]
+                return [{"id": filter_val(call, "eq", "id")}]
             if t == "events":
                 return [{"id": "event-fake"}]
             return []
@@ -581,15 +440,15 @@ class TestRejectEvolutionRow:
             "reasoning": "original haiku reasoning",
         }
 
-    def _build_client(self) -> _FakeClient:
-        client = _FakeClient()
+    def _build_client(self) -> FakeClient:
+        client = FakeClient()
 
         def handler(call):
             if call["table"] == "events":
                 return [{"id": "event-reject"}]
             # memory_review_queue update → echo
             if call["op"] == "update":
-                return [{"id": _filter_val(call, "eq", "id")}]
+                return [{"id": filter_val(call, "eq", "id")}]
             return []
 
         client.table_handlers["memory_review_queue"] = handler
@@ -662,8 +521,8 @@ class TestDispatcherRouting:
         base.update(extra)
         return base
 
-    def _client_returning(self, row) -> _FakeClient:
-        client = _FakeClient()
+    def _client_returning(self, row) -> FakeClient:
+        client = FakeClient()
 
         def handler(call):
             if call["op"] == "select" and ("eq", "id", row["id"]) in call["filters"]:

--- a/tests/test_memory_calibration.py
+++ b/tests/test_memory_calibration.py
@@ -111,6 +111,9 @@ class TestMemoryCalibrationSummary:
         monkeypatch.setattr("server._get_client", lambda: client)
 
         result = await _handle_memory_calibration_summary({})
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].type == "text"
         assert "Error calling memory_calibration_summary" in result[0].text
         assert "rpc blew up" in result[0].text
 

--- a/tests/test_memory_recall_hook.py
+++ b/tests/test_memory_recall_hook.py
@@ -11,26 +11,9 @@ plain import statement.
 from __future__ import annotations
 
 import importlib.util
-import sys
-import types
 from pathlib import Path
 
-
-# Stub httpx / dotenv / supabase if not installed — we only test pure
-# helpers here, the module-level imports must still succeed.
-for _stub in ("httpx", "dotenv", "supabase"):
-    if _stub not in sys.modules:
-        try:
-            __import__(_stub)
-        except ImportError:
-            mod = types.ModuleType(_stub)
-            if _stub == "dotenv":
-                mod.load_dotenv = lambda *a, **k: None
-            sys.modules[_stub] = mod
-    if _stub == "dotenv" and not hasattr(sys.modules[_stub], "load_dotenv"):
-        sys.modules[_stub].load_dotenv = lambda *a, **k: None
-    if _stub == "supabase" and not hasattr(sys.modules[_stub], "create_client"):
-        sys.modules[_stub].create_client = lambda *a, **k: None
+from test_utils import StubClient, TableStub
 
 
 _HOOK_PATH = Path(__file__).resolve().parent.parent / "scripts" / "memory-recall-hook.py"
@@ -569,45 +552,28 @@ class TestMergeWithLinks:
 # ---------------------------------------------------------------------------
 
 
-class _StubClient:
-    """Minimal supabase-client stand-in for expand_links tests."""
-    def __init__(self, *, data=None, raise_exc=None):
-        self._data = data or []
-        self._raise = raise_exc
-        self.rpc_calls: list[tuple[str, dict]] = []
-
-    def rpc(self, name, params):
-        self.rpc_calls.append((name, params))
-        return self
-
-    def execute(self):
-        if self._raise:
-            raise self._raise
-        return types.SimpleNamespace(data=self._data)
-
-
 class TestExpandLinks:
     def test_empty_top_rows_no_rpc(self):
-        client = _StubClient(data=[{"id": "x"}])
+        client = StubClient(data=[{"id": "x"}])
         out = mrh.expand_links(client, [])
         assert out == []
         assert client.rpc_calls == []
 
     def test_all_top_rows_missing_id_no_rpc(self):
         # Defensive: if all seeds lack ids, don't bother hitting the RPC.
-        client = _StubClient(data=[{"id": "x"}])
+        client = StubClient(data=[{"id": "x"}])
         out = mrh.expand_links(client, [{"name": "no-id"}])
         assert out == []
         assert client.rpc_calls == []
 
     def test_rpc_exception_returns_empty(self):
         # Fail-soft contract: RPC failure must not raise or pollute results.
-        client = _StubClient(raise_exc=RuntimeError("connection lost"))
+        client = StubClient(raise_exc=RuntimeError("connection lost"))
         out = mrh.expand_links(client, [{"id": "seed"}])
         assert out == []
 
     def test_successful_rpc_returns_scored_rows(self):
-        client = _StubClient(data=[
+        client = StubClient(data=[
             {"id": "child", "linked_from": "seed", "link_strength": 1.0},
         ])
         out = mrh.expand_links(client, [{"id": "seed"}])
@@ -617,7 +583,7 @@ class TestExpandLinks:
     def test_rpc_called_with_top_k_seed_ids(self):
         # Seed slice must respect LINK_EXPAND_TOP_K — we don't want to expand
         # a 25-row RRF list into a graph fetch.
-        client = _StubClient(data=[])
+        client = StubClient(data=[])
         seeds = [{"id": f"s{i}"} for i in range(10)]
         mrh.expand_links(client, seeds)
         assert len(client.rpc_calls) == 1
@@ -703,66 +669,25 @@ class TestCosineSim:
 # ---------------------------------------------------------------------------
 
 
-class _TableStub:
-    """Supabase table/select-chain stand-in for check_known_unknown_gate tests.
-
-    Supports the `.table().select().eq().not_.is_().limit().execute()` chain
-    used by the gate. `data` is the rows returned; `raise_exc` bubbles through
-    any method to exercise the fail-soft path.
-    """
-    def __init__(self, *, data=None, raise_exc=None):
-        self._data = data or []
-        self._raise = raise_exc
-        self.calls: list[tuple[str, tuple]] = []
-        # `.not_` is an accessor on the query builder, not a method, so
-        # expose it as an attribute that chains back to self.
-        self.not_ = self
-
-    def table(self, name):
-        self.calls.append(("table", (name,)))
-        return self
-
-    def select(self, *cols):
-        self.calls.append(("select", cols))
-        return self
-
-    def eq(self, col, val):
-        self.calls.append(("eq", (col, val)))
-        return self
-
-    def is_(self, col, val):
-        self.calls.append(("is_", (col, val)))
-        return self
-
-    def limit(self, n):
-        self.calls.append(("limit", (n,)))
-        return self
-
-    def execute(self):
-        if self._raise:
-            raise self._raise
-        return types.SimpleNamespace(data=self._data)
-
-
 class TestCheckKnownUnknownGate:
     def test_empty_embedding_returns_false_without_db_call(self):
         # Short-circuit: no prompt embedding (Voyage failed) → no point
         # scanning the table. Don't hit the DB for a guaranteed miss.
-        client = _TableStub(data=[{"query_embedding": "[1,0,0]"}])
+        client = TableStub(data=[{"query_embedding": "[1,0,0]"}])
         assert mrh.check_known_unknown_gate(client, None) is False
         assert client.calls == []
 
-        client2 = _TableStub()
+        client2 = TableStub()
         assert mrh.check_known_unknown_gate(client2, []) is False
         assert client2.calls == []
 
     def test_no_open_unknowns_returns_false(self):
-        client = _TableStub(data=[])
+        client = TableStub(data=[])
         assert mrh.check_known_unknown_gate(client, [1.0, 0.0, 0.0]) is False
 
     def test_below_threshold_returns_false(self):
         # cosine([1,0,0], [0.5, 0.866, 0]) = 0.5 — well below 0.85.
-        client = _TableStub(data=[
+        client = TableStub(data=[
             {"query_embedding": "[0.5, 0.866, 0.0]"}
         ])
         assert mrh.check_known_unknown_gate(client, [1.0, 0.0, 0.0]) is False
@@ -770,14 +695,14 @@ class TestCheckKnownUnknownGate:
     def test_at_threshold_triggers(self):
         # Stored vector exactly at the threshold — must trigger (>=, not >).
         # Cosine of identical unit vectors is 1.0 >= 0.85.
-        client = _TableStub(data=[
+        client = TableStub(data=[
             {"query_embedding": "[1.0, 0.0, 0.0]"}
         ])
         assert mrh.check_known_unknown_gate(client, [1.0, 0.0, 0.0]) is True
 
     def test_above_threshold_triggers(self):
         # Small perturbation: cosine ≈ 0.995 — widen.
-        client = _TableStub(data=[
+        client = TableStub(data=[
             {"query_embedding": "[0.99, 0.1, 0.0]"}
         ])
         assert mrh.check_known_unknown_gate(client, [1.0, 0.0, 0.0]) is True
@@ -785,7 +710,7 @@ class TestCheckKnownUnknownGate:
     def test_scans_until_hit(self):
         # First row misses (cosine 0), second row triggers. Confirms we
         # don't bail on the first miss.
-        client = _TableStub(data=[
+        client = TableStub(data=[
             {"query_embedding": "[0.0, 1.0, 0.0]"},  # orthogonal: miss
             {"query_embedding": "[1.0, 0.0, 0.0]"},  # identical: hit
         ])
@@ -795,7 +720,7 @@ class TestCheckKnownUnknownGate:
         # Rows without an embedding (stored as None) don't count even
         # though the query filters them out — defensive against schema
         # changes or partial rows.
-        client = _TableStub(data=[
+        client = TableStub(data=[
             {"query_embedding": None},
             {"query_embedding": "[1.0, 0.0, 0.0]"},
         ])
@@ -804,20 +729,20 @@ class TestCheckKnownUnknownGate:
     def test_malformed_embedding_skipped(self):
         # A row whose stored embedding can't be parsed is treated as a miss,
         # not a crash — the hook must never raise.
-        client = _TableStub(data=[
+        client = TableStub(data=[
             {"query_embedding": "not a vector"},
         ])
         assert mrh.check_known_unknown_gate(client, [1.0, 0.0, 0.0]) is False
 
     def test_db_exception_returns_false(self):
         # Fail-soft: any Supabase error falls back to default (brief) path.
-        client = _TableStub(raise_exc=RuntimeError("connection lost"))
+        client = TableStub(raise_exc=RuntimeError("connection lost"))
         assert mrh.check_known_unknown_gate(client, [1.0, 0.0, 0.0]) is False
 
     def test_query_filters_open_and_nonnull(self):
         # Sanity: verify we scoped the query correctly so the SCAN_LIMIT cap
         # is meaningful. Without `status=open` we'd pull resolved gaps too.
-        client = _TableStub(data=[])
+        client = TableStub(data=[])
         mrh.check_known_unknown_gate(client, [1.0, 0.0, 0.0])
         # eq(status, open) and limit(SCAN_LIMIT) must both appear.
         assert ("eq", ("status", "open")) in client.calls

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,3 +72,138 @@ class TableStub:
         if self._raise:
             raise self._raise
         return types.SimpleNamespace(data=self._data)
+
+
+class FakeResp:
+    """Minimal response wrapper storing .data for fake client handlers."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeTableQuery:
+    """Chainable fake supporting select/eq/in_/filter/order/limit/is_/update/delete/insert.
+
+    Used by FakeClient to simulate the supabase-py query builder chain.
+    Each ``execute()`` call records operation details on the parent and
+    delegates to the parent's ``table_handlers`` when configured.
+    """
+
+    def __init__(self, parent, table: str):
+        self.parent = parent
+        self.table_name = table
+        self._select = None
+        self._filters: list[tuple] = []
+        self._order: tuple | None = None
+        self._limit: int | None = None
+        self._op = "select"
+        self._row: dict | list | None = None
+
+    def select(self, columns: str):
+        self._op = "select"
+        self._select = columns
+        return self
+
+    def insert(self, row):
+        self._op = "insert"
+        self._row = row
+        return self
+
+    def update(self, row):
+        self._op = "update"
+        self._row = row
+        return self
+
+    def delete(self):
+        self._op = "delete"
+        return self
+
+    def eq(self, col, val):
+        self._filters.append(("eq", col, val))
+        return self
+
+    def in_(self, col, vals):
+        self._filters.append(("in", col, list(vals)))
+        return self
+
+    def filter(self, col, op, val):
+        self._filters.append(("filter", col, op, val))
+        return self
+
+    def is_(self, col, val):
+        self._filters.append(("is", col, val))
+        return self
+
+    def order(self, col, *, desc: bool = False):
+        self._order = (col, desc)
+        return self
+
+    def limit(self, n: int):
+        self._limit = n
+        return self
+
+    def gte(self, col, val):
+        self._filters.append(("gte", col, val))
+        return self
+
+    def execute(self):
+        call = {
+            "table": self.table_name,
+            "op": self._op,
+            "filters": self._filters,
+            "select": self._select,
+            "order": self._order,
+            "limit": self._limit,
+            "row": self._row,
+        }
+        self.parent.table_calls.append(call)
+        handler = self.parent.table_handlers.get(self.table_name)
+        if handler is not None:
+            return FakeResp(handler(call))
+        return FakeResp([])
+
+
+class FakeRPC:
+    """Stand-in for supabase-py RPC builder; delegates to parent handlers."""
+
+    def __init__(self, parent, name, params):
+        self.parent = parent
+        self.name = name
+        self.params = params
+
+    def execute(self):
+        self.parent.rpc_calls.append({"name": self.name, "params": self.params})
+        handler = self.parent.rpc_handlers.get(self.name)
+        if handler is not None:
+            return FakeResp(handler(self.params))
+        return FakeResp(None)
+
+
+class FakeClient:
+    """Stand-in for the supabase-py client with handler-based routing.
+
+    ``rpc_handlers`` / ``table_handlers`` are dicts keyed by name; each
+    handler receives the call dict (for tables) or params (for RPCs) and
+    returns the ``.data`` payload. Every RPC and table call is recorded
+    for test assertions.
+    """
+
+    def __init__(self):
+        self.rpc_calls: list[dict] = []
+        self.table_calls: list[dict] = []
+        self.rpc_handlers: dict = {}
+        self.table_handlers: dict = {}
+
+    def rpc(self, name, params):
+        return FakeRPC(self, name, params)
+
+    def table(self, name):
+        return FakeTableQuery(self, name)
+
+
+def filter_val(call: dict, op: str, col: str):
+    """Return the filter value for the first matching (op, col) pair."""
+    for f in call["filters"]:
+        if f[0] == op and f[1] == col:
+            return f[2]
+    return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,74 @@
+"""Shared test utilities for mcp-memory tests.
+
+Contains reusable stub classes that replace Supabase client patterns
+across multiple test modules (test_memory_recall_hook.py,
+test_memory_server.py, etc.).
+"""
+
+from __future__ import annotations
+
+import types
+
+
+class StubClient:
+    """Minimal supabase-client stand-in for expand_links-style tests.
+
+    Records RPC call params and supports both success and exception paths.
+    """
+
+    def __init__(self, *, data=None, raise_exc=None):
+        self._data = data or []
+        self._raise = raise_exc
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def rpc(self, name, params):
+        self.rpc_calls.append((name, params))
+        return self
+
+    def execute(self):
+        if self._raise:
+            raise self._raise
+        return types.SimpleNamespace(data=self._data)
+
+
+class TableStub:
+    """Supabase table/select-chain stand-in for table-query tests.
+
+    Supports the ``.table().select().eq().not_.is_().limit().execute()``
+    chain used by gates and CRUD-style helpers.  ``data`` is the rows
+    returned; ``raise_exc`` bubbles through any method to exercise the
+    fail-soft path.
+    """
+
+    def __init__(self, *, data=None, raise_exc=None):
+        self._data = data or []
+        self._raise = raise_exc
+        self.calls: list[tuple[str, tuple]] = []
+        # ``.not_`` is an accessor on the query builder, not a method, so
+        # expose it as an attribute that chains back to self.
+        self.not_ = self
+
+    def table(self, name):
+        self.calls.append(("table", (name,)))
+        return self
+
+    def select(self, *cols):
+        self.calls.append(("select", cols))
+        return self
+
+    def eq(self, col, val):
+        self.calls.append(("eq", (col, val)))
+        return self
+
+    def is_(self, col, val):
+        self.calls.append(("is_", (col, val)))
+        return self
+
+    def limit(self, n):
+        self.calls.append(("limit", (n,)))
+        return self
+
+    def execute(self):
+        if self._raise:
+            raise self._raise
+        return types.SimpleNamespace(data=self._data)


### PR DESCRIPTION
## Summary

- Move `FakeClient`, `FakeTableQuery`, `FakeRPC`, `FakeResp`, and `filter_val` from `test_consolidation_review.py` into shared `tests/test_utils.py`
- Remove redundant module-level stubs (handled by conftest.py)
- All 246 tests pass across 4 test files

Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)