### PR TITLE
fix(agents): harden task-dispatch drain per code-review (#909)

### DIFF
--- a/agents/executor.py
+++ b/agents/executor.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from agents.scope_hash import _hash_scope_files  # re-export — see issue #773
+from agents.scope_hash import _hash_scope_files  # noqa: F401 — re-export, see issue #773
 from agents.usage_probe import UsageProbe, read_usage
 
 logger = logging.getLogger(__name__)
@@ -43,6 +43,10 @@ _SENSITIVE_ENV_KEYS: frozenset[str] = frozenset(
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_AUTH_TOKEN",
         "CLAUDE_API_KEY",
+        # A base-url redirect is a billing trap too: it can point the spawned
+        # `claude -p` at a metered API gateway instead of the Max session.
+        "ANTHROPIC_BASE_URL",
+        "CLAUDE_BASE_URL",
     }
 )
 
@@ -117,17 +121,13 @@ def _resolve_claude_binary(override: str | None = None) -> str:
     if override:
         if os.path.exists(override):
             return override
-        raise FileNotFoundError(
-            f"claude binary override does not exist: {override!r}"
-        )
+        raise FileNotFoundError(f"claude binary override does not exist: {override!r}")
 
     env_path = os.environ.get("JARVIS_CLAUDE_BIN")
     if env_path:
         if os.path.exists(env_path):
             return env_path
-        raise FileNotFoundError(
-            f"JARVIS_CLAUDE_BIN points to a missing file: {env_path!r}"
-        )
+        raise FileNotFoundError(f"JARVIS_CLAUDE_BIN points to a missing file: {env_path!r}")
 
     found = shutil.which("claude")
     if found:
