### PR TITLE
feat(recall): expose query_embedding param to eliminate double-embed in hook

### DIFF
--- a/mcp-memory/recall.py
+++ b/mcp-memory/recall.py
@@ -546,6 +546,7 @@ async def recall(
     boost_types: set[str] | None = None,
     boost_multiplier: float = 1.5,
     config: RecallConfig = PROD_RECALL_CONFIG,
+    query_embedding: list[float] | None = None,
 ) -> list[RecallHit]:
     """Run the hybrid-recall pipeline and return ranked RecallHits.
 
@@ -581,12 +582,21 @@ async def recall(
     (a misclassified-but-relevant memory still survives single-signal). When
     None or empty, no boost is applied. Default multiplier 1.5 matches the
     pre-#499 hook calibration.
+
+    ``query_embedding`` (#508): pre-computed embedding for the query. When
+    provided, ``recall()`` skips the internal ``_embed_query()`` call and
+    uses this directly. This eliminates the double-embed overhead when
+    the caller (notably the UserPromptSubmit hook) already computed an
+    embedding for its own gate check. Falls back to embedding internally
+    when None (default), preserving the existing behavior for all current
+    callers.
     """
     # Late-bind `server` so test patches of the embedding model + embed
     # function still apply. Same pattern as handlers/memory.py.
     import server  # noqa: PLC0415
 
-    query_embedding = await server._embed_query(query)
+    if query_embedding is None:
+        query_embedding = await server._embed_query(query)
     if query_embedding is None:
         return []
 

--- a/scripts/memory-recall-hook.py
+++ b/scripts/memory-recall-hook.py
@@ -22,10 +22,10 @@ Known divergences vs pre-#499 behavior (documented, not bugs):
   • TYPE_BOOST_MULTIPLIER (soft rewriter-type boost in rrf_merge) is not
     yet threaded into recall(). Future slice: add boost_types to
     RecallConfig or recall() signature.
-  • Hook embeds the prompt TWICE per invocation: once via embed() for
-    the known-unknown gate, once via server._embed_query inside recall().
-    Future slice: expose query_embedding from recall() to eliminate the
-    redundant call.
+  • Hook used to embed the prompt TWICE per invocation. Resolved by #508:
+    embed() for the known-unknown gate now passes query_embedding into
+    recall(), which skips its internal _embed_query(). Single Voyage API
+    call per invocation.
 """
 
 import asyncio
@@ -445,10 +445,8 @@ def main():
     # Embed and rewrite run in parallel — both are network-bound.
     # embed() result feeds the known-unknown gate (Phase 7.3 widening).
     # rewrite_prompt() result feeds the header note (entities display).
-    # Note: recall() does its own embed internally for the search RPCs.
-    # The double embed is a known inefficiency (#499 divergence); future
-    # slice: expose query_embedding from recall() to eliminate the redundant
-    # embed() call here.
+    # The embed() result is now passed into recall() via query_embedding,
+    # eliminating the pre-#508 double-embed overhead.
     with ThreadPoolExecutor(max_workers=2) as ex:
         fut_embed = ex.submit(embed, prompt)
         fut_rewrite = ex.submit(rewrite_prompt, prompt)
@@ -494,6 +492,7 @@ def main():
                 boost_types=boost_types,
                 boost_multiplier=TYPE_BOOST_MULTIPLIER,
                 config=hook_config,
+                query_embedding=query_embedding,
             )
         )
     except Exception:


### PR DESCRIPTION
## Summary

- Added optional `query_embedding: list[float] | None = None` parameter to `recall()` in `mcp-memory/recall.py`
- When provided, `recall()` skips the internal `_embed_query()` call and uses the pre-computed embedding directly
- The UserPromptSubmit hook now passes its known-unknown gate embedding into `recall()`, cutting Voyage API calls per invocation from 2 to 1
- Updated hook docstring and inline comments to reflect the resolved double-embed
- No behavioral change for existing callers (MCP server handler, eval harness)

Closes #508

## Test plan

- [x] `test_recall_orchestrator.py` — all 7 pass
- [x] `test_memory_recall_hook.py` — all 97 pass