### PR TITLE
feat(ci): merge-train auto-updates stale auto-merge PRs (#891 residual)

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -1,0 +1,156 @@
+name: Merge Train
+
+# Auto-updates stale auto-merge PRs so strict branch protection can let them
+# merge. Background (memory: stuck_automerge_rootcause_taxonomy):
+#
+#   With branch protection `strict: true` (branch must be up to date with base)
+#   and NO merge queue (unavailable on personal-account repos), any PR that
+#   falls BEHIND `main` never auto-updates — so auto-merge never fires and PRs
+#   pile up serialized behind `main`. On 2026-06-03 this jammed 24 PRs (#891).
+#
+# This workflow is the portable replacement for a merge queue: on every push to
+# `main` (cascade) and on a schedule (cold-start / self-heal), it finds stale
+# auto-merge PRs and calls the update-branch API on them.
+#
+# CRITICAL — why a GitHub App token, not GITHUB_TOKEN:
+#   A branch update performed with the default GITHUB_TOKEN does NOT create new
+#   workflow runs (GitHub recursion prevention). The required checks would then
+#   sit at "Expected — waiting for status" forever and auto-merge would still
+#   stall. The update must be pushed by a non-GITHUB_TOKEN credential. We use a
+#   dedicated GitHub App ("jarvis-ci") installation token, minted per-run.
+#   Decision: 2ccfa29a (no PAT, per #891).
+#
+# Portability: references ${{ github.repository }} only — no hardcoded
+# owner/repo/paths. Works on private repos (redrobot) once the App is installed.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Cold-start / self-heal: catches PRs that settled to BEHIND with no
+    # subsequent push, and recovers a cascade that broke mid-chain.
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+# One train per repo at a time. Don't cancel an in-flight run — a cancelled
+# self-heal tick could drop a PR that needed updating.
+concurrency:
+  group: merge-train-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  update-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert App credentials present
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APP_ID}" ] || [ -z "${APP_PRIVATE_KEY}" ]; then
+            echo "::error::merge-train requires the 'jarvis-ci' GitHub App, but APP_ID and/or APP_PRIVATE_KEY repo secrets are unset."
+            echo "Why: update-branch pushed by the default GITHUB_TOKEN does not re-trigger required checks (GitHub recursion prevention), so auto-merge stalls. A GitHub App installation token is required."
+            echo "Setup (one-time per repo):"
+            echo "  1. Create a GitHub App with permissions: Contents=Read&write, Pull requests=Read&write."
+            echo "  2. Install the App on this repository."
+            echo "  3. Add repo secrets: APP_ID (the App's numeric id) and APP_PRIVATE_KEY (the .pem private key)."
+            echo "Until then the merge train cannot run on this repo."
+            exit 1
+          fi
+          echo "App credentials present."
+
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Update stale auto-merge PR branches
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.event.repository.default_branch }}
+          CAP: "10"
+        run: |
+          set -euo pipefail
+
+          # Candidate PRs: open, non-draft, auto-merge enabled, not parked for
+          # the owner. Sorted oldest-first (FIFO — deterministic, no starvation).
+          mapfile -t candidates < <(
+            gh pr list --repo "$REPO" --state open \
+              --json number,isDraft,autoMergeRequest,labels,createdAt \
+              --jq 'sort_by(.createdAt) | .[]
+                    | select(.isDraft | not)
+                    | select(.autoMergeRequest != null)
+                    | select([.labels[].name] | index("status:owner-queue") | not)
+                    | .number'
+          )
+
+          if [ "${#candidates[@]}" -eq 0 ]; then
+            echo "::notice::No eligible auto-merge PRs. Nothing to do."
+            exit 0
+          fi
+
+          echo "Candidates (oldest-first): ${candidates[*]}"
+          updated=0
+
+          for n in "${candidates[@]}"; do
+            if [ "$updated" -ge "$CAP" ]; then
+              echo "::notice::Update cap ($CAP) reached; remaining stale PRs will be picked up on the next run."
+              break
+            fi
+
+            # Mergeability is computed asynchronously; right after a push it is
+            # often UNKNOWN. Poll a few times (gh pr view forces computation)
+            # before trusting the verdict — otherwise we'd skip everything.
+            ms="UNKNOWN"; mg="UNKNOWN"
+            for _try in 1 2 3 4 5; do
+              read -r ms mg < <(
+                gh pr view "$n" --repo "$REPO" --json mergeStateStatus,mergeable \
+                  --jq '"\(.mergeStateStatus) \(.mergeable)"'
+              )
+              if [ "$ms" != "UNKNOWN" ] && [ "$mg" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 5
+            done
+
+            has_label="$(gh pr view "$n" --repo "$REPO" --json labels --jq '[.labels[].name] | index("needs-rebase") != null')"
+
+            if [ "$mg" = "CONFLICTING" ] || [ "$ms" = "DIRTY" ]; then
+              # Can't fast-forward — surface for manual rebase, skip, continue.
+              gh label create needs-rebase --repo "$REPO" \
+                --color D93F0B --description "Branch conflicts with base; needs a manual rebase" >/dev/null 2>&1 || true
+              if [ "$has_label" != "true" ]; then
+                gh pr edit "$n" --repo "$REPO" --add-label needs-rebase >/dev/null
+                gh pr comment "$n" --repo "$REPO" --body \
+                  "🚆 merge-train: this branch conflicts with \`$BASE_REF\` and can't be fast-forwarded, so auto-merge is stuck. Rebase/resolve conflicts and the train will pick it up automatically once it's mergeable. (auto-applied \`needs-rebase\`)"
+              fi
+              echo "::notice::#$n is CONFLICTING — labelled needs-rebase, skipped."
+              continue
+            fi
+
+            # No longer conflicting but still carrying a stale label → clear it.
+            if [ "$has_label" = "true" ]; then
+              gh pr edit "$n" --repo "$REPO" --remove-label needs-rebase >/dev/null 2>&1 || true
+              echo "::notice::#$n no longer conflicting — removed stale needs-rebase label."
+            fi
+
+            if [ "$ms" = "BEHIND" ]; then
+              if gh api --method PUT "repos/$REPO/pulls/$n/update-branch" >/dev/null 2>&1; then
+                echo "::notice::#$n was BEHIND — branch updated (checks will re-run, then auto-merge)."
+                updated=$((updated + 1))
+              else
+                echo "::warning::#$n update-branch call failed (race or permissions); will retry next run."
+              fi
+            else
+              echo "::debug::#$n mergeStateStatus=$ms — no update needed."
+            fi
+          done
+
+          echo "::notice::merge-train finished — $updated branch(es) updated this run."

--- a/tests/ci/test_merge_train_guard.py
+++ b/tests/ci/test_merge_train_guard.py
@@ -1,0 +1,214 @@
+"""Meta-test for .github/workflows/merge-train.yml.
+
+Reimplements the merge-train's PR-selection rule in Python and asserts it
+picks/excludes the PRs the workflow promises, plus a config dimension that
+keeps the YAML and this test in lockstep.
+
+Why this test exists (CLAUDE.md §326): merge-train.yml is NOT path-filtered,
+so #326's *config* mandate doesn't strictly apply. But the selection rule is
+exactly the silent-drift class #326 targets — a wrong filter would quietly
+update the wrong PRs (or none) with no red signal. The *logic* dimension is
+worth a sibling test even though the path-filter dimension is N/A.
+
+Selection rule mirrored here (see the `--jq` filter + bash loop in the YAML):
+  candidate  = open AND not draft AND auto-merge enabled AND no
+               `status:owner-queue` label, sorted oldest-first (createdAt asc)
+  conflict   = candidate whose mergeable==CONFLICTING or mergeStateStatus==DIRTY
+               -> labelled needs-rebase, skipped (never updated)
+  update     = candidate whose mergeStateStatus==BEHIND -> update-branch,
+               capped at CAP (default 10), oldest-first
+  other      = candidate in any other state -> left alone
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "merge-train.yml"
+)
+
+CAP = 10
+
+
+def _is_candidate(pr: dict) -> bool:
+    """Open + non-draft + auto-merge-enabled + not owner-parked."""
+    if pr.get("isDraft"):
+        return False
+    if not pr.get("autoMerge"):
+        return False
+    if "status:owner-queue" in pr.get("labels", []):
+        return False
+    return True
+
+
+def select(prs: list[dict], cap: int = CAP) -> tuple[list[int], list[int]]:
+    """Mirror the workflow's selection rule.
+
+    Returns (to_update, to_flag_conflict) as lists of PR numbers, oldest-first.
+    """
+    candidates = sorted(
+        (p for p in prs if _is_candidate(p)),
+        key=lambda p: p["createdAt"],
+    )
+
+    to_update: list[int] = []
+    to_flag_conflict: list[int] = []
+
+    for pr in candidates:
+        ms = pr.get("mergeStateStatus")
+        mg = pr.get("mergeable")
+        if mg == "CONFLICTING" or ms == "DIRTY":
+            to_flag_conflict.append(pr["number"])
+            continue
+        if ms == "BEHIND" and len(to_update) < cap:
+            to_update.append(pr["number"])
+        # any other state (CLEAN / BLOCKED / UNSTABLE / UNKNOWN) -> left alone
+
+    return to_update, to_flag_conflict
+
+
+def _pr(number, *, created, draft=False, auto=True, ms="BEHIND", mg="MERGEABLE", labels=None):
+    return {
+        "number": number,
+        "createdAt": created,
+        "isDraft": draft,
+        "autoMerge": auto,
+        "mergeStateStatus": ms,
+        "mergeable": mg,
+        "labels": labels or [],
+    }
+
+
+# ---- logic dimension --------------------------------------------------------
+
+
+def test_picks_behind_auto_prs_oldest_first():
+    prs = [
+        _pr(3, created="2026-06-03"),
+        _pr(1, created="2026-06-01"),
+        _pr(2, created="2026-06-02"),
+    ]
+    to_update, conflicts = select(prs)
+    assert to_update == [1, 2, 3], "must update oldest-first"
+    assert conflicts == []
+
+
+def test_draft_excluded():
+    prs = [_pr(1, created="2026-06-01", draft=True)]
+    assert select(prs) == ([], [])
+
+
+def test_non_auto_merge_excluded():
+    prs = [_pr(1, created="2026-06-01", auto=False)]
+    assert select(prs) == ([], [])
+
+
+def test_owner_queue_label_excluded():
+    prs = [_pr(1, created="2026-06-01", labels=["status:owner-queue"])]
+    assert select(prs) == ([], [])
+
+
+def test_owner_queue_excluded_even_with_other_labels():
+    prs = [_pr(1, created="2026-06-01", labels=["bug", "status:owner-queue"])]
+    assert select(prs) == ([], [])
+
+
+def test_conflicting_goes_to_flag_not_update():
+    prs = [_pr(1, created="2026-06-01", mg="CONFLICTING")]
+    to_update, conflicts = select(prs)
+    assert to_update == []
+    assert conflicts == [1]
+
+
+def test_dirty_state_treated_as_conflict():
+    prs = [_pr(1, created="2026-06-01", ms="DIRTY", mg="UNKNOWN")]
+    to_update, conflicts = select(prs)
+    assert to_update == []
+    assert conflicts == [1]
+
+
+def test_non_behind_states_left_alone():
+    for state in ("CLEAN", "BLOCKED", "UNSTABLE", "UNKNOWN", "HAS_HOOKS"):
+        prs = [_pr(1, created="2026-06-01", ms=state)]
+        to_update, conflicts = select(prs)
+        assert to_update == [], f"{state} must not be force-updated"
+        assert conflicts == []
+
+
+def test_empty_set_no_pick():
+    assert select([]) == ([], [])
+
+
+def test_cap_enforced():
+    prs = [_pr(n, created=f"2026-06-{n:02d}") for n in range(1, 16)]  # 15 BEHIND
+    to_update, _ = select(prs, cap=10)
+    assert len(to_update) == 10
+    assert to_update == list(range(1, 11)), "cap keeps the 10 oldest"
+
+
+def test_conflicts_do_not_consume_cap():
+    # 10 conflicting (flagged, not updated) + 2 behind -> both behind get updated.
+    prs = [_pr(n, created=f"2026-06-{n:02d}", mg="CONFLICTING") for n in range(1, 11)]
+    prs += [_pr(11, created="2026-06-11"), _pr(12, created="2026-06-12")]
+    to_update, conflicts = select(prs, cap=10)
+    assert to_update == [11, 12]
+    assert len(conflicts) == 10
+
+
+def test_mixed_realistic_set():
+    prs = [
+        _pr(1, created="2026-06-01", ms="BEHIND"),                       # update
+        _pr(2, created="2026-06-02", draft=True),                        # excluded (draft)
+        _pr(3, created="2026-06-03", auto=False),                        # excluded (no auto)
+        _pr(4, created="2026-06-04", mg="CONFLICTING"),                  # conflict
+        _pr(5, created="2026-06-05", labels=["status:owner-queue"]),     # excluded (parked)
+        _pr(6, created="2026-06-06", ms="CLEAN"),                        # left alone
+        _pr(7, created="2026-06-07", ms="BEHIND"),                       # update
+    ]
+    to_update, conflicts = select(prs)
+    assert to_update == [1, 7]
+    assert conflicts == [4]
+
+
+# ---- config dimension (keep YAML and test in lockstep) ----------------------
+
+
+def test_workflow_exists():
+    assert WORKFLOW_PATH.is_file(), "merge-train.yml missing"
+
+
+def test_workflow_uses_app_token_not_github_token():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "create-github-app-token" in text, (
+        "merge-train must mint a GitHub App token — GITHUB_TOKEN-pushed "
+        "updates do not re-trigger required checks (recursion prevention)."
+    )
+
+
+def test_workflow_filters_match_selection_rule():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    for token in ("isDraft", "autoMergeRequest", "status:owner-queue", "BEHIND", "update-branch"):
+        assert token in text, f"merge-train.yml no longer references {token!r}; selection rule drifted from this test."
+
+
+def test_workflow_has_concurrency_guard():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "concurrency:" in text and "cancel-in-progress: false" in text, (
+        "merge-train must serialize per-repo without cancelling in-flight self-heal runs."
+    )
+
+
+def test_workflow_flags_conflicts_with_needs_rebase():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "needs-rebase" in text, "conflict handling (needs-rebase label) drifted."
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem (the #891 residual)

#891's layer-1 (`auto-merge-enable.yml`, shipped in #892) enables auto-merge on green PRs — but with branch protection `strict: true` (branch must be up to date with base) and **no merge queue** (unavailable on personal-account repos), any PR that falls BEHIND `main` never auto-updates, so auto-merge never fires. PRs serialize behind `main`. On 2026-06-03 this jammed **24 PRs**. #891's body explicitly names "a push-triggered train-updater" as the fuller fix — this is it.

## Fix — merge-train (portable replacement for a merge queue)

`.github/workflows/merge-train.yml`: on push-to-`main` (cascade) + a `*/15` schedule (cold-start / self-heal), find open non-draft auto-merge PRs that aren't owner-parked, oldest-first, and call `update-branch` on the BEHIND ones (cap 10/run). Once updated, a PR's checks re-run and it auto-merges; the resulting push to `main` triggers the next cascade.

- **CONFLICTING** PRs → `needs-rebase` label + one comment, skipped (self-clears when resolved).
- **mergeStateStatus=UNKNOWN** (async after a push) → polled before filtering, so the push trigger isn't decorative.
- **Cap 10/run** → drains a big jam in waves without rate-limit risk.

### Why a GitHub App token, not GITHUB_TOKEN

An `update-branch` pushed by the default `GITHUB_TOKEN` does **not** create new workflow runs (GitHub recursion prevention). Required checks would then sit at "Expected — waiting for status" forever and auto-merge would still stall — re-creating the jam. The update must be pushed by a non-`GITHUB_TOKEN` credential. We mint a short-lived **GitHub App** installation token per run (honors #891's "no PAT"; amortizes to the reactive-core executor which will also need repo write).

## ⚠️ Owner action required before this can merge (draft until done)

This workflow **fails loudly** until the `jarvis-ci` GitHub App is provisioned. One-time setup:

1. Create a GitHub App: permissions **Contents: Read & write**, **Pull requests: Read & write**.
2. Install it on this repo (and on `redrobot` for the universal-CI rollout).
3. Add repo secrets: `APP_ID` (numeric app id) and `APP_PRIVATE_KEY` (the `.pem`).
4. Add `merge-train` is **not** a required check — leave branch protection as-is.

Then flip this PR to ready; it merges through the normal gates.

## Tests

`tests/ci/test_merge_train_guard.py` — reimplements the selection rule (oldest-first FIFO, draft/owner-queue/non-auto/conflicting exclusion, cap, empty-set) + config-dimension assertions that keep the YAML in lockstep. 17/17 green locally; full `tests/ci` suite 325 passed.

## Grill / decisions

Grilled (sampling-tier cold critic at AC-lock): caught the GITHUB_TOKEN re-trigger trap, the UNKNOWN-after-push window, and the one-vs-all throughput fork (resolved → all-eligible cap 10). Strict mode re-affirmed over drop-strict (competing-refactor-stack incident = real semantic-conflict risk).

Decisions: `a136acc9` (train-updater over merge queue — merge queue unavailable on personal accounts), `2ccfa29a` (GitHub App token over PAT).

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)
