### PR TITLE
feat(agents): close task_queue running→done + liveness reaper (#921)

### DIFF
--- a/agents/task_dispatch.py
+++ b/agents/task_dispatch.py
@@ -1,17 +1,24 @@
 """task_dispatch — close the reactive forward path (#909).
 
-The reactive forward path was left open after #741/#744::
+The reactive forward path is now closed end-to-end (#741/#744 → #909 → #921)::
 
     event → wake_driver → orchestrator.handle_event
-          → task_queue.enqueue(row) → ❌ MISSING → executor.spawn
+          → task_queue.enqueue(row) → drain_tasks → executor.spawn
+          → poll_completions → running → done | failed
 
-Nothing claimed a pending ``task_queue`` row and called :func:`executor.spawn`.
-This module is the missing link: :func:`drain_tasks` claims pending
-``sandcastle`` rows, transitions each to ``running``, and fires
-``executor.spawn(goal)`` — symmetric to how :func:`wake_driver.drain_pending`
-drains *events*. Completion (``running → done``) re-enters **externally** via
-GitHub Path-A workflows as a fresh ``event`` (no internal polling; closure
-deferred to #921).
+:func:`drain_tasks` claims pending ``sandcastle`` rows, transitions each to
+``running``, and fires ``executor.spawn(goal)`` — symmetric to how
+:func:`wake_driver.drain_pending` drains *events*. The spawned processes are
+handed back as :attr:`DrainResult.procs`; :func:`poll_completions` (#921)
+closes each row when its process exits — exit 0 → ``done``, non-zero →
+``failed``. **Model P semantics: ``done`` means the spawned process exited
+cleanly, nothing more** — not task success, not PR-merged. Outcome truth
+re-enters externally via GitHub Path-A workflows as fresh *events*.
+
+**Restart limitation (#921):** the proc map lives only in the driver process.
+A restart forgets every live process — those rows age out and the orphan
+reaper (:func:`reclaim_stale_tasks`) fails them as a backstop, which Path A
+then self-heals. A PID sidecar that survives restarts is #952.
 
 Design mirrors :mod:`agents.wake_driver`: the pure logic
 (:func:`drain_tasks` / :func:`reclaim_stale_tasks`) runs over a
@@ -32,7 +39,10 @@ would let the claimed-reclaimer (AC5) hand the same task to a second spawn.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
@@ -44,8 +54,8 @@ logger = logging.getLogger(__name__)
 # never claimed by the drain (AC2).
 DEFAULT_ASSIGNEE = "sandcastle"
 
-# Max concurrent running sandcastle tasks (AC3). Until #921 wires real
-# completion closure, the loop self-throttles to this cap.
+# Max concurrent running sandcastle tasks (AC3). Measures compute concurrency:
+# slots free as soon as poll_completions observes the process exit (#921).
 DEFAULT_CONCURRENCY_CAP = 5
 
 # A row stuck in ``claimed`` past this long means the drainer died between the
@@ -53,16 +63,21 @@ DEFAULT_CONCURRENCY_CAP = 5
 # to ``pending`` (AC5). Matches the wake_driver event watchdog default.
 DEFAULT_CLAIMED_STALE_SECONDS = 300
 
-# A ``running`` row older than this is reaped to ``failed`` (AC6). Deliberately
-# generous (≫ normal task runtime) — a crude time-based stopgap until #921 adds
-# a liveness-aware reaper. Its only job is to stop orphaned rows ratcheting the
-# cap toward 0.
+# One 6h knob, two consumers (#921): rows whose process the driver no longer
+# tracks (orphans — e.g. after a restart) are reaped to ``failed`` past this
+# age, and *tracked* processes still alive past it are tree-killed as runaways.
+# Deliberately generous (≫ normal task runtime); live tracked rows under the
+# threshold are never time-reaped (AC5).
 DEFAULT_RUNNING_REAP_SECONDS = 6 * 60 * 60
 
 # Spawn a task's goal, fire-and-forget. Raises on a hard launch failure (AC7b).
 Spawn = Callable[[str], Any]
 # Resolve the claude binary; raises FileNotFoundError when unresolved (AC7a).
 ResolveBinary = Callable[[], str]
+# Quota probe — returns a UsageReading-shaped object with .near_exhaustion
+# (#921 AC4). The production default is false-safe: it never raises, a probe
+# error reads as near-exhaustion, so a broken probe pauses dispatch.
+ReadUsage = Callable[[], Any]
 
 
 @runtime_checkable
@@ -73,7 +88,7 @@ class TaskQueuePort(Protocol):
     :mod:`agents.task_queue`, and by an in-memory fake in the tests.
 
     ``runtime_checkable`` makes ``isinstance(x, TaskQueuePort)`` check only that
-    the five method *names* are present — not their signatures — so the
+    the six method *names* are present — not their signatures — so the
     ``isinstance`` assertion in the tests is a structural smoke check, not a
     full conformance proof.
     """
@@ -97,6 +112,9 @@ class TaskQueuePort(Protocol):
     ) -> list[dict[str, Any]]:
         """List ``running`` rows older than the reaper threshold for ``assignee``."""
 
+    def requeue_running(self, task_id: str) -> bool:
+        """Return one process-less ``running`` row to ``pending`` (direct UPDATE, #921 AC4)."""
+
 
 @dataclass(frozen=True)
 class DrainResult:
@@ -107,10 +125,16 @@ class DrainResult:
     # True iff the whole drain was skipped because the claude binary did not
     # resolve (AC7a) — distinct from "ran, claimed nothing".
     skipped_no_binary: bool = False
-    # True iff the drain stopped early because a spawn was throttled (quota
-    # near-exhaustion). The one in-flight row is left ``running`` for the AC6
-    # reaper; remaining rows stay ``pending`` and self-heal next drain.
+    # True iff the drain skipped/stopped on quota near-exhaustion — either the
+    # AC4 pre-flight (nothing claimed) or a mid-drain throttled spawn (the one
+    # in-flight row is requeued to ``pending``; on requeue failure the AC6
+    # reaper is the backstop). Remaining rows stay ``pending`` and self-heal.
     throttled: bool = False
