### PR TITLE
feat(config): workflow supercharge — SessionEnd state save, model tiering, skill diet

### DIFF
--- a/.claude-userlevel/.mcp.json
+++ b/.claude-userlevel/.mcp.json
@@ -22,15 +22,6 @@
     "obsidian": {
       "command": "npx",
       "args": ["-y", "@bitbonsai/mcpvault@latest", "${OBSIDIAN_VAULT_PATH}"]
-    },
-    "bambu-printer": {
-      "command": "npx",
-      "args": ["-y", "bambu-printer-mcp"],
-      "env": {
-        "BAMBU_IP": "${BAMBU_IP}",
-        "BAMBU_TOKEN": "${BAMBU_TOKEN}",
-        "BAMBU_SERIAL": "${BAMBU_SERIAL}"
-      }
     }
   }
 }

--- a/.claude-userlevel/README.md
+++ b/.claude-userlevel/README.md
@@ -43,6 +43,21 @@ rewritten to absolute paths inside the jarvis repo at install time by
 in-repo artefacts, and the rewrite logic is the single place path-portability
 concerns land.
 
+### Hardware-bound MCP servers stay per-device
+
+`bambu-printer` (and any future hardware-tied server) is intentionally **not**
+in `.claude-userlevel/.mcp.json`: the installer registers every listed server
+at user scope on *every* device, and a server whose hardware/env
+(`BAMBU_IP`, …) is absent on a machine error-spams each session there.
+Register such servers manually on the device that owns the hardware:
+
+```
+claude mcp add -s user bambu-printer -e BAMBU_IP=... -e BAMBU_TOKEN=... -e BAMBU_SERIAL=... -- npx -y bambu-printer-mcp
+```
+
+The installer never removes user-scope servers, so a manual registration
+survives future `install.ps1 -Apply` runs.
+
 ## Why a whitelist in `install-manifest.yaml`?
 
 An explicit whitelist means dropping a README, experiment note, or

--- a/.claude-userlevel/settings.json
+++ b/.claude-userlevel/settings.json
@@ -74,6 +74,13 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          { "type": "command", "command": "python scripts/pre-compact-backup.py" }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup",
@@ -206,5 +213,17 @@
         ]
       }
     ]
+  },
+  "fallbackModel": "claude-sonnet-4-6",
+  "statusLine": {
+    "type": "inline",
+    "format": "{model} | ctx {context_usage}% | {git_branch}"
+  },
+  "skillOverrides": {
+    "setup-tasks": "name-only",
+    "last-work-report": "name-only",
+    "caveman": "name-only",
+    "status-record": "name-only",
+    "autonomous-loop": "name-only"
   }
 }

--- a/.claude-userlevel/skills/status-record/SKILL.md
+++ b/.claude-userlevel/skills/status-record/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: status-record
+model: claude-haiku-4-5
 description: "Periodic state snapshot to memory: per-repo git/CI/PR/issue/milestone state, written as a structured event under tag `status-snapshot`. Type 1 (cron-triggered). Records only — no decisions, no actions. Owner reads back inline via `memory_recall(query=\"status-snapshot\", type=reference)`."
 ---
 

--- a/.claude-userlevel/skills/zoom-out/SKILL.md
+++ b/.claude-userlevel/skills/zoom-out/SKILL.md
@@ -2,6 +2,7 @@
 name: zoom-out
 description: Tell the agent to zoom out and give broader context or a higher-level perspective. Use when you're unfamiliar with a section of code or need to understand how it fits into the bigger picture.
 disable-model-invocation: true
+model: claude-sonnet-4-6
 ---
 
 I don't know this area of code well. Go up a layer of abstraction. Give me a map of all the relevant modules and callers, using the project's domain glossary vocabulary.

--- a/scripts/pre-compact-backup.py
+++ b/scripts/pre-compact-backup.py
@@ -1,4 +1,4 @@
-"""PreCompact hook: capture a durable session snapshot before auto-compaction.
+"""PreCompact + SessionEnd hook: capture a durable session snapshot.
 
 Parses the session JSONL transcript, composes a structured markdown snapshot,
 and upserts it to Supabase (name=`session_snapshot_<session_id>`, type=project)
@@ -10,11 +10,14 @@ Invariants:
 - Snapshot content stays under SIZE_BUDGET bytes (~30KB). Long transcripts
   keep only the last TAIL_KEEP entries with a dropped-head counter.
 
-Registered in `.claude/settings.json` under `PreCompact` for both `auto` and
-`manual` matchers.
+Registered in user-level `settings.json` under `PreCompact` (matchers `auto`,
+`manual`) and `SessionEnd` (all end reasons) — the same snapshot doubles as a
+post-session state save that `session-context.py` picks up on resume (#279).
 
 Hook input (stdin, JSON):
-  session_id, transcript_path, cwd, hook_event_name, trigger ("auto"|"manual")
+  session_id, transcript_path, cwd, hook_event_name,
+  trigger ("auto"|"manual") for PreCompact / end_reason ("clear"|"logout"|...)
+  for SessionEnd
 
 Related:
 - `scripts/session-context.py` — reads snapshots on resume (Phase 2, #279)
@@ -409,7 +412,12 @@ def main() -> int:
         session_id = hook.get("session_id") or hook.get("sessionId") or "unknown-session"
         transcript_path = hook.get("transcript_path") or hook.get("transcriptPath") or ""
         cwd = hook.get("cwd") or os.getcwd()
-        trigger = hook.get("trigger") or hook.get("matcher") or "unknown"
+        trigger = (
+            hook.get("trigger")
+            or hook.get("matcher")
+            or hook.get("end_reason")
+            or "unknown"
+        )
 
         if not transcript_path:
             print("[pre-compact] no transcript_path in hook input", file=sys.stderr)


### PR DESCRIPTION
[no-issue] — owner-requested configuration review/update (workflow-supercharge session), fix-inline per #428.

## What

| Area | Change |
|---|---|
| Post-session state save | `SessionEnd` hook in `.claude-userlevel/settings.json` wired to the existing `scripts/pre-compact-backup.py`; the script now accepts `end_reason` payloads alongside PreCompact `trigger`/`matcher`. Snapshot lands in Supabase (`session_snapshot_<id>`), picked up by `session-context.py` on resume (#279). |
| Model tiering | `status-record` skill pinned to haiku (mechanical cron snapshot), `zoom-out` pinned to sonnet. `context: fork` deliberately NOT applied to zoom-out — the skill depends on conversation history. |
| Fallback | Top-level `fallbackModel: claude-sonnet-4-6` so quota pressure degrades instead of stopping. |
| Statusline | Inline statusline `{model} | ctx {context_usage}% | {git_branch}` — context % visible at a glance. |
| Skill diet | `skillOverrides: name-only` for 5 rarely-invoked skills (`setup-tasks`, `last-work-report`, `caveman`, `status-record`, `autonomous-loop`) — trims per-session skill-listing tokens. |
| MCP hygiene | `bambu-printer` removed from centrally-installed `.claude-userlevel/.mcp.json` (hardware-bound; error-spams the 2 devices without the printer). Manual per-device registration documented in README; installer add-only semantics keep Main PC's existing user-scope registration. |

## Notes

- `statusLine` / `fallbackModel` / `skillOverrides` schemas are newer than the pinned settings doc (v2.1.148) — verified against w15–w23 intel memory; if statusline doesn't render after restart, swap to `command` type.
- Deep-merge semantics: all three are new top-level keys, and `SessionEnd` is a new event — no collision with user-local settings.
- `pre-compact-backup.py` change is one expression + docstring; full test suite (36) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)