### PR TITLE
fix(installer): move pruned orphan skills outside skills/ dir

### DIFF
--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -512,25 +512,33 @@ def build_plan(
                     note=f"include={include}" if include else "",
                 )
             )
-            # Orphan cleanup (#576): if the entry pins an `include` whitelist
+            # Orphan cleanup (#576 #927): if the entry pins an `include` whitelist
             # and the destination already exists, anything under dest not in
             # the whitelist is a leftover from a previous install whose
-            # source/manifest no longer lists it. Quarantine each leftover.
-            # Skip names containing `.bak.orphan` — they're already quarantined
-            # from a prior install; re-quarantining grows the suffix chain
-            # unboundedly (foo.bak.orphan → foo.bak.orphan.bak.orphan → ...).
+            # source/manifest no longer lists it. Move each leftover to a
+            # `.skills-orphaned/` sibling OUTSIDE the skills dir so the skill
+            # loader never picks it up (naming it .bak.orphan inside skills/
+            # was the original bug — Claude Code loads any subdir regardless
+            # of suffix).
+            # Skip names containing `.bak.` — leftovers from the old naming
+            # scheme; the suffix chain guard still prevents re-quarantine.
             if include and dest.exists() and dest.is_dir():
+                orphan_dir = dest.parent / ".skills-orphaned"
                 allowed = set(include)
                 for child in sorted(dest.iterdir()):
                     if child.name in allowed:
                         continue
                     if ".bak." in child.name:
                         continue
