### PR TITLE
fix(config): statusLine type:command (inline is silently ignored) [no-issue]

### DIFF
--- a/.claude-userlevel/settings.json
+++ b/.claude-userlevel/settings.json
@@ -216,8 +216,8 @@
   },
   "fallbackModel": "claude-sonnet-4-6",
   "statusLine": {
-    "type": "inline",
-    "format": "{model} | ctx {context_usage}% | {git_branch}"
+    "type": "command",
+    "command": "python scripts/statusline.py"
   },
   "skillOverrides": {
     "setup-tasks": "name-only",

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Status line for Claude Code.
+
+Reads the status-line JSON payload on stdin and prints a single line:
+
+    <model> | ctx <N>% | <git-branch>
+
+Replaces the old (now-unsupported) settings.json `statusLine.type: "inline"`
++ `format: "{model} | ctx {context_usage}% | {git_branch}"`, which Claude Code
+no longer recognises (only `type: "command"` is valid). Wired in via
+settings.json -> statusLine.command.
+
+Payload fields used (see Claude Code status-line schema):
+- model.display_name          -> model name
+- context_window.used_percentage -> context usage (may be null early in session)
+- cwd                         -> dir to resolve the git branch from
+"""
+import json
+import subprocess
+import sys
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        # No/invalid payload: emit nothing rather than a Python traceback.
+        return
+
+    model = data.get("model", {}).get("display_name") or "?"
+
+    cw = data.get("context_window") or {}
+    used = cw.get("used_percentage")
+    ctx = f"ctx {int(used)}%" if isinstance(used, (int, float)) else "ctx -"
+
+    cwd = data.get("cwd") or data.get("workspace", {}).get("current_dir") or "."
+    try:
+        branch = subprocess.run(
+            ["git", "-C", cwd, "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        branch = ""
+    branch = branch or "no repo"
+
+    print(f"{model} | {ctx} | {branch}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,60 @@
+"""Tests for scripts/statusline.py — the Claude Code status-line formatter.
+
+The script reads a status-line JSON payload on stdin and prints one line:
+``<model> | ctx <N>% | <git-branch>``. These pin the formatting contract and
+the fail-soft branches (missing fields, invalid JSON, non-repo cwd).
+"""
+import importlib.util
+import io
+import json
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "statusline.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("statusline", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run(monkeypatch, capsys, payload, *, raw=None):
+    stdin = raw if raw is not None else json.dumps(payload)
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin))
+    _load().main()
+    return capsys.readouterr().out
+
+
+def test_full_payload(monkeypatch, capsys, tmp_path):
+    # tmp_path is not a git repo -> branch resolves to "no repo"
+    out = _run(
+        monkeypatch,
+        capsys,
+        {
+            "model": {"display_name": "Opus 4.8"},
+            "context_window": {"used_percentage": 42.7},
+            "cwd": str(tmp_path),
+        },
+    )
+    assert out.strip() == "Opus 4.8 | ctx 42% | no repo"
+
+
+def test_missing_context_window(monkeypatch, capsys, tmp_path):
+    out = _run(
+        monkeypatch,
+        capsys,
+        {"model": {"display_name": "Haiku"}, "cwd": str(tmp_path)},
+    )
+    assert out.startswith("Haiku |")
+    assert "ctx -" in out
+
+
+def test_missing_model_falls_back(monkeypatch, capsys, tmp_path):
+    out = _run(monkeypatch, capsys, {"cwd": str(tmp_path)})
+    assert out.startswith("? |")
+
+
+def test_invalid_json_emits_nothing(monkeypatch, capsys):
+    out = _run(monkeypatch, capsys, None, raw="not json{{")
+    assert out == ""


### PR DESCRIPTION
[no-issue] — drive-by fix to config shipped in #954 (Fix > track, #428).

## Problem
The `statusLine` added in #954 used `type:"inline"` + a `{format}` string. Claude Code only honors `type:"command"` — the inline form is silently ignored, so the status line never rendered. The live mirror on Main PC had been hand-edited to a working `command` config, which the next `install.ps1 -Apply` would have clobbered with the broken source.

## Fix
- `scripts/statusline.py` — reads the status-line JSON on stdin, prints `<model> | ctx <N>% | <branch>`. Fail-soft on missing fields / invalid JSON / non-repo cwd.
- `.claude-userlevel/settings.json` — `statusLine` → `type:"command"` with a relative `python scripts/statusline.py`. The installer's `_transform_json_paths` walks every string leaf (verified — not just hooks) and rewrites `scripts/` to the device-absolute repo path on apply, so it resolves on all 3 devices.
- `tests/test_statusline.py` — pins the formatting contract + fail-soft branches (4 tests, green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)