+    # (task_id, proc) per *successful* spawn that yielded a pollable process
+    # handle (#921 AC1). Throttled spawns (proc=None), raising spawns, and
+    # proc-less results contribute no pair. The wake_driver folds these into
+    # its {task_id: proc} liveness map to close running→done on process exit.
+    procs: tuple[tuple[str, Any], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -119,6 +143,145 @@ class ReclaimResult:
 
     reclaimed_claimed: int = 0
     reaped_running: int = 0
+
+
+@dataclass(frozen=True)
+class TrackedProc:
+    """A live spawn under liveness tracking (#921 AC2).
+
+    ``proc`` is the ``Popen``-shaped handle from :class:`executor.SpawnResult`;
+    ``started_at`` is a monotonic-clock stamp taken when the wake_driver folded
+    the pair into its map (the runaway check measures age against it, AC6).
+    """
+
+    proc: Any
+    started_at: float
+
+
+@dataclass(frozen=True)
+class CompletionResult:
+    """What one :func:`poll_completions` did (#921 AC2)."""
+
+    done: int = 0
+    failed_exit: int = 0
+
+
+def poll_completions(port: TaskQueuePort, procs: dict[str, TrackedProc]) -> CompletionResult:
+    """Close ``running`` rows whose process has exited (#921 AC2, Model P).
+
+    For each tracked pair: ``poll() is None`` → still running, kept;
+    ``poll() == 0`` → ``transition(done)``; ``poll() != 0`` →
+    ``transition(failed, reason="exit <rc>")``. Closed entries are dropped from
+    ``procs`` (mutated in place) so the freed slots are visible to the same
+    tick's drain.
+
+    **``done`` means the process exited 0 — nothing more.** Not task success,
+    not PR merged; the child may have produced garbage and exited cleanly.
+    Outcome truth re-enters externally via Path-A GitHub events.
+
+    Per-row isolation: a ``transition`` raising logs, drops the entry, and
+    continues — the row stays ``running`` in the store with no live handle, so
+    the AC5/AC6 orphan reaper is the backstop. No counter is incremented for it.
+    """
+    done = 0
+    failed_exit = 0
+    for task_id, tracked in list(procs.items()):
+        rc = tracked.proc.poll()
+        if rc is None:
+            continue
+        try:
+            if rc == 0:
+                port.transition(task_id, "done")
+                done += 1
+            else:
+                port.transition(task_id, "failed", reason=f"exit {rc}")
+                failed_exit += 1
+        except Exception:  # noqa: BLE001 — isolate one bad row, reaper backstops it
+            logger.exception(
+                "[task_dispatch] completion transition for task %s failed; "
+                "dropped from tracking (reaper backstop)",
+                task_id,
+            )
+        finally:
+            procs.pop(task_id, None)
+    return CompletionResult(done=done, failed_exit=failed_exit)
+
+
+def kill_process_tree(proc: Any, *, platform: str = sys.platform) -> None:
+    """Kill a spawned process AND its children (#921 AC6).
+
+    On Windows ``Popen.kill()`` is an alias for ``terminate()`` — it kills only
+    the direct process, and a ``claude -p`` child's own subprocesses (git, gh,
+    tools) survive as orphans. ``taskkill /PID <pid> /T /F`` walks the tree.
+    POSIX falls back to ``proc.kill()`` (the spawned process is the process
+    group leader for our use; good enough until a POSIX deployment exists).
+
+    Best-effort ``wait`` afterwards reaps the handle so ``poll()`` reflects the
+    death immediately; a hung wait is swallowed (the next tick's poll re-checks).
+    """
+    if platform == "win32":
+        subprocess.run(
+            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+        )
+    else:
+        proc.kill()
+    try:
+        proc.wait(timeout=10)
+    except Exception:  # noqa: BLE001 — reap is best-effort; poll re-checks next tick
+        pass
+
+
+def kill_runaways(
+    port: TaskQueuePort,
+    procs: dict[str, TrackedProc],
+    *,
+    max_runtime_seconds: float = DEFAULT_RUNNING_REAP_SECONDS,
+    now: Callable[[], float] = time.monotonic,
+    kill: Callable[[Any], None] = kill_process_tree,
+) -> int:
+    """Tree-kill live processes that exceeded the max runtime (#921 AC6).
+
+    The orphan reaper (:func:`reclaim_stale_tasks`) deliberately skips rows
+    with a live tracked process — this is the counterpart that bounds those:
+    a process still alive past ``max_runtime_seconds`` (same one 6h knob as
+    the reaper) is killed with its whole tree, its row transitioned
+    ``running → failed`` (``reason="killed: exceeded max runtime"``), and the
+    entry dropped. Killed runaways fold into the tick's failed-exit counter.
+
+    Already-exited processes are skipped — :func:`poll_completions` owns those
+    (their real exit code decides done vs failed). Per-row isolation: a *kill*
+    raising keeps the entry (the process may still be alive; failing the row
+    would lie — retried next tick); a *transition* raising after a successful
+    kill drops the entry to the reaper backstop, like ``poll_completions``.
+    """
+    killed = 0
+    for task_id, tracked in list(procs.items()):
+        if tracked.proc.poll() is not None:
+            continue  # exited — poll_completions closes it with the real rc
+        if now() - tracked.started_at <= max_runtime_seconds:
+            continue
+        try:
+            kill(tracked.proc)
+        except Exception:  # noqa: BLE001 — possibly still alive; retry next tick
+            logger.exception(
+                "[task_dispatch] tree-kill of runaway task %s failed; will retry",
+                task_id,
+            )
+            continue
+        try:
+            port.transition(task_id, "failed", reason="killed: exceeded max runtime")
+            killed += 1
+        except Exception:  # noqa: BLE001 — killed but row not closed; reaper backstops
+            logger.exception(
+                "[task_dispatch] runaway task %s killed but transition failed; "
+                "dropped from tracking (reaper backstop)",
+                task_id,
+            )
+        finally:
+            procs.pop(task_id, None)
+    return killed
 
 
 def default_spawn(goal: str) -> Any:
@@ -142,6 +305,18 @@ def default_resolve_binary() -> str:
     return _resolve_claude_binary()
 
 
+def default_read_usage() -> Any:
+    """Production quota-probe adapter (lazy import; see :func:`default_spawn`).
+
+    :func:`agents.usage_probe.read_usage` is false-safe — it never raises, a
+    probe failure returns ``near_exhaustion=True`` — so the AC4 pre-flight
+    pauses dispatch rather than flooding it when the probe is broken.
+    """
+    from agents.usage_probe import read_usage
+
+    return read_usage()
+
+
 def drain_tasks(
     port: TaskQueuePort,
     spawn: Spawn = default_spawn,
@@ -149,6 +324,7 @@ def drain_tasks(
     assignee: str = DEFAULT_ASSIGNEE,
     cap: int = DEFAULT_CONCURRENCY_CAP,
     resolve_binary: ResolveBinary = default_resolve_binary,
+    read_usage: ReadUsage = default_read_usage,
 ) -> DrainResult:
     """Claim pending ``assignee`` tasks up to the cap and spawn each (AC2–AC4, AC7–AC9).
 
@@ -174,8 +350,9 @@ def drain_tasks(
     next slot. A ``spawn`` raising (AC7b) marks *that* task ``running→failed``
     (terminal — the external event loop re-drives) and the drain continues. A
     ``spawn`` returning a *throttled* result (quota near-exhaustion: no process
-    launched) stops the drain — the one in-flight row is left ``running`` for
-    the AC6 reaper, the rest stay ``pending``; quota will not recover mid-drain.
+    launched) stops the drain — the one in-flight row is requeued to
+    ``pending`` (#921 AC4; reaper backstop if the requeue fails), the rest stay
+    ``pending``; quota will not recover mid-drain.
     """
     # AC7a — pre-flight once; an unusable binary skips the whole drain. Widened
     # past FileNotFoundError to the other no-usable-binary failures (not
@@ -190,6 +367,20 @@ def drain_tasks(
         )
         return DrainResult(skipped_no_binary=True)
 
+    # AC4 (#921) — quota pre-flight, once per drain. Near-exhaustion skips the
+    # *entire* drain: zero claims, zero churn, rows stay visibly ``pending``
+    # until quota recovers. The default probe is false-safe (a probe error
+    # reads as near-exhaustion), so a broken probe pauses dispatch too.
+    # executor.spawn re-checks per spawn — that per-spawn gate remains the
+    # backstop for a quota flip mid-drain.
+    reading = read_usage()
+    if getattr(reading, "near_exhaustion", False):
+        logger.warning(
+            "[task_dispatch] quota near-exhaustion at drain start; skipping drain "
+            "(no claims, rows stay pending until quota recovers)"
+        )
+        return DrainResult(throttled=True)
+
     # AC3 — budget sampled once at drain start.
     budget = cap - port.count_running(assignee=assignee)
     if budget <= 0:
@@ -197,6 +388,7 @@ def drain_tasks(
 
     spawned = 0
     failed = 0
+    procs: list[tuple[str, Any]] = []
     for _ in range(budget):
         row = port.claim_next(assignee=assignee)  # AC2 routing; AC9 lost-race → None
         if row is None:
@@ -225,20 +417,34 @@ def drain_tasks(
             continue
 
         # The executor declined to launch (quota near-exhaustion): no process
-        # exists, but the row is already ``running`` (reaped by AC6 — bounded to
-        # this one row). Quota won't recover mid-drain, so stop claiming rather
-        # than strand the whole budget. Not a spawn failure → not counted.
+        # exists, but the row is already ``running`` (Ordering B). Requeue it to
+        # ``pending`` so the next drain retries as soon as quota recovers
+        # (#921 AC4) — without this it would strand 6h until the reaper failed
+        # a task that never ran. Quota won't recover mid-drain, so stop
+        # claiming. Not a spawn failure → not counted.
         if getattr(result, "throttled", False):
+            try:
+                requeued = port.requeue_running(task_id)
+            except Exception:  # noqa: BLE001 — requeue is best-effort
+                requeued = False
+                logger.exception("[task_dispatch] requeue of throttled task %s raised", task_id)
             logger.warning(
                 "[task_dispatch] spawn throttled (quota near-exhaustion); "
-                "stopping drain — task %s left running for the reaper",
+                "stopping drain — task %s %s",
                 task_id,
+                "requeued to pending" if requeued else "left running for the reaper",
             )
-            return DrainResult(spawned=spawned, failed=failed, throttled=True)
+            return DrainResult(spawned=spawned, failed=failed, throttled=True, procs=tuple(procs))
 
         spawned += 1
+        # AC1 (#921) — retain the process handle so the wake_driver can poll
+        # completion. Spawns without a handle (test fakes, defensive None)
+        # still count as spawned but cannot be liveness-tracked.
+        proc = getattr(result, "proc", None)
+        if proc is not None:
+            procs.append((task_id, proc))
 
-    return DrainResult(spawned=spawned, failed=failed)
+    return DrainResult(spawned=spawned, failed=failed, procs=tuple(procs))
 
 
 def reclaim_stale_tasks(
@@ -247,37 +453,51 @@ def reclaim_stale_tasks(
     assignee: str = DEFAULT_ASSIGNEE,
     claimed_stale_after_seconds: float = DEFAULT_CLAIMED_STALE_SECONDS,
     running_reap_after_seconds: float = DEFAULT_RUNNING_REAP_SECONDS,
+    live_task_ids: Collection[str] = (),
 ) -> ReclaimResult:
-    """Sweep stranded tasks before a drain (AC5 + AC6).
+    """Sweep stranded tasks before a drain (#909 AC5/AC6, #921 AC5 orphan-only).
 
-    - **AC5** — stale ``claimed`` rows return to ``pending`` via a direct UPDATE
-      that bypasses the FSM (``claimed → pending`` is not a legal transition;
-      this mirrors :meth:`wake_driver.PsycopgEventQueue.reclaim_stale`). Never
+    - **Stale claimed** rows return to ``pending`` via a direct UPDATE that
+      bypasses the FSM (``claimed → pending`` is not a legal transition; this
+      mirrors :meth:`wake_driver.PsycopgEventQueue.reclaim_stale`). Never
       touches ``running``.
-    - **AC6** — stale ``running`` rows (older than the generous reaper
-      threshold) are transitioned ``running → failed`` so orphaned rows (a
-      child that died without opening a PR, or a crash in the running↔spawn
-      window) stop ratcheting the cap toward 0. A fresh ``running`` row is left
-      untouched because the port's staleness query excludes it.
+    - **Orphaned running** rows — stale AND not in ``live_task_ids`` — are
+      transitioned ``running → failed`` so rows with no process behind them (a
+      child that died without a completion, a crash in the running↔spawn
+      window, a pre-restart spawn) stop ratcheting the cap toward 0.
+
+    ``live_task_ids`` is the wake_driver's tracked-process map keyset (#921
+    AC5): a row with a live handle is *not* an orphan however old — legitimate
+    long tasks are never time-reaped; genuinely stuck live processes are
+    :func:`kill_runaways`' job, which kills the tree and closes the row
+    explicitly. Restart semantics: a fresh driver has an empty map, so every
+    stale running row is an orphan again (AC7 — the map does not survive
+    restart; the backstop self-heals via Path-A).
 
     Invoked by :func:`wake_driver.tick` *before* :func:`drain_tasks`, so a row
     reclaimed this pass is eligible to be re-claimed and spawned in the same
     tick — symmetric to the event watchdog running before ``drain_pending``.
     """
-    # AC5 — stale claimed → pending (FSM-bypassing direct UPDATE).
+    # Stale claimed → pending (FSM-bypassing direct UPDATE).
     reclaimed = port.reclaim_stale_claimed(
         assignee=assignee, older_than_seconds=claimed_stale_after_seconds
     )
 
-    # AC6 — stale running → failed (time-based stopgap; #921 = liveness-aware).
+    # Orphaned running → failed (stale + no tracked live process).
     reaped = 0
     for row in port.list_stale_running(
         assignee=assignee, older_than_seconds=running_reap_after_seconds
     ):
+        task_id = str(row["id"])
+        if task_id in live_task_ids:
+            continue
         port.transition(
-            str(row["id"]),
+            task_id,
             "failed",
-            reason=f"reaped: no completion within {running_reap_after_seconds:.0f}s",
+            reason=(
+                f"reaped: orphaned running row (no tracked process) "
+                f"after {running_reap_after_seconds:.0f}s"
+            ),
         )
         reaped += 1
 
@@ -318,3 +538,6 @@ class SupabaseTaskQueue:
         return task_queue.list_stale_running(
             assignee=assignee, older_than_seconds=older_than_seconds
         )
+
+    def requeue_running(self, task_id: str) -> bool:
+        return task_queue.requeue_running(task_id)

--- a/agents/task_queue.py
+++ b/agents/task_queue.py
@@ -288,6 +288,36 @@ def reclaim_stale_claimed(
     return len(result.data or [])
 
 
+def requeue_running(
+    task_id: str,
+    *,
+    client: Client | None = None,
+) -> bool:
+    """Return one ``running`` row to ``pending`` via a direct UPDATE (#921 AC4).
+
+    For the mid-drain quota flip: under Ordering B the row is transitioned
+    ``running`` *before* the spawn, so when the executor then declines to
+    launch (throttled — no process exists), the row would otherwise sit
+    ``running`` until the reaper fails it hours later. Requeueing it lets the
+    next drain pick it up as soon as quota recovers.
+
+    Like :func:`reclaim_stale_claimed`, this deliberately bypasses the FSM
+    (``pending`` is not a legal target from ``running``). The ``status``
+    filter is the optimistic lock: only a row still ``running`` is touched.
+    Returns ``True`` iff the row was requeued. Callers tolerate ``False``
+    (row changed under us) — the reaper remains the backstop.
+    """
+    cli = client or get_client()
+    result = (
+        cli.table("task_queue")
+        .update({"status": "pending", "claimed_at": None})
+        .eq("id", task_id)
+        .eq("status", "running")
+        .execute()
+    )
+    return bool(result.data)
+
+
 def list_stale_running(
     *,
     assignee: str,
@@ -298,9 +328,11 @@ def list_stale_running(
 
     Age is measured from ``claimed_at`` — there is no ``running_at`` column,
     and claimed→running is immediate under Ordering B, so ``claimed_at`` is
-    a faithful proxy for running-start. The #909 running-reaper transitions
-    each returned row ``running → failed``; the threshold is deliberately
-    generous (≫ normal task runtime) until #921 adds liveness-aware reaping.
+    a faithful proxy for running-start. The reaper is liveness-aware as of
+    #921: the wake_driver filters out rows whose process it still tracks, so
+    only *orphans* (rows with no tracked process — e.g. after a driver
+    restart) are transitioned ``running → failed``. The threshold stays
+    deliberately generous (≫ normal task runtime) as a backstop.
     """
     cli = client or get_client()
     # Only the id is needed — the reaper transitions by id; selecting "*" would

--- a/agents/wake_driver.py
+++ b/agents/wake_driver.py
@@ -22,6 +22,15 @@ Behavior:
   model). wake_driver deliberately does **not** import
   :func:`agents.orchestrator.handle_event` — the driver is a decisionless
   program and the router is a separate concern.
+- **Task completion loop (#921).** When a ``task_port`` is wired in, each tick
+  also polls the processes spawned by earlier ticks (the in-memory liveness
+  map owned by :func:`run`) and closes their ``task_queue`` rows: exit 0 →
+  ``done``, non-zero → ``failed``. Model P semantics — ``done`` means *the
+  spawned process exited cleanly*, nothing more; it is not task success and
+  not PR-merged. Outcome truth re-enters via Path-A GitHub events. **Restart
+  limitation:** the map is process-local, so a driver restart forgets every
+  live process — those rows age out as orphans and the reaper backstop fails
+  them (self-healing via Path A; a PID sidecar that survives restarts is #952).
 
 The pure loop (:func:`drain_pending` / :func:`run_watchdog` / :func:`tick` /
 :func:`run`) operates over an :class:`EventQueuePort`, so it is unit-testable
@@ -39,6 +48,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
@@ -49,13 +59,19 @@ from agents.config import load_config
 from agents.task_dispatch import (
     DEFAULT_CLAIMED_STALE_SECONDS,
     DEFAULT_RUNNING_REAP_SECONDS,
+    ReadUsage,
     ResolveBinary,
     Spawn,
     SupabaseTaskQueue,
     TaskQueuePort,
+    TrackedProc,
+    default_read_usage,
     default_resolve_binary,
     default_spawn,
     drain_tasks,
+    kill_process_tree,
+    kill_runaways,
+    poll_completions,
     reclaim_stale_tasks,
 )
 
@@ -104,10 +120,14 @@ class EventQueuePort(Protocol):
 
 @dataclass(frozen=True)
 class TickResult:
-    """What one :func:`tick` did — event watchdog + drain, then task sweep + drain.
+    """What one :func:`tick` did — completion poll, watchdogs, then both drains.
 
     The ``tasks_*`` fields default to 0 so an event-only tick (no ``task_port``)
-    constructs unchanged.
+    constructs unchanged. ``tasks_done`` / ``tasks_failed_exit`` count rows
+    closed by the #921 completion poll (Model P: *done* = process exited 0,
+    nothing more — not task success, not PR merged). Runaways tree-killed by
+    the same step fold into ``tasks_failed_exit`` (their rows end ``failed``
+    just like a non-zero exit).
     """
 
     reclaimed: int
@@ -116,6 +136,8 @@ class TickResult:
     tasks_reaped: int = 0
     tasks_spawned: int = 0
     tasks_failed: int = 0
+    tasks_done: int = 0
+    tasks_failed_exit: int = 0
 
 
 def default_orchestrator(event: dict[str, Any]) -> None:
@@ -171,12 +193,35 @@ def tick(
     task_port: TaskQueuePort | None = None,
     task_spawn: Spawn = default_spawn,
     task_resolve_binary: ResolveBinary = default_resolve_binary,
+    task_read_usage: ReadUsage = default_read_usage,
     task_claimed_stale_after_seconds: float = DEFAULT_CLAIMED_STALE_SECONDS,
     task_running_reap_after_seconds: float = DEFAULT_RUNNING_REAP_SECONDS,
+    task_procs: dict[str, TrackedProc] | None = None,
+    task_clock: Callable[[], float] = time.monotonic,
+    task_kill: Callable[[Any], None] = kill_process_tree,
 ) -> TickResult:
-    """One unit of work — four ordered steps (#909 AC1)::
+    """One unit of work — five ordered steps (#909 AC1, #921 AC3)::
 
-        reclaim_stale(events) → reclaim_stale_tasks() → drain_pending(events) → drain_tasks()
+        poll_completions() + kill_runaways()                  # Step 0, #921
+        → reclaim_stale(events) → reclaim_stale_tasks()       # watchdogs
+        → drain_pending(events) → drain_tasks()               # drains
+
+    Step 0 closes ``running`` rows whose tracked process exited (rc 0 → done,
+    rc ≠0 → failed) and tree-kills live processes past the reap threshold —
+    *before* anything else, so freed cap slots are visible to this same tick's
+    drain and freshly-closed rows are no longer ``running`` when the orphan
+    reaper scans. It runs only when ``task_procs`` (the cross-tick liveness
+    map, owned by :func:`run`) is supplied; ``--once`` and event-only ticks
+    skip it.
+
+    The task watchdog receives the map's keyset as ``live_task_ids`` (#921
+    AC5): rows with a live tracked process are never time-reaped, however old —
+    a fresh driver (empty/absent map) treats every stale running row as an
+    orphan again, which is the documented restart limitation (the map does not
+    survive restart; Path-A re-drives the lost work; PID sidecar = #952).
+
+    After the drain, each spawned ``(task_id, proc)`` pair is folded into
+    ``task_procs`` stamped with ``task_clock`` so a later tick can close it.
 
     Both watchdogs run **before** both drains, so a row stranded by a previous
     crash (event *or* task) is returned to ``pending`` and re-driven within the
@@ -186,17 +231,33 @@ def tick(
     swept by the idle-timeout watchdog (AC1; task-NOTIFY latency deferred to
     #922).
 
-    The task steps (2 and 4) are each isolated in their own try/except: the
+    The task steps (0, 2 and 4) are each isolated in their own try/except: the
     task_queue rides supabase-py while events ride psycopg, so a task-store
     outage is an independent failure mode. It must not block the event drain
     (Step 3) — events are the primary wake path. A failing task step is logged
     and its rows stay in place (``claimed``/``running`` → swept next tick;
     ``pending`` → re-drained next tick), exactly as a crash would leave them.
     """
+    # Step 0 — completion poll + runaway kill (#921 AC2/AC3/AC6).
+    completions = None
+    runaways_killed = 0
+    if task_port is not None and task_procs is not None:
+        try:
+            completions = poll_completions(task_port, task_procs)
+            runaways_killed = kill_runaways(
+                task_port,
+                task_procs,
+                max_runtime_seconds=task_running_reap_after_seconds,
+                now=task_clock,
+                kill=task_kill,
+            )
+        except Exception:  # noqa: BLE001 — task-store outage must not block event drain
+            logger.exception("[wake_driver] completion poll failed; tracked rows retry next tick")
+
     # Step 1 — event watchdog.
     reclaimed = run_watchdog(port, stale_after_seconds=stale_after_seconds)
 
-    # Step 2 — task watchdog (stale claimed → pending, stale running → failed).
+    # Step 2 — task watchdog (stale claimed → pending, orphaned running → failed).
     task_reclaim = None
     if task_port is not None:
         try:
@@ -204,6 +265,7 @@ def tick(
                 task_port,
                 claimed_stale_after_seconds=task_claimed_stale_after_seconds,
                 running_reap_after_seconds=task_running_reap_after_seconds,
+                live_task_ids=frozenset(task_procs or ()),
             )
         except Exception:  # noqa: BLE001 — task-store outage must not block event drain
             logger.exception(
@@ -213,11 +275,21 @@ def tick(
     # Step 3 — event drain.
     processed = drain_pending(port, orchestrator)
 
-    # Step 4 — task drain (claim → running → spawn, capped, Ordering B).
+    # Step 4 — task drain (claim → running → spawn, capped, Ordering B), then
+    # fold the new handles into the liveness map for later ticks to close.
     task_drain = None
     if task_port is not None:
         try:
-            task_drain = drain_tasks(task_port, task_spawn, resolve_binary=task_resolve_binary)
+            task_drain = drain_tasks(
+                task_port,
+                task_spawn,
+                resolve_binary=task_resolve_binary,
+                read_usage=task_read_usage,
+            )
+            if task_procs is not None:
+                started = task_clock()
+                for task_id, proc in task_drain.procs:
+                    task_procs[task_id] = TrackedProc(proc=proc, started_at=started)
         except Exception:  # noqa: BLE001 — task-store outage must not crash the tick
             logger.exception(
                 "[wake_driver] task drain failed; pending tasks left for the next tick"
@@ -230,6 +302,8 @@ def tick(
         tasks_reaped=task_reclaim.reaped_running if task_reclaim else 0,
         tasks_spawned=task_drain.spawned if task_drain else 0,
         tasks_failed=task_drain.failed if task_drain else 0,
+        tasks_done=completions.done if completions else 0,
+        tasks_failed_exit=(completions.failed_exit if completions else 0) + runaways_killed,
     )
 
 
@@ -242,8 +316,12 @@ def run(
     task_port: TaskQueuePort | None = None,
     task_spawn: Spawn = default_spawn,
     task_resolve_binary: ResolveBinary = default_resolve_binary,
+    task_read_usage: ReadUsage = default_read_usage,
     task_claimed_stale_after_seconds: float = DEFAULT_CLAIMED_STALE_SECONDS,
     task_running_reap_after_seconds: float = DEFAULT_RUNNING_REAP_SECONDS,
+    task_procs: dict[str, TrackedProc] | None = None,
+    task_clock: Callable[[], float] = time.monotonic,
+    task_kill: Callable[[Any], None] = kill_process_tree,
 ) -> None:
     """The event-driven loop: block on a wake signal, then run one tick.
 
@@ -254,18 +332,22 @@ def run(
     the loop.
 
     When ``task_port`` is supplied, each tick also sweeps and drains the
-    ``task_queue`` (#909). The same idle-timeout that runs the event watchdog
-    runs the task watchdog, so tasks left ``claimed``/``running`` by a crash
-    are swept even on an idle queue. The ``task_spawn`` / ``task_resolve_binary``
-    / ``task_*_after_seconds`` knobs are forwarded to each :func:`tick` so the
-    spawn function, binary resolver, and staleness thresholds stay injectable
-    end-to-end (tests and operators), not just at the ``tick`` boundary.
+    ``task_queue`` (#909) and the loop owns the **liveness map** (#921): one
+    ``{task_id: TrackedProc}`` dict created here (or injected via
+    ``task_procs``) and handed to every tick, so a process spawned in tick N
+    is polled to completion in tick N+M. The map lives only in this process —
+    a restart loses it, stale rows become orphans, and the reaper backstop
+    fails them (documented #921 AC7 limitation; PID sidecar = #952). The
+    ``task_*`` knobs are forwarded to each :func:`tick` so spawn, resolver,
+    quota probe, thresholds, clock, and killer stay injectable end-to-end
+    (tests and operators), not just at the ``tick`` boundary.
 
     A tick that raises is logged and swallowed so a transient failure does
     not tear down the driver — the offending event stays ``claimed`` and the
     watchdog re-claims it next pass (at-least-once, never silently lost).
     """
     keep_going = should_continue or (lambda: True)
+    procs = task_procs if task_procs is not None else ({} if task_port is not None else None)
     while keep_going():
         port.wait_for_wake(timeout_seconds=stale_after_seconds)
         try:
@@ -276,8 +358,12 @@ def run(
                 task_port=task_port,
                 task_spawn=task_spawn,
                 task_resolve_binary=task_resolve_binary,
+                task_read_usage=task_read_usage,
                 task_claimed_stale_after_seconds=task_claimed_stale_after_seconds,
                 task_running_reap_after_seconds=task_running_reap_after_seconds,
+                task_procs=procs,
+                task_clock=task_clock,
+                task_kill=task_kill,
             )
         except Exception:  # noqa: BLE001 — daemon must survive a bad tick
             logger.exception("[wake_driver] tick failed; event left claimed for watchdog re-claim")
@@ -369,6 +455,10 @@ def main() -> int:
     queue = _build_psycopg_queue()
     task_port = SupabaseTaskQueue()  # tasks ride supabase-py; events ride psycopg
     if args.once:
+        # Deliberately no task_procs: a one-shot tick has no map from a prior
+        # tick to poll, so completion-poll/runaway-kill are skipped and the
+        # orphan reaper sees an empty live set — i.e. the #921 restart
+        # semantics (stale running rows fail via the backstop).
         result = tick(
             queue,
             default_orchestrator,

--- a/tests/test_agents_task_dispatch.py
+++ b/tests/test_agents_task_dispatch.py
@@ -23,7 +23,11 @@ from agents.task_dispatch import (
     DrainResult,
     SupabaseTaskQueue,
     TaskQueuePort,
+    TrackedProc,
     drain_tasks,
+    kill_process_tree,
+    kill_runaways,
+    poll_completions,
     reclaim_stale_tasks,
 )
 
@@ -58,6 +62,7 @@ class FakeTaskQueue:
         self.transitions: list[tuple[str, str, str | None]] = []
         self.reclaimed_count = 0
         self.stale_running: list[dict[str, Any]] = []
+        self.requeued: list[str] = []
 
     def claim_next(self, *, assignee: str) -> dict[str, Any] | None:
         for i, row in enumerate(self._pending):
@@ -84,9 +89,29 @@ class FakeTaskQueue:
     ) -> list[dict[str, Any]]:
         return list(self.stale_running)
 
+    def requeue_running(self, task_id: str) -> bool:
+        self.requeued.append(task_id)
+        return True
+
 
 def _always_resolve() -> str:
     return "claude"
+
+
+class _FakeProc:
+    """Minimal ``Popen``-shaped handle: ``poll()`` returns the scripted rc."""
+
+    def __init__(self, rc: int | None = None, pid: int = 4242) -> None:
+        self._rc = rc
+        self.pid = pid
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self._rc
+
+    def kill(self) -> None:
+        self.killed = True
+        self._rc = -9
 
 
 class _ThrottledResult:
@@ -101,6 +126,43 @@ class _ThrottledResult:
     reason = "quota near-exhaustion"
 
 
+class _FixedProbe:
+    def __init__(self, reading: Any) -> None:
+        self._reading = reading
+
+    def read(self) -> Any:
+        return self._reading
+
+
+def _healthy_reading() -> Any:
+    from agents.usage_probe import UsageReading
+
+    return UsageReading(
+        limit_window=timedelta(hours=5),
+        used=10,
+        total=100,
+        reset_at=datetime.now(UTC),
+        near_exhaustion=False,
+    )
+
+
+def _exhausted_reading() -> Any:
+    from agents.usage_probe import UsageReading
+
+    return UsageReading(
+        limit_window=timedelta(hours=5),
+        used=100,
+        total=100,
+        reset_at=datetime.now(UTC),
+        near_exhaustion=True,
+    )
+
+
+def _healthy_usage() -> Any:
+    """Injectable stand-in for ``read_usage`` — plenty of headroom."""
+    return _healthy_reading()
+
+
 # ---------------------------------------------------------------------------
 # AC3 — concurrency cap: budget = cap − count_running, sampled once
 # ---------------------------------------------------------------------------
@@ -111,7 +173,13 @@ class TestConcurrencyCap:
         # 3 already running, cap 5 -> budget 2 -> only 2 of 4 pending spawned.
         q = FakeTaskQueue(pending=[_row(f"t{i}") for i in range(4)], running_count=3)
         spawns: list[str] = []
-        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q,
+            lambda g: spawns.append(g),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
         assert len(spawns) == 2
         assert len(q.claimed) == 2
         assert res.spawned == 2
@@ -119,7 +187,13 @@ class TestConcurrencyCap:
     def test_no_spawn_when_at_cap(self) -> None:
         q = FakeTaskQueue(pending=[_row("t0")], running_count=5)
         spawns: list[str] = []
-        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q,
+            lambda g: spawns.append(g),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
         assert spawns == []
         assert q.claimed == []
         assert res.spawned == 0
@@ -140,7 +214,9 @@ class TestAssigneeRouting:
             running_count=0,
         )
         spawns: list[str] = []
-        drain_tasks(q, lambda g: spawns.append(g), resolve_binary=_always_resolve)
+        drain_tasks(
+            q, lambda g: spawns.append(g), resolve_binary=_always_resolve, read_usage=_healthy_usage
+        )
         assert q.claimed == ["sand"]
         assert spawns == ["do sand"]
 
@@ -166,7 +242,12 @@ class TestOrderingB:
 
         q.transition = recording_transition  # type: ignore[method-assign]
 
-        drain_tasks(q, lambda g: events.append(("spawn", g)), resolve_binary=_always_resolve)
+        drain_tasks(
+            q,
+            lambda g: events.append(("spawn", g)),
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
 
         # The running transition must be recorded BEFORE the spawn — a row is
         # never left 'claimed' once we have committed to spawning it, and spawn
@@ -183,7 +264,9 @@ class TestAtomicClaim:
     def test_empty_queue_no_spawn(self) -> None:
         q = FakeTaskQueue(pending=[], running_count=0)
         spawns: list[str] = []
-        res = drain_tasks(q, lambda g: spawns.append(g), resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q, lambda g: spawns.append(g), resolve_binary=_always_resolve, read_usage=_healthy_usage
+        )
         assert spawns == []
         assert res.spawned == 0
 
@@ -194,7 +277,13 @@ class TestAtomicClaim:
         # makes the lost race safe is unit-tested in test_agents_task_queue).
         q = FakeTaskQueue(pending=[_row("only")], running_count=0)
         spawns: list[str] = []
-        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q,
+            lambda g: spawns.append(g),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
         assert spawns == ["do only"]
         assert res.spawned == 1
 
@@ -250,6 +339,45 @@ class TestBinaryPreflight:
 
 
 # ---------------------------------------------------------------------------
+# #921 AC4 — quota pre-flight: near-exhaustion skips the entire drain
+# ---------------------------------------------------------------------------
+
+
+class TestQuotaPreflight:
+    def test_near_exhaustion_skips_entire_drain(self) -> None:
+        # Zero claims, zero churn — rows stay visibly pending. The false-safe
+        # probe contract means a broken probe also lands here.
+        q = FakeTaskQueue(pending=[_row("t0"), _row("t1")], running_count=0)
+        spawns: list[str] = []
+        res = drain_tasks(
+            q,
+            lambda g: spawns.append(g),
+            resolve_binary=_always_resolve,
+            read_usage=_exhausted_reading,
+        )
+        assert q.claimed == []
+        assert spawns == []
+        assert res.throttled is True
+        assert res.spawned == 0
+        assert len(q._pending) == 2
+
+    def test_consulted_once_at_drain_start(self) -> None:
+        # One probe per drain, not one per task — mirrors the binary pre-flight.
+        calls = {"n": 0}
+
+        def usage() -> Any:
+            calls["n"] += 1
+            return _healthy_reading()
+
+        q = FakeTaskQueue(pending=[_row(f"t{i}") for i in range(3)], running_count=0)
+        res = drain_tasks(
+            q, lambda g: None, cap=5, resolve_binary=_always_resolve, read_usage=usage
+        )
+        assert calls["n"] == 1
+        assert res.spawned == 3
+
+
+# ---------------------------------------------------------------------------
 # AC7b — spawn raises: mark that task failed (terminal), continue the drain
 # ---------------------------------------------------------------------------
 
@@ -264,7 +392,9 @@ class TestSpawnFailureIsTerminal:
                 raise RuntimeError("spawn blew up")
             spawns.append(goal)
 
-        res = drain_tasks(q, spawn, cap=5, resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q, spawn, cap=5, resolve_binary=_always_resolve, read_usage=_healthy_usage
+        )
 
         failed = [t for t in q.transitions if t[1] == "failed"]
         assert len(failed) == 1
@@ -289,13 +419,19 @@ class TestThrottledSpawn:
         # drained the WHOLE budget into 'running' rows, orphaning every one for
         # the 6h reaper. The drain must instead bail after a single row.
         q = FakeTaskQueue(pending=[_row(f"t{i}") for i in range(4)], running_count=0)
-        res = drain_tasks(q, lambda g: _ThrottledResult(), cap=5, resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q,
+            lambda g: _ThrottledResult(),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
 
         assert res.spawned == 0
         assert res.failed == 0
         assert res.throttled is True
         # Exactly one row was claimed+transitioned-running before the drain
-        # bailed — bounded blast radius (that row is reaped by AC6), not the cap.
+        # bailed — bounded blast radius (that row is requeued, #921), not the cap.
         assert len(q.claimed) == 1
         assert ("t0", "running", None) in q.transitions
         # A throttle is NOT a spawn failure — the row must not be marked failed.
@@ -311,14 +447,87 @@ class TestThrottledSpawn:
             return None if calls["n"] == 1 else _ThrottledResult()
 
         q = FakeTaskQueue(pending=[_row("t0"), _row("t1"), _row("t2")], running_count=0)
-        res = drain_tasks(q, spawn, cap=5, resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q, spawn, cap=5, resolve_binary=_always_resolve, read_usage=_healthy_usage
+        )
 
         assert res.spawned == 1
         assert res.throttled is True
-        assert len(q.claimed) == 2  # t0 (spawned) + t1 (throttled, left running)
+        assert len(q.claimed) == 2  # t0 (spawned) + t1 (throttled, requeued)
 
     def test_drain_result_has_throttled_field_default_false(self) -> None:
         assert DrainResult().throttled is False
+
+
+# ---------------------------------------------------------------------------
+# #921 AC4 — mid-drain throttle requeues the in-flight running row to pending
+# ---------------------------------------------------------------------------
+
+
+class TestThrottleRequeue:
+    def test_midthrottle_requeues_running_row(self) -> None:
+        # The throttled row is already `running` (Ordering B) but no process
+        # exists — requeue it to `pending` instead of stranding it 6h for the
+        # reaper to fail a task that never ran.
+        q = FakeTaskQueue(pending=[_row("t0"), _row("t1")], running_count=0)
+        res = drain_tasks(
+            q,
+            lambda g: _ThrottledResult(),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
+
+        assert res.throttled is True
+        assert q.requeued == ["t0"]
+        # Requeued ≠ failed — the row must not get a terminal transition.
+        assert [t for t in q.transitions if t[1] == "failed"] == []
+
+    def test_requeue_raise_leaves_row_for_reaper(self) -> None:
+        # If the requeue UPDATE itself fails, the row stays `running` and the
+        # AC5/AC6 reaper is the backstop — the drain must not crash.
+        class Q(FakeTaskQueue):
+            def requeue_running(self, task_id: str) -> bool:
+                raise RuntimeError("supabase transient error")
+
+        q = Q(pending=[_row("t0")], running_count=0)
+        res = drain_tasks(
+            q,
+            lambda g: _ThrottledResult(),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
+
+        assert res.throttled is True
+        assert [t for t in q.transitions if t[1] == "failed"] == []
+
+    def test_requeue_false_is_tolerated(self) -> None:
+        # Optimistic-lock miss (row changed under us) → False; same backstop.
+        class Q(FakeTaskQueue):
+            def requeue_running(self, task_id: str) -> bool:
+                return False
+
+        q = Q(pending=[_row("t0")], running_count=0)
+        res = drain_tasks(
+            q,
+            lambda g: _ThrottledResult(),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
+
+        assert res.throttled is True
+
+    def test_healthy_drain_never_requeues(self) -> None:
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+        drain_tasks(
+            q,
+            lambda g: _HealthySpawnResult(object()),
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
+        assert q.requeued == []
 
 
 # ---------------------------------------------------------------------------
@@ -337,7 +546,13 @@ class TestRunningTransitionFailureIsSafe:
                 return super().transition(task_id, to_status, reason=reason)
 
         q = Q(pending=[_row("t0")], running_count=0)
-        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q,
+            lambda g: spawns.append(g),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
 
         # The row was claimed but the running transition failed: never spawned,
         # never marked failed — left 'claimed' for the AC5 reclaimer.
@@ -358,7 +573,13 @@ class TestRunningTransitionFailureIsSafe:
                 return super().transition(task_id, to_status, reason=reason)
 
         q = Q(pending=[_row("bad"), _row("good")], running_count=0)
-        res = drain_tasks(q, lambda g: spawns.append(g), cap=5, resolve_binary=_always_resolve)
+        res = drain_tasks(
+            q,
+            lambda g: spawns.append(g),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
 
         assert spawns == ["do good"]
         assert res.spawned == 1
@@ -387,26 +608,6 @@ class _CapturedPopen:
         return _Handle()
 
 
-class _FixedProbe:
-    def __init__(self, reading: Any) -> None:
-        self._reading = reading
-
-    def read(self) -> Any:
-        return self._reading
-
-
-def _healthy_reading() -> Any:
-    from agents.usage_probe import UsageReading
-
-    return UsageReading(
-        limit_window=timedelta(hours=5),
-        used=10,
-        total=100,
-        reset_at=datetime.now(UTC),
-        near_exhaustion=False,
-    )
-
-
 class TestBillingTrapThroughDrain:
     def test_api_keys_stripped_from_spawned_env(self, monkeypatch: Any, tmp_path: Any) -> None:
         from agents import executor
@@ -433,7 +634,7 @@ class TestBillingTrapThroughDrain:
                 stderr_log_dir=str(tmp_path),
             )
 
-        drain_tasks(q, spawn, resolve_binary=lambda: str(fake_bin))
+        drain_tasks(q, spawn, resolve_binary=lambda: str(fake_bin), read_usage=_healthy_usage)
 
         assert len(captured.calls) == 1
         env = captured.calls[0]["env"]
@@ -504,6 +705,263 @@ class TestRunningReaper:
 
 
 # ---------------------------------------------------------------------------
+# #921 AC5 — reaper is orphan-only: live-tracked rows are never time-reaped
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanOnlyReaper:
+    def test_live_rows_not_reaped(self) -> None:
+        # A row with a live tracked process is NOT an orphan, however old —
+        # long-running tasks are legitimate; runaways are AC6's job (tree-kill),
+        # not the time-reaper's.
+        q = FakeTaskQueue()
+        q.stale_running = [{"id": "live"}, {"id": "orphan"}]
+        res = reclaim_stale_tasks(q, live_task_ids={"live"})
+        failed = [t for t in q.transitions if t[1] == "failed"]
+        assert {t[0] for t in failed} == {"orphan"}
+        assert res.reaped_running == 1
+
+    def test_orphan_reason_names_orphan(self) -> None:
+        q = FakeTaskQueue()
+        q.stale_running = [{"id": "orphan"}]
+        reclaim_stale_tasks(q, live_task_ids=set())
+        failed = [t for t in q.transitions if t[1] == "failed"]
+        assert failed[0][2] and "orphan" in failed[0][2]
+
+    def test_default_live_set_empty_reaps_all_stale(self) -> None:
+        # Restart semantics: a fresh driver has no map, so every stale running
+        # row is an orphan (AC7 — the in-memory map does not survive restart).
+        q = FakeTaskQueue()
+        q.stale_running = [{"id": "a"}, {"id": "b"}]
+        res = reclaim_stale_tasks(q)
+        assert res.reaped_running == 2
+
+
+# ---------------------------------------------------------------------------
+# #921 AC1 — DrainResult exposes spawned (task_id, proc) pairs
+# ---------------------------------------------------------------------------
+
+
+class _HealthySpawnResult:
+    """Stand-in for ``executor.SpawnResult`` on the healthy path: proc launched."""
+
+    def __init__(self, proc: Any) -> None:
+        self.proc = proc
+        self.throttled = False
+        self.reason = None
+
+
+class TestSpawnedProcPairs:
+    def test_healthy_spawn_contributes_pair(self) -> None:
+        handle = object()
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+        res = drain_tasks(
+            q,
+            lambda g: _HealthySpawnResult(handle),
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
+        assert res.procs == (("t0", handle),)
+        assert res.spawned == 1
+
+    def test_multiple_healthy_spawns_pair_in_claim_order(self) -> None:
+        handles = {"do t0": object(), "do t1": object()}
+        q = FakeTaskQueue(pending=[_row("t0"), _row("t1")], running_count=0)
+        res = drain_tasks(
+            q,
+            lambda g: _HealthySpawnResult(handles[g]),
+            cap=5,
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
+        assert res.procs == (("t0", handles["do t0"]), ("t1", handles["do t1"]))
+
+    def test_throttled_spawn_contributes_no_pair(self) -> None:
+        # No process launched — nothing for the driver to poll.
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+        res = drain_tasks(
+            q,
+            lambda g: _ThrottledResult(),
+            resolve_binary=_always_resolve,
+            read_usage=_healthy_usage,
+        )
+        assert res.procs == ()
+
+    def test_raising_spawn_contributes_no_pair(self) -> None:
+        def spawn(goal: str) -> Any:
+            raise RuntimeError("spawn blew up")
+
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+        res = drain_tasks(q, spawn, resolve_binary=_always_resolve, read_usage=_healthy_usage)
+        assert res.procs == ()
+        assert res.failed == 1
+
+    def test_procless_spawn_result_contributes_no_pair(self) -> None:
+        # A spawn returning None (or result.proc=None) launched nothing the
+        # driver can poll — counted as spawned, but no pair.
+        q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
+        res = drain_tasks(
+            q, lambda g: None, resolve_binary=_always_resolve, read_usage=_healthy_usage
+        )
+        assert res.procs == ()
+        assert res.spawned == 1
+
+    def test_procs_default_empty_tuple(self) -> None:
+        assert DrainResult().procs == ()
+
+
+# ---------------------------------------------------------------------------
+# #921 AC2 — poll_completions closes running→done/failed on process exit
+# ---------------------------------------------------------------------------
+
+
+class TestPollCompletions:
+    def test_still_running_kept_no_transition(self) -> None:
+        q = FakeTaskQueue()
+        procs = {"t0": TrackedProc(_FakeProc(rc=None), started_at=0.0)}
+        res = poll_completions(q, procs)
+        assert res.done == 0
+        assert res.failed_exit == 0
+        assert "t0" in procs
+        assert q.transitions == []
+
+    def test_exit_zero_closes_done_and_drops(self) -> None:
+        # Model P: done = the spawned process exited 0 — NOT task success,
+        # NOT PR merged. Path-A events carry the actual outcome.
+        q = FakeTaskQueue()
+        procs = {"t0": TrackedProc(_FakeProc(rc=0), started_at=0.0)}
+        res = poll_completions(q, procs)
+        assert res.done == 1
+        assert ("t0", "done", None) in q.transitions
+        assert procs == {}
+
+    def test_nonzero_exit_closes_failed_with_rc_in_reason(self) -> None:
+        q = FakeTaskQueue()
+        procs = {"t0": TrackedProc(_FakeProc(rc=3), started_at=0.0)}
+        res = poll_completions(q, procs)
+        assert res.failed_exit == 1
+        failed = [t for t in q.transitions if t[1] == "failed"]
+        assert len(failed) == 1
+        assert failed[0][0] == "t0"
+        assert failed[0][2] and "exit 3" in failed[0][2]
+        assert procs == {}
+
+    def test_mixed_batch(self) -> None:
+        q = FakeTaskQueue()
+        procs = {
+            "live": TrackedProc(_FakeProc(rc=None), started_at=0.0),
+            "ok": TrackedProc(_FakeProc(rc=0), started_at=0.0),
+            "boom": TrackedProc(_FakeProc(rc=1), started_at=0.0),
+        }
+        res = poll_completions(q, procs)
+        assert res.done == 1
+        assert res.failed_exit == 1
+        assert set(procs) == {"live"}
+
+    def test_transition_raise_isolated_drops_entry(self) -> None:
+        # One bad row must not block the others. The bad entry is dropped —
+        # its row stays `running` and the reaper backstop fails it later.
+        class Q(FakeTaskQueue):
+            def transition(self, task_id: str, to_status: str, *, reason: str | None = None) -> Any:
+                if task_id == "bad":
+                    raise RuntimeError("supabase transient error")
+                return super().transition(task_id, to_status, reason=reason)
+
+        q = Q()
+        procs = {
+            "bad": TrackedProc(_FakeProc(rc=0), started_at=0.0),
+            "ok": TrackedProc(_FakeProc(rc=0), started_at=0.0),
+        }
+        res = poll_completions(q, procs)
+        assert res.done == 1  # only 'ok' counted
+        assert ("ok", "done", None) in q.transitions
+        assert procs == {}  # both dropped — 'bad' falls to the reaper backstop
+
+
+# ---------------------------------------------------------------------------
+# #921 AC6 — runaway live processes are tree-killed and failed
+# ---------------------------------------------------------------------------
+
+
+class TestKillRunaways:
+    def test_runaway_killed_failed_and_dropped(self) -> None:
+        q = FakeTaskQueue()
+        proc = _FakeProc(rc=None)
+        kills: list[Any] = []
+        procs = {"t0": TrackedProc(proc, started_at=0.0)}
+        n = kill_runaways(q, procs, max_runtime_seconds=100, now=lambda: 200.0, kill=kills.append)
+        assert n == 1
+        assert kills == [proc]
+        failed = [t for t in q.transitions if t[1] == "failed"]
+        assert failed[0][0] == "t0"
+        assert failed[0][2] and "killed" in failed[0][2] and "max runtime" in failed[0][2]
+        assert procs == {}
+
+    def test_young_live_proc_untouched(self) -> None:
+        q = FakeTaskQueue()
+        kills: list[Any] = []
+        procs = {"t0": TrackedProc(_FakeProc(rc=None), started_at=0.0)}
+        n = kill_runaways(q, procs, max_runtime_seconds=100, now=lambda: 50.0, kill=kills.append)
+        assert n == 0
+        assert kills == []
+        assert "t0" in procs
+        assert q.transitions == []
+
+    def test_exited_proc_skipped_for_poll(self) -> None:
+        # An already-exited proc is poll_completions' job (rc decides
+        # done/failed); killing it would be a no-op and failing it could lie.
+        q = FakeTaskQueue()
+        kills: list[Any] = []
+        procs = {"t0": TrackedProc(_FakeProc(rc=0), started_at=0.0)}
+        n = kill_runaways(q, procs, max_runtime_seconds=100, now=lambda: 200.0, kill=kills.append)
+        assert n == 0
+        assert kills == []
+        assert "t0" in procs
+
+    def test_kill_raise_isolated_keeps_entry(self) -> None:
+        # A failed kill leaves a possibly-alive process — do NOT fail the row
+        # (that would lie); keep the entry and retry next tick.
+        q = FakeTaskQueue()
+        live = _FakeProc(rc=None)
+        procs = {
+            "bad": TrackedProc(live, started_at=0.0),
+            "ok": TrackedProc(_FakeProc(rc=None), started_at=0.0),
+        }
+
+        calls = {"n": 0}
+
+        def kill(proc: Any) -> None:
+            calls["n"] += 1
+            if proc is live:
+                raise OSError("taskkill unavailable")
+
+        n = kill_runaways(q, procs, max_runtime_seconds=100, now=lambda: 200.0, kill=kill)
+        assert n == 1  # only 'ok' was killed+failed
+        assert "bad" in procs and "ok" not in procs
+        assert {t[0] for t in q.transitions if t[1] == "failed"} == {"ok"}
+        assert calls["n"] == 2  # both attempted — isolation, not abort
+
+
+class TestKillProcessTree:
+    def test_windows_uses_taskkill_tree_force(self, monkeypatch: Any) -> None:
+        # Bare Popen.kill() is terminate() on Windows — children survive. The
+        # tree-kill must go through taskkill /T /F.
+        import agents.task_dispatch as td
+
+        runs: list[list[str]] = []
+        monkeypatch.setattr(td.subprocess, "run", lambda argv, **kw: runs.append(list(argv)))
+        proc = _FakeProc(rc=None, pid=1234)
+        kill_process_tree(proc, platform="win32")
+        assert runs == [["taskkill", "/PID", "1234", "/T", "/F"]]
+        assert proc.killed is False  # win32 path never calls Popen.kill()
+
+    def test_posix_uses_proc_kill(self) -> None:
+        proc = _FakeProc(rc=None, pid=1234)
+        kill_process_tree(proc, platform="linux")
+        assert proc.killed is True
+
+
+# ---------------------------------------------------------------------------
 # AC10 — injectable-port architecture
 # ---------------------------------------------------------------------------
 
@@ -518,6 +976,8 @@ class TestInjectablePortArchitecture:
         # If drain_tasks required a live client this whole module would not run.
         q = FakeTaskQueue(pending=[_row("t0")], running_count=0)
         spawns: list[str] = []
-        drain_tasks(q, lambda g: spawns.append(g), resolve_binary=_always_resolve)
+        drain_tasks(
+            q, lambda g: spawns.append(g), resolve_binary=_always_resolve, read_usage=_healthy_usage
+        )
         assert spawns == ["do t0"]
         assert os.environ is not None  # sanity — no monkeypatch leaked

--- a/tests/test_agents_task_queue.py
+++ b/tests/test_agents_task_queue.py
@@ -18,6 +18,7 @@ from agents.task_queue import (
     enqueue,
     list_stale_running,
     reclaim_stale_claimed,
+    requeue_running,
     transition,
 )
 
@@ -643,3 +644,38 @@ class TestListStaleRunning:
         )
         rows = list_stale_running(assignee="sandcastle", older_than_seconds=300, client=client)
         assert {r["id"] for r in rows} == {"old"}
+
+
+# ===========================================================================
+# requeue_running (#921 AC4) — mid-drain throttle returns the row to pending
+# ===========================================================================
+
+
+class TestRequeueRunning:
+    """AC4: a throttled-but-already-running row goes back to `pending` (no process)."""
+
+    def test_requeues_running_to_pending(self, client: _StubClient) -> None:
+        client.seed(
+            "task_queue",
+            [
+                _running(id="run", assignee="sandcastle", idempotency_key="k1"),
+            ],
+        )
+        assert requeue_running("run", client=client) is True
+        rows = {r["id"]: r for r in client.table("task_queue")._rows}
+        assert rows["run"]["status"] == "pending"
+        assert rows["run"]["claimed_at"] is None
+
+    def test_returns_false_when_not_running(self, client: _StubClient) -> None:
+        client.seed(
+            "task_queue",
+            [
+                _claimed(id="clm", idempotency_key="k1"),
+            ],
+        )
+        assert requeue_running("clm", client=client) is False
+        rows = {r["id"]: r for r in client.table("task_queue")._rows}
+        assert rows["clm"]["status"] == "claimed"
+
+    def test_returns_false_when_missing(self, client: _StubClient) -> None:
+        assert requeue_running("ghost", client=client) is False

--- a/tests/test_wake_driver.py
+++ b/tests/test_wake_driver.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pytest
 
 from agents import wake_driver
+from agents.task_dispatch import TrackedProc
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -301,6 +302,7 @@ class _RecordingTaskQueue:
         self._pending = list(pending or [])
         self._stale_claimed = stale_claimed
         self._stale_running = list(stale_running or [])
+        self.transitions: list[tuple[str, str, str | None]] = []
 
     def claim_next(self, *, assignee: str):
         for i, r in enumerate(self._pending):
@@ -314,6 +316,7 @@ class _RecordingTaskQueue:
 
     def transition(self, task_id: str, to_status: str, *, reason=None):
         self._log.append(f"task_transition:{to_status}")
+        self.transitions.append((task_id, to_status, reason))
         return {"id": task_id, "status": to_status}
 
     def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
@@ -343,6 +346,39 @@ class _LoggingEventQueue(FakeEventQueue):
         return row
 
 
+class _HealthyUsage:
+    """UsageReading-shaped fake — quota fine, drain proceeds (#921 AC4)."""
+
+    near_exhaustion = False
+
+
+def _healthy_usage() -> _HealthyUsage:
+    return _HealthyUsage()
+
+
+class _TickProc:
+    """Popen-shaped fake with a scripted return code — never a real process.
+
+    Tests that hand live (``rc=None``) instances to ``tick`` must also inject
+    ``task_clock`` (and rely on the injected ``task_kill``) so the runaway
+    killer never reaches a real ``taskkill`` against the fake pid.
+    """
+
+    def __init__(self, rc: int | None = None, pid: int = 4242) -> None:
+        self._rc = rc
+        self.pid = pid
+
+    def poll(self) -> int | None:
+        return self._rc
+
+
+class _SpawnHandle:
+    """SpawnResult-shaped fake exposing a pollable ``proc`` (not throttled)."""
+
+    def __init__(self, proc: _TickProc) -> None:
+        self.proc = proc
+
+
 def test_tick_runs_the_four_steps_in_order():
     log: list = []
     eq = _LoggingEventQueue(log, [_ev("e1", state="claimed")])
@@ -357,6 +393,7 @@ def test_tick_runs_the_four_steps_in_order():
         task_port=tq,
         task_spawn=lambda goal: None,
         task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
     )
 
     # AC1 order: reclaim(events) → reclaim_tasks() → drain(events) → drain_tasks()
@@ -376,6 +413,8 @@ def test_tick_without_task_port_is_event_only():
     assert result.tasks_reclaimed == 0
     assert result.tasks_reaped == 0
     assert result.tasks_failed == 0
+    assert result.tasks_done == 0
+    assert result.tasks_failed_exit == 0
 
 
 def test_tick_reports_task_counts():
@@ -394,6 +433,7 @@ def test_tick_reports_task_counts():
         task_port=tq,
         task_spawn=lambda goal: None,
         task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
     )
     assert result.tasks_reclaimed == 2  # AC5 stale claimed → pending
     assert result.tasks_reaped == 1  # AC6 stale running → failed
@@ -454,6 +494,7 @@ def test_tick_task_watchdog_failure_does_not_block_event_drain():
         stale_after_seconds=300,
         task_port=_RaisingOnReclaimTaskQueue(),
         task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
     )
     assert result.processed == 2  # events drained despite the task-side outage
     assert result.tasks_reclaimed == 0
@@ -470,6 +511,7 @@ def test_tick_task_drain_failure_does_not_crash_tick():
         stale_after_seconds=300,
         task_port=_RaisingOnDrainTaskQueue(),
         task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
     )
     assert result.processed == 1
     assert result.tasks_spawned == 0
@@ -509,6 +551,7 @@ def test_run_forwards_task_spawn_and_resolver_to_tick():
         task_port=tq,
         task_spawn=lambda goal: spawned.append(goal),
         task_resolve_binary=fake_resolve,
+        task_read_usage=_healthy_usage,
     )
 
     assert spawned == ["do-the-thing"]  # injected spawn forwarded, not the default
@@ -552,8 +595,266 @@ def test_run_forwards_task_thresholds_to_tick():
         should_continue=should_continue,
         task_port=_ThresholdPort(),
         task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
         task_claimed_stale_after_seconds=111,
         task_running_reap_after_seconds=222,
     )
 
     assert seen == {"claimed": 111, "running": 222}
+
+
+# --- #921 AC2/AC3/AC8: completion poll closes running→done in the tick ------
+
+
+def test_tick_completion_poll_runs_before_watchdogs_and_drains():
+    # AC3 ordering: Step 0 (completion poll) precedes the event watchdog, the
+    # task watchdog, and both drains — so an exited child's slot is freed and
+    # its row closed before this same tick reaps or re-claims anything.
+    log: list = []
+    eq = _LoggingEventQueue(log, [_ev("e1", state="claimed")])
+    eq.events[0]["claimed_at"] = 0.0
+    eq.clock = 999.0
+    tq = _RecordingTaskQueue(log, pending=[{"id": "t2", "goal": "g", "assignee": "sandcastle"}])
+    procs = {"t1": TrackedProc(proc=_TickProc(rc=0), started_at=0.0)}
+
+    wake_driver.tick(
+        eq,
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_spawn=lambda goal: None,
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs=procs,
+        task_clock=lambda: 0.0,
+    )
+
+    done_at = log.index("task_transition:done")
+    assert done_at < log.index("event_reclaim")
+    assert done_at < log.index("task_reclaim")
+    assert done_at < log.index("task_drain")
+
+
+def test_tick_reports_completion_counts_and_drops_closed_entries():
+    # AC2/AC8: exit 0 → done, exit ≠0 → failed_exit; both dropped from the
+    # map; a still-running entry is kept.
+    log: list = []
+    tq = _RecordingTaskQueue(log)
+    procs = {
+        "ok": TrackedProc(proc=_TickProc(rc=0), started_at=0.0),
+        "bad": TrackedProc(proc=_TickProc(rc=3), started_at=0.0),
+        "live": TrackedProc(proc=_TickProc(rc=None), started_at=0.0),
+    }
+
+    result = wake_driver.tick(
+        FakeEventQueue([]),
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_spawn=lambda goal: None,
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs=procs,
+        task_clock=lambda: 0.0,
+    )
+
+    assert result.tasks_done == 1
+    assert result.tasks_failed_exit == 1
+    assert set(procs) == {"live"}
+    assert ("ok", "done", None) in tq.transitions
+    assert ("bad", "failed", "exit 3") in tq.transitions
+
+
+def test_tick_shields_live_rows_from_the_orphan_reaper():
+    # #921 AC5: a stale running row WITH a live tracked process is not reaped;
+    # the stale row with no tracked process is an orphan → failed.
+    log: list = []
+    tq = _RecordingTaskQueue(log, stale_running=[{"id": "live"}, {"id": "orphan"}])
+    procs = {"live": TrackedProc(proc=_TickProc(rc=None), started_at=0.0)}
+
+    result = wake_driver.tick(
+        FakeEventQueue([]),
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs=procs,
+        task_clock=lambda: 0.0,
+    )
+
+    assert result.tasks_reaped == 1
+    failed_ids = [t[0] for t in tq.transitions if t[1] == "failed"]
+    assert failed_ids == ["orphan"]
+    assert "live" in procs  # still tracked, still running
+
+
+def test_tick_kills_runaway_live_processes():
+    # #921 AC6: a live process past the reap threshold is tree-killed via the
+    # injected kill, its row failed, the entry dropped — and it folds into
+    # tasks_failed_exit.
+    log: list = []
+    tq = _RecordingTaskQueue(log)
+    proc = _TickProc(rc=None)
+    procs = {"runaway": TrackedProc(proc=proc, started_at=0.0)}
+    killed: list = []
+
+    result = wake_driver.tick(
+        FakeEventQueue([]),
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs=procs,
+        task_clock=lambda: 999_999.0,  # way past the 6h knob
+        task_running_reap_after_seconds=60,
+        task_kill=killed.append,
+    )
+
+    assert killed == [proc]
+    assert result.tasks_failed_exit == 1
+    assert procs == {}
+    assert any(
+        t[0] == "runaway" and t[1] == "failed" and "max runtime" in (t[2] or "")
+        for t in tq.transitions
+    )
+
+
+def test_tick_merges_spawned_procs_into_the_tracking_map():
+    # AC2: a successful spawn's (task_id, proc) pair lands in the map, stamped
+    # with the injected clock — so the NEXT tick can poll it to completion.
+    log: list = []
+    proc = _TickProc(rc=None)
+    tq = _RecordingTaskQueue(log, pending=[{"id": "t1", "goal": "g", "assignee": "sandcastle"}])
+    procs: dict = {}
+
+    wake_driver.tick(
+        FakeEventQueue([]),
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_spawn=lambda goal: _SpawnHandle(proc),
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs=procs,
+        task_clock=lambda: 42.0,
+    )
+
+    assert set(procs) == {"t1"}
+    assert procs["t1"].proc is proc
+    assert procs["t1"].started_at == 42.0
+
+
+def test_tick_without_task_procs_reaps_all_stale_running_as_orphans():
+    # AC7 restart simulation: no map (fresh driver / --once) → poll and kill
+    # are skipped, and EVERY stale running row is an orphan again — reaped to
+    # failed; Path-A re-drives the lost work as fresh events.
+    log: list = []
+    tq = _RecordingTaskQueue(log, stale_running=[{"id": "r1"}, {"id": "r2"}])
+
+    result = wake_driver.tick(
+        FakeEventQueue([]),
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+    )
+
+    assert result.tasks_reaped == 2
+    assert result.tasks_done == 0
+    assert result.tasks_failed_exit == 0
+
+
+def test_run_retains_the_tracking_map_across_ticks():
+    # AC2 end-to-end: tick 1 spawns t1 into the injected map; the process
+    # exits between ticks; tick 2 polls the SAME map and closes running→done.
+    # A per-tick map would lose the handle and never close the row.
+    log: list = []
+    q = FakeEventQueue([])
+    q.wake_signals = [True, True]
+    tq = _RecordingTaskQueue(log, pending=[{"id": "t1", "goal": "g", "assignee": "sandcastle"}])
+    proc = _TickProc(rc=None)  # alive during tick 1...
+    procs: dict = {}
+    ticks = {"n": 0}
+
+    def should_continue() -> bool:
+        ticks["n"] += 1
+        if ticks["n"] == 2:
+            proc._rc = 0  # ...exits before tick 2
+        return ticks["n"] <= 2
+
+    wake_driver.run(
+        q,
+        wake_driver.default_orchestrator,
+        should_continue=should_continue,
+        task_port=tq,
+        task_spawn=lambda goal: _SpawnHandle(proc),
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs=procs,
+        task_clock=lambda: 0.0,
+    )
+
+    assert ("t1", "done", None) in tq.transitions
+    assert procs == {}
+
+
+def test_run_creates_and_retains_a_map_when_not_injected():
+    # run() must own a map even when none is injected — otherwise the
+    # production loop (main()) would never close running→done.
+    log: list = []
+    q = FakeEventQueue([])
+    q.wake_signals = [True, True]
+    tq = _RecordingTaskQueue(log, pending=[{"id": "t1", "goal": "g", "assignee": "sandcastle"}])
+    proc = _TickProc(rc=None)
+    ticks = {"n": 0}
+
+    def should_continue() -> bool:
+        ticks["n"] += 1
+        if ticks["n"] == 2:
+            proc._rc = 0
+        return ticks["n"] <= 2
+
+    wake_driver.run(
+        q,
+        wake_driver.default_orchestrator,
+        should_continue=should_continue,
+        task_port=tq,
+        task_spawn=lambda goal: _SpawnHandle(proc),
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_clock=lambda: 0.0,
+    )
+
+    assert ("t1", "done", None) in tq.transitions
+
+
+def test_run_forwards_task_read_usage_to_the_drain():
+    # #921 AC4: without forwarding, the drain silently falls back to the
+    # production probe (live Supabase) no matter what main() injected.
+    calls = {"n": 0}
+
+    def probe() -> _HealthyUsage:
+        calls["n"] += 1
+        return _HealthyUsage()
+
+    q = FakeEventQueue([])
+    q.wake_signals = [True]
+    ticks = {"n": 0}
+
+    def should_continue() -> bool:
+        ticks["n"] += 1
+        return ticks["n"] <= 1
+
+    wake_driver.run(
+        q,
+        wake_driver.default_orchestrator,
+        should_continue=should_continue,
+        task_port=_RecordingTaskQueue([]),
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=probe,
+    )
+
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
Closes the Path-A completion link left open by #909: `drain_tasks` now hands back spawned `(task_id, proc)` pairs, and the wake_driver owns a cross-tick liveness map it polls every tick — process exit 0 → `transition(done)`, non-zero → `transition(failed, \"exit <rc>\")`. The stale-running reaper becomes orphan-only (rows with a tracked live process are shielded), tracked processes alive past the 6h threshold are tree-killed as runaways, and a quota pre-flight + mid-drain requeue pause dispatch under near-exhaustion.

## Why
After #909 a spawned task's `running` row had no internal closer — it sat until the time-based reaper failed it hours later, ratcheting the concurrency cap toward 0 and lying about outcomes. #921 closes `running → done|failed` on **process exit** (Model P: `done` = process exited cleanly, NOT task success and NOT PR-merged — outcome truth re-enters via Path-A GitHub events).
Closes #921

## Decisions & Alternatives
Grilled; decision UUIDs `47523fa7-0d86-4646-b9bc-f50cd73ff5fa`, `2489782f-cd76-48db-87ba-5ad949e0623b`; implementation episode `d53ace14-5689-4653-a893-0e38402c9dae`. Key calls:
- **Model P (poll process exit) over Model E (parse GitHub events for completion)** — the driver already holds the Popen handle; event-parsing would couple completion to workflow naming and lose crashed-before-PR cases.
- **In-memory map owned by `run()`, mutated in place by `tick()`** — restart loses the map; stale rows become orphans and the reaper backstop fails them (self-heals via Path A). The durable alternative (PID sidecar file) is deliberately deferred to #952 to keep this slice schema-free (AC10).
- **Tick ordering: completion-poll → watchdogs → drains** — freed slots are visible to the same tick's drain; freshly-closed rows are no longer `running` when the orphan reaper scans.
- **Runaway kill = `taskkill /PID <pid> /T /F` on win32** (`Popen.kill()` is `terminate()` on Windows and orphans the child tree). Asymmetric isolation: kill-raise keeps the entry (retry next tick), transition-raise after kill drops it (reaper backstop).
- **Mid-drain quota flip requeues via FSM-bypassing `running → pending` UPDATE** with `.eq(\"status\",\"running\")` optimistic lock — under Ordering B the row went `running` before the throttled spawn declined, so no process exists and requeue is safe.
- **One 6h knob** (`DEFAULT_RUNNING_REAP_SECONDS`) shared by orphan reaper and runaway killer — two thresholds would invite drift; the semantics differ by liveness, not by age.

## Risk Assessment
- **MEDIUM**: new completion/runaway logic in the tick loop — pure functions over injectable ports, 120 unit tests, but it gates real `task_queue` row closure.
- **MEDIUM**: FSM-bypassing `requeue_running` UPDATE (mirrors the existing `reclaim_stale_claimed` pattern; optimistic-locked).
- **LOW**: docstring/comment cleanup; `TickResult` field additions (defaulted — existing constructors unchanged).
- Runaway kill path: injectable `clock`/`kill` everywhere; tests never reach a real `taskkill` (fake procs + injected clock; hazard documented in test helper).

## Testing
- `python -m pytest tests/test_wake_driver.py tests/test_agents_task_dispatch.py tests/test_agents_task_queue.py -q` → **120 passed in 0.48s** (31 wake_driver / 53 dispatch / 36 queue).
- TDD red→green per AC bullet: 16 RED (TypeError on new tick/run kwargs) confirmed before GREEN wiring.
- Fixed a live-network leak found en route: the old tick hit the real Supabase quota probe in unit tests (10s runtime + DeprecationWarnings); `task_read_usage` injection removes it — suite now 0.5s, warning-free.
- Restart simulation: tick without `task_procs` reaps all stale running rows as orphans (AC7).
- No E2E smoke needed beyond unit level: no schema change, no new I/O paths (spawn/DB calls ride existing #909 adapters; all new logic is pure over ports).

## Files Changed
- `agents/task_dispatch.py` — `DrainResult.procs`, `TrackedProc`, `CompletionResult`, `poll_completions`, `kill_process_tree`, `kill_runaways`, quota pre-flight + mid-drain requeue in `drain_tasks`, orphan-only `reclaim_stale_tasks(live_task_ids=...)`, `SupabaseTaskQueue.requeue_running`; stale \"deferred to #921\" docs rewritten.
- `agents/task_queue.py` — `requeue_running` (FSM-bypassing optimistic-locked UPDATE); `list_stale_running` docstring updated to liveness-aware semantics.
- `agents/wake_driver.py` — tick Step 0 (poll + runaway kill), `live_task_ids` shield, `task_read_usage` forwarding, map merge of spawned procs, `TickResult.tasks_done/tasks_failed_exit`; `run()` owns the map across ticks; `--once` deliberately mapless (restart semantics); module docstring documents the #921 loop + restart limitation.
- `tests/test_agents_task_dispatch.py`, `tests/test_agents_task_queue.py`, `tests/test_wake_driver.py` — AC-tied coverage for all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)