+                    orphan_dest = orphan_dir / child.name
+                    if orphan_dest.exists():
+                        stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+                        orphan_dest = orphan_dir / f"{child.name}-{stamp}"
                     actions.append(
                         Action(
                             kind="prune_orphan",
                             source=str(child),
-                            dest=str(_backup_dest(child, "orphan")),
+                            dest=str(orphan_dest),
                             group=gid,
                             note=f"absent from {entry['dest']} include whitelist",
                         )
@@ -821,11 +829,13 @@ def apply_plan(
         elif action.kind == "prune_orphan":
             src = Path(action.source)
             dst = Path(action.dest)
-            # `dst` was computed at plan time; recompute if a sibling backup
-            # has appeared since (rare race during long installs).
+            # dst was computed at plan time; recompute if a collision appeared
+            # since (rare race during long installs).
             if dst.exists():
-                dst = _backup_dest(src, "orphan")
+                stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+                dst = dst.parent / f"{dst.name}-{stamp}"
             if src.exists():
+                dst.parent.mkdir(parents=True, exist_ok=True)
                 src.rename(dst)
                 print(f"quarantined orphan {src} -> {dst}", file=sys.stderr)
         elif action.kind == "register_mcp_user":

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -338,13 +338,16 @@ def test_build_plan_emits_prune_orphan_for_stale_skill_dir(
     orphans = [a for a in plan.actions if a.kind == "prune_orphan"]
     assert len(orphans) == 1
     assert Path(orphans[0].source).name == "deprecated-skill"
-    assert ".bak.orphan" in orphans[0].dest
+    # dest must land in .skills-orphaned/ OUTSIDE skills/ (#927)
+    dest = Path(orphans[0].dest)
+    assert dest.parent == target / ".skills-orphaned"
+    assert dest.name == "deprecated-skill"
 
 
 def test_apply_plan_quarantines_orphan_skill(
     manifest: Path, fake_repo: Path, tmp_path: Path
 ) -> None:
-    """apply_plan moves orphan dir to a quarantine sibling, doesn't delete."""
+    """apply_plan moves orphan dir to .skills-orphaned/ outside skills/, not a sibling rename."""
     m = installer.load_manifest(manifest)
     installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
     target = tmp_path / "claude_home"
@@ -357,9 +360,12 @@ def test_apply_plan_quarantines_orphan_skill(
     installer.apply_plan(plan, m, run_env=None)
 
     assert not orphan_dir.exists(), "orphan should have been moved out of skills/"
-    quarantined = list((target / "skills").glob("deprecated-skill.bak.orphan*"))
-    assert len(quarantined) == 1
-    assert (quarantined[0] / "SKILL.md").read_text(encoding="utf-8") == "# stale\n"
+    # Must land in .skills-orphaned/ — NOT inside skills/ (#927)
+    quarantined = target / ".skills-orphaned" / "deprecated-skill"
+    assert quarantined.exists(), ".skills-orphaned/deprecated-skill must exist"
+    assert (quarantined / "SKILL.md").read_text(encoding="utf-8") == "# stale\n"
+    # No .bak.orphan remnant inside skills/
+    assert not list((target / "skills").glob("deprecated-skill*"))
     # Whitelisted skill still present.
     assert (target / "skills" / "implement" / "SKILL.md").exists()
 
@@ -477,6 +483,31 @@ def test_existing_bak_orphan_is_not_re_quarantined(
     assert "dnd-prep.bak.orphan-20260516-120000" not in orphan_sources, (
         "timestamped quarantine variant must also be skipped"
     )
+
+
+def test_prune_orphan_dest_is_outside_skills_dir(
+    manifest: Path, fake_repo: Path, tmp_path: Path
+) -> None:
+    """Orphan dest must be outside skills/ so the skill loader ignores it (#927).
+
+    The original bug: dest was computed with path.with_name() which stays inside
+    skills/ — Claude Code loads any subdir there regardless of suffix.
+    """
+    m = installer.load_manifest(manifest)
+    installer.apply_plan(installer.build_plan(m, fake_repo), m, run_env=None)
+    target = tmp_path / "claude_home"
+    (target / "skills" / "stale-skill").mkdir()
+    (target / ".jarvis-version").write_text("old-sha\n", encoding="utf-8")
+
+    plan = installer.build_plan(m, fake_repo)
+    orphans = [a for a in plan.actions if a.kind == "prune_orphan"]
+    assert len(orphans) == 1
+    dest = Path(orphans[0].dest)
+    skills_dir = target / "skills"
+    assert skills_dir not in dest.parents, (
+        f"orphan dest {dest} must not be inside skills/ — skill loader picks it up"
+    )
+    assert dest.parent == target / ".skills-orphaned"
 
 
 def test_disabled_group_is_skipped(manifest: Path, fake_repo: Path) -> None:


### PR DESCRIPTION
## Summary

`prune_orphan` was renaming orphaned skill dirs to `skills/foo.bak.orphan` — still inside `skills/`. Claude Code loads any subdirectory there regardless of suffix, so removed skills kept appearing as loadable slash-commands. Fixed by moving orphans to `~/.claude/.skills-orphaned/foo` (created on demand), which the skill loader never scans.

## Why

Closes #927

Skills deleted from the install manifest (e.g. `grill-me`, `analyze-comms`, `tdd`) were still visible and invokable after `install.ps1 -Apply` because `prune_orphan` only renamed them in-place inside `skills/`. The skip guard `if ".bak." in child.name` prevented re-quarantine on subsequent installs, leaving them permanent.

## Decisions & Alternatives

- **Chose sibling dir `.skills-orphaned/`** rather than changing `_backup_dest` (which would affect MCP quarantine paths too). Keeps the two concerns separate.
- **Kept `.bak.` skip guard** for backward compat — old `.bak.orphan` dirs from previous installs that are still inside `skills/` are still skipped; they must be manually deleted (as was done in this session).
- **Alternative rejected**: moving to `~/.claude/.orphaned/` — less obvious what the contents are; `.skills-orphaned/` is self-documenting.

## Risk Assessment

- **LOW**: installer-only change; affects where orphaned dirs land after apply. Whitelisted skills and all other install groups unaffected. Backward compat preserved for pre-existing `.bak.orphan` dirs.

## Testing

- `pytest tests/test_installer.py -x -q` → 79/79 passed
- Updated 2 existing tests (`test_build_plan_emits_prune_orphan_for_stale_skill_dir`, `test_apply_plan_quarantines_orphan_skill`) to assert dest is in `.skills-orphaned/`
- Added 1 new test (`test_prune_orphan_dest_is_outside_skills_dir`) asserting dest parent is never inside `skills/`

## Files Changed

- `scripts/install/installer.py` — plan-side: compute orphan dest in `.skills-orphaned/` sibling; apply-side: add `mkdir(parents=True, exist_ok=True)` + fix collision recompute
- `tests/test_installer.py` — update 2 tests + add 1 new regression test