### PR TITLE
feat(agents): close the task-dispatch loop — claim pending row → spawn (#909)

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "orchestrator",
     "safety",
     "supabase_client",
+    "task_dispatch",
     "task_queue",
     "usage_probe",
     "wake_driver",

--- a/agents/task_dispatch.py
+++ b/agents/task_dispatch.py
@@ -1,0 +1,280 @@
+"""task_dispatch — close the reactive forward path (#909).
+
+The reactive forward path was left open after #741/#744::
+
+    event → wake_driver → orchestrator.handle_event
+          → task_queue.enqueue(row) → ❌ MISSING → executor.spawn
+
+Nothing claimed a pending ``task_queue`` row and called :func:`executor.spawn`.
+This module is the missing link: :func:`drain_tasks` claims pending
+``sandcastle`` rows, transitions each to ``running``, and fires
+``executor.spawn(goal)`` — symmetric to how :func:`wake_driver.drain_pending`
+drains *events*. Completion (``running → done``) re-enters **externally** via
+GitHub Path-A workflows as a fresh ``event`` (no internal polling; closure
+deferred to #921).
+
+Design mirrors :mod:`agents.wake_driver`: the pure logic
+(:func:`drain_tasks` / :func:`reclaim_stale_tasks`) runs over a
+:class:`TaskQueuePort` Protocol, so it is unit-testable with an in-memory fake
+(fake queue + fake spawn + fake running-count) — no live DB, no real
+``claude -p``. :class:`SupabaseTaskQueue` is the thin real adapter over
+:mod:`agents.task_queue` (supabase-py / PostgREST). Events ride raw psycopg
+(they need ``LISTEN``); tasks ride supabase-py — the split is deliberate (AC10).
+
+Crash-safety follows **Ordering B** (grill decision ``2489782f``): per task,
+``claim → transition(running) → spawn``. Transitioning to ``running`` *before*
+the spawn means a crash in the window leaves the row ``running`` (swept by the
+generous reaper, AC6) rather than ``claimed`` with a live process — the latter
+would let the claimed-reclaimer (AC5) hand the same task to a second spawn.
+``claimed`` therefore strictly means *claimed-but-not-yet-spawned*.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from agents import task_queue
+
+logger = logging.getLogger(__name__)
+
+# Only sandcastle rows are auto-spawned; assignee='owner' escalation rows are
+# never claimed by the drain (AC2).
+DEFAULT_ASSIGNEE = "sandcastle"
+
+# Max concurrent running sandcastle tasks (AC3). Until #921 wires real
+# completion closure, the loop self-throttles to this cap.
+DEFAULT_CONCURRENCY_CAP = 5
+
+# A row stuck in ``claimed`` past this long means the drainer died between the
+# claim and the running transition — no process exists, so it is safe to return
+# to ``pending`` (AC5). Matches the wake_driver event watchdog default.
+DEFAULT_CLAIMED_STALE_SECONDS = 300
+
+# A ``running`` row older than this is reaped to ``failed`` (AC6). Deliberately
+# generous (≫ normal task runtime) — a crude time-based stopgap until #921 adds
+# a liveness-aware reaper. Its only job is to stop orphaned rows ratcheting the
+# cap toward 0.
+DEFAULT_RUNNING_REAP_SECONDS = 6 * 60 * 60
+
+# Spawn a task's goal, fire-and-forget. Raises on a hard launch failure (AC7b).
+Spawn = Callable[[str], Any]
+# Resolve the claude binary; raises FileNotFoundError when unresolved (AC7a).
+ResolveBinary = Callable[[], str]
+
+
+@runtime_checkable
+class TaskQueuePort(Protocol):
+    """The slice of the task FSM the dispatch loop depends on (AC10).
+
+    Implemented for real by :class:`SupabaseTaskQueue` over
+    :mod:`agents.task_queue`, and by an in-memory fake in the tests.
+    """
+
+    def claim_next(self, *, assignee: str) -> dict[str, Any] | None:
+        """Claim the highest-priority pending row for ``assignee`` (pending→claimed)."""
+
+    def count_running(self, *, assignee: str) -> int:
+        """Count rows currently ``running`` for ``assignee`` (concurrency cap)."""
+
+    def transition(
+        self, task_id: str, to_status: str, *, reason: str | None = None
+    ) -> dict[str, Any]:
+        """Advance a task through the FSM (validated in the real adapter)."""
+
+    def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+        """Return stale ``claimed`` rows to ``pending`` (direct UPDATE, FSM-bypassing)."""
+
+    def list_stale_running(
+        self, *, assignee: str, older_than_seconds: float
+    ) -> list[dict[str, Any]]:
+        """List ``running`` rows older than the reaper threshold for ``assignee``."""
+
+
+@dataclass(frozen=True)
+class DrainResult:
+    """What one :func:`drain_tasks` did."""
+
+    spawned: int = 0
+    failed: int = 0
+    # True iff the whole drain was skipped because the claude binary did not
+    # resolve (AC7a) — distinct from "ran, claimed nothing".
+    skipped_no_binary: bool = False
+
+
+@dataclass(frozen=True)
+class ReclaimResult:
+    """What one :func:`reclaim_stale_tasks` did."""
+
+    reclaimed_claimed: int = 0
+    reaped_running: int = 0
+
+
+def _default_spawn(goal: str) -> Any:
+    """Production spawn adapter — fire-and-forget ``claude -p`` via the executor.
+
+    Returns the :class:`executor.SpawnResult`. A throttled result (quota
+    near-exhaustion) means no process launched while the row is already
+    ``running``; the AC6 reaper reclaims it after the generous threshold.
+    Liveness-aware handling is deferred to #921. Imported lazily so the tested
+    drain logic (which injects its own spawn) need not pull executor's
+    subprocess/usage-probe dependencies.
+    """
+    from agents.executor import spawn as executor_spawn
+
+    return executor_spawn(goal)
+
+
+def _default_resolve_binary() -> str:
+    """Production binary-resolution adapter (lazy import; see :func:`_default_spawn`)."""
+    from agents.executor import _resolve_claude_binary
+
+    return _resolve_claude_binary()
+
+
+def drain_tasks(
+    port: TaskQueuePort,
+    spawn: Spawn = _default_spawn,
+    *,
+    assignee: str = DEFAULT_ASSIGNEE,
+    cap: int = DEFAULT_CONCURRENCY_CAP,
+    resolve_binary: ResolveBinary = _default_resolve_binary,
+) -> DrainResult:
+    """Claim pending ``assignee`` tasks up to the cap and spawn each (AC2–AC4, AC7–AC9).
+
+    Order of operations:
+
+    1. **Pre-flight binary resolution, once (AC7a).** If the claude binary does
+       not resolve, skip the *entire* drain — zero claims, nothing marked
+       ``failed``, every row stays ``pending`` so the next drain self-heals once
+       the env is fixed. No internal retry.
+    2. **Budget, sampled once (AC3).** ``budget = cap − count_running(assignee)``.
+       Nothing exits ``running`` mid-drain, so the snapshot is exact; the loop
+       spawns at most ``budget`` tasks and leaves the rest ``pending``.
+    3. **Per task, Ordering B (AC4).** ``claim_next`` (pending→claimed) →
+       ``transition(running)`` → ``spawn(goal)``. The running transition
+       precedes the spawn so a crash in the window can only strand a ``running``
+       row (reaped, AC6), never a ``claimed`` row with a live process (which
+       would double-spawn under the AC5 reclaimer).
+
+    A ``claim_next`` returning ``None`` (empty queue or lost race, AC9) breaks
+    the loop cleanly. A ``spawn`` raising (AC7b) marks *that* task
+    ``running→failed`` (terminal — the external event loop re-drives) and the
+    drain continues with the next claim.
+    """
+    # AC7a — pre-flight once; unresolved binary skips the whole drain.
+    try:
+        resolve_binary()
+    except FileNotFoundError:
+        logger.warning(
+            "[task_dispatch] claude binary unresolved; skipping drain "
+            "(no claims, rows stay pending, self-heals when env is fixed)"
+        )
+        return DrainResult(skipped_no_binary=True)
+
+    # AC3 — budget sampled once at drain start.
+    budget = cap - port.count_running(assignee=assignee)
+    if budget <= 0:
+        return DrainResult()
+
+    spawned = 0
+    failed = 0
+    for _ in range(budget):
+        row = port.claim_next(assignee=assignee)  # AC2 routing; AC9 lost-race → None
+        if row is None:
+            break
+        task_id = str(row["id"])
+
+        # AC4 Ordering B — running BEFORE spawn.
+        port.transition(task_id, "running")
+        try:
+            spawn(row["goal"])  # AC8 billing-trap rides executor._sanitize_env
+        except Exception as exc:  # noqa: BLE001 — AC7b: isolate one bad spawn
+            # AC7b — terminal failure; no internal retry, external loop re-drives.
+            port.transition(task_id, "failed", reason=f"spawn raised: {exc}")
+            failed += 1
+            continue
+        spawned += 1
+
+    return DrainResult(spawned=spawned, failed=failed)
+
+
+def reclaim_stale_tasks(
+    port: TaskQueuePort,
+    *,
+    assignee: str = DEFAULT_ASSIGNEE,
+    claimed_stale_after_seconds: float = DEFAULT_CLAIMED_STALE_SECONDS,
+    running_reap_after_seconds: float = DEFAULT_RUNNING_REAP_SECONDS,
+) -> ReclaimResult:
+    """Sweep stranded tasks before a drain (AC5 + AC6).
+
+    - **AC5** — stale ``claimed`` rows return to ``pending`` via a direct UPDATE
+      that bypasses the FSM (``claimed → pending`` is not a legal transition;
+      this mirrors :meth:`wake_driver.PsycopgEventQueue.reclaim_stale`). Never
+      touches ``running``.
+    - **AC6** — stale ``running`` rows (older than the generous reaper
+      threshold) are transitioned ``running → failed`` so orphaned rows (a
+      child that died without opening a PR, or a crash in the running↔spawn
+      window) stop ratcheting the cap toward 0. A fresh ``running`` row is left
+      untouched because the port's staleness query excludes it.
+
+    Invoked by :func:`wake_driver.tick` *before* :func:`drain_tasks`, so a row
+    reclaimed this pass is eligible to be re-claimed and spawned in the same
+    tick — symmetric to the event watchdog running before ``drain_pending``.
+    """
+    # AC5 — stale claimed → pending (FSM-bypassing direct UPDATE).
+    reclaimed = port.reclaim_stale_claimed(
+        assignee=assignee, older_than_seconds=claimed_stale_after_seconds
+    )
+
+    # AC6 — stale running → failed (time-based stopgap; #921 = liveness-aware).
+    reaped = 0
+    for row in port.list_stale_running(
+        assignee=assignee, older_than_seconds=running_reap_after_seconds
+    ):
+        port.transition(
+            str(row["id"]),
+            "failed",
+            reason=f"reaped: no completion within {running_reap_after_seconds:.0f}s",
+        )
+        reaped += 1
+
+    return ReclaimResult(reclaimed_claimed=reclaimed, reaped_running=reaped)
+
+
+class SupabaseTaskQueue:
+    """Real :class:`TaskQueuePort` over :mod:`agents.task_queue` (AC10).
+
+    Thin delegation — the FSM and SQL live in :mod:`agents.task_queue`. Tasks
+    stay on supabase-py (PostgREST); only events need raw psycopg (``LISTEN``),
+    so this is the task-side analogue of
+    :class:`wake_driver.PsycopgEventQueue`. Constructible without touching the
+    network (each call resolves the Supabase client lazily inside
+    ``task_queue``). Not unit-tested (needs live Supabase); the tested logic
+    lives in :func:`drain_tasks` / :func:`reclaim_stale_tasks` above.
+    """
+
+    def claim_next(self, *, assignee: str) -> dict[str, Any] | None:
+        return task_queue.claim_next(assignee=assignee)
+
+    def count_running(self, *, assignee: str) -> int:
+        return task_queue.count_running(assignee=assignee)
+
+    def transition(
+        self, task_id: str, to_status: str, *, reason: str | None = None
+    ) -> dict[str, Any]:
+        return task_queue.transition(task_id, to_status, reason=reason)
+
+    def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+        return task_queue.reclaim_stale_claimed(
+            assignee=assignee, older_than_seconds=older_than_seconds
+        )
+
+    def list_stale_running(
+        self, *, assignee: str, older_than_seconds: float
+    ) -> list[dict[str, Any]]:
+        return task_queue.list_stale_running(
+            assignee=assignee, older_than_seconds=older_than_seconds
+        )

--- a/agents/task_queue.py
+++ b/agents/task_queue.py
@@ -90,9 +90,18 @@ def enqueue(
 
 
 def claim_next(
+    *,
+    assignee: str | None = None,
     client: Client | None = None,
 ) -> dict[str, Any] | None:
     """Claim the highest-priority pending task (priority desc, FIFO ties).
+
+    When ``assignee`` is given, only pending rows with that assignee are
+    eligible — the filter is applied in the SELECT, so a higher-priority
+    row owned by a different assignee never shadows an eligible one. The
+    task-dispatch loop (#909) passes ``assignee='sandcastle'`` so that
+    ``assignee='owner'`` escalation rows are never auto-claimed/spawned.
+    Omitting ``assignee`` preserves the original any-assignee behavior.
 
     Returns the claimed row with status updated to ``claimed``, or
     ``None`` if the queue is empty or another worker claimed the task
@@ -104,14 +113,11 @@ def claim_next(
     cli = client or get_client()
 
     # Read the highest-priority pending task
+    query = cli.table("task_queue").select("*").eq("status", "pending")
+    if assignee is not None:
+        query = query.eq("assignee", assignee)
     rows = (
-        cli.table("task_queue")
-        .select("*")
-        .eq("status", "pending")
-        .order("priority", desc=True)
-        .order("created_at", desc=False)
-        .limit(1)
-        .execute()
+        query.order("priority", desc=True).order("created_at", desc=False).limit(1).execute()
     ).data or []
 
     if not rows:
@@ -216,3 +222,95 @@ def transition(
         )
 
     return updated[0]
+
+
+def _cutoff_iso(older_than_seconds: float) -> str:
+    """ISO-8601 timestamp ``older_than_seconds`` in the past (UTC).
+
+    Used as the ``< claimed_at`` boundary for staleness queries. Computed
+    client-side; the few-ms client/server clock skew is irrelevant against
+    the 300s+ thresholds these helpers run with.
+    """
+    from datetime import timedelta
+
+    return (datetime.now(timezone.utc) - timedelta(seconds=older_than_seconds)).isoformat()
+
+
+def count_running(
+    *,
+    assignee: str,
+    client: Client | None = None,
+) -> int:
+    """Count tasks currently in ``running`` for the given assignee.
+
+    Backs the #909 concurrency cap: ``budget = cap − count_running(...)``,
+    sampled once at drain start. Bounded by the cap (plus a handful of
+    other-assignee rows), so a row count is cheap.
+    """
+    cli = client or get_client()
+    rows = (
+        cli.table("task_queue")
+        .select("id")
+        .eq("status", "running")
+        .eq("assignee", assignee)
+        .execute()
+    ).data or []
+    return len(rows)
+
+
+def reclaim_stale_claimed(
+    *,
+    assignee: str,
+    older_than_seconds: float,
+    client: Client | None = None,
+) -> int:
+    """Return stale ``claimed`` rows to ``pending`` via a direct UPDATE.
+
+    ``claimed`` strictly means *claimed but not yet spawned* under the #909
+    Ordering-B contract (claim → transition(running) → spawn). A row stuck
+    in ``claimed`` past ``older_than_seconds`` means the drainer died between
+    the claim and the running transition; returning it to ``pending`` lets a
+    later drain re-claim it. No process is running for it, so this is safe.
+
+    This deliberately bypasses the FSM (``pending`` is not a legal target
+    from ``claimed`` in :data:`_VALID_TRANSITIONS`) — it mirrors the events
+    watchdog's ``reclaim_stale``. It never touches ``running`` rows (those
+    have a live process; the reaper handles them). Returns the count
+    reclaimed.
+    """
+    cli = client or get_client()
+    result = (
+        cli.table("task_queue")
+        .update({"status": "pending", "claimed_at": None})
+        .eq("status", "claimed")
+        .eq("assignee", assignee)
+        .lt("claimed_at", _cutoff_iso(older_than_seconds))
+        .execute()
+    )
+    return len(result.data or [])
+
+
+def list_stale_running(
+    *,
+    assignee: str,
+    older_than_seconds: float,
+    client: Client | None = None,
+) -> list[dict[str, Any]]:
+    """List ``running`` rows older than the reaper threshold for an assignee.
+
+    Age is measured from ``claimed_at`` — there is no ``running_at`` column,
+    and claimed→running is immediate under Ordering B, so ``claimed_at`` is
+    a faithful proxy for running-start. The #909 running-reaper transitions
+    each returned row ``running → failed``; the threshold is deliberately
+    generous (≫ normal task runtime) until #921 adds liveness-aware reaping.
+    """
+    cli = client or get_client()
+    rows = (
+        cli.table("task_queue")
+        .select("*")
+        .eq("status", "running")
+        .eq("assignee", assignee)
+        .lt("claimed_at", _cutoff_iso(older_than_seconds))
+        .execute()
+    ).data or []
+    return rows

--- a/agents/wake_driver.py
+++ b/agents/wake_driver.py
@@ -46,6 +46,18 @@ from typing import TYPE_CHECKING, Any, Protocol
 from dotenv import load_dotenv
 
 from agents.config import load_config
+from agents.task_dispatch import (
+    DEFAULT_CLAIMED_STALE_SECONDS,
+    DEFAULT_RUNNING_REAP_SECONDS,
+    ResolveBinary,
+    Spawn,
+    SupabaseTaskQueue,
+    TaskQueuePort,
+    _default_resolve_binary,
+    _default_spawn,
+    drain_tasks,
+    reclaim_stale_tasks,
+)
 
 if TYPE_CHECKING:
     import psycopg
@@ -92,10 +104,18 @@ class EventQueuePort(Protocol):
 
 @dataclass(frozen=True)
 class TickResult:
-    """What one :func:`tick` did — watchdog reclaims + events drained."""
+    """What one :func:`tick` did — event watchdog + drain, then task sweep + drain.
+
+    The ``tasks_*`` fields default to 0 so an event-only tick (no ``task_port``)
+    constructs unchanged.
+    """
 
     reclaimed: int
     processed: int
+    tasks_reclaimed: int = 0
+    tasks_reaped: int = 0
+    tasks_spawned: int = 0
+    tasks_failed: int = 0
 
 
 def default_orchestrator(event: dict[str, Any]) -> None:
@@ -148,15 +168,52 @@ def tick(
     orchestrator: Orchestrator,
     *,
     stale_after_seconds: float,
+    task_port: TaskQueuePort | None = None,
+    task_spawn: Spawn = _default_spawn,
+    task_resolve_binary: ResolveBinary = _default_resolve_binary,
+    task_claimed_stale_after_seconds: float = DEFAULT_CLAIMED_STALE_SECONDS,
+    task_running_reap_after_seconds: float = DEFAULT_RUNNING_REAP_SECONDS,
 ) -> TickResult:
-    """One unit of work: reclaim stale rows, then drain the pending queue.
+    """One unit of work — four ordered steps (#909 AC1)::
 
-    The watchdog runs **first** so a row stranded by a previous crash is
-    returned to ``pending`` and drained within the same tick.
+        reclaim_stale(events) → reclaim_stale_tasks() → drain_pending(events) → drain_tasks()
+
+    Both watchdogs run **before** both drains, so a row stranded by a previous
+    crash (event *or* task) is returned to ``pending`` and re-driven within the
+    same tick. Tasks are swept and drained only when ``task_port`` is supplied;
+    omitting it preserves the original event-only behavior. There is no task
+    NOTIFY — a task is born from an event that already woke the driver, or is
+    swept by the idle-timeout watchdog (AC1; task-NOTIFY latency deferred to
+    #922).
     """
+    # Step 1 — event watchdog.
     reclaimed = run_watchdog(port, stale_after_seconds=stale_after_seconds)
+
+    # Step 2 — task watchdog (stale claimed → pending, stale running → failed).
+    task_reclaim = None
+    if task_port is not None:
+        task_reclaim = reclaim_stale_tasks(
+            task_port,
+            claimed_stale_after_seconds=task_claimed_stale_after_seconds,
+            running_reap_after_seconds=task_running_reap_after_seconds,
+        )
+
+    # Step 3 — event drain.
     processed = drain_pending(port, orchestrator)
-    return TickResult(reclaimed=reclaimed, processed=processed)
+
+    # Step 4 — task drain (claim → running → spawn, capped, Ordering B).
+    task_drain = None
+    if task_port is not None:
+        task_drain = drain_tasks(task_port, task_spawn, resolve_binary=task_resolve_binary)
+
+    return TickResult(
+        reclaimed=reclaimed,
+        processed=processed,
+        tasks_reclaimed=task_reclaim.reclaimed_claimed if task_reclaim else 0,
+        tasks_reaped=task_reclaim.reaped_running if task_reclaim else 0,
+        tasks_spawned=task_drain.spawned if task_drain else 0,
+        tasks_failed=task_drain.failed if task_drain else 0,
+    )
 
 
 def run(
@@ -165,6 +222,7 @@ def run(
     *,
     stale_after_seconds: float = DEFAULT_STALE_AFTER_SECONDS,
     should_continue: Callable[[], bool] | None = None,
+    task_port: TaskQueuePort | None = None,
 ) -> None:
     """The event-driven loop: block on a wake signal, then run one tick.
 
@@ -174,6 +232,11 @@ def run(
     busy sleep-poll; ``should_continue`` (default: forever) lets tests bound
     the loop.
 
+    When ``task_port`` is supplied, each tick also sweeps and drains the
+    ``task_queue`` (#909). The same idle-timeout that runs the event watchdog
+    runs the task watchdog, so tasks left ``claimed``/``running`` by a crash
+    are swept even on an idle queue.
+
     A tick that raises is logged and swallowed so a transient failure does
     not tear down the driver — the offending event stays ``claimed`` and the
     watchdog re-claims it next pass (at-least-once, never silently lost).
@@ -182,7 +245,7 @@ def run(
     while keep_going():
         port.wait_for_wake(timeout_seconds=stale_after_seconds)
         try:
-            tick(port, orchestrator, stale_after_seconds=stale_after_seconds)
+            tick(port, orchestrator, stale_after_seconds=stale_after_seconds, task_port=task_port)
         except Exception:  # noqa: BLE001 — daemon must survive a bad tick
             logger.exception("[wake_driver] tick failed; event left claimed for watchdog re-claim")
 
@@ -271,12 +334,23 @@ def main() -> int:
     args = parser.parse_args()
 
     queue = _build_psycopg_queue()
+    task_port = SupabaseTaskQueue()  # tasks ride supabase-py; events ride psycopg
     if args.once:
-        result = tick(queue, default_orchestrator, stale_after_seconds=args.watchdog_seconds)
+        result = tick(
+            queue,
+            default_orchestrator,
+            stale_after_seconds=args.watchdog_seconds,
+            task_port=task_port,
+        )
         logger.info(
-            "[wake_driver] one-shot tick: reclaimed=%d processed=%d",
+            "[wake_driver] one-shot tick: reclaimed=%d processed=%d "
+            "tasks_reclaimed=%d tasks_reaped=%d tasks_spawned=%d tasks_failed=%d",
             result.reclaimed,
             result.processed,
+            result.tasks_reclaimed,
+            result.tasks_reaped,
+            result.tasks_spawned,
+            result.tasks_failed,
         )
         return 0
 
@@ -286,7 +360,12 @@ def main() -> int:
         args.watchdog_seconds,
     )
     try:
-        run(queue, default_orchestrator, stale_after_seconds=args.watchdog_seconds)
+        run(
+            queue,
+            default_orchestrator,
+            stale_after_seconds=args.watchdog_seconds,
+            task_port=task_port,
+        )
     except KeyboardInterrupt:
         logger.info("[wake_driver] KeyboardInterrupt — stopping")
     return 0

--- a/tests/test_agents_task_dispatch.py
+++ b/tests/test_agents_task_dispatch.py
@@ -1,0 +1,391 @@
+"""Unit tests for agents/task_dispatch.py — the #909 task-dispatch loop.
+
+The whole point of AC10 is that the dispatch logic is a pure function over a
+``TaskQueuePort`` Protocol plus an injected ``spawn`` callable, so every test
+here runs against an in-memory fake — no Supabase client, no real ``claude``
+binary. The one exception is the AC8 billing-trap test, which drives the *real*
+``executor.spawn`` through the drain path (with an injected ``Popen``) to prove
+the env-sanitization safety property survives integration.
+
+Each test names the acceptance criterion it covers (see issue #909, grilled
+2026-06-01, decision 2489782f).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from agents.task_dispatch import (
+    DEFAULT_ASSIGNEE,
+    DEFAULT_CONCURRENCY_CAP,
+    SupabaseTaskQueue,
+    TaskQueuePort,
+    drain_tasks,
+    reclaim_stale_tasks,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _row(task_id: str, *, assignee: str = "sandcastle", goal: str | None = None) -> dict[str, Any]:
+    return {
+        "id": task_id,
+        "goal": goal or f"do {task_id}",
+        "assignee": assignee,
+        "status": "pending",
+    }
+
+
+class FakeTaskQueue:
+    """In-memory ``TaskQueuePort`` for driving ``drain_tasks`` deterministically.
+
+    ``claim_next`` hands out seeded pending rows FIFO, filtered by assignee —
+    mirroring the real SELECT filter so a non-matching row is never claimed.
+    """
+
+    def __init__(
+        self, *, pending: list[dict[str, Any]] | None = None, running_count: int = 0
+    ) -> None:
+        self._pending = list(pending or [])
+        self._running_count = running_count
+        self.claimed: list[str] = []
+        self.transitions: list[tuple[str, str, str | None]] = []
+        self.reclaimed_count = 0
+        self.stale_running: list[dict[str, Any]] = []
+
+    def claim_next(self, *, assignee: str) -> dict[str, Any] | None:
+        for i, row in enumerate(self._pending):
+            if row.get("assignee") == assignee:
+                claimed = self._pending.pop(i)
+                self.claimed.append(claimed["id"])
+                return claimed
+        return None
+
+    def count_running(self, *, assignee: str) -> int:
+        return self._running_count
+
+    def transition(
+        self, task_id: str, to_status: str, *, reason: str | None = None
+    ) -> dict[str, Any]:
+        self.transitions.append((task_id, to_status, reason))
+        return {"id": task_id, "status": to_status}
+
+    def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+        return self.reclaimed_count
+
+    def list_stale_running(
+        self, *, assignee: str, older_than_seconds: float
+    ) -> list[dict[str, Any]]:
+        return list(self.stale_running)
+
+
+def _always_resolve() -> str:
+    return "claude"
+
+
+# ---------------------------------------------------------------------------
+# AC3 — concurrency cap: budget = cap − count_running, sampled once
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrencyCap:
+    def test_budget_limits_spawns(self) -> None:
+        # 3 already running, cap 5 -> budget 2 -> only 2 of 4 pending spawned.
+        q = FakeTaskQueue(pending=[_row(f"t{i}") for i in range(4)], running_count=3)
+        spawns: list[str] = []
+        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+        assert len(spawns) == 2
+        assert len(q.claimed) == 2
+        assert res.spawned == 2
+
+    def test_no_spawn_when_at_cap(self) -> None:
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=5)
+        spawns: list[str] = []
+        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+        assert spawns == []
+        assert q.claimed == []
+        assert res.spawned == 0
+
+    def test_default_cap_is_five(self) -> None:
+        assert DEFAULT_CONCURRENCY_CAP == 5
+
+
+# ---------------------------------------------------------------------------
+# AC2 — assignee routing: only 'sandcastle' claimed; 'owner' never spawned
+# ---------------------------------------------------------------------------
+
+
+class TestAssigneeRouting:
+    def test_owner_rows_never_claimed(self) -> None:
+        q = FakeTaskQueue(
+            pending=[_row("own", assignee="owner"), _row("sand", assignee="sandcastle")],
+            running_count=0,
+        )
+        spawns: list[str] = []
+        drain_tasks(q, lambda g: spawns.append(g), resolve_binary=_always_resolve)
+        assert q.claimed == ["sand"]
+        assert spawns == ["do sand"]
+
+    def test_default_assignee_is_sandcastle(self) -> None:
+        assert DEFAULT_ASSIGNEE == "sandcastle"
+
+
+# ---------------------------------------------------------------------------
+# AC4 — Ordering B: claim → transition(running) → spawn
+# ---------------------------------------------------------------------------
+
+
+class TestOrderingB:
+    def test_transition_running_before_spawn(self) -> None:
+        events: list[tuple[str, ...]] = []
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+
+        original = q.transition
+
+        def recording_transition(task_id: str, to_status: str, *, reason: str | None = None) -> Any:
+            events.append(("transition", task_id, to_status))
+            return original(task_id, to_status, reason=reason)
+
+        q.transition = recording_transition  # type: ignore[method-assign]
+
+        drain_tasks(q, lambda g: events.append(("spawn", g)), resolve_binary=_always_resolve)
+
+        # The running transition must be recorded BEFORE the spawn — a row is
+        # never left 'claimed' once we have committed to spawning it, and spawn
+        # is never invoked for a row still 'pending'/'claimed'.
+        assert events == [("transition", "t0", "running"), ("spawn", "do t0")]
+
+
+# ---------------------------------------------------------------------------
+# AC9 — atomic claim: lost race returns None -> no spawn, no phantom work
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicClaim:
+    def test_empty_queue_no_spawn(self) -> None:
+        q = FakeTaskQueue(pending=[], running_count=0)
+        spawns: list[str] = []
+        res = drain_tasks(q, lambda g: spawns.append(g), resolve_binary=_always_resolve)
+        assert spawns == []
+        assert res.spawned == 0
+
+    def test_none_claim_stops_drain_no_phantom_spawn(self) -> None:
+        # Budget allows 5 but a competing drainer left only one claimable row;
+        # subsequent claims return None and the loop stops cleanly without
+        # spawning for an unclaimed row (the optimistic-lock atomicity that
+        # makes the lost race safe is unit-tested in test_agents_task_queue).
+        q = FakeTaskQueue(pending=[_row("only")], running_count=0)
+        spawns: list[str] = []
+        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+        assert spawns == ["do only"]
+        assert res.spawned == 1
+
+
+# ---------------------------------------------------------------------------
+# AC7a — binary unresolved: skip whole drain, zero claims, self-heals
+# ---------------------------------------------------------------------------
+
+
+class TestBinaryPreflight:
+    def test_unresolved_binary_skips_entire_drain(self) -> None:
+        q = FakeTaskQueue(pending=[_row("t0"), _row("t1")], running_count=0)
+        spawns: list[str] = []
+
+        def resolve_missing() -> str:
+            raise FileNotFoundError("claude binary not found")
+
+        res = drain_tasks(q, lambda g: spawns.append(g), resolve_binary=resolve_missing)
+
+        assert q.claimed == []  # zero claims — no row touched
+        assert spawns == []
+        assert res.skipped_no_binary is True
+        assert res.spawned == 0
+        assert len(q._pending) == 2  # rows stay pending -> next drain self-heals
+
+
+# ---------------------------------------------------------------------------
+# AC7b — spawn raises: mark that task failed (terminal), continue the drain
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnFailureIsTerminal:
+    def test_spawn_raise_marks_failed_and_continues(self) -> None:
+        q = FakeTaskQueue(pending=[_row("boom"), _row("ok")], running_count=0)
+        spawns: list[str] = []
+
+        def spawn(goal: str) -> None:
+            if goal == "do boom":
+                raise RuntimeError("spawn blew up")
+            spawns.append(goal)
+
+        res = drain_tasks(q, spawn, cap=5, resolve_binary=_always_resolve)
+
+        failed = [t for t in q.transitions if t[1] == "failed"]
+        assert len(failed) == 1
+        assert failed[0][0] == "boom"
+        assert failed[0][2] and "spawn" in failed[0][2]  # reason documents the cause
+        # 'boom' was transitioned running THEN failed (no retry); 'ok' spawned.
+        assert ("boom", "running", None) in q.transitions
+        assert spawns == ["do ok"]
+        assert res.spawned == 1
+        assert res.failed == 1
+
+
+# ---------------------------------------------------------------------------
+# AC8 — billing-trap holds through the integrated drain path
+# ---------------------------------------------------------------------------
+
+
+class _CapturedPopen:
+    """Records argv + env passed to each Popen instantiation (no real process)."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, argv: list[str], **kwargs: Any) -> Any:
+        self.calls.append({"argv": list(argv), "env": dict(kwargs.get("env") or {})})
+
+        class _Handle:
+            pid = 4242
+
+            def poll(self) -> None:
+                return None
+
+        return _Handle()
+
+
+class _FixedProbe:
+    def __init__(self, reading: Any) -> None:
+        self._reading = reading
+
+    def read(self) -> Any:
+        return self._reading
+
+
+def _healthy_reading() -> Any:
+    from agents.usage_probe import UsageReading
+
+    return UsageReading(
+        limit_window=timedelta(hours=5),
+        used=10,
+        total=100,
+        reset_at=datetime.now(UTC),
+        near_exhaustion=False,
+    )
+
+
+class TestBillingTrapThroughDrain:
+    def test_api_keys_stripped_from_spawned_env(self, monkeypatch: Any, tmp_path: Any) -> None:
+        from agents import executor
+
+        fake_bin = tmp_path / "claude.exe"
+        fake_bin.write_text("")
+
+        captured = _CapturedPopen()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-must-be-stripped")
+        monkeypatch.setenv("CLAUDE_API_KEY", "sk-also-stripped")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-stripped")
+        monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake_bin))
+        monkeypatch.setenv("PATH_FROM_PARENT", "keep-me")
+
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+
+        def spawn(goal: str) -> Any:
+            return executor.spawn(
+                goal,
+                popen=captured,
+                probe=_FixedProbe(_healthy_reading()),
+                stderr_log_dir=str(tmp_path),
+            )
+
+        drain_tasks(q, spawn, resolve_binary=lambda: str(fake_bin))
+
+        assert len(captured.calls) == 1
+        env = captured.calls[0]["env"]
+        assert "ANTHROPIC_API_KEY" not in env, "billing-trap leak through drain path"
+        assert "CLAUDE_API_KEY" not in env
+        assert "ANTHROPIC_AUTH_TOKEN" not in env
+        assert env.get("PATH_FROM_PARENT") == "keep-me", "non-sensitive env must survive"
+
+
+# ---------------------------------------------------------------------------
+# AC5 — reclaim_stale_tasks: stale claimed -> pending (assignee+threshold scoped)
+# ---------------------------------------------------------------------------
+
+
+class TestReclaimStaleClaimed:
+    def test_reclaims_with_assignee_and_threshold(self) -> None:
+        calls: dict[str, Any] = {}
+
+        class Q(FakeTaskQueue):
+            def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+                calls["claimed"] = (assignee, older_than_seconds)
+                return 1
+
+            def list_stale_running(self, *, assignee: str, older_than_seconds: float) -> list:
+                calls["running"] = (assignee, older_than_seconds)
+                return []
+
+        res = reclaim_stale_tasks(
+            Q(),
+            assignee="sandcastle",
+            claimed_stale_after_seconds=300,
+            running_reap_after_seconds=21600,
+        )
+        assert calls["claimed"] == ("sandcastle", 300)
+        assert calls["running"] == ("sandcastle", 21600)
+        assert res.reclaimed_claimed == 1
+
+    def test_reclaimed_count_propagates(self) -> None:
+        q = FakeTaskQueue()
+        q.reclaimed_count = 3
+        res = reclaim_stale_tasks(q)
+        assert res.reclaimed_claimed == 3
+
+
+# ---------------------------------------------------------------------------
+# AC6 — running reaper: stale running -> failed; nothing stale -> no-op
+# ---------------------------------------------------------------------------
+
+
+class TestRunningReaper:
+    def test_stale_running_marked_failed(self) -> None:
+        q = FakeTaskQueue()
+        q.stale_running = [{"id": "stuck1"}, {"id": "stuck2"}]
+        res = reclaim_stale_tasks(q, running_reap_after_seconds=21600)
+        failed = [t for t in q.transitions if t[1] == "failed"]
+        assert {t[0] for t in failed} == {"stuck1", "stuck2"}
+        assert all(t[2] and "reaped" in t[2] for t in failed)
+        assert res.reaped_running == 2
+
+    def test_noop_when_nothing_stale(self) -> None:
+        q = FakeTaskQueue()
+        q.stale_running = []
+        res = reclaim_stale_tasks(q)
+        assert res.reaped_running == 0
+        assert q.transitions == []
+
+
+# ---------------------------------------------------------------------------
+# AC10 — injectable-port architecture
+# ---------------------------------------------------------------------------
+
+
+class TestInjectablePortArchitecture:
+    def test_port_protocol_and_real_adapter_exist(self) -> None:
+        # The Protocol is the seam; SupabaseTaskQueue is the prod adapter.
+        adapter = SupabaseTaskQueue()  # constructible without touching the network
+        assert isinstance(adapter, TaskQueuePort)  # runtime_checkable Protocol
+
+    def test_drain_runs_against_a_fake_no_live_client(self) -> None:
+        # If drain_tasks required a live client this whole module would not run.
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+        spawns: list[str] = []
+        drain_tasks(q, lambda g: spawns.append(g), resolve_binary=_always_resolve)
+        assert spawns == ["do t0"]
+        assert os.environ is not None  # sanity — no monkeypatch leaked

--- a/tests/test_agents_task_queue.py
+++ b/tests/test_agents_task_queue.py
@@ -14,7 +14,10 @@ from agents.task_queue import (
     _TERMINAL_STATES,
     _VALID_TRANSITIONS,
     claim_next,
+    count_running,
     enqueue,
+    list_stale_running,
+    reclaim_stale_claimed,
     transition,
 )
 
@@ -34,11 +37,16 @@ class _StubSelect:
         self._parent = parent
         self._rows = list(rows)
         self._filters: list[tuple[str, Any]] = []
+        self._lt_filters: list[tuple[str, Any]] = []
         self._order: list[tuple[str, bool]] = []
         self._limit_n: int | None = None
 
     def eq(self, col: str, val: Any) -> _StubSelect:
         self._filters.append((col, val))
+        return self
+
+    def lt(self, col: str, val: Any) -> _StubSelect:
+        self._lt_filters.append((col, val))
         return self
 
     def order(self, col: str, *, desc: bool = False, **kwargs: Any) -> _StubSelect:
@@ -53,6 +61,8 @@ class _StubSelect:
         rows = list(self._rows)
         for col, val in self._filters:
             rows = [r for r in rows if r.get(col) == val]
+        for col, val in self._lt_filters:
+            rows = [r for r in rows if r.get(col) is not None and r.get(col) < val]
         for col, desc in reversed(self._order):
             rows.sort(
                 key=lambda r: (r.get(col) is None, r.get(col)),
@@ -65,21 +75,29 @@ class _StubSelect:
 
 
 class _StubUpdate:
-    def __init__(self, parent: _StubTable, rows: list[dict[str, Any]],
-                 payload: dict[str, Any]) -> None:
+    def __init__(
+        self, parent: _StubTable, rows: list[dict[str, Any]], payload: dict[str, Any]
+    ) -> None:
         self._parent = parent
         self._rows = rows
         self._payload = payload
         self._eq_filters: list[tuple[str, Any]] = []
+        self._lt_filters: list[tuple[str, Any]] = []
 
     def eq(self, col: str, val: Any) -> _StubUpdate:
         self._eq_filters.append((col, val))
         return self
 
+    def lt(self, col: str, val: Any) -> _StubUpdate:
+        self._lt_filters.append((col, val))
+        return self
+
     def execute(self) -> _StubResponse:
         matched: list[dict[str, Any]] = []
         for row in self._rows:
-            if all(row.get(c) == v for c, v in self._eq_filters):
+            eq_ok = all(row.get(c) == v for c, v in self._eq_filters)
+            lt_ok = all(row.get(c) is not None and row.get(c) < v for c, v in self._lt_filters)
+            if eq_ok and lt_ok:
                 row.update(self._payload)
                 matched.append(dict(row))
         self._parent.calls.append(("update", dict(self._eq_filters)))
@@ -87,8 +105,9 @@ class _StubUpdate:
 
 
 class _StubInsert:
-    def __init__(self, parent: _StubTable, rows: list[dict[str, Any]],
-                 payload: dict[str, Any]) -> None:
+    def __init__(
+        self, parent: _StubTable, rows: list[dict[str, Any]], payload: dict[str, Any]
+    ) -> None:
         self._parent = parent
         self._rows = rows
         self._payload = payload
@@ -165,15 +184,23 @@ def _pending(**kw: Any) -> dict[str, Any]:
 
 
 def _claimed(**kw: Any) -> dict[str, Any]:
-    base = _pending(id="tq-claimed", status="claimed", idempotency_key="key-claimed",
-                    claimed_at="2026-05-21T01:00:00")
+    base = _pending(
+        id="tq-claimed",
+        status="claimed",
+        idempotency_key="key-claimed",
+        claimed_at="2026-05-21T01:00:00",
+    )
     base.update(kw)
     return base
 
 
 def _running(**kw: Any) -> dict[str, Any]:
-    base = _claimed(id="tq-running", status="running", idempotency_key="key-running",
-                    claimed_at="2026-05-21T01:00:00")
+    base = _claimed(
+        id="tq-running",
+        status="running",
+        idempotency_key="key-running",
+        claimed_at="2026-05-21T01:00:00",
+    )
     base.update(kw)
     return base
 
@@ -211,9 +238,12 @@ class TestEnqueue:
         assert row["scope_files"] == ["src/main.py"]
 
     def test_idempotency_key_collision(self, client: _StubClient) -> None:
-        client.seed("task_queue", [
-            _pending(idempotency_key="dup-key"),
-        ])
+        client.seed(
+            "task_queue",
+            [
+                _pending(idempotency_key="dup-key"),
+            ],
+        )
         row = enqueue(
             goal="duplicate",
             priority=0,
@@ -242,9 +272,7 @@ class TestEnqueue:
         )
         assert row is not None
         assert row["assignee"] == "owner"
-        assert row["escalated_reason"] == (
-            "security_alert (critical) — owner review required"
-        )
+        assert row["escalated_reason"] == ("security_alert (critical) — owner review required")
 
     def test_escalated_reason_omitted_when_none(self, client: _StubClient) -> None:
         row = enqueue(
@@ -263,11 +291,14 @@ class TestEnqueue:
 
 class TestClaimNext:
     def test_claims_highest_priority(self, client: _StubClient) -> None:
-        client.seed("task_queue", [
-            _pending(id="low", priority=1, idempotency_key="key-low"),
-            _pending(id="high", priority=10, idempotency_key="key-high"),
-            _pending(id="medium", priority=5, idempotency_key="key-med"),
-        ])
+        client.seed(
+            "task_queue",
+            [
+                _pending(id="low", priority=1, idempotency_key="key-low"),
+                _pending(id="high", priority=10, idempotency_key="key-high"),
+                _pending(id="medium", priority=5, idempotency_key="key-med"),
+            ],
+        )
         row = claim_next(client=client)
         assert row is not None
         assert row["id"] == "high"
@@ -275,12 +306,23 @@ class TestClaimNext:
         assert row["claimed_at"] is not None
 
     def test_fifo_for_tie(self, client: _StubClient) -> None:
-        client.seed("task_queue", [
-            _pending(id="first", priority=5, idempotency_key="key-a",
-                     created_at="2026-05-21T00:00:00"),
-            _pending(id="second", priority=5, idempotency_key="key-b",
-                     created_at="2026-05-21T01:00:00"),
-        ])
+        client.seed(
+            "task_queue",
+            [
+                _pending(
+                    id="first",
+                    priority=5,
+                    idempotency_key="key-a",
+                    created_at="2026-05-21T00:00:00",
+                ),
+                _pending(
+                    id="second",
+                    priority=5,
+                    idempotency_key="key-b",
+                    created_at="2026-05-21T01:00:00",
+                ),
+            ],
+        )
         row = claim_next(client=client)
         assert row is not None
         assert row["id"] == "first"
@@ -290,18 +332,24 @@ class TestClaimNext:
         assert row is None
 
     def test_ignores_non_pending_status(self, client: _StubClient) -> None:
-        client.seed("task_queue", [
-            _claimed(id="claimed-task"),
-            _running(id="running-task"),
-        ])
+        client.seed(
+            "task_queue",
+            [
+                _claimed(id="claimed-task"),
+                _running(id="running-task"),
+            ],
+        )
         row = claim_next(client=client)
         assert row is None
 
     def test_optimistic_lock_race(self, client: _StubClient) -> None:
         """Another worker claimed the task between our read and update."""
-        client.seed("task_queue", [
-            _pending(id="race", idempotency_key="key-race"),
-        ])
+        client.seed(
+            "task_queue",
+            [
+                _pending(id="race", idempotency_key="key-race"),
+            ],
+        )
 
         # First claim succeeds
         first = claim_next(client=client)
@@ -417,9 +465,7 @@ class TestFSMDefinition:
         all_states = {"pending", "claimed", "running", "done", "failed", "parked"}
         non_terminal = all_states - _TERMINAL_STATES
         defined = set(_VALID_TRANSITIONS.keys())
-        assert defined == non_terminal, (
-            f"Missing transition rules for: {non_terminal - defined}"
-        )
+        assert defined == non_terminal, f"Missing transition rules for: {non_terminal - defined}"
 
     def test_no_transition_from_terminal_states(self) -> None:
         for state in _TERMINAL_STATES:
@@ -436,3 +482,164 @@ class TestFSMDefinition:
                 assert target in all_states, (
                     f"Transition {state} -> {target}: {target!r} is not a valid state"
                 )
+
+
+# ===========================================================================
+# claim_next — assignee filter (#909 AC2)
+# ===========================================================================
+
+
+class TestClaimNextAssignee:
+    """AC2: drain claims/spawns ONLY assignee='sandcastle' rows; owner never."""
+
+    def test_claims_only_matching_assignee(self, client: _StubClient) -> None:
+        # owner row has higher priority — if the filter were post-claim instead
+        # of in the SELECT, the owner row would be read first and the claim of a
+        # sandcastle row would never happen.
+        client.seed(
+            "task_queue",
+            [
+                _pending(id="sand", assignee="sandcastle", priority=5, idempotency_key="k-s"),
+                _pending(id="own", assignee="owner", priority=10, idempotency_key="k-o"),
+            ],
+        )
+        row = claim_next(assignee="sandcastle", client=client)
+        assert row is not None
+        assert row["id"] == "sand"
+        assert row["status"] == "claimed"
+
+    def test_returns_none_when_no_matching_assignee(self, client: _StubClient) -> None:
+        client.seed(
+            "task_queue",
+            [
+                _pending(id="own", assignee="owner", idempotency_key="k-o"),
+            ],
+        )
+        assert claim_next(assignee="sandcastle", client=client) is None
+
+    def test_no_assignee_filter_claims_any(self, client: _StubClient) -> None:
+        # Backward-compat: omitting assignee preserves the original behavior.
+        client.seed(
+            "task_queue",
+            [
+                _pending(id="any", assignee="owner", idempotency_key="k"),
+            ],
+        )
+        row = claim_next(client=client)
+        assert row is not None
+        assert row["id"] == "any"
+
+
+# ===========================================================================
+# count_running (#909 AC3)
+# ===========================================================================
+
+
+class TestCountRunning:
+    """AC3: concurrency budget = cap − count_running(assignee)."""
+
+    def test_counts_running_for_assignee(self, client: _StubClient) -> None:
+        client.seed(
+            "task_queue",
+            [
+                _running(id="r1", assignee="sandcastle", idempotency_key="k1"),
+                _running(id="r2", assignee="sandcastle", idempotency_key="k2"),
+                _running(id="r3", assignee="owner", idempotency_key="k3"),
+                _claimed(id="c1", assignee="sandcastle", idempotency_key="k4"),
+                _pending(id="p1", assignee="sandcastle", idempotency_key="k5"),
+            ],
+        )
+        assert count_running(assignee="sandcastle", client=client) == 2
+
+    def test_zero_when_none_running(self, client: _StubClient) -> None:
+        client.seed(
+            "task_queue",
+            [
+                _pending(id="p", assignee="sandcastle", idempotency_key="k"),
+            ],
+        )
+        assert count_running(assignee="sandcastle", client=client) == 0
+
+
+# ===========================================================================
+# reclaim_stale_claimed (#909 AC5) — direct UPDATE bypassing the FSM
+# ===========================================================================
+
+
+class TestReclaimStaleClaimed:
+    """AC5: stale `claimed` sandcastle rows return to `pending` (not-yet-spawned)."""
+
+    _OLD = "2020-01-01T00:00:00+00:00"
+
+    def test_reclaims_old_claimed_to_pending(self, client: _StubClient) -> None:
+        fresh = datetime.now(timezone.utc).isoformat()
+        client.seed(
+            "task_queue",
+            [
+                _claimed(
+                    id="stale", assignee="sandcastle", idempotency_key="k1", claimed_at=self._OLD
+                ),
+                _claimed(id="fresh", assignee="sandcastle", idempotency_key="k2", claimed_at=fresh),
+            ],
+        )
+        n = reclaim_stale_claimed(assignee="sandcastle", older_than_seconds=300, client=client)
+        assert n == 1
+        rows = {r["id"]: r for r in client.table("task_queue")._rows}
+        assert rows["stale"]["status"] == "pending"
+        assert rows["stale"]["claimed_at"] is None
+        assert rows["fresh"]["status"] == "claimed"
+
+    def test_only_reclaims_matching_assignee(self, client: _StubClient) -> None:
+        client.seed(
+            "task_queue",
+            [
+                _claimed(id="own", assignee="owner", idempotency_key="k1", claimed_at=self._OLD),
+            ],
+        )
+        assert (
+            reclaim_stale_claimed(assignee="sandcastle", older_than_seconds=300, client=client) == 0
+        )
+
+    def test_does_not_touch_running(self, client: _StubClient) -> None:
+        client.seed(
+            "task_queue",
+            [
+                _running(
+                    id="run", assignee="sandcastle", idempotency_key="k1", claimed_at=self._OLD
+                ),
+            ],
+        )
+        assert (
+            reclaim_stale_claimed(assignee="sandcastle", older_than_seconds=300, client=client) == 0
+        )
+        rows = {r["id"]: r for r in client.table("task_queue")._rows}
+        assert rows["run"]["status"] == "running"
+
+
+# ===========================================================================
+# list_stale_running (#909 AC6) — running-reaper candidate selection
+# ===========================================================================
+
+
+class TestListStaleRunning:
+    """AC6: select stale `running` sandcastle rows for the reaper to fail."""
+
+    _OLD = "2020-01-01T00:00:00+00:00"
+
+    def test_lists_old_running_for_assignee(self, client: _StubClient) -> None:
+        fresh = datetime.now(timezone.utc).isoformat()
+        client.seed(
+            "task_queue",
+            [
+                _running(
+                    id="old", assignee="sandcastle", idempotency_key="k1", claimed_at=self._OLD
+                ),
+                _running(id="new", assignee="sandcastle", idempotency_key="k2", claimed_at=fresh),
+                _running(id="own", assignee="owner", idempotency_key="k3", claimed_at=self._OLD),
+                _claimed(
+                    id="clm", assignee="sandcastle", idempotency_key="k4", claimed_at=self._OLD
+                ),
+            ],
+        )
+        rows = list_stale_running(assignee="sandcastle", older_than_seconds=300, client=client)
+        assert {r["id"] for r in rows} == {"old"}

--- a/tests/test_wake_driver.py
+++ b/tests/test_wake_driver.py
@@ -283,3 +283,116 @@ def test_apscheduler_and_sqlalchemy_dropped_from_deps():
     assert "sqlalchemy" not in joined, (
         "sqlalchemy was only APScheduler's jobstore driver — drop it too"
     )
+
+
+# --- #909 AC1: tick gains task reclaim + task drain, four ordered steps -----
+
+
+class _RecordingTaskQueue:
+    """Minimal TaskQueuePort that logs the calls drain/reclaim make, in order.
+
+    Shares the order log with a _LoggingEventQueue so a single tick's
+    event-side and task-side operations can be asserted against AC1's
+    ``reclaim(events) → reclaim_tasks() → drain(events) → drain_tasks()`` order.
+    """
+
+    def __init__(self, log: list, *, pending=None, stale_claimed: int = 0, stale_running=None):
+        self._log = log
+        self._pending = list(pending or [])
+        self._stale_claimed = stale_claimed
+        self._stale_running = list(stale_running or [])
+
+    def claim_next(self, *, assignee: str):
+        for i, r in enumerate(self._pending):
+            if r.get("assignee", "sandcastle") == assignee:
+                self._log.append("task_drain")
+                return self._pending.pop(i)
+        return None
+
+    def count_running(self, *, assignee: str) -> int:
+        return 0
+
+    def transition(self, task_id: str, to_status: str, *, reason=None):
+        self._log.append(f"task_transition:{to_status}")
+        return {"id": task_id, "status": to_status}
+
+    def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+        self._log.append("task_reclaim")
+        return self._stale_claimed
+
+    def list_stale_running(self, *, assignee: str, older_than_seconds: float):
+        self._log.append("task_list_running")
+        return list(self._stale_running)
+
+
+class _LoggingEventQueue(FakeEventQueue):
+    """FakeEventQueue that records reclaim/drain into a shared order log."""
+
+    def __init__(self, log: list, events=None):
+        super().__init__(events)
+        self._log = log
+
+    def reclaim_stale(self, *, older_than_seconds: float) -> int:
+        self._log.append("event_reclaim")
+        return super().reclaim_stale(older_than_seconds=older_than_seconds)
+
+    def claim_next(self):
+        row = super().claim_next()
+        if row is not None:
+            self._log.append("event_drain")
+        return row
+
+
+def test_tick_runs_the_four_steps_in_order():
+    log: list = []
+    eq = _LoggingEventQueue(log, [_ev("e1", state="claimed")])
+    eq.events[0]["claimed_at"] = 0.0
+    eq.clock = 999.0  # the claimed event is stale → reclaimed → drained this tick
+    tq = _RecordingTaskQueue(log, pending=[{"id": "t1", "goal": "g", "assignee": "sandcastle"}])
+
+    wake_driver.tick(
+        eq,
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_spawn=lambda goal: None,
+        task_resolve_binary=lambda: "claude",
+    )
+
+    # AC1 order: reclaim(events) → reclaim_tasks() → drain(events) → drain_tasks()
+    assert log.index("event_reclaim") < log.index("task_reclaim")
+    assert log.index("task_list_running") < log.index("event_drain")
+    assert log.index("event_drain") < log.index("task_drain")
+
+
+def test_tick_without_task_port_is_event_only():
+    # Backward-compat: omitting task_port skips both task steps entirely.
+    q = FakeEventQueue([_ev("a")])
+    result = wake_driver.tick(q, wake_driver.default_orchestrator, stale_after_seconds=300)
+    assert result.processed == 1
+    assert result.tasks_spawned == 0
+    assert result.tasks_reclaimed == 0
+    assert result.tasks_reaped == 0
+    assert result.tasks_failed == 0
+
+
+def test_tick_reports_task_counts():
+    log: list = []
+    eq = FakeEventQueue([])
+    tq = _RecordingTaskQueue(
+        log,
+        pending=[{"id": "t1", "goal": "g", "assignee": "sandcastle"}],
+        stale_claimed=2,
+        stale_running=[{"id": "r1"}],
+    )
+    result = wake_driver.tick(
+        eq,
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_spawn=lambda goal: None,
+        task_resolve_binary=lambda: "claude",
+    )
+    assert result.tasks_reclaimed == 2  # AC5 stale claimed → pending
+    assert result.tasks_reaped == 1  # AC6 stale running → failed
+    assert result.tasks_spawned == 1  # AC2/AC3/AC4 the pending sandcastle row


### PR DESCRIPTION
## Summary
Closes the reactive forward path's missing link. `agents/task_dispatch.py` adds `drain_tasks` — it claims pending `sandcastle` rows from `task_queue`, transitions each to `running`, and fires `executor.spawn(goal)` — plus `reclaim_stale_tasks` to sweep stranded rows. `wake_driver.tick` now runs four ordered steps (event-watchdog → task-watchdog → event-drain → task-drain), so a task born from an event (or stranded by a crash) is swept and drained in the same tick. The pure logic runs over a `TaskQueuePort` Protocol, unit-tested with an in-memory fake — no live DB, no real `claude -p`.

## Why
After #741/#744 the path `event → wake_driver → orchestrator.handle_event → task_queue.enqueue(row)` existed, but **nothing claimed a pending row and called `executor.spawn`** — the loop was open. This is the foundational M44 slice: it closes that gap symmetrically to how `wake_driver.drain_pending` drains *events*.

Closes #909

## Decisions & Alternatives
Grill decision: `2489782f-cd76-48db-87ba-5ad949e0623b`.

- **Ordering B (claim → transition(running) → spawn)** over Ordering A (claim → spawn → transition). The `running` transition must precede the spawn so a crash in the window strands a `running` row (reaped by AC6) rather than a `claimed` row sitting next to a live process — the latter would let the AC5 reclaimer hand the same task to a *second* spawn. `claimed` therefore strictly means *claimed-but-not-yet-spawned*. Trade-off: a throttled `SpawnResult` (quota near-exhaustion → no process launched) leaves the row `running` until the generous AC6 reaper reclaims it. Liveness-aware handling is deferred to #921, not invented here.
- **Injectable-port architecture (AC10)** — pure `drain_tasks`/`reclaim_stale_tasks` over a `@runtime_checkable TaskQueuePort` Protocol; `SupabaseTaskQueue` is the thin real adapter, `FakeTaskQueue` drives the tests. Mirrors wake_driver's `EventQueuePort`/`PsycopgEventQueue`/`FakeEventQueue`. Rejected: testing against live Supabase (slow, flaky, needs network).
- **supabase-py for tasks vs raw psycopg for events** — events need `LISTEN/NOTIFY` (psycopg only); tasks don't, so they ride the existing supabase-py path in `task_queue.py`. The split is deliberate, not an inconsistency.
- **`claimed_at` as the running-age proxy** — there is no `running_at` column, and claimed→running is immediate under Ordering B, so `claimed_at` is a faithful staleness boundary for both the AC5 claimed-reclaimer and the AC6 running-reaper.
- **Budget sampled once at drain start** — `budget = cap − count_running(assignee)` taken once; nothing exits `running` mid-drain, so the snapshot is exact.
- **`reclaim_stale_claimed` bypasses the FSM** — `claimed → pending` is not a legal transition; a direct UPDATE (mirroring the event watchdog's `reclaim_stale`) is correct because no process is running for a stale-claimed row.
- Deferred (stated, not invented): internal completion closure → #921; task-NOTIFY wake latency → #922.

## Risk Assessment
- **LOW**: `agents/__init__.py` `__all__` entry; new dataclasses/constants.
- **MEDIUM**: `wake_driver.tick`/`run`/`main` signature extension — fully backward-compatible (task fields default to 0, `task_port=None` preserves event-only behavior); `task_queue.py` new query helpers.
- **HIGH**: crash-safety ordering (Ordering B) and the billing-trap path. AC8 rides `executor._sanitize_env` (strips `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`/`CLAUDE_API_KEY` so spawned `claude -p` bills Claude Max, not API) — a drain-path test asserts those keys are absent from the spawned env while `PATH` survives.

## Testing
- `pytest tests/test_agents_task_dispatch.py tests/test_wake_driver.py tests/test_agents_task_queue.py` → **71 passed**.
- `pytest tests/test_agents_executor.py` → 19 passed, 1 deselected. The deselected test (`test_resolve_claude_binary_raises_with_actionable_message`) is a **pre-existing, Windows-local-only env flake unrelated to #909** — it fails identically on clean `main` (verified via `git stash`), because this dev machine has `claude` installed at a default Windows path that the test's monkeypatch doesn't stub. On CI (`os.name != 'nt'`) the Windows-path fallback is skipped, so it raises and passes. Flagged for a separate fix.
- `ruff check --fix` → all checks passed; `ruff format` applied.
- Coverage traces 1:1 to AC1–AC10: concurrency cap, assignee routing, Ordering B (shared event-log asserts `transition(running)` precedes `spawn`), atomic-claim/lost-race, binary pre-flight skip, spawn-failure terminal, billing-trap through the drain path, claimed-reclaimer, running-reaper, port architecture (`isinstance(SupabaseTaskQueue(), TaskQueuePort)`).

## Files Changed
- `agents/task_dispatch.py` — **new**. `TaskQueuePort` Protocol, `DrainResult`/`ReclaimResult` dataclasses, `drain_tasks`, `reclaim_stale_tasks`, `SupabaseTaskQueue` adapter, default spawn/binary lazy adapters.
- `agents/wake_driver.py` — `tick` extended to four ordered steps with optional `task_port`; `run`/`main` forward `task_port`; `TickResult` gains `tasks_reclaimed/reaped/spawned/failed` (default 0).
- `agents/task_queue.py` — `claim_next(assignee=...)` SELECT-level filter; new `count_running`, `reclaim_stale_claimed`, `list_stale_running`, `_cutoff_iso` helpers.
- `agents/__init__.py` — `task_dispatch` added to `__all__`.
- `tests/test_agents_task_dispatch.py` — **new**, 17 tests (AC2–AC10).
- `tests/test_wake_driver.py` — 3 tests for the four-step tick ordering + task-count propagation.
- `tests/test_agents_task_queue.py` — tests for the new query helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
