### PR TITLE
fix(ci): gitleaks required check must run on every PR

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,11 +1,15 @@
 name: Gitleaks Secret Scanning
 
+# NOTE: `Detect secrets with gitleaks` is a REQUIRED status check. A required
+# check MUST NOT be path-filtered on `pull_request`: when paths-ignore skips
+# the run (e.g. a docs-only or empty-diff PR), GitHub holds the required
+# context at "Expected — waiting for status" and the PR is permanently BLOCKED
+# even with every other gate green (this stalled PR #894). So the PR trigger
+# runs unconditionally. The `push` trigger keeps its filter — it isn't a merge
+# gate, and a secret scan on every doc commit to main is wasted minutes.
+# See memory: stuck_automerge_rootcause_taxonomy (case 3); decision da8b97e4.
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.gitignore'
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem

`Detect secrets with gitleaks` is a **required** status check, but `gitleaks.yml` was path-filtered (`paths-ignore: **/*.md, docs/**, .gitignore`) on `pull_request`. When a PR's diff is empty or docs-only, the path filter skips the run — and GitHub then holds the required context at "Expected — waiting for status" **forever**, so the PR is permanently `BLOCKED` even with every other gate green.

This stalled PR #894 (empty-diff duplicate, all 5 other checks green, stuck `BLOCKED`). It is the third independent stuck-auto-merge root cause from the 24-PR jam RCA, alongside strict-mode batch serialization (#891) and GITHUB_TOKEN anti-recursion.

## Fix

Drop `paths-ignore` from the `pull_request` trigger so the required check always reports. The `push`-to-`main` trigger keeps its filter (it isn't a merge gate, and scanning every doc commit to `main` is wasted minutes). A secret scanner has no reason to skip docs-only PRs anyway — secrets can appear in docs.

## Why no linked issue

Trivial, reversible, scope-obvious config fix in our own repo (`Fix > track`, #428). The rationale is recorded as decision `da8b97e4` and memory `stuck_automerge_rootcause_taxonomy`.

[no-issue]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
