### PR TITLE
fix(ci): unjam review gate — allow bot-triggered runs + enforce verdict on retry path

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -57,6 +57,21 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: ./.claude/marketplace
           plugins: code-review@jarvis-fork-plugins
+          # claude-code-action@v1 added an `allowed_bots` gate that hard-fails
+          # ("Workflow initiated by non-human actor") when the triggering actor
+          # is a Bot. Two LEGITIMATE bot triggers exist in this pipeline and
+          # both jammed the `review` check across every in-flight PR:
+          #   - code-review-retry.yml re-dispatches via workflow_dispatch
+          #     (actor: github-actions[bot]) on a failed run.
+          #   - merge-train.yml's update-branch fires a `synchronize` whose
+          #     actor is the merge-train GitHub App token (a [bot] login).
+          # "*" is safe here despite the action's public-repo warning: the
+          # job-level `if:` requires head.repo.full_name == github.repository,
+          # so fork/external PRs never reach this step, and workflow_dispatch /
+          # branch pushes both require repo write access. No untrusted external
+          # actor can initiate this run. Allowed-tools are also locked
+          # read-only below. Uniform across owned repos for the M48 baseline.
+          allowed_bots: "*"
           prompt: |
             Run /code-review for PR #${{ steps.pr.outputs.number }} in repo ${{ github.repository }}.
 
@@ -104,8 +119,19 @@ jobs:
       #     bots comment too) and findings-shaped selection would wrongly
       #     gate on `### Simplification opportunities` comments, which are
       #     informational-only by design (see event-dispatch.yml).
+      #
+      # Runs on BOTH pull_request and workflow_dispatch. The dispatch path is
+      # the retry (code-review-retry.yml dispatches with --ref <head_branch>,
+      # so its check attaches to the PR head SHA and feeds the `review` gate).
+      # If the verdict step were gated to pull_request only, a retry that
+      # surfaced findings would post them but skip this gate → the run goes
+      # green → auto-merge with findings. That hole was dormant only because
+      # the `allowed_bots` jam made retries fail at the action level; closing
+      # that jam (above) makes retries succeed, so this gate must enforce on
+      # the dispatch path too. steps.pr.outputs.number resolves on dispatch
+      # via inputs.pr_number, so the lookup works for both events.
       - name: Verify review verdict
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}

--- a/tests/ci/test_code_review_verdict_guard.py
+++ b/tests/ci/test_code_review_verdict_guard.py
@@ -256,9 +256,46 @@ def verdict_step(workflow_text) -> dict:
     return next(s for s in steps if s.get("name") == "Verify review verdict")
 
 
+@pytest.fixture(scope="module")
+def review_step(workflow_text) -> dict:
+    workflow = yaml.safe_load(workflow_text)
+    steps = workflow["jobs"]["review"]["steps"]
+    return next(s for s in steps if s.get("name") == "Run /code-review")
+
+
+class TestReviewStepBotGate:
+    def test_allowed_bots_wildcard_is_set(self, review_step):
+        # claude-code-action@v1's `allowed_bots` gate hard-fails on a Bot
+        # actor. Two legitimate bot triggers feed the `review` check:
+        # code-review-retry.yml (workflow_dispatch as github-actions[bot]) and
+        # merge-train.yml's update-branch (synchronize as the App token). With
+        # this unset, every retried / merge-train-updated PR jams the gate.
+        assert review_step["with"].get("allowed_bots") == "*", (
+            "Run /code-review must set allowed_bots: '*' — otherwise bot-"
+            "triggered runs (retry dispatch, merge-train synchronize) fail at "
+            "the action level and the `review` check goes permanently red. "
+            "Safe here: the job-level `if:` excludes fork PRs and "
+            "workflow_dispatch requires repo write access, so no untrusted "
+            "external actor can initiate this run."
+        )
+
+
 class TestVerdictStepWiring:
-    def test_step_exists_and_gates_on_pull_request(self, verdict_step):
-        assert verdict_step["if"] == "github.event_name == 'pull_request'"
+    def test_step_gates_on_pull_request_and_dispatch(self, verdict_step):
+        # MUST also run on workflow_dispatch: the retry path
+        # (code-review-retry.yml) dispatches with --ref <head_branch>, so its
+        # check attaches to the PR head SHA and feeds the `review` gate. Gating
+        # to pull_request only would let a retry that surfaced findings post
+        # them but skip this step → the run goes green → auto-merge with
+        # findings. Dormant only while the allowed_bots jam made retries fail
+        # at the action level; once that's fixed, this gate must enforce on the
+        # dispatch path too.
+        gate = verdict_step["if"]
+        assert "github.event_name == 'pull_request'" in gate
+        assert "github.event_name == 'workflow_dispatch'" in gate, (
+            "Verdict must enforce on the retry (workflow_dispatch) path, not "
+            "just pull_request — else the retry path is an auto-merge bypass."
+        )
 
     def test_selector_matches_title_variants_not_literal_prefix(self, verdict_step):
         run = verdict_step["run"]


### PR DESCRIPTION
## What

Two changes to `.github/workflows/code-review.yml`, same subsystem (the `review` merge gate):

1. **`allowed_bots: "*"`** on the `Run /code-review` step. `anthropics/claude-code-action@v1` added an `allowed_bots` gate that hard-fails (`Workflow initiated by non-human actor: github-actions (type: Bot)`) when the triggering actor is a Bot. Two **legitimate** bot triggers feed this check and both jammed it:
   - `code-review-retry.yml` re-dispatches via `workflow_dispatch` (actor `github-actions[bot]`).
   - `merge-train.yml`'s `update-branch` fires a `synchronize` as the merge-train GitHub App token (a `[bot]` login).
2. **Verdict step now gates on `workflow_dispatch` too** (was `pull_request` only). Sibling fix: closing the bot jam *activates* a latent fail-open — the retry dispatches with `--ref <head_branch>`, so its check attaches to the PR head SHA and feeds the `review` gate; a retry that surfaced findings would post them but **skip** the verdict step → run goes green → auto-merge with unaddressed findings (the #957-class hole).

## Why `*` is safe (despite the action's public-repo warning)

The job-level `if:` already requires `head.repo.full_name == github.repository`, so fork/external PRs never reach this step; `workflow_dispatch` and branch pushes require repo write access. No untrusted external actor can initiate this run. Allowed-tools remain locked read-only. Uniform value across owned repos for the M48 baseline.

## Tests

`tests/ci/test_code_review_verdict_guard.py` (per #326 guard-test convention) now asserts:
- `allowed_bots: "*"` is set on the review step.
- the verdict `if:` covers both `pull_request` and `workflow_dispatch`.

`tests/ci/test_code_review_verdict_guard.py` (31) + `tests/ci/test_code_review_retry.py` (39) pass locally.

## Merge note

This PR self-modifies `code-review.yml`; `claude-code-action@v1` refuses to run on self-modifying PRs, so the `review` check fails as expected → **admin-merge** per documented policy.

`[no-issue]` — drive-by CI fix unblocking the AFK pipeline (per #428).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
