### PR TITLE
fix(sandcastle): honor completion signal + enrich watchdog failure diagnostics

### DIFF
--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -478,6 +478,63 @@ function Format-RedactedError {
     return ($Message -replace [regex]::Escape($Secret), '<TOKEN-REDACTED>')
 }
 
+# Sandcastle tagged-error classes (node_modules/@ai-hero/sandcastle/dist/errors.js).
+# The orchestrate() loop returns cleanly on every *normal* termination (no
+# commits, no completion signal, max iterations all return a result). The only
+# way `npm run sandcastle` exits non-zero is one of these throwing -- so a
+# nightly `exit=1` is always a real crash, never a benign "nothing to do".
+# Surfacing the class into the outcome turns an opaque exit code into an
+# actionable signal (idle-timeout vs worktree-teardown vs API error) without
+# needing the Workshop-disk run.log. Order: most specific first (substring-safe
+# anyway, matches are on the literal class token).
+$script:SandcastleErrorClasses = @(
+    'AgentIdleTimeoutError', 'ContainerStartTimeoutError', 'MergeToHostTimeoutError',
+    'WorktreeError', 'DockerError', 'SyncError', 'SessionCaptureError',
+    'PromptError', 'AgentError', 'ExecError'
+)
+
+function Get-LogTail {
+    # Last N non-empty lines of the run.log -- the tail carries the thrown
+    # tagged-error stack from `npm run sandcastle`. Guards a missing/locked file
+    # (returns '') so the failure path never crashes while reporting a failure.
+    [CmdletBinding()]
+    param([string]$LogFile, [int]$Lines = 12)
+    if (-not $LogFile -or -not (Test-Path -LiteralPath $LogFile)) { return '' }
+    try {
+        $all = @(Get-Content -LiteralPath $LogFile -Encoding utf8 -ErrorAction Stop |
+            Where-Object { $_.Trim() })
+    } catch { return '' }
+    if (-not $all.Count) { return '' }
+    ($all | Select-Object -Last $Lines) -join "`n"
+}
+
+function Get-SandcastleErrorClass {
+    # First known tagged-error class mentioned in $Text (reason + log tail), or ''.
+    [CmdletBinding()]
+    param([string]$Text)
+    if (-not $Text) { return '' }
+    foreach ($cls in $script:SandcastleErrorClasses) {
+        if ($Text -match [regex]::Escape($cls)) { return $cls }
+    }
+    return ''
+}
+
+function Protect-LogTail {
+    # Defense-in-depth before a container log tail reaches Supabase: strip any
+    # known literal secrets, then redact generic token shapes by pattern. The
+    # agent is instructed never to print secrets, but a crash tail is untrusted.
+    [CmdletBinding()]
+    param([string]$Text, [string[]]$Secrets = @())
+    if (-not $Text) { return '' }
+    foreach ($s in $Secrets) {
+        if ($s) { $Text = $Text -replace [regex]::Escape($s), '<SECRET-REDACTED>' }
+    }
+    $Text = $Text -replace 'gh[pousr]_[A-Za-z0-9]{20,}', '<GH-TOKEN-REDACTED>'
+    $Text = $Text -replace 'github_pat_[A-Za-z0-9_]{20,}', '<GH-TOKEN-REDACTED>'
+    $Text = $Text -replace 'sk-ant-[A-Za-z0-9\-_]{20,}', '<ANTHROPIC-KEY-REDACTED>'
+    return $Text
+}
+
 function Send-TelegramAlert {
     [CmdletBinding()]
     param(
@@ -928,6 +985,7 @@ function Invoke-Watchdog {
     $branch = $null
     $iter = 0
     $partialReason = $null
+    $queueDrained = $false     # agent emitted the completion signal (queue empty)
     $tierCompleted = $null    # 'tier0' | 'tier1' | 'tier2:deepseek' | 'tier2:claude'
 
     while ($iter -lt $MaxIterations) {
@@ -992,6 +1050,12 @@ function Invoke-Watchdog {
 
         if (-not $invocation.ok) {
             $reason = if ($invocation.reason) { $invocation.reason } else { "exit=$($invocation.exitCode)" }
+            # Diagnose the crash from the run.log tail so a nightly `exit=1` is
+            # actionable from Supabase alone (the Workshop run.log is not
+            # reachable from the orchestrator host). Redact before persisting.
+            $logTail  = Get-LogTail -LogFile $logFile
+            $errClass = Get-SandcastleErrorClass -Text "$reason`n$logTail"
+            $logTail  = Protect-LogTail -Text $logTail -Secrets @($supabaseKey, $supabaseUrl, $tgToken)
             # Full chain failure: label the issue if we know which one was attempted.
             $labelApplied = $false
             if ($targetIssue -and $repoSlug) {
@@ -999,7 +1063,10 @@ function Invoke-Watchdog {
             }
             $totalUsage.tier = $tierUsed
             $totalUsage.too_large_for_local = $labelApplied
-            Record 'failure' "sandcastle invocation failed: $reason (tier=$tierUsed issue=$targetIssue label=$labelApplied)" $totalUsage $reason
+            if ($errClass) { $totalUsage.error_class = $errClass }
+            if ($logTail)  { $totalUsage.diag_tail   = $logTail }
+            $classNote = if ($errClass) { " class=$errClass" } else { '' }
+            Record 'failure' "sandcastle invocation failed: $reason (tier=$tierUsed issue=$targetIssue label=$labelApplied)$classNote" $totalUsage $reason
             throw "sandcastle invocation failed: $reason"
         }
 
@@ -1022,6 +1089,21 @@ function Invoke-Watchdog {
                 $totalUsage.cache_read_input_tokens    += [int]$it.usage.cacheReadInputTokens
                 $totalUsage.cache_creation_input_tokens+= [int]$it.usage.cacheCreationInputTokens
             }
+        }
+
+        # Honor the agent's completion signal (prompt.md §Done): it fires only
+        # when the AFK queue is drained -- nothing left to pick. Re-invoking on
+        # an empty queue is pure downside: wasted runs plus a fresh crash surface
+        # (e.g. an idle-timeout while the model sits on an empty queue), and a
+        # crash on any redundant iteration would overwrite this night's verdict
+        # with a spurious `failure` and discard the work already done. Stop here
+        # and let the success path record the run. (A flaky model that emits the
+        # signal early loses at most one extra issue this night; tomorrow's run
+        # picks it back up -- far cheaper than the manufactured-failure cascade.)
+        if ($r.completionSignal) {
+            $queueDrained = $true
+            Write-Host "[watchdog] agent signaled queue drained after iteration $iter -- stopping early."
+            break
         }
     }
 
@@ -1054,7 +1136,7 @@ function Invoke-Watchdog {
             Write-SandcastleDecisionMemory `
                 -SupabaseUrl $supabaseUrl -SupabaseKey $supabaseKey `
                 -Project 'redrobot' `
-                -Name "pytest-gate:$pytestReason:$branch" `
+                -Name "pytest-gate:${pytestReason}:$branch" `
                 -Description "pytest gate blocked sandcastle PR on $branch ($pytestReason)" `
                 -Content "Sandcastle run $runId blocked PR on branch $branch for redrobot. Reason: $pytestReason. $($pytestResult.summary)" `
                 -RunId $runId
@@ -1073,7 +1155,14 @@ function Invoke-Watchdog {
         return
     }
 
-    $summary = "success -- branch=$branch iterations=$iter commits=$($allCommits.Count)"
+    if ($queueDrained -and $allCommits.Count -eq 0) {
+        # Clean "nothing to do" heartbeat -- the queue was empty/all-attempted.
+        # Recorded as success (the run worked), not failure, so it neither
+        # pollutes the outcome log nor masks real crashes.
+        $summary = "success:idle -- queue drained, no eligible issues (iterations=$iter)"
+    } else {
+        $summary = "success -- branch=$branch iterations=$iter commits=$($allCommits.Count)"
+    }
     Record 'success' $summary $totalUsage ''
     Write-Host "[watchdog] $summary"
 }

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -187,6 +187,72 @@ Describe 'Format-RedactedError' {
     }
 }
 
+Describe 'Get-SandcastleErrorClass' {
+    It 'detects an idle-timeout crash' {
+        Get-SandcastleErrorClass -Text 'foo AgentIdleTimeoutError: idle 600s' |
+            Should Be 'AgentIdleTimeoutError'
+    }
+    It 'detects a worktree-teardown crash' {
+        Get-SandcastleErrorClass -Text 'WorktreeError: git worktree remove failed' |
+            Should Be 'WorktreeError'
+    }
+    It 'does not confuse AgentIdleTimeoutError for the generic AgentError' {
+        Get-SandcastleErrorClass -Text 'AgentIdleTimeoutError thrown' |
+            Should Be 'AgentIdleTimeoutError'
+    }
+    It 'returns empty when no known class is present' {
+        Get-SandcastleErrorClass -Text 'random failure exit=1' | Should Be ''
+    }
+    It 'returns empty on empty input' {
+        Get-SandcastleErrorClass -Text '' | Should Be ''
+    }
+}
+
+Describe 'Protect-LogTail' {
+    It 'redacts a known literal secret' {
+        $out = Protect-LogTail -Text 'before SUPER-SECRET-VALUE after' -Secrets @('SUPER-SECRET-VALUE')
+        $out | Should Not Match 'SUPER-SECRET-VALUE'
+        $out | Should Match 'SECRET-REDACTED'
+    }
+    It 'redacts a GitHub token shape by pattern (no literal needed)' {
+        # Built at runtime so the token shape never appears as a source literal
+        # (keeps gitleaks quiet on the test file itself).
+        $tok = 'ghp_' + ('a' * 36)
+        $out = Protect-LogTail -Text "stderr: auth $tok rejected"
+        $out | Should Not Match 'ghp_a'
+        $out | Should Match 'GH-TOKEN-REDACTED'
+    }
+    It 'redacts an Anthropic key shape by pattern' {
+        $tok = 'sk-ant-' + ('x' * 24)
+        $out = Protect-LogTail -Text "key=$tok"
+        $out | Should Not Match 'sk-ant-x'
+        $out | Should Match 'ANTHROPIC-KEY-REDACTED'
+    }
+    It 'returns empty string on empty input' {
+        Protect-LogTail -Text '' | Should Be ''
+    }
+}
+
+Describe 'Get-LogTail' {
+    It 'returns empty string when the log file does not exist' {
+        Get-LogTail -LogFile (Join-Path $env:TEMP "no-such-$([guid]::NewGuid()).log") |
+            Should Be ''
+    }
+    It 'returns empty string when LogFile is blank' {
+        Get-LogTail -LogFile '' | Should Be ''
+    }
+    It 'returns the last N non-empty lines joined by newline' {
+        $f = Join-Path $env:TEMP "logtail-$([guid]::NewGuid()).log"
+        @('l1', '', 'l2', 'l3', '', 'l4') | Set-Content -LiteralPath $f -Encoding utf8
+        try {
+            $out = Get-LogTail -LogFile $f -Lines 2
+            $out | Should Be "l3`nl4"
+        } finally {
+            Remove-Item -LiteralPath $f -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 Describe 'Test-IsOOM' {
     It 'flags exit code 137 (Linux OOM-kill) without a log file' {
         Test-IsOOM -Reason 'exit=137' -LogFile '' | Should Be $true
@@ -895,6 +961,78 @@ Describe 'Invoke-Watchdog daemon-state matrix' {
                 $Status -eq 'partial' -and
                 $Summary -like '*window-expired*' -and
                 $Summary -like '*iterations=1*'
+            }
+    }
+
+    It 'stops looping early when the agent signals the queue is drained' {
+        # Completion signal (prompt.md §Done) => queue empty. The watchdog must
+        # NOT keep re-invoking on an empty queue (those redundant runs are the
+        # source of the spurious nightly `failure` rows). One invocation, then
+        # a clean success:idle heartbeat -- not five rolls of the crash dice.
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Test-WindowExpired { $false }   # isolate from leaked window mocks (Pester 3.4 It-scope leak)
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok = $true; exitCode = 0
+                result = [pscustomobject]@{
+                    branch           = $null
+                    commits          = @()
+                    completionSignal = '<promise>COMPLETE</promise>'
+                    iterations       = @()
+                }
+            }
+        }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 5 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle   -Times 1 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' -and $Summary -like '*success:idle*' }
+        Assert-MockCalled Send-TelegramAlert  -Times 0 -Exactly -Scope It
+    }
+
+    It 'does NOT stop early when a productive iteration omits the completion signal' {
+        # Regression guard for the multi-issue-per-night flow: an iteration that
+        # did work but left issues in the queue carries no completion signal, so
+        # the watchdog must run the full MaxIterations (one issue per iteration).
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Test-WindowExpired { $false }   # isolate from leaked window mocks (Pester 3.4 It-scope leak)
+        # BeforeEach mock returns a result WITHOUT completionSignal => no early stop.
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 3 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle   -Times 3 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' -and $Summary -notlike '*success:idle*' }
+    }
+
+    It 'enriches the failure outcome with the tagged-error class and a redacted log tail' {
+        # An opaque `exit=1` must arrive in Supabase carrying the crash class
+        # (so Worktree vs idle vs API is distinguishable) and a secret-scrubbed
+        # tail of the run.log.
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Test-WindowExpired { $false }   # isolate from leaked window mocks (Pester 3.4 It-scope leak)
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{ ok = $false; exitCode = 1; result = $null; reason = 'exit=1' }
+        }
+        Mock Get-LogTail {
+            "agent noise`nWorktreeError: git worktree remove failed: NTFS reparse point`ntrailing"
+        }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'm' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter {
+                $Status -eq 'failure' -and
+                $Summary -like '*class=WorktreeError*' -and
+                $LlmMetrics.error_class -eq 'WorktreeError' -and
+                $LlmMetrics.diag_tail -like '*WorktreeError*'
             }
     }
 }


### PR DESCRIPTION
## What

The redrobot sandcastle watchdog (`scripts/sandcastle/Run-Sandcastle.ps1`, cron `redrobot-watchdog-*`) recorded a `failure` outcome nearly every night. This diagnoses the cause and ships the watchdog-side fixes.

**Verdict: REAL crash, not a benign empty-queue no-op.** `@ai-hero/sandcastle`'s `run()`/`orchestrate()` returns cleanly on every no-work path (records success) and only exits non-zero on a tagged error (`WorktreeError`, `DockerError`, `AgentError`, …). So `exit=1` is always a genuine crash. The `issue=` blank in the failure string is a red herring — the run crashed before/around picking an issue, not because a label query found nothing.

## Two failure modes (from outcome `lessons` JSON, back to 2026-05-26)

- **Mode 2** (05-28, 05-31, 06-02) — non-zero tokens: a real DeepSeek agent session produced work, then `exit=1`. Leading hypothesis: **`WorktreeError` on teardown** (venv-in-bind-mount NTFS reparse hazard documented in `redrobot/.sandcastle/prompt.md`). Corroborated by ~20 `feat/784..813` redrobot slices dated 05-30/05-31.
- **Mode 1** (05-26, 06-03→06-07) — 0 tokens: agent never started, plausible cascade from a prior night's orphaned worktree/lock.

## Fixes

| | Fix | Effect |
|---|---|---|
| **A** | Honor `result.completionSignal` | Break the re-invoke loop on a drained queue; record `success:idle` instead of re-rolling. |
| **B** | Failure diagnostics | Every failure row now carries `error_class` + a **redacted** `diag_tail`. Names the real crash class next run, so real failures stop hiding behind generic `exit=1` rows. |
| **C** | Parse fix | `${pytestReason}` braces — the bare `:$pytestReason:` adjacency (5b209a2) is a hard WinPS 5.1 parse error that silently bricks the whole script. |

New helpers: `Get-SandcastleErrorClass`, `Protect-LogTail`, `Get-LogTail`.

## Tests

3 new `Invoke-Watchdog` tests (completion-signal break, no-early-stop on a productive iteration, failure-row enrichment) + unit tests for the three helpers. Each new test pins `Mock Test-WindowExpired { $false }` to isolate from a Pester 3.4 It-scope mock leak. Local run: all new tests pass; the 5 remaining failures are pre-existing/environmental (`Get-RelatedTestFiles` Windows path-regex, `Invoke-PytestGate` temp-git fixtures lacking `origin/main`) and untouched by this diff.

## Deferred

The deeper **`WorktreeError` teardown root cause** (resilient `git worktree remove` + orphaned-worktree/reparse cleanup so a crashed night can't cascade) is intentionally **not** here — it should be designed against the crash class Fix B confirms on the next nightly run, not an unconfirmed hypothesis. Follow-up to be filed once the next failure row carries `error_class`.

## Safety

No robot-control or motion code touched (jarvis tooling only). No secrets in diff; `Protect-LogTail` strips `gh`/`github_pat`/`sk-ant` token shapes and literal known secrets from the log tail before it reaches any outcome row.

Closes #946