@@ -214,7 +214,8 @@ def spawn(
     if reading.near_exhaustion:
         logger.warning(
             "spawn refused — quota near-exhaustion (used=%d/%d)",
-            reading.used, reading.total,
+            reading.used,
+            reading.total,
         )
         return SpawnResult(
             proc=None,

--- a/agents/task_dispatch.py
+++ b/agents/task_dispatch.py
@@ -71,6 +71,11 @@ class TaskQueuePort(Protocol):
 
     Implemented for real by :class:`SupabaseTaskQueue` over
     :mod:`agents.task_queue`, and by an in-memory fake in the tests.
+
+    ``runtime_checkable`` makes ``isinstance(x, TaskQueuePort)`` check only that
+    the five method *names* are present — not their signatures — so the
+    ``isinstance`` assertion in the tests is a structural smoke check, not a
+    full conformance proof.
     """
 
     def claim_next(self, *, assignee: str) -> dict[str, Any] | None:
@@ -102,6 +107,10 @@ class DrainResult:
     # True iff the whole drain was skipped because the claude binary did not
     # resolve (AC7a) — distinct from "ran, claimed nothing".
     skipped_no_binary: bool = False
+    # True iff the drain stopped early because a spawn was throttled (quota
+    # near-exhaustion). The one in-flight row is left ``running`` for the AC6
+    # reaper; remaining rows stay ``pending`` and self-heal next drain.
+    throttled: bool = False
 
 
 @dataclass(frozen=True)
@@ -112,23 +121,22 @@ class ReclaimResult:
     reaped_running: int = 0
 
 
-def _default_spawn(goal: str) -> Any:
+def default_spawn(goal: str) -> Any:
     """Production spawn adapter — fire-and-forget ``claude -p`` via the executor.
 
     Returns the :class:`executor.SpawnResult`. A throttled result (quota
-    near-exhaustion) means no process launched while the row is already
-    ``running``; the AC6 reaper reclaims it after the generous threshold.
-    Liveness-aware handling is deferred to #921. Imported lazily so the tested
-    drain logic (which injects its own spawn) need not pull executor's
-    subprocess/usage-probe dependencies.
+    near-exhaustion) means no process launched; :func:`drain_tasks` inspects the
+    ``throttled`` flag and stops the drain rather than counting a phantom spawn.
+    Imported lazily so the tested drain logic (which injects its own spawn) need
+    not pull executor's subprocess/usage-probe dependencies.
     """
     from agents.executor import spawn as executor_spawn
 
     return executor_spawn(goal)
 
 
-def _default_resolve_binary() -> str:
-    """Production binary-resolution adapter (lazy import; see :func:`_default_spawn`)."""
+def default_resolve_binary() -> str:
+    """Production binary-resolution adapter (lazy import; see :func:`default_spawn`)."""
     from agents.executor import _resolve_claude_binary
 
     return _resolve_claude_binary()
@@ -136,20 +144,21 @@ def _default_resolve_binary() -> str:
 
 def drain_tasks(
     port: TaskQueuePort,
-    spawn: Spawn = _default_spawn,
+    spawn: Spawn = default_spawn,
     *,
     assignee: str = DEFAULT_ASSIGNEE,
     cap: int = DEFAULT_CONCURRENCY_CAP,
-    resolve_binary: ResolveBinary = _default_resolve_binary,
+    resolve_binary: ResolveBinary = default_resolve_binary,
 ) -> DrainResult:
     """Claim pending ``assignee`` tasks up to the cap and spawn each (AC2–AC4, AC7–AC9).
 
     Order of operations:
 
     1. **Pre-flight binary resolution, once (AC7a).** If the claude binary does
-       not resolve, skip the *entire* drain — zero claims, nothing marked
-       ``failed``, every row stays ``pending`` so the next drain self-heals once
-       the env is fixed. No internal retry.
+       not resolve — missing, not executable, or the executor import is broken —
+       skip the *entire* drain: zero claims, nothing marked ``failed``, every
+       row stays ``pending`` so the next drain self-heals once the env is fixed.
+       No internal retry.
     2. **Budget, sampled once (AC3).** ``budget = cap − count_running(assignee)``.
        Nothing exits ``running`` mid-drain, so the snapshot is exact; the loop
        spawns at most ``budget`` tasks and leaves the rest ``pending``.
@@ -160,14 +169,21 @@ def drain_tasks(
        would double-spawn under the AC5 reclaimer).
 
     A ``claim_next`` returning ``None`` (empty queue or lost race, AC9) breaks
-    the loop cleanly. A ``spawn`` raising (AC7b) marks *that* task
-    ``running→failed`` (terminal — the external event loop re-drives) and the
-    drain continues with the next claim.
+    the loop cleanly. A ``transition(running)`` raising leaves the row
+    ``claimed`` (no process launched) for the AC5 reclaimer and skips to the
+    next slot. A ``spawn`` raising (AC7b) marks *that* task ``running→failed``
+    (terminal — the external event loop re-drives) and the drain continues. A
+    ``spawn`` returning a *throttled* result (quota near-exhaustion: no process
+    launched) stops the drain — the one in-flight row is left ``running`` for
+    the AC6 reaper, the rest stay ``pending``; quota will not recover mid-drain.
     """
-    # AC7a — pre-flight once; unresolved binary skips the whole drain.
+    # AC7a — pre-flight once; an unusable binary skips the whole drain. Widened
+    # past FileNotFoundError to the other no-usable-binary failures (not
+    # executable → PermissionError; broken executor import → ImportError): all
+    # mean "cannot spawn", so skip-and-self-heal beats claim-and-strand.
     try:
         resolve_binary()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError, ImportError):
         logger.warning(
             "[task_dispatch] claude binary unresolved; skipping drain "
             "(no claims, rows stay pending, self-heals when env is fixed)"
@@ -187,15 +203,39 @@ def drain_tasks(
             break
         task_id = str(row["id"])
 
-        # AC4 Ordering B — running BEFORE spawn.
-        port.transition(task_id, "running")
+        # AC4 Ordering B — running BEFORE spawn. Guard it: a transient store
+        # error here leaves the row ``claimed`` with no process, so the AC5
+        # reclaimer returns it to ``pending``. Skip to the next slot rather than
+        # spawn against a row we failed to mark running.
         try:
-            spawn(row["goal"])  # AC8 billing-trap rides executor._sanitize_env
+            port.transition(task_id, "running")
+        except Exception:  # noqa: BLE001 — isolate a transient transition error
+            logger.exception(
+                "[task_dispatch] could not mark task %s running; left claimed for the reclaimer",
+                task_id,
+            )
+            continue
+
+        try:
+            result = spawn(row["goal"])  # AC8 billing-trap rides executor._sanitize_env
         except Exception as exc:  # noqa: BLE001 — AC7b: isolate one bad spawn
             # AC7b — terminal failure; no internal retry, external loop re-drives.
             port.transition(task_id, "failed", reason=f"spawn raised: {exc}")
             failed += 1
             continue
+
+        # The executor declined to launch (quota near-exhaustion): no process
+        # exists, but the row is already ``running`` (reaped by AC6 — bounded to
+        # this one row). Quota won't recover mid-drain, so stop claiming rather
+        # than strand the whole budget. Not a spawn failure → not counted.
+        if getattr(result, "throttled", False):
+            logger.warning(
+                "[task_dispatch] spawn throttled (quota near-exhaustion); "
+                "stopping drain — task %s left running for the reaper",
+                task_id,
+            )
+            return DrainResult(spawned=spawned, failed=failed, throttled=True)
+
         spawned += 1
 
     return DrainResult(spawned=spawned, failed=failed)

--- a/agents/task_queue.py
+++ b/agents/task_queue.py
@@ -25,7 +25,7 @@ Usage::
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -231,8 +231,6 @@ def _cutoff_iso(older_than_seconds: float) -> str:
     client-side; the few-ms client/server clock skew is irrelevant against
     the 300s+ thresholds these helpers run with.
     """
-    from datetime import timedelta
-
     return (datetime.now(timezone.utc) - timedelta(seconds=older_than_seconds)).isoformat()
 
 
@@ -305,9 +303,11 @@ def list_stale_running(
     generous (≫ normal task runtime) until #921 adds liveness-aware reaping.
     """
     cli = client or get_client()
+    # Only the id is needed — the reaper transitions by id; selecting "*" would
+    # ship every column over the wire for no reader.
     rows = (
         cli.table("task_queue")
-        .select("*")
+        .select("id")
         .eq("status", "running")
         .eq("assignee", assignee)
         .lt("claimed_at", _cutoff_iso(older_than_seconds))

--- a/agents/wake_driver.py
+++ b/agents/wake_driver.py
@@ -53,8 +53,8 @@ from agents.task_dispatch import (
     Spawn,
     SupabaseTaskQueue,
     TaskQueuePort,
-    _default_resolve_binary,
-    _default_spawn,
+    default_resolve_binary,
+    default_spawn,
     drain_tasks,
     reclaim_stale_tasks,
 )
@@ -169,8 +169,8 @@ def tick(
     *,
     stale_after_seconds: float,
     task_port: TaskQueuePort | None = None,
-    task_spawn: Spawn = _default_spawn,
-    task_resolve_binary: ResolveBinary = _default_resolve_binary,
+    task_spawn: Spawn = default_spawn,
+    task_resolve_binary: ResolveBinary = default_resolve_binary,
     task_claimed_stale_after_seconds: float = DEFAULT_CLAIMED_STALE_SECONDS,
     task_running_reap_after_seconds: float = DEFAULT_RUNNING_REAP_SECONDS,
 ) -> TickResult:
@@ -185,6 +185,13 @@ def tick(
     NOTIFY — a task is born from an event that already woke the driver, or is
     swept by the idle-timeout watchdog (AC1; task-NOTIFY latency deferred to
     #922).
+
+    The task steps (2 and 4) are each isolated in their own try/except: the
+    task_queue rides supabase-py while events ride psycopg, so a task-store
+    outage is an independent failure mode. It must not block the event drain
+    (Step 3) — events are the primary wake path. A failing task step is logged
+    and its rows stay in place (``claimed``/``running`` → swept next tick;
+    ``pending`` → re-drained next tick), exactly as a crash would leave them.
     """
     # Step 1 — event watchdog.
     reclaimed = run_watchdog(port, stale_after_seconds=stale_after_seconds)
@@ -192,11 +199,16 @@ def tick(
     # Step 2 — task watchdog (stale claimed → pending, stale running → failed).
     task_reclaim = None
     if task_port is not None:
-        task_reclaim = reclaim_stale_tasks(
-            task_port,
-            claimed_stale_after_seconds=task_claimed_stale_after_seconds,
-            running_reap_after_seconds=task_running_reap_after_seconds,
-        )
+        try:
+            task_reclaim = reclaim_stale_tasks(
+                task_port,
+                claimed_stale_after_seconds=task_claimed_stale_after_seconds,
+                running_reap_after_seconds=task_running_reap_after_seconds,
+            )
+        except Exception:  # noqa: BLE001 — task-store outage must not block event drain
+            logger.exception(
+                "[wake_driver] task watchdog failed; stale task rows left for the next tick"
+            )
 
     # Step 3 — event drain.
     processed = drain_pending(port, orchestrator)
@@ -204,7 +216,12 @@ def tick(
     # Step 4 — task drain (claim → running → spawn, capped, Ordering B).
     task_drain = None
     if task_port is not None:
-        task_drain = drain_tasks(task_port, task_spawn, resolve_binary=task_resolve_binary)
+        try:
+            task_drain = drain_tasks(task_port, task_spawn, resolve_binary=task_resolve_binary)
+        except Exception:  # noqa: BLE001 — task-store outage must not crash the tick
+            logger.exception(
+                "[wake_driver] task drain failed; pending tasks left for the next tick"
+            )
 
     return TickResult(
         reclaimed=reclaimed,
@@ -223,6 +240,10 @@ def run(
     stale_after_seconds: float = DEFAULT_STALE_AFTER_SECONDS,
     should_continue: Callable[[], bool] | None = None,
     task_port: TaskQueuePort | None = None,
+    task_spawn: Spawn = default_spawn,
+    task_resolve_binary: ResolveBinary = default_resolve_binary,
+    task_claimed_stale_after_seconds: float = DEFAULT_CLAIMED_STALE_SECONDS,
+    task_running_reap_after_seconds: float = DEFAULT_RUNNING_REAP_SECONDS,
 ) -> None:
     """The event-driven loop: block on a wake signal, then run one tick.
 
@@ -235,7 +256,10 @@ def run(
     When ``task_port`` is supplied, each tick also sweeps and drains the
     ``task_queue`` (#909). The same idle-timeout that runs the event watchdog
     runs the task watchdog, so tasks left ``claimed``/``running`` by a crash
-    are swept even on an idle queue.
+    are swept even on an idle queue. The ``task_spawn`` / ``task_resolve_binary``
+    / ``task_*_after_seconds`` knobs are forwarded to each :func:`tick` so the
+    spawn function, binary resolver, and staleness thresholds stay injectable
+    end-to-end (tests and operators), not just at the ``tick`` boundary.
 
     A tick that raises is logged and swallowed so a transient failure does
     not tear down the driver — the offending event stays ``claimed`` and the
@@ -245,7 +269,16 @@ def run(
     while keep_going():
         port.wait_for_wake(timeout_seconds=stale_after_seconds)
         try:
-            tick(port, orchestrator, stale_after_seconds=stale_after_seconds, task_port=task_port)
+            tick(
+                port,
+                orchestrator,
+                stale_after_seconds=stale_after_seconds,
+                task_port=task_port,
+                task_spawn=task_spawn,
+                task_resolve_binary=task_resolve_binary,
+                task_claimed_stale_after_seconds=task_claimed_stale_after_seconds,
+                task_running_reap_after_seconds=task_running_reap_after_seconds,
+            )
         except Exception:  # noqa: BLE001 — daemon must survive a bad tick
             logger.exception("[wake_driver] tick failed; event left claimed for watchdog re-claim")
 

--- a/tests/test_agents_executor.py
+++ b/tests/test_agents_executor.py
@@ -49,6 +49,10 @@ def test_sensitive_env_keys_cover_known_variants() -> None:
     assert "ANTHROPIC_API_KEY" in _SENSITIVE_ENV_KEYS
     assert "ANTHROPIC_AUTH_TOKEN" in _SENSITIVE_ENV_KEYS
     assert "CLAUDE_API_KEY" in _SENSITIVE_ENV_KEYS
+    # A base-url redirect is as much a billing trap as a key: it can point the
+    # spawned `claude -p` at a metered API gateway instead of the Max session.
+    assert "ANTHROPIC_BASE_URL" in _SENSITIVE_ENV_KEYS
+    assert "CLAUDE_BASE_URL" in _SENSITIVE_ENV_KEYS
 
 
 def test_spawn_allowlist_excludes_dangerous_permissions() -> None:
@@ -74,8 +78,9 @@ def test_spawn_allowlist_excludes_dangerous_permissions() -> None:
 
     for pattern in ["merge", "delete"]:
         for tool in _SPAWN_ALLOWED_TOOLS:
-            assert pattern not in tool, \
+            assert pattern not in tool, (
                 f"Destructive pattern '{pattern}' found in allowlist entry '{tool}'"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -83,7 +88,9 @@ def test_spawn_allowlist_excludes_dangerous_permissions() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_claude_binary_override_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+def test_resolve_claude_binary_override_wins(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
     from agents.executor import _resolve_claude_binary
 
     real = tmp_path / "real-claude.exe"
@@ -104,7 +111,8 @@ def test_resolve_claude_binary_override_must_exist(tmp_path: Any) -> None:
 
 
 def test_resolve_claude_binary_env_var_wins_over_path(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
 ) -> None:
     from agents.executor import _resolve_claude_binary
 
@@ -125,7 +133,8 @@ def test_resolve_claude_binary_env_var_must_exist(monkeypatch: pytest.MonkeyPatc
 
 
 def test_resolve_claude_binary_falls_through_to_shutil_which(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
 ) -> None:
     import shutil as _shutil
     from agents.executor import _resolve_claude_binary
@@ -175,6 +184,8 @@ def test_sanitize_env_strips_all_known_variants() -> None:
         "ANTHROPIC_API_KEY": "a",
         "ANTHROPIC_AUTH_TOKEN": "b",
         "CLAUDE_API_KEY": "c",
+        "ANTHROPIC_BASE_URL": "https://metered.example/v1",
+        "CLAUDE_BASE_URL": "https://metered.example/v1",
     }
     out = _sanitize_env(src)
     assert out == {"SAFE": "keep"}
@@ -333,7 +344,6 @@ class _FixedProbe:
 
 
 def _healthy_reading() -> Any:
-    from datetime import timedelta
 
     from agents.usage_probe import UsageReading
 
@@ -347,7 +357,6 @@ def _healthy_reading() -> Any:
 
 
 def _exhausted_reading() -> Any:
-    from datetime import timedelta
 
     from agents.usage_probe import UsageReading
 
@@ -362,9 +371,11 @@ def _exhausted_reading() -> Any:
 
 def _false_safe_error_probe() -> _FixedProbe:
     """Probe that raises — confirms the false-safe contract in the executor."""
+
     class _RaisingProbe:
         def read(self) -> Any:
             raise RuntimeError("probe broken")
+
     return _RaisingProbe()  # type: ignore[return-value]
 
 

--- a/tests/test_agents_task_dispatch.py
+++ b/tests/test_agents_task_dispatch.py
@@ -20,6 +20,7 @@ from typing import Any
 from agents.task_dispatch import (
     DEFAULT_ASSIGNEE,
     DEFAULT_CONCURRENCY_CAP,
+    DrainResult,
     SupabaseTaskQueue,
     TaskQueuePort,
     drain_tasks,
@@ -86,6 +87,18 @@ class FakeTaskQueue:
 
 def _always_resolve() -> str:
     return "claude"
+
+
+class _ThrottledResult:
+    """Stand-in for ``executor.SpawnResult`` when quota is near-exhaustion.
+
+    No process was launched (``proc=None``); the ``throttled`` flag is the
+    signal :func:`drain_tasks` must honor instead of counting a spawn.
+    """
+
+    proc = None
+    throttled = True
+    reason = "quota near-exhaustion"
 
 
 # ---------------------------------------------------------------------------
@@ -207,6 +220,34 @@ class TestBinaryPreflight:
         assert res.spawned == 0
         assert len(q._pending) == 2  # rows stay pending -> next drain self-heals
 
+    def test_permissionerror_in_resolve_also_skips_drain(self) -> None:
+        # A binary that exists but is not executable means "cannot spawn" just
+        # as much as a missing one — skip the whole drain, claim nothing.
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+        spawns: list[str] = []
+
+        def resolve_denied() -> str:
+            raise PermissionError("claude is not executable")
+
+        res = drain_tasks(q, lambda g: spawns.append(g), resolve_binary=resolve_denied)
+
+        assert res.skipped_no_binary is True
+        assert q.claimed == []
+        assert spawns == []
+
+    def test_importerror_in_resolve_also_skips_drain(self) -> None:
+        # A broken executor import surfaces as ImportError from the lazy
+        # default resolver — still "cannot spawn", so skip not strand.
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+
+        def resolve_broken() -> str:
+            raise ImportError("executor dependency missing")
+
+        res = drain_tasks(q, lambda g: None, resolve_binary=resolve_broken)
+
+        assert res.skipped_no_binary is True
+        assert q.claimed == []
+
 
 # ---------------------------------------------------------------------------
 # AC7b — spawn raises: mark that task failed (terminal), continue the drain
@@ -234,6 +275,93 @@ class TestSpawnFailureIsTerminal:
         assert spawns == ["do ok"]
         assert res.spawned == 1
         assert res.failed == 1
+
+
+# ---------------------------------------------------------------------------
+# review #2 — throttled spawn (quota near-exhaustion) is not a spawn
+# ---------------------------------------------------------------------------
+
+
+class TestThrottledSpawn:
+    def test_throttle_stops_drain_without_miscounting(self) -> None:
+        # Quota near-exhaustion: executor.spawn returns throttled=True, proc=None
+        # — no process launched. The pre-fix bug counted this as `spawned` and
+        # drained the WHOLE budget into 'running' rows, orphaning every one for
+        # the 6h reaper. The drain must instead bail after a single row.
+        q = FakeTaskQueue(pending=[_row(f"t{i}") for i in range(4)], running_count=0)
+        res = drain_tasks(q, lambda g: _ThrottledResult(), cap=5, resolve_binary=_always_resolve)
+
+        assert res.spawned == 0
+        assert res.failed == 0
+        assert res.throttled is True
+        # Exactly one row was claimed+transitioned-running before the drain
+        # bailed — bounded blast radius (that row is reaped by AC6), not the cap.
+        assert len(q.claimed) == 1
+        assert ("t0", "running", None) in q.transitions
+        # A throttle is NOT a spawn failure — the row must not be marked failed.
+        assert [t for t in q.transitions if t[1] == "failed"] == []
+
+    def test_throttle_midway_spawns_healthy_then_stops(self) -> None:
+        # First task spawns healthily, the second hits the quota wall. The
+        # healthy spawn still counts; the drain then stops on the throttle.
+        calls = {"n": 0}
+
+        def spawn(goal: str) -> Any:
+            calls["n"] += 1
+            return None if calls["n"] == 1 else _ThrottledResult()
+
+        q = FakeTaskQueue(pending=[_row("t0"), _row("t1"), _row("t2")], running_count=0)
+        res = drain_tasks(q, spawn, cap=5, resolve_binary=_always_resolve)
+
+        assert res.spawned == 1
+        assert res.throttled is True
+        assert len(q.claimed) == 2  # t0 (spawned) + t1 (throttled, left running)
+
+    def test_drain_result_has_throttled_field_default_false(self) -> None:
+        assert DrainResult().throttled is False
+
+
+# ---------------------------------------------------------------------------
+# review #5 — a failed running-transition leaves the row claimed (AC5 reclaims)
+# ---------------------------------------------------------------------------
+
+
+class TestRunningTransitionFailureIsSafe:
+    def test_transition_running_raise_skips_row_no_spawn(self) -> None:
+        spawns: list[str] = []
+
+        class Q(FakeTaskQueue):
+            def transition(self, task_id: str, to_status: str, *, reason: str | None = None) -> Any:
+                if to_status == "running":
+                    raise RuntimeError("supabase transient error")
+                return super().transition(task_id, to_status, reason=reason)
+
+        q = Q(pending=[_row("t0")], running_count=0)
+        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+
+        # The row was claimed but the running transition failed: never spawned,
+        # never marked failed — left 'claimed' for the AC5 reclaimer.
+        assert spawns == []
+        assert res.spawned == 0
+        assert res.failed == 0
+        assert [t for t in q.transitions if t[1] == "failed"] == []
+
+    def test_transition_running_raise_continues_to_next_row(self) -> None:
+        # A transient transition error on one row must not abort the drain —
+        # it skips that row (left claimed) and continues with the next.
+        spawns: list[str] = []
+
+        class Q(FakeTaskQueue):
+            def transition(self, task_id: str, to_status: str, *, reason: str | None = None) -> Any:
+                if to_status == "running" and task_id == "bad":
+                    raise RuntimeError("transient")
+                return super().transition(task_id, to_status, reason=reason)
+
+        q = Q(pending=[_row("bad"), _row("good")], running_count=0)
+        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+
+        assert spawns == ["do good"]
+        assert res.spawned == 1
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +418,8 @@ class TestBillingTrapThroughDrain:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-must-be-stripped")
         monkeypatch.setenv("CLAUDE_API_KEY", "sk-also-stripped")
         monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-stripped")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://metered.example/v1")
+        monkeypatch.setenv("CLAUDE_BASE_URL", "https://metered.example/v1")
         monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake_bin))
         monkeypatch.setenv("PATH_FROM_PARENT", "keep-me")
 
@@ -310,6 +440,8 @@ class TestBillingTrapThroughDrain:
         assert "ANTHROPIC_API_KEY" not in env, "billing-trap leak through drain path"
         assert "CLAUDE_API_KEY" not in env
         assert "ANTHROPIC_AUTH_TOKEN" not in env
+        assert "ANTHROPIC_BASE_URL" not in env, "base-url redirect leak through drain path"
+        assert "CLAUDE_BASE_URL" not in env
         assert env.get("PATH_FROM_PARENT") == "keep-me", "non-sensitive env must survive"
 
 

--- a/tests/test_wake_driver.py
+++ b/tests/test_wake_driver.py
@@ -361,6 +361,8 @@ def test_tick_runs_the_four_steps_in_order():
 
     # AC1 order: reclaim(events) → reclaim_tasks() → drain(events) → drain_tasks()
     assert log.index("event_reclaim") < log.index("task_reclaim")
+    # Within the task watchdog, claimed-reclaim precedes the running-reaper scan.
+    assert log.index("task_reclaim") < log.index("task_list_running")
     assert log.index("task_list_running") < log.index("event_drain")
     assert log.index("event_drain") < log.index("task_drain")
 
@@ -396,3 +398,162 @@ def test_tick_reports_task_counts():
     assert result.tasks_reclaimed == 2  # AC5 stale claimed → pending
     assert result.tasks_reaped == 1  # AC6 stale running → failed
     assert result.tasks_spawned == 1  # AC2/AC3/AC4 the pending sandcastle row
+
+
+# --- review #1: the task side and event side are isolated within a tick -----
+
+
+class _RaisingOnReclaimTaskQueue:
+    """TaskQueuePort whose task watchdog raises — models a Supabase outage in
+    tick Step 2 (the task reclaim), which must not starve the event drain."""
+
+    def claim_next(self, *, assignee: str):
+        return None
+
+    def count_running(self, *, assignee: str) -> int:
+        return 0
+
+    def transition(self, task_id: str, to_status: str, *, reason=None):
+        return {"id": task_id, "status": to_status}
+
+    def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+        raise RuntimeError("supabase unreachable")
+
+    def list_stale_running(self, *, assignee: str, older_than_seconds: float):
+        return []
+
+
+class _RaisingOnDrainTaskQueue:
+    """TaskQueuePort whose drain raises — models a task-store outage in tick
+    Step 4 (after events already drained in Step 3)."""
+
+    def claim_next(self, *, assignee: str):
+        raise RuntimeError("supabase unreachable")
+
+    def count_running(self, *, assignee: str) -> int:
+        return 0
+
+    def transition(self, task_id: str, to_status: str, *, reason=None):
+        return {"id": task_id, "status": to_status}
+
+    def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+        return 0
+
+    def list_stale_running(self, *, assignee: str, older_than_seconds: float):
+        return []
+
+
+def test_tick_task_watchdog_failure_does_not_block_event_drain():
+    # A Supabase outage in the task watchdog (Step 2) must not starve the
+    # psycopg-backed event path (Step 3). Events still drain; task counts are
+    # zero; the tick returns instead of raising.
+    q = FakeEventQueue([_ev("a"), _ev("b")])
+    result = wake_driver.tick(
+        q,
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=_RaisingOnReclaimTaskQueue(),
+        task_resolve_binary=lambda: "claude",
+    )
+    assert result.processed == 2  # events drained despite the task-side outage
+    assert result.tasks_reclaimed == 0
+    assert result.tasks_reaped == 0
+
+
+def test_tick_task_drain_failure_does_not_crash_tick():
+    # A failure in the task drain (Step 4) is contained — the event drain
+    # (Step 3) already ran, and the tick returns a result instead of raising.
+    q = FakeEventQueue([_ev("a")])
+    result = wake_driver.tick(
+        q,
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=_RaisingOnDrainTaskQueue(),
+        task_resolve_binary=lambda: "claude",
+    )
+    assert result.processed == 1
+    assert result.tasks_spawned == 0
+    assert result.tasks_failed == 0
+
+
+# --- review #3: run() forwards every task param to tick() -------------------
+
+
+def test_run_forwards_task_spawn_and_resolver_to_tick():
+    # run() must forward task_spawn / task_resolve_binary, else the loop
+    # silently falls back to the production defaults (real claude binary, real
+    # spawn) no matter what main() injected. Drive one iteration and assert the
+    # injected fakes were the ones used.
+    log: list = []
+    q = FakeEventQueue([])
+    q.wake_signals = [True]
+    tq = _RecordingTaskQueue(
+        log, pending=[{"id": "t1", "goal": "do-the-thing", "assignee": "sandcastle"}]
+    )
+    spawned: list[str] = []
+    resolved = {"n": 0}
+    ticks = {"n": 0}
+
+    def should_continue() -> bool:
+        ticks["n"] += 1
+        return ticks["n"] <= 1
+
+    def fake_resolve() -> str:
+        resolved["n"] += 1
+        return "claude"
+
+    wake_driver.run(
+        q,
+        wake_driver.default_orchestrator,
+        should_continue=should_continue,
+        task_port=tq,
+        task_spawn=lambda goal: spawned.append(goal),
+        task_resolve_binary=fake_resolve,
+    )
+
+    assert spawned == ["do-the-thing"]  # injected spawn forwarded, not the default
+    assert resolved["n"] == 1  # injected resolver forwarded, not the default
+
+
+def test_run_forwards_task_thresholds_to_tick():
+    # The claimed/running staleness thresholds must reach reclaim_stale_tasks;
+    # a partial forward would silently apply the module defaults instead.
+    seen: dict = {}
+
+    class _ThresholdPort:
+        def claim_next(self, *, assignee: str):
+            return None
+
+        def count_running(self, *, assignee: str) -> int:
+            return 0
+
+        def transition(self, task_id: str, to_status: str, *, reason=None):
+            return {"id": task_id}
+
+        def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+            seen["claimed"] = older_than_seconds
+            return 0
+
+        def list_stale_running(self, *, assignee: str, older_than_seconds: float):
+            seen["running"] = older_than_seconds
+            return []
+
+    q = FakeEventQueue([])
+    q.wake_signals = [False]
+    ticks = {"n": 0}
+
+    def should_continue() -> bool:
+        ticks["n"] += 1
+        return ticks["n"] <= 1
+
+    wake_driver.run(
+        q,
+        wake_driver.default_orchestrator,
+        should_continue=should_continue,
+        task_port=_ThresholdPort(),
+        task_resolve_binary=lambda: "claude",
+        task_claimed_stale_after_seconds=111,
+        task_running_reap_after_seconds=222,
+    )
+
+    assert seen == {"claimed": 111, "running": 222}


### PR DESCRIPTION
## Summary
Follow-up to [#950](https://github.com/Osasuwu/jarvis/pull/950), which shipped the task-dispatch loop's core. This addresses the substantive Claude code-review findings from that PR (it was "APPROVE WITH COMMENTS" — advisory, so it auto-merged before the comments were worked through). All crash-safety and billing-trap properties are preserved; the failure modes are made more conservative. Done test-first (red→green).

## Why
The original review surfaced real correctness/robustness gaps in `drain_tasks` and the wake_driver task steps. None blocked the merge, but each is worth closing while the design is fresh.
Closes #909

## Decisions & Alternatives
- **Throttle stops the drain (finding #2).** A throttled `SpawnResult` (quota near-exhaustion → no process launched) now stops claiming instead of counting a phantom spawn. The one in-flight row is left `running` for the AC6 reaper; the rest stay `pending`. Chose result-inspection + early-return over injecting a new `quota_ok` pre-flight port — smaller diff, no churn across the 17 existing drain call-sites. Trade-off: one row stranded-running per throttled tick (AC6-reaped) instead of zero. Quota will not recover mid-drain, so stopping is correct.
- **Guard the running transition (finding #5).** A transient store error on `transition(running)` now leaves the row `claimed` (no process) for the AC5 reclaimer and skips to the next slot, rather than spawning against a row we failed to mark running (which would risk a double-spawn under Ordering B).
- **Widen the pre-flight guard (finding #6).** `resolve_binary()` now skips the whole drain on `PermissionError` (binary not executable) and `ImportError` (broken executor import) in addition to `FileNotFoundError`. All three mean "cannot spawn" — skip-and-self-heal beats claim-and-strand.
- **Isolate the task steps in `tick()` (findings #1, #3).** `task_queue` rides supabase-py while events ride psycopg, so a task-store outage is an independent failure mode. Steps 2 (task watchdog) and 4 (task drain) are each wrapped in `try/except` so they cannot block the event drain (Step 3, the primary wake path). `run()` now forwards `task_spawn`, `task_resolve_binary`, and both staleness thresholds to `tick()` so they stay injectable end-to-end, not just at the `tick` boundary.
- **Billing-trap covers base-url redirects (finding #4).** `ANTHROPIC_BASE_URL` / `CLAUDE_BASE_URL` added to `_SENSITIVE_ENV_KEYS` — a base-url redirect can point the spawned `claude -p` at a metered API gateway instead of the Max session, which is a billing trap just like an API key.
- **Public rename (finding #9).** `_default_spawn`/`_default_resolve_binary` → `default_spawn`/`default_resolve_binary` — they are the production injection points `wake_driver` imports, not private helpers.
- **Nits (#10):** `list_stale_running` selects only `id` (the reaper transitions by id); `timedelta` import consolidated.
- Marked the `_hash_scope_files` re-export `# noqa: F401` so `ruff --fix` stops stripping it (latent F401; CI does not run ruff, so the bare import survived only by luck).

## Risk Assessment
- **LOW**: base-url key additions, `select("id")`, import consolidation, the F401 noqa, the public rename.
- **MEDIUM**: the three `drain_tasks` behavior changes (throttle-stop, guarded transition, widened pre-flight) and the `tick()` task-step isolation. Each is covered by new tests and makes an existing failure mode strictly more conservative — no new spawn paths.

## Testing
- `pytest tests/test_agents_task_dispatch.py tests/test_wake_driver.py tests/test_agents_executor.py` — 65 passed (1 Windows-local flake deselected; CI Linux passes it).
- Full suite: **2161 passed**, 1 deselected.
- `ruff check` + `ruff format` — clean.
- +14 new tests: throttle-stops-drain (no miscount), throttle-midway (spawns healthy then stops), guarded running transition (skip + continue to next row), widened pre-flight (`PermissionError`, `ImportError`), base-url billing-trap through the drain, task-step isolation in `tick()` (watchdog/drain failure does not block event drain), and `run()`→`tick()` parameter forwarding.

## Files Changed
- `agents/task_dispatch.py` — throttle-stop, guarded running transition, widened pre-flight, public rename, `DrainResult.throttled` field.
- `agents/wake_driver.py` — task-step `try/except` isolation in `tick()`, `run()` forwards the four task knobs, import rename.
- `agents/executor.py` — base-url keys in `_SENSITIVE_ENV_KEYS`, `_hash_scope_files` re-export `# noqa: F401`.
- `agents/task_queue.py` — `list_stale_running` selects `id`, `timedelta` import consolidated.
- `tests/test_agents_task_dispatch.py`, `tests/test_wake_driver.py`, `tests/test_agents_executor.py` — the 14 new tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
