### PR TITLE
fix(agents): harden Model-P completion loop per code-review (#921)

### DIFF
--- a/agents/task_dispatch.py
+++ b/agents/task_dispatch.py
@@ -131,9 +131,11 @@ class DrainResult:
     # reaper is the backstop). Remaining rows stay ``pending`` and self-heal.
     throttled: bool = False
     # (task_id, proc) per *successful* spawn that yielded a pollable process
-    # handle (#921 AC1). Throttled spawns (proc=None), raising spawns, and
-    # proc-less results contribute no pair. The wake_driver folds these into
-    # its {task_id: proc} liveness map to close running→done on process exit.
+    # handle (#921 AC1). A raising spawn never reaches the append; a throttled
+    # spawn returns early (the whole drain stops) before it; a result without
+    # a ``proc`` attribute counts as spawned but is skipped here. The
+    # wake_driver folds these pairs into its {task_id: TrackedProc} liveness
+    # map to close running→done on process exit.
     procs: tuple[tuple[str, Any], ...] = ()
 
 
@@ -171,9 +173,10 @@ def poll_completions(port: TaskQueuePort, procs: dict[str, TrackedProc]) -> Comp
 
     For each tracked pair: ``poll() is None`` → still running, kept;
     ``poll() == 0`` → ``transition(done)``; ``poll() != 0`` →
-    ``transition(failed, reason="exit <rc>")``. Closed entries are dropped from
-    ``procs`` (mutated in place) so the freed slots are visible to the same
-    tick's drain.
+    ``transition(failed, reason="exit <rc>")``. The DB transition is what frees
+    the cap slot (``count_running`` drops) for the same tick's drain; dropping
+    the closed entry from ``procs`` (mutated in place) just stops it from being
+    re-polled and shields the row from the watchdogs.
 
     **``done`` means the process exited 0 — nothing more.** Not task success,
     not PR merged; the child may have produced garbage and exited cleanly.
@@ -212,19 +215,33 @@ def kill_process_tree(proc: Any, *, platform: str = sys.platform) -> None:
 
     On Windows ``Popen.kill()`` is an alias for ``terminate()`` — it kills only
     the direct process, and a ``claude -p`` child's own subprocesses (git, gh,
-    tools) survive as orphans. ``taskkill /PID <pid> /T /F`` walks the tree.
-    POSIX falls back to ``proc.kill()`` (the spawned process is the process
-    group leader for our use; good enough until a POSIX deployment exists).
+    tools) survive as orphans. ``taskkill /PID <pid> /T /F`` walks the tree; if
+    taskkill itself can't launch (stripped PATH), degrade to ``proc.kill()`` —
+    direct child only, better than leaving the runaway alive.
+
+    POSIX gets plain ``proc.kill()`` — direct child only. ``os.killpg`` would
+    be WRONG here: :func:`executor.spawn` does not pass
+    ``start_new_session=True``, so the child shares the driver's process group
+    and ``killpg`` would kill the driver itself. A POSIX tree-kill needs the
+    spawn-side change first; production runs on Windows, so this is deferred.
 
     Best-effort ``wait`` afterwards reaps the handle so ``poll()`` reflects the
     death immediately; a hung wait is swallowed (the next tick's poll re-checks).
     """
     if platform == "win32":
-        subprocess.run(
-            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
-            capture_output=True,
-            check=False,
-        )
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                capture_output=True,
+                check=False,
+            )
+        except OSError:  # taskkill missing/unlaunchable — degrade to direct kill
+            logger.exception(
+                "[task_dispatch] taskkill unavailable for pid %s; "
+                "falling back to Popen.kill() (children may survive)",
+                proc.pid,
+            )
+            proc.kill()
     else:
         proc.kill()
     try:
@@ -412,7 +429,16 @@ def drain_tasks(
             result = spawn(row["goal"])  # AC8 billing-trap rides executor._sanitize_env
         except Exception as exc:  # noqa: BLE001 — AC7b: isolate one bad spawn
             # AC7b — terminal failure; no internal retry, external loop re-drives.
-            port.transition(task_id, "failed", reason=f"spawn raised: {exc}")
+            try:
+                port.transition(task_id, "failed", reason=f"spawn raised: {exc}")
+            except Exception:  # noqa: BLE001 — the failed-mark itself can raise; an
+                # escape here would discard the already-spawned handles in ``procs``
+                # (orphans for the 6h reaper). Row stays running; reaper backstops.
+                logger.exception(
+                    "[task_dispatch] could not mark task %s failed after spawn raise; "
+                    "row left running for the reaper",
+                    task_id,
+                )
             failed += 1
             continue
 
@@ -491,15 +517,21 @@ def reclaim_stale_tasks(
         task_id = str(row["id"])
         if task_id in live_task_ids:
             continue
-        port.transition(
-            task_id,
-            "failed",
-            reason=(
-                f"reaped: orphaned running row (no tracked process) "
-                f"after {running_reap_after_seconds:.0f}s"
-            ),
-        )
-        reaped += 1
+        try:
+            port.transition(
+                task_id,
+                "failed",
+                reason=(
+                    f"reaped: orphaned running row (no tracked process) "
+                    f"after {running_reap_after_seconds:.0f}s"
+                ),
+            )
+            reaped += 1
+        except Exception:  # noqa: BLE001 — isolate one bad row; the rest still reap
+            logger.exception(
+                "[task_dispatch] orphan reap of task %s failed; retried next sweep",
+                task_id,
+            )
 
     return ReclaimResult(reclaimed_claimed=reclaimed, reaped_running=reaped)
 

--- a/agents/wake_driver.py
+++ b/agents/wake_driver.py
@@ -238,12 +238,17 @@ def tick(
     and its rows stay in place (``claimed``/``running`` → swept next tick;
     ``pending`` → re-drained next tick), exactly as a crash would leave them.
     """
-    # Step 0 — completion poll + runaway kill (#921 AC2/AC3/AC6).
+    # Step 0 — completion poll + runaway kill (#921 AC2/AC3/AC6). Two
+    # independent halves: a completion-poll blowup must not stop the runaway
+    # killer from bounding live processes, so each gets its own isolation.
     completions = None
     runaways_killed = 0
     if task_port is not None and task_procs is not None:
         try:
             completions = poll_completions(task_port, task_procs)
+        except Exception:  # noqa: BLE001 — task-store outage must not block event drain
+            logger.exception("[wake_driver] completion poll failed; tracked rows retry next tick")
+        try:
             runaways_killed = kill_runaways(
                 task_port,
                 task_procs,
@@ -251,8 +256,8 @@ def tick(
                 now=task_clock,
                 kill=task_kill,
             )
-        except Exception:  # noqa: BLE001 — task-store outage must not block event drain
-            logger.exception("[wake_driver] completion poll failed; tracked rows retry next tick")
+        except Exception:  # noqa: BLE001 — same isolation for the runaway killer
+            logger.exception("[wake_driver] runaway kill failed; live rows retry next tick")
 
     # Step 1 — event watchdog.
     reclaimed = run_watchdog(port, stale_after_seconds=stale_after_seconds)
@@ -280,6 +285,10 @@ def tick(
     task_drain = None
     if task_port is not None:
         try:
+            # Stamp BEFORE the drain: a broken clock then fails the step while
+            # no process exists yet — stamped after, the raise would discard
+            # the just-spawned handles (orphans for the 6h reaper).
+            started = task_clock()
             task_drain = drain_tasks(
                 task_port,
                 task_spawn,
@@ -287,7 +296,6 @@ def tick(
                 read_usage=task_read_usage,
             )
             if task_procs is not None:
-                started = task_clock()
                 for task_id, proc in task_drain.procs:
                     task_procs[task_id] = TrackedProc(proc=proc, started_at=started)
         except Exception:  # noqa: BLE001 — task-store outage must not crash the tick

--- a/tests/test_agents_task_dispatch.py
+++ b/tests/test_agents_task_dispatch.py
@@ -14,6 +14,7 @@ Each test names the acceptance criterion it covers (see issue #909, grilled
 from __future__ import annotations
 
 import os
+import subprocess
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -105,6 +106,7 @@ class _FakeProc:
         self._rc = rc
         self.pid = pid
         self.killed = False
+        self.waited = False
 
     def poll(self) -> int | None:
         return self._rc
@@ -112,6 +114,10 @@ class _FakeProc:
     def kill(self) -> None:
         self.killed = True
         self._rc = -9
+
+    def wait(self, timeout: float | None = None) -> int | None:
+        self.waited = True
+        return self._rc
 
 
 class _ThrottledResult:
@@ -405,6 +411,35 @@ class TestSpawnFailureIsTerminal:
         assert spawns == ["do ok"]
         assert res.spawned == 1
         assert res.failed == 1
+
+    def test_failed_mark_raise_does_not_abort_drain(self) -> None:
+        # review #957-1 (MAJOR): the AC7b failure-marking itself can raise
+        # (store outage). That must not escape drain_tasks — an escape discards
+        # DrainResult.procs for already-spawned tasks, orphaning live children
+        # onto the 6h reaper instead of next-tick completion polling.
+        class Q(FakeTaskQueue):
+            def transition(
+                self, task_id: str, to_status: str, *, reason: str | None = None
+            ) -> dict[str, Any]:
+                if to_status == "failed":
+                    raise RuntimeError("store outage")
+                return super().transition(task_id, to_status, reason=reason)
+
+        handle = object()
+        q = Q(pending=[_row("boom"), _row("ok")], running_count=0)
+
+        def spawn(goal: str) -> Any:
+            if goal == "do boom":
+                raise RuntimeError("spawn blew up")
+            return _HealthySpawnResult(handle)
+
+        res = drain_tasks(
+            q, spawn, cap=5, resolve_binary=_always_resolve, read_usage=_healthy_usage
+        )
+
+        assert res.failed == 1  # still counted despite the failed-mark raising
+        assert res.spawned == 1  # the drain continued past the bad row
+        assert res.procs == (("ok", handle),)  # spawned handle survives for tracking
 
 
 # ---------------------------------------------------------------------------
@@ -736,6 +771,25 @@ class TestOrphanOnlyReaper:
         res = reclaim_stale_tasks(q)
         assert res.reaped_running == 2
 
+    def test_orphan_transition_raise_isolated(self) -> None:
+        # review #957-5 (MINOR): one orphan's failed-mark raising must not
+        # abort the sweep — the remaining orphans are still reaped this pass
+        # (per-row isolation, mirroring poll_completions).
+        class Q(FakeTaskQueue):
+            def transition(
+                self, task_id: str, to_status: str, *, reason: str | None = None
+            ) -> dict[str, Any]:
+                if task_id == "bad":
+                    raise RuntimeError("transient store error")
+                return super().transition(task_id, to_status, reason=reason)
+
+        q = Q()
+        q.stale_running = [{"id": "bad"}, {"id": "ok"}]
+        res = reclaim_stale_tasks(q)
+        assert res.reaped_running == 1  # 'bad' raised → not counted
+        failed = [t[0] for t in q.transitions if t[1] == "failed"]
+        assert failed == ["ok"]  # the sweep continued past the bad row
+
 
 # ---------------------------------------------------------------------------
 # #921 AC1 — DrainResult exposes spawned (task_id, proc) pairs
@@ -958,6 +1012,45 @@ class TestKillProcessTree:
     def test_posix_uses_proc_kill(self) -> None:
         proc = _FakeProc(rc=None, pid=1234)
         kill_process_tree(proc, platform="linux")
+        assert proc.killed is True
+
+    def test_reaps_handle_with_wait(self, monkeypatch: Any) -> None:
+        # review #957-3: the post-kill wait must actually run (it reaps the
+        # handle so poll() reflects the death immediately), win32 and POSIX
+        # alike — a fake without wait() was silently masking this call.
+        import agents.task_dispatch as td
+
+        monkeypatch.setattr(td.subprocess, "run", lambda argv, **kw: None)
+        win = _FakeProc(rc=None, pid=1234)
+        kill_process_tree(win, platform="win32")
+        posix = _FakeProc(rc=None, pid=1234)
+        kill_process_tree(posix, platform="linux")
+        assert win.waited is True
+        assert posix.waited is True
+
+    def test_hung_wait_is_swallowed(self) -> None:
+        # A child that won't reap within the timeout must not hang the driver
+        # tick: TimeoutExpired is swallowed, the next tick's poll re-checks.
+        class _HangingProc(_FakeProc):
+            def wait(self, timeout: float | None = None) -> int | None:
+                raise subprocess.TimeoutExpired(cmd="claude", timeout=timeout or 10)
+
+        proc = _HangingProc(rc=None, pid=1234)
+        kill_process_tree(proc, platform="linux")
+        assert proc.killed is True  # the kill happened despite the hung wait
+
+    def test_missing_taskkill_falls_back_to_proc_kill(self, monkeypatch: Any) -> None:
+        # review #957-7 (MINOR): taskkill absent from PATH (stripped env,
+        # minimal container) must not leave the runaway alive — fall back to
+        # plain Popen.kill(), which at least takes down the direct child.
+        import agents.task_dispatch as td
+
+        def raising_run(argv: list[str], **kw: Any) -> None:
+            raise FileNotFoundError("taskkill not found")
+
+        monkeypatch.setattr(td.subprocess, "run", raising_run)
+        proc = _FakeProc(rc=None, pid=1234)
+        kill_process_tree(proc, platform="win32")
         assert proc.killed is True
 
 

--- a/tests/test_wake_driver.py
+++ b/tests/test_wake_driver.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 from agents import wake_driver
-from agents.task_dispatch import TrackedProc
+from agents.task_dispatch import TaskQueuePort, TrackedProc
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -326,6 +326,17 @@ class _RecordingTaskQueue:
     def list_stale_running(self, *, assignee: str, older_than_seconds: float):
         self._log.append("task_list_running")
         return list(self._stale_running)
+
+    def requeue_running(self, task_id: str) -> bool:
+        self._log.append("task_requeue")
+        return True
+
+
+def test_recording_task_queue_conforms_to_the_port_protocol():
+    # review #957-2 (MAJOR): the fake must satisfy the full TaskQueuePort
+    # surface (incl. requeue_running, #921 AC4) — a partial fake lets tick
+    # paths that touch the missing method blow up only in production.
+    assert isinstance(_RecordingTaskQueue([]), TaskQueuePort)
 
 
 class _LoggingEventQueue(FakeEventQueue):
@@ -744,6 +755,104 @@ def test_tick_merges_spawned_procs_into_the_tracking_map():
     assert set(procs) == {"t1"}
     assert procs["t1"].proc is proc
     assert procs["t1"].started_at == 42.0
+
+
+def test_tick_stamps_the_clock_before_spawning():
+    # review #957-4 (MAJOR): the started_at stamp must be taken BEFORE the
+    # drain runs. Taken after, a raising clock discards the just-spawned
+    # handles — live children orphaned onto the 6h reaper. Clock-first means
+    # a broken clock fails the step before any process exists.
+    order: list = []
+
+    def clock() -> float:
+        order.append("clock")
+        return 0.0
+
+    def spawn(goal: str) -> _SpawnHandle:
+        order.append("spawn")
+        return _SpawnHandle(_TickProc(rc=None))
+
+    tq = _RecordingTaskQueue([], pending=[{"id": "t1", "goal": "g", "assignee": "sandcastle"}])
+
+    wake_driver.tick(
+        FakeEventQueue([]),
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_spawn=spawn,
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs={},
+        task_clock=clock,
+    )
+
+    assert "spawn" in order and "clock" in order
+    assert order.index("clock") < order.index("spawn")
+
+
+def test_tick_with_a_broken_clock_spawns_nothing():
+    # Consequence of clock-first ordering (review #957-4): a broken clock
+    # fails Step 4 before the drain — no child is spawned only to have its
+    # handle dropped on the floor.
+    spawned: list = []
+
+    def bad_clock() -> float:
+        raise RuntimeError("clock broken")
+
+    def spawn(goal: str) -> _SpawnHandle:
+        spawned.append(goal)
+        return _SpawnHandle(_TickProc(rc=None))
+
+    tq = _RecordingTaskQueue([], pending=[{"id": "t1", "goal": "g", "assignee": "sandcastle"}])
+
+    wake_driver.tick(
+        FakeEventQueue([]),
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_spawn=spawn,
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs={},
+        task_clock=bad_clock,
+    )
+
+    assert spawned == []
+
+
+def test_tick_poll_blowup_does_not_block_the_runaway_killer():
+    # review #957-6 (MINOR): Step 0's two halves are independent — a
+    # completion-poll blowup must not stop the runaway killer from bounding
+    # live processes. Each half needs its own isolation.
+    class _ExplodingProc:
+        pid = 1
+
+        def poll(self) -> int | None:
+            raise RuntimeError("handle gone")
+
+    log: list = []
+    tq = _RecordingTaskQueue(log)
+    runaway = _TickProc(rc=None)
+    procs = {
+        "runaway": TrackedProc(proc=runaway, started_at=0.0),
+        "exploder": TrackedProc(proc=_ExplodingProc(), started_at=0.0),
+    }
+    killed: list = []
+
+    wake_driver.tick(
+        FakeEventQueue([]),
+        wake_driver.default_orchestrator,
+        stale_after_seconds=300,
+        task_port=tq,
+        task_resolve_binary=lambda: "claude",
+        task_read_usage=_healthy_usage,
+        task_procs=procs,
+        task_clock=lambda: 999_999.0,
+        task_running_reap_after_seconds=60,
+        task_kill=killed.append,
+    )
+
+    assert killed == [runaway]
 
 
 def test_tick_without_task_procs_reaps_all_stale_running_as_orphans():


### PR DESCRIPTION
## Summary
Post-merge hardening for the Claude code-review findings on PR #957 (the #921 Model-P completion loop). All 4 MAJOR and 6 MINOR findings addressed — 5 behavior fixes TDD red→green, 2 test-fake gaps closed, 3 docstring corrections. `[no-issue]` — drive-by hardening per #428; parent issue #921 is closed (shipped in #957), same pattern as #951 for #909.

## Why
The `review` gate false-passed on #957: the verdict parser greps `Found N issues:` but the bot comment used `### MAJOR findings` format, so 10 real findings shipped unaddressed. Per /implement §7.5 and the #951 precedent, findings get a follow-up hardening PR.

## Decisions & Alternatives
- **Finding #1 (MAJOR)** — the AC7b failed-mark `transition` in `drain_tasks` is now guarded: a store outage during failure-marking no longer escapes the drain and discards already-spawned handles (which would orphan live children onto the 6h reaper). Counter still increments; row stays `running` for the reaper backstop.
- **Finding #4 (MAJOR)** — `tick` Step 4 stamps `task_clock()` **before** `drain_tasks`: a broken clock now fails the step while no process exists, instead of after spawning (and then dropping the handles).
- **Finding #6 (MINOR)** — `tick` Step 0 split into two independent try blocks: a completion-poll blowup no longer prevents the runaway killer from bounding live processes.
- **Finding #5 (MINOR)** — per-row isolation in the `reclaim_stale_tasks` orphan loop, mirroring `poll_completions`: one bad row no longer aborts the sweep.
- **Finding #7 (MINOR)** — `taskkill` launch failure (OSError) falls back to `proc.kill()` — direct child only, better than leaving the runaway alive.
- **Findings #2/#3 (MAJOR, test-only)** — `_RecordingTaskQueue` gains `requeue_running` + an `isinstance(…, TaskQueuePort)` conformance test; `_FakeProc` gains `wait()` so the post-kill reap path is actually exercised (was silently masked by the swallowed AttributeError).
- **Finding #10 — reviewer suggestion REJECTED**: implementing `os.killpg` on POSIX would kill the driver itself, because `executor.spawn` does not pass `start_new_session=True` — the child shares the driver''s process group. Documented the constraint in the docstring instead; a POSIX tree-kill needs the spawn-side change first (production runs on Windows Workshop).
- **Findings #8/#9** — docstring causality fixes: the DB transition is what frees the cap slot (not the `procs.pop`); `DrainResult.procs` filtering described per actual control flow.

## Risk Assessment
- **LOW**: docstrings (#8/#9/#10), test fakes (#2/#3).
- **MEDIUM**: defensive try/except additions (#1, #5, #6, #7) and the Step-4 clock reorder (#4) — all failure-path-only; happy paths byte-identical, pinned by the existing 84-test suite.

## Testing
- TDD: 6 RED tests written first, confirmed failing for the right reason, then minimal fixes → GREEN.
- `pytest tests/test_agents_task_dispatch.py tests/test_wake_driver.py tests/test_agents_task_queue.py` — **129 passed**.
- `ruff check --fix` + `ruff format` — clean, no reformats.

## Files Changed
- `agents/task_dispatch.py` — findings #1, #5, #7 (guards) + #8, #9, #10 (docstrings)
- `agents/wake_driver.py` — findings #4 (clock-before-drain), #6 (split Step 0)
- `tests/test_agents_task_dispatch.py` — RED tests for #1/#5/#7; `_FakeProc.wait` + wait-coverage tests (#3)
- `tests/test_wake_driver.py` — `requeue_running` + protocol conformance (#2); tick tests for #4/#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)