### PR TITLE
feat(#972): subscription Agent SDK credit auth path for sandcastle (opt-in; DeepSeek stays primary)

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -78,6 +78,42 @@ VOYAGE_API_KEY=pa-...
 # ANTHROPIC_API_KEY=sk-ant-...
 
 # ---------------------------------------------------------------------------
+# Subscription Agent SDK credit (issue #972)
+# ---------------------------------------------------------------------------
+# Since 2026-06-15 headless `claude -p` usage draws a separate monthly Agent
+# SDK credit (Max 5x = $100/mo, API rates, no rollover) instead of the
+# subscription chat pool. To bill the credit instead of the metered API, the
+# in-container `claude` must authenticate with a subscription OAuth token, NOT
+# an API key.
+#
+# One-time host step (interactive — run on the host machine, logged into the
+# Max subscription):
+#     claude setup-token        # prints a ~1-year OAuth token; copy it below
+#
+# main.mts auth modes (SANDCASTLE_AGENT_AUTH_MODE):
+#   endpoint     — ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (Ollama / DeepSeek).
+#   subscription — CLAUDE_CODE_OAUTH_TOKEN below; ALL ANTHROPIC_* stay unset
+#                  (they outrank the OAuth token and would route to PAID API).
+# Default when unset: "subscription" for a manual `npm run sandcastle` that has
+# CLAUDE_CODE_OAUTH_TOKEN and no watchdog override; otherwise "endpoint". The
+# watchdog (scripts/sandcastle/Run-Sandcastle.ps1) sets SANDCASTLE_AGENT_AUTH_MODE
+# explicitly per tier.
+#
+# Model defaults to claude-opus-4-8 (regular, NOT 1M — extra billing) and
+# effort to medium. Override per run:
+#   SANDCASTLE_AGENT_MODEL=claude-opus-4-8
+#   SANDCASTLE_AGENT_EFFORT=medium          # low | medium | high | max
+#
+# CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-...
+# SANDCASTLE_AGENT_AUTH_MODE=subscription
+#
+# IMPORTANT: keep usage-credits overflow DISABLED on the Anthropic account so
+# credit exhaustion HARD-STOPS the run (no silent spill to paid API) — the
+# watchdog then escalates down to the DeepSeek tier. NB a DeepSeek 402 (zero
+# balance) is silent (Tier-2 402 signature = exit 1 + 0 tokens + empty
+# diag_tail), so monitor that fallback too.
+
+# ---------------------------------------------------------------------------
 # Telegram alerting (slice 6 — issue #544)
 # ---------------------------------------------------------------------------
 # Watchdog (scripts/sandcastle/Run-Sandcastle.ps1) posts a single short

--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -70,9 +70,15 @@ VOYAGE_API_KEY=pa-...
 # The watchdog hands the per-tier endpoint + key to main.mts via
 # SANDCASTLE_AGENT_BASE_URL and SANDCASTLE_AGENT_AUTH_TOKEN (the Tier-2 API key —
 # DeepSeek/Claude). You normally never set these by hand; they're listed here
-# only so the wiring is discoverable. Whenever the watchdog sets them it also
-# pins SANDCASTLE_AGENT_AUTH_MODE=endpoint, which supersedes subscription mode
-# for that run (tier escalation always falls back to a metered/local endpoint).
+# only so the wiring is discoverable.
+#
+# Two independent mechanisms — don't conflate them:
+#   - BASE_URL/AUTH_TOKEN: set ONLY on the endpoint tiers (Ollama / DeepSeek).
+#     The subscription tier leaves them unset.
+#   - SANDCASTLE_AGENT_AUTH_MODE: ALWAYS set by Invoke-Sandcastle on every tier
+#     (default 'endpoint'; the subscription tier passes 'subscription'). It is
+#     never left to main.mts auto-detection on a watchdog run. So a watchdog
+#     endpoint tier always supersedes subscription mode for that run.
 
 # DeepSeek (or any DeepSeek-compatible Anthropic-API endpoint).
 # DEEPSEEK_BASE_URL=https://api.deepseek.com/anthropic
@@ -104,7 +110,15 @@ VOYAGE_API_KEY=pa-...
 # Default when unset: "subscription" for a manual `npm run sandcastle` that has
 # CLAUDE_CODE_OAUTH_TOKEN and no watchdog override; otherwise "endpoint". The
 # watchdog (scripts/sandcastle/Run-Sandcastle.ps1) sets SANDCASTLE_AGENT_AUTH_MODE
-# explicitly per tier.
+# explicitly per tier, so it never relies on this auto-detection.
+#
+# CAUTION — keep CLAUDE_CODE_OAUTH_TOKEN in THIS .sandcastle/.env file only; do
+# NOT export it as a system/user/shell environment variable. The safety against
+# accidental subscription billing rests on every Invoke-Sandcastle caller passing
+# -AuthMode explicitly (default 'endpoint'). If the token is exported host-wide
+# AND a future caller omits -AuthMode, main.mts auto-detect silently flips that
+# run to subscription billing. A token confined to .env can't leak into an
+# unrelated `claude -p` invocation on the host.
 #
 # Model defaults to claude-opus-4-8 (regular, NOT 1M — extra billing) and
 # effort to medium. Override per run:
@@ -116,8 +130,12 @@ VOYAGE_API_KEY=pa-...
 #
 # IMPORTANT: keep usage-credits overflow DISABLED on the Anthropic account so
 # credit exhaustion HARD-STOPS the run (no silent spill to paid API) — the
-# watchdog then escalates down to the DeepSeek tier. NB a DeepSeek 402 (zero
-# balance) is silent (Tier-2 402 signature = exit 1 + 0 tokens + empty
+# watchdog then escalates down to the DeepSeek tier. NB the exact exhaustion
+# signature is NOT yet characterized (#972): the fallback only fires if the
+# hard-stop surfaces as a non-zero exit. Should exhaustion instead produce
+# exit 0 or partial-success output, the DeepSeek fallback would not trigger —
+# monitor the first real exhaustion to confirm. NB likewise a DeepSeek 402
+# (zero balance) is silent (Tier-2 402 signature = exit 1 + 0 tokens + empty
 # diag_tail), so monitor that fallback too.
 
 # ---------------------------------------------------------------------------

--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -66,6 +66,13 @@ VOYAGE_API_KEY=pa-...
 #                            of -Tier2Provider.
 # Cron runs MUST NOT auto-promote to Claude; the label is the explicit gate.
 # On full chain failure the issue gets the `too-large-for-local` label.
+#
+# The watchdog hands the per-tier endpoint + key to main.mts via
+# SANDCASTLE_AGENT_BASE_URL and SANDCASTLE_AGENT_AUTH_TOKEN (the Tier-2 API key —
+# DeepSeek/Claude). You normally never set these by hand; they're listed here
+# only so the wiring is discoverable. Whenever the watchdog sets them it also
+# pins SANDCASTLE_AGENT_AUTH_MODE=endpoint, which supersedes subscription mode
+# for that run (tier escalation always falls back to a metered/local endpoint).
 
 # DeepSeek (or any DeepSeek-compatible Anthropic-API endpoint).
 # DEEPSEEK_BASE_URL=https://api.deepseek.com/anthropic

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -37,8 +37,13 @@ import { dirname } from "node:path";
 // token sits in .env, while letting a manual `npm run sandcastle` exercise the
 // credit.
 const oauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+// Treat a blank value (`SANDCASTLE_AGENT_AUTH_MODE=` in a misconfigured .env)
+// the same as unset: `??` only coalesces null/undefined, so without the
+// trim()+`||` a blank would skip auto-detection and throw the opaque `got ""`.
+// `||` lets "" fall through to the BaseUrl/OAuth auto-detect below instead.
+const explicitAuthMode = process.env.SANDCASTLE_AGENT_AUTH_MODE?.trim();
 const authMode =
-  process.env.SANDCASTLE_AGENT_AUTH_MODE ??
+  explicitAuthMode ||
   (process.env.SANDCASTLE_AGENT_BASE_URL
     ? "endpoint"
     : oauthToken

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -25,9 +25,12 @@ import { dirname } from "node:path";
 //                    headless usage draws the monthly Agent SDK credit (API
 //                    rates, hard-stop on exhaustion) instead of the metered API.
 //                    ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY
-//                    MUST be unset here — they take precedence in Claude Code's
-//                    auth order and would silently route to PAID pay-per-token
-//                    billing (real money). The two modes never share env keys.
+//                    and the CLAUDE_CODE_USE_{BEDROCK,VERTEX,FOUNDRY} provider
+//                    switches MUST be unset here — they all resolve auth before
+//                    CLAUDE_CODE_OAUTH_TOKEN in Claude Code's order and would
+//                    silently route to PAID pay-per-token billing or a cloud
+//                    provider (real money). Enforced by the denylist guard below.
+//                    The two modes never share env keys.
 //
 // Default: honor an explicit watchdog/operator SANDCASTLE_AGENT_AUTH_MODE; else
 // "endpoint" whenever the watchdog is driving an endpoint tier
@@ -117,19 +120,44 @@ if (subscription && !oauthToken) {
 // distant use site (where the safety is non-obvious).
 const oauthTokenStr: string = subscription ? oauthToken! : "";
 if (subscription) {
-  // Real-money guard: withholding ANTHROPIC_* from authEnv (below) is not enough.
+  // Real-money guard: withholding these from authEnv (below) is not enough.
   // If any are already set on the HOST process (leftover endpoint-mode run, a
   // sourced .env, the commented Tier-2 block in .env.example), an ambient
   // passthrough can leak them into the container, where they OUTRANK
   // CLAUDE_CODE_OAUTH_TOKEN in Claude Code's auth order and silently route the
-  // run to paid pay-per-token billing. Refuse to start instead.
-  for (const key of ["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"]) {
+  // run to paid pay-per-token billing (or a cloud-provider account). Refuse to
+  // start instead.
+  //
+  // Denylist = every var that resolves auth BEFORE step 5 (CLAUDE_CODE_OAUTH_TOKEN)
+  // in Claude Code's precedence chain (docs: code.claude.com/docs/en/authentication,
+  // /env-vars, /third-party-integrations — verified 2026-06-18):
+  //   1. CLAUDE_CODE_USE_{BEDROCK,VERTEX,FOUNDRY} — flip auth to a cloud provider,
+  //      bypassing the subscription token entirely (and billing AWS/GCP/Azure).
+  //   2. ANTHROPIC_AUTH_TOKEN — gateway/proxy bearer token.
+  //   3. ANTHROPIC_API_KEY — Console pay-per-token key (highest billing risk).
+  //   + ANTHROPIC_BASE_URL — redirects all calls to a custom endpoint; not strictly
+  //      an auth step, but a set base-url is a misconfig that must not ride along.
+  // NOT included on purpose: CLAUDE_API_KEY / CLAUDE_BASE_URL are NOT Claude Code
+  // env vars (the ANTHROPIC_-prefixed ones are the real names) — Claude Code's auth
+  // resolution never reads them, so blocking them would be cargo-cult. Provider
+  // sub-keys (AWS_*, ANTHROPIC_VERTEX_*, ANTHROPIC_FOUNDRY_*) only matter once a
+  // CLAUDE_CODE_USE_* flag is set, which we already block, so the flag is the
+  // sufficient gate.
+  const billingOverrideKeys = [
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+  ];
+  for (const key of billingOverrideKeys) {
     if (process.env[key]) {
       throw new Error(
         `SANDCASTLE_AGENT_AUTH_MODE=subscription: ${key} is set in the host ` +
-          "environment — unset it first. ANTHROPIC_* take auth precedence over " +
+          "environment — unset it first. It takes auth precedence over " +
           "CLAUDE_CODE_OAUTH_TOKEN and would silently route this run to paid " +
-          "pay-per-token billing (real money).",
+          "pay-per-token billing or a cloud provider (real money).",
       );
     }
   }

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -75,6 +75,15 @@ const agentEffort: Effort | undefined = subscription
       return e as Effort;
     })()
   : undefined;
+if (!subscription && process.env.SANDCASTLE_AGENT_EFFORT) {
+  // Endpoint mode may front Ollama, which 400s on --effort, so the flag is
+  // dropped. Warn rather than fail silently — an operator who set it deserves
+  // to know it had no effect.
+  console.warn(
+    "[sandcastle] SANDCASTLE_AGENT_EFFORT is set but ignored in endpoint mode " +
+      "(only the subscription/Claude path supports --effort).",
+  );
+}
 
 // Endpoint-mode connection (unused in subscription mode). Tier 0/1 use the
 // literal "ollama" auth token (Ollama's native Anthropic endpoint ignores it);
@@ -85,14 +94,32 @@ const agentBaseUrl =
   "http://host.docker.internal:11434";
 const agentAuthToken = process.env.SANDCASTLE_AGENT_AUTH_TOKEN ?? "ollama";
 if (subscription && !oauthToken) {
-  // Unreachable via the default (subscription default requires a token), but
-  // guard the explicit SANDCASTLE_AGENT_AUTH_MODE=subscription case so we never
-  // fall through to unauthenticated or paid-API billing.
+  // Unreachable via auto-detection (it only picks "subscription" when a token is
+  // present), but guards the explicit SANDCASTLE_AGENT_AUTH_MODE=subscription
+  // case so we never fall through to unauthenticated or paid-API billing.
   throw new Error(
     "SANDCASTLE_AGENT_AUTH_MODE=subscription requires CLAUDE_CODE_OAUTH_TOKEN " +
       "(generate once on the host with `claude setup-token`). Refusing to run — " +
       "without it Claude Code would fall back to paid API billing or fail auth.",
   );
+}
+if (subscription) {
+  // Real-money guard: withholding ANTHROPIC_* from authEnv (below) is not enough.
+  // If any are already set on the HOST process (leftover endpoint-mode run, a
+  // sourced .env, the commented Tier-2 block in .env.example), an ambient
+  // passthrough can leak them into the container, where they OUTRANK
+  // CLAUDE_CODE_OAUTH_TOKEN in Claude Code's auth order and silently route the
+  // run to paid pay-per-token billing. Refuse to start instead.
+  for (const key of ["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"]) {
+    if (process.env[key]) {
+      throw new Error(
+        `SANDCASTLE_AGENT_AUTH_MODE=subscription: ${key} is set in the host ` +
+          "environment — unset it first. ANTHROPIC_* take auth precedence over " +
+          "CLAUDE_CODE_OAUTH_TOKEN and would silently route this run to paid " +
+          "pay-per-token billing (real money).",
+      );
+    }
+  }
 }
 
 // Auth env injected into the container — exactly one of the two paths, so the

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -85,7 +85,9 @@ if (!subscription && process.env.SANDCASTLE_AGENT_EFFORT) {
   );
 }
 
-// Endpoint-mode connection (unused in subscription mode). Tier 0/1 use the
+// Endpoint-mode connection. Unused in subscription mode, but still computed
+// unconditionally so one startup code path covers both modes (the Ollama env
+// vars are only *consumed* on the endpoint branch below). Tier 0/1 use the
 // literal "ollama" auth token (Ollama's native Anthropic endpoint ignores it);
 // Tier 2 carries a real API key (DeepSeek / Claude API).
 const agentBaseUrl =
@@ -95,8 +97,9 @@ const agentBaseUrl =
 const agentAuthToken = process.env.SANDCASTLE_AGENT_AUTH_TOKEN ?? "ollama";
 if (subscription && !oauthToken) {
   // Unreachable via auto-detection (it only picks "subscription" when a token is
-  // present), but guards the explicit SANDCASTLE_AGENT_AUTH_MODE=subscription
-  // case so we never fall through to unauthenticated or paid-API billing.
+  // present) but reachable via the explicit SANDCASTLE_AGENT_AUTH_MODE=subscription
+  // override — this guards that case so we never fall through to unauthenticated
+  // or paid-API billing.
   throw new Error(
     "SANDCASTLE_AGENT_AUTH_MODE=subscription requires CLAUDE_CODE_OAUTH_TOKEN " +
       "(generate once on the host with `claude setup-token`). Refusing to run — " +

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -106,6 +106,11 @@ if (subscription && !oauthToken) {
       "without it Claude Code would fall back to paid API billing or fail auth.",
   );
 }
+// The guard above guarantees oauthToken is set whenever `subscription` is true.
+// TS cannot carry that narrowing across the intervening for-loop and the authEnv
+// ternary, so pin it to a non-null string here rather than asserting `!` at the
+// distant use site (where the safety is non-obvious).
+const oauthTokenStr: string = subscription ? oauthToken! : "";
 if (subscription) {
   // Real-money guard: withholding ANTHROPIC_* from authEnv (below) is not enough.
   // If any are already set on the HOST process (leftover endpoint-mode run, a
@@ -128,7 +133,7 @@ if (subscription) {
 // Auth env injected into the container — exactly one of the two paths, so the
 // ANTHROPIC_* vars are absent on the subscription path (precedence guard above).
 const authEnv: Record<string, string> = subscription
-  ? { CLAUDE_CODE_OAUTH_TOKEN: oauthToken! }
+  ? { CLAUDE_CODE_OAUTH_TOKEN: oauthTokenStr }
   : { ANTHROPIC_BASE_URL: agentBaseUrl, ANTHROPIC_AUTH_TOKEN: agentAuthToken };
 
 // Token never printed; mode/model/effort are safe and useful for "how much did

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -10,23 +10,106 @@ import { dirname } from "node:path";
 // 436f9549, 228a2d9b, 0c3017c6 referenced from epic #534. Watchdog + schedule
 // land in slice 4 — this file stays config-only.
 
-// Agent model + endpoint. Slice 5 (#543) introduces multi-tier escalation:
-// the PS1 watchdog re-invokes us with SANDCASTLE_AGENT_{MODEL,BASE_URL,AUTH_TOKEN}
+// Agent model + auth. Slice 5 (#543) introduces multi-tier escalation: the PS1
+// watchdog re-invokes us with SANDCASTLE_AGENT_{MODEL,BASE_URL,AUTH_TOKEN}
 // overridden when retrying on a smaller Ollama model (Tier 1) or a remote
-// DeepSeek/Claude API endpoint (Tier 2). Falls back to the slice-1/2 Ollama
-// defaults when the watchdog isn't driving — single-shot manual smoke runs
-// keep working unchanged.
+// DeepSeek/Claude API endpoint (Tier 2). Issue #972 adds a third auth path —
+// the Claude subscription Agent SDK credit. Two mutually exclusive modes
+// (SANDCASTLE_AGENT_AUTH_MODE):
+//   "endpoint"     — ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN point Claude Code
+//                    at an Anthropic-compatible endpoint: local Ollama (Tier
+//                    0/1) or remote DeepSeek/Claude API (Tier 2). Pay-per-token
+//                    or local. The slice-1/2 behavior.
+//   "subscription" — CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`)
+//                    authenticates Claude Code with the Max subscription, so
+//                    headless usage draws the monthly Agent SDK credit (API
+//                    rates, hard-stop on exhaustion) instead of the metered API.
+//                    ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY
+//                    MUST be unset here — they take precedence in Claude Code's
+//                    auth order and would silently route to PAID pay-per-token
+//                    billing (real money). The two modes never share env keys.
+//
+// Default: honor an explicit watchdog/operator SANDCASTLE_AGENT_AUTH_MODE; else
+// "endpoint" whenever the watchdog is driving an endpoint tier
+// (SANDCASTLE_AGENT_BASE_URL set) or no OAuth token is present; "subscription"
+// only for an un-driven manual run that carries CLAUDE_CODE_OAUTH_TOKEN. This
+// keeps the nightly Ollama/DeepSeek tiers byte-for-byte unchanged even if a
+// token sits in .env, while letting a manual `npm run sandcastle` exercise the
+// credit.
+const oauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+const authMode =
+  process.env.SANDCASTLE_AGENT_AUTH_MODE ??
+  (process.env.SANDCASTLE_AGENT_BASE_URL
+    ? "endpoint"
+    : oauthToken
+      ? "subscription"
+      : "endpoint");
+if (authMode !== "endpoint" && authMode !== "subscription") {
+  throw new Error(
+    `SANDCASTLE_AGENT_AUTH_MODE must be "endpoint" or "subscription", got "${authMode}".`,
+  );
+}
+const subscription = authMode === "subscription";
+
 const agentModel =
   process.env.SANDCASTLE_AGENT_MODEL ??
-  process.env.OLLAMA_MODEL ??
-  "qwen3-coder:30b";
+  (subscription
+    ? // Regular Opus 4.8 — NOT the 1M-context variant (extra billing per owner
+      // policy; AFK slices never need 1M).
+      "claude-opus-4-8"
+    : (process.env.OLLAMA_MODEL ?? "qwen3-coder:30b"));
+
+// Thinking effort. Only meaningful on the subscription/Claude path — the
+// endpoint path may front Ollama, which 400s on an unknown --effort flag — so
+// it stays undefined for "endpoint" to preserve current behavior exactly.
+const EFFORT_LEVELS = ["low", "medium", "high", "max"] as const;
+type Effort = (typeof EFFORT_LEVELS)[number];
+const agentEffort: Effort | undefined = subscription
+  ? (() => {
+      const e = process.env.SANDCASTLE_AGENT_EFFORT ?? "medium";
+      if (!EFFORT_LEVELS.includes(e as Effort)) {
+        throw new Error(
+          `SANDCASTLE_AGENT_EFFORT must be one of ${EFFORT_LEVELS.join(", ")}, got "${e}".`,
+        );
+      }
+      return e as Effort;
+    })()
+  : undefined;
+
+// Endpoint-mode connection (unused in subscription mode). Tier 0/1 use the
+// literal "ollama" auth token (Ollama's native Anthropic endpoint ignores it);
+// Tier 2 carries a real API key (DeepSeek / Claude API).
 const agentBaseUrl =
   process.env.SANDCASTLE_AGENT_BASE_URL ??
   process.env.OLLAMA_BASE_URL ??
   "http://host.docker.internal:11434";
-// Tier 0/1 use the literal "ollama" auth token (Ollama's native Anthropic
-// endpoint ignores it); Tier 2 carries a real API key (DeepSeek / Claude).
 const agentAuthToken = process.env.SANDCASTLE_AGENT_AUTH_TOKEN ?? "ollama";
+if (subscription && !oauthToken) {
+  // Unreachable via the default (subscription default requires a token), but
+  // guard the explicit SANDCASTLE_AGENT_AUTH_MODE=subscription case so we never
+  // fall through to unauthenticated or paid-API billing.
+  throw new Error(
+    "SANDCASTLE_AGENT_AUTH_MODE=subscription requires CLAUDE_CODE_OAUTH_TOKEN " +
+      "(generate once on the host with `claude setup-token`). Refusing to run — " +
+      "without it Claude Code would fall back to paid API billing or fail auth.",
+  );
+}
+
+// Auth env injected into the container — exactly one of the two paths, so the
+// ANTHROPIC_* vars are absent on the subscription path (precedence guard above).
+const authEnv: Record<string, string> = subscription
+  ? { CLAUDE_CODE_OAUTH_TOKEN: oauthToken! }
+  : { ANTHROPIC_BASE_URL: agentBaseUrl, ANTHROPIC_AUTH_TOKEN: agentAuthToken };
+
+// Token never printed; mode/model/effort are safe and useful for "how much did
+// it eat" run accounting.
+console.error(
+  `[sandcastle] auth=${authMode} model=${agentModel}` +
+    (agentEffort ? ` effort=${agentEffort}` : "") +
+    (subscription
+      ? " billing=max-agent-sdk-credit"
+      : ` endpoint=${agentBaseUrl}`),
+);
 // When the watchdog retries on the same issue (escalation chain, AC #3),
 // it sets SANDCASTLE_TARGET_ISSUE so prompt.md can pin the agent to that
 // issue instead of picking afresh from the queue.
@@ -81,10 +164,15 @@ const result = await run({
   sandbox: docker({
     imageName: "sandcastle:jarvis",
     env: {
-      // Native Anthropic-compatible endpoint exposed by Ollama ≥ 0.14 (Jan 2026)
-      // for Tier 0/1; remote provider URL + key for Tier 2 (slice 5, #543).
-      ANTHROPIC_BASE_URL: agentBaseUrl,
-      ANTHROPIC_AUTH_TOKEN: agentAuthToken,
+      // Auth path (issue #972): exactly one of
+      //   endpoint mode     → ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (Ollama
+      //                       Tier 0/1 via the native Anthropic endpoint, or
+      //                       remote DeepSeek/Claude API Tier 2, slice 5 #543), or
+      //   subscription mode → CLAUDE_CODE_OAUTH_TOKEN (Max Agent SDK credit).
+      // ANTHROPIC_* and CLAUDE_CODE_OAUTH_TOKEN are never set together — the
+      // former take precedence in Claude Code auth order and would route the
+      // subscription path to paid pay-per-token billing.
+      ...authEnv,
       // Forward host-side gh credentials so the agent can claim issues + open PRs.
       GH_TOKEN: ghToken,
       // Memory MCP bridge — Claude Code expands ${...} in the project-scope
@@ -103,7 +191,7 @@ const result = await run({
       SANDCASTLE_TARGET_PR: targetPr,
     },
   }),
-  agent: claudeCode(agentModel),
+  agent: claudeCode(agentModel, agentEffort ? { effort: agentEffort } : undefined),
   promptFile: "./.sandcastle/prompt.md",
   maxIterations,
   branchStrategy: { type: "merge-to-head" },

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -207,6 +207,7 @@ function Format-SandcastleActionArgs {
         [string]$WindowEnd,
         [bool]$SubscriptionPrimary = $true,
         [string]$SubscriptionModel = 'claude-opus-4-8',
+        [ValidateSet('low', 'medium', 'high', 'max')]
         [string]$SubscriptionEffort = 'medium'
     )
     $watchdogQuoted = '"' + $WatchdogPath + '"'
@@ -423,6 +424,17 @@ $argParts = Format-SandcastleActionArgs -WatchdogPath $watchdog `
     -WindowEnd $WindowEnd `
     -SubscriptionPrimary $SubscriptionPrimary `
     -SubscriptionModel $SubscriptionModel -SubscriptionEffort $SubscriptionEffort
+
+# Surface the billing-impacting tier choice on every registration. The default
+# is -SubscriptionPrimary $true (#972) — a bare `Register-SandcastleTask.ps1
+# -Repo X` now registers a task that bills the Anthropic Max Agent-SDK credit,
+# a change from the prior DeepSeek-primary default. Make that explicit so it is
+# never a silent flip.
+if ($SubscriptionPrimary) {
+    Write-Host "[register] PRIMARY tier: subscription ($SubscriptionModel, effort=$SubscriptionEffort) — bills the Agent-SDK credit; DeepSeek fallback=$(if ($Tier2Provider) { $Tier2Provider } else { '<none>' })." -ForegroundColor Yellow
+} else {
+    Write-Host "[register] PRIMARY tier: $(if ($Tier2Provider) { "endpoint ($Tier2Provider)" } else { 'Ollama local' }) — subscription credit NOT used."
+}
 
 $action = New-ScheduledTaskAction -Execute $pwshExe `
     -Argument ($argParts -join ' ') `

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -64,17 +64,20 @@
     API key from .env instead (carries Max-subscription quota risk -- prefer
     deepseek for unattended cron).
 
-    When -SubscriptionPrimary is on (the default), Tier2Provider is NOT promoted
-    to primary; it stays wired as the credit-exhaustion fallback only.
+    By default (-SubscriptionPrimary $false) Tier2Provider IS the AFK primary
+    via the auto-appended -Tier2AsPrimary. Only when -SubscriptionPrimary is
+    opted in does Tier2Provider step back to the credit-exhaustion fallback.
 
 .PARAMETER SubscriptionPrimary
-    #972. Default $true: register the AFK task with the Anthropic Max Agent-SDK
-    credit as the primary tier (Opus 4.8 @ medium effort, bills the $100/mo
-    credit via CLAUDE_CODE_OAUTH_TOKEN in .sandcastle/.env), DeepSeek as the
-    fallback. Requires CLAUDE_CODE_OAUTH_TOKEN set on the host. Pass
-    -SubscriptionPrimary $false to revert to the legacy DeepSeek-as-primary
-    registration. (Space form, not the colon `:$false` switch syntax — this is a
-    [bool] param; `:$false` is a binding error on Windows PowerShell 5.1.)
+    #972. Default $false: DeepSeek (Tier 2) is the AFK primary. Opt in with
+    -SubscriptionPrimary $true to register the Anthropic Max Agent-SDK credit
+    as the primary tier (Opus 4.8 @ medium effort, bills the $100/mo credit via
+    CLAUDE_CODE_OAUTH_TOKEN in .sandcastle/.env), DeepSeek as the fallback.
+    Requires CLAUDE_CODE_OAUTH_TOKEN set on the host. 2026-06-17: kept OFF —
+    Anthropic shelved the separate Agent-SDK automation quota at launch, so the
+    credit path is dormant code until that lands. (Space form, not the colon
+    `:$true` switch syntax — this is a [bool] param; `:$true` is a binding error
+    on Windows PowerShell 5.1.)
 
 .PARAMETER SubscriptionModel
     Subscription-tier model. Default claude-opus-4-8 (regular, NOT the 1M
@@ -135,12 +138,13 @@ param(
     [ValidateSet('', 'deepseek', 'claude')]
     [string]$Tier2Provider = 'deepseek',
 
-    # #972: subscription Agent-SDK credit is the primary AFK tier by default
-    # (Opus 4.8 @ medium effort, bills the $100/mo Max credit). DeepSeek stays
-    # wired as the credit-exhaustion fallback. Pass -SubscriptionPrimary $false
-    # (space form — `:$false` colon syntax is a [bool]-binding error on PS 5.1)
-    # to fall back to the legacy Tier-2-as-primary (DeepSeek) registration.
-    [bool]$SubscriptionPrimary = $true,
+    # #972: subscription Agent-SDK credit primary is an OPT-IN tier, default OFF.
+    # 2026-06-17: Anthropic shelved the separate Agent-SDK automation quota at
+    # launch, so the credit path stays in the code but is not used — DeepSeek
+    # (Tier 2) is the default AFK primary again. Pass -SubscriptionPrimary $true
+    # (space form — `:$true` colon syntax is a [bool]-binding error on PS 5.1)
+    # to opt back in once the credit is real and CLAUDE_CODE_OAUTH_TOKEN is set.
+    [bool]$SubscriptionPrimary = $false,
 
     [string]$SubscriptionModel = 'claude-opus-4-8',
 
@@ -205,7 +209,7 @@ function Format-SandcastleActionArgs {
         [string]$Tier2Provider,
         [int]$MaxIterations,
         [string]$WindowEnd,
-        [bool]$SubscriptionPrimary = $true,
+        [bool]$SubscriptionPrimary = $false,
         [string]$SubscriptionModel = 'claude-opus-4-8',
         [ValidateSet('low', 'medium', 'high', 'max')]
         [string]$SubscriptionEffort = 'medium'
@@ -426,10 +430,10 @@ $argParts = Format-SandcastleActionArgs -WatchdogPath $watchdog `
     -SubscriptionModel $SubscriptionModel -SubscriptionEffort $SubscriptionEffort
 
 # Surface the billing-impacting tier choice on every registration. The default
-# is -SubscriptionPrimary $true (#972) — a bare `Register-SandcastleTask.ps1
-# -Repo X` now registers a task that bills the Anthropic Max Agent-SDK credit,
-# a change from the prior DeepSeek-primary default. Make that explicit so it is
-# never a silent flip.
+# is -SubscriptionPrimary $false (#972) — a bare `Register-SandcastleTask.ps1
+# -Repo X` registers a DeepSeek-primary task; opting into the subscription
+# credit (which bills the Anthropic Max Agent-SDK credit) is explicit. Print the
+# resolved tier either way so a billing flip is never silent.
 if ($SubscriptionPrimary) {
     Write-Host "[register] PRIMARY tier: subscription ($SubscriptionModel, effort=$SubscriptionEffort) — bills the Agent-SDK credit; DeepSeek fallback=$(if ($Tier2Provider) { $Tier2Provider } else { '<none>' })." -ForegroundColor Yellow
 } else {

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -64,6 +64,26 @@
     API key from .env instead (carries Max-subscription quota risk -- prefer
     deepseek for unattended cron).
 
+    When -SubscriptionPrimary is on (the default), Tier2Provider is NOT promoted
+    to primary; it stays wired as the credit-exhaustion fallback only.
+
+.PARAMETER SubscriptionPrimary
+    #972. Default $true: register the AFK task with the Anthropic Max Agent-SDK
+    credit as the primary tier (Opus 4.8 @ medium effort, bills the $100/mo
+    credit via CLAUDE_CODE_OAUTH_TOKEN in .sandcastle/.env), DeepSeek as the
+    fallback. Requires CLAUDE_CODE_OAUTH_TOKEN set on the host. Pass
+    -SubscriptionPrimary:$false to revert to the legacy DeepSeek-as-primary
+    registration.
+
+.PARAMETER SubscriptionModel
+    Subscription-tier model. Default claude-opus-4-8 (regular, NOT the 1M
+    context variant — that carries extra billing).
+
+.PARAMETER SubscriptionEffort
+    Subscription-tier effort: low | medium | high | max. Default medium —
+    model = task depth, effort = task width; AFK slices are single sharpened
+    verticals, so depth-heavy / width-bounded.
+
 .PARAMETER RepoRoot
     Filesystem path to the target repo. Defaults to the jarvis repo discovered
     from this script's own path (../../). For -Repo redrobot, pass the
@@ -114,6 +134,17 @@ param(
     [ValidateSet('', 'deepseek', 'claude')]
     [string]$Tier2Provider = 'deepseek',
 
+    # #972: subscription Agent-SDK credit is the primary AFK tier by default
+    # (Opus 4.8 @ medium effort, bills the $100/mo Max credit). DeepSeek stays
+    # wired as the credit-exhaustion fallback. Pass -SubscriptionPrimary:$false
+    # to fall back to the legacy Tier-2-as-primary (DeepSeek) registration.
+    [bool]$SubscriptionPrimary = $true,
+
+    [string]$SubscriptionModel = 'claude-opus-4-8',
+
+    [ValidateSet('low', 'medium', 'high', 'max')]
+    [string]$SubscriptionEffort = 'medium',
+
     [string]$RepoRoot,
 
     [int]$MaxIterations = 5,
@@ -133,7 +164,10 @@ $ErrorActionPreference = 'Stop'
 
 function Get-ConfigDeviceName {
     param([string]$DeviceJsonPath)
-    if (Test-Path $DeviceJsonPath) {
+    # Guard empty/null path: Test-Path '' is a terminating parameter-binding
+    # error under Windows PowerShell 5.1 (tolerated in pwsh 7). An absent path
+    # means "no device.json" -> return null, never throw.
+    if ($DeviceJsonPath -and (Test-Path $DeviceJsonPath)) {
         try {
             return (Get-Content $DeviceJsonPath -Raw | ConvertFrom-Json).name
         } catch {
@@ -168,7 +202,10 @@ function Format-SandcastleActionArgs {
         [string]$Tier1Model,
         [string]$Tier2Provider,
         [int]$MaxIterations,
-        [string]$WindowEnd
+        [string]$WindowEnd,
+        [bool]$SubscriptionPrimary = $true,
+        [string]$SubscriptionModel = 'claude-opus-4-8',
+        [string]$SubscriptionEffort = 'medium'
     )
     $watchdogQuoted = '"' + $WatchdogPath + '"'
     $argParts = @(
@@ -181,7 +218,16 @@ function Format-SandcastleActionArgs {
         '-WindowEnd', $WindowEnd
     )
     if ($Tier1Model)    { $argParts += @('-Tier1Model', $Tier1Model) }
-    if ($Tier2Provider) {
+    if ($SubscriptionPrimary) {
+        # #972: subscription Agent-SDK credit is primary for AFK runs. DeepSeek
+        # stays wired as the credit-exhaustion fallback (-Tier2Provider) but NOT
+        # -Tier2AsPrimary — subscription is senior; the watchdog supersedes
+        # Tier-2-as-primary when both are present.
+        $argParts += '-SubscriptionPrimary'
+        $argParts += @('-SubscriptionModel', $SubscriptionModel)
+        $argParts += @('-SubscriptionEffort', $SubscriptionEffort)
+        if ($Tier2Provider) { $argParts += @('-Tier2Provider', $Tier2Provider) }
+    } elseif ($Tier2Provider) {
         $argParts += @('-Tier2Provider', $Tier2Provider)
         # 2026-05-14: Tier 2 runs as primary for AFK scheduled tasks. Local Ollama
         # tiers fail the real-Claude-Code tool_use fidelity check on qwen2.5-coder:14b
@@ -372,7 +418,9 @@ $pwshExe = Get-PowerShellExe
 $argParts = Format-SandcastleActionArgs -WatchdogPath $watchdog `
     -Repo $Repo -Model $Model -Tier1Model $Tier1Model `
     -Tier2Provider $Tier2Provider -MaxIterations $MaxIterations `
-    -WindowEnd $WindowEnd
+    -WindowEnd $WindowEnd `
+    -SubscriptionPrimary $SubscriptionPrimary `
+    -SubscriptionModel $SubscriptionModel -SubscriptionEffort $SubscriptionEffort
 
 $action = New-ScheduledTaskAction -Execute $pwshExe `
     -Argument ($argParts -join ' ') `

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -72,8 +72,9 @@
     credit as the primary tier (Opus 4.8 @ medium effort, bills the $100/mo
     credit via CLAUDE_CODE_OAUTH_TOKEN in .sandcastle/.env), DeepSeek as the
     fallback. Requires CLAUDE_CODE_OAUTH_TOKEN set on the host. Pass
-    -SubscriptionPrimary:$false to revert to the legacy DeepSeek-as-primary
-    registration.
+    -SubscriptionPrimary $false to revert to the legacy DeepSeek-as-primary
+    registration. (Space form, not the colon `:$false` switch syntax — this is a
+    [bool] param; `:$false` is a binding error on Windows PowerShell 5.1.)
 
 .PARAMETER SubscriptionModel
     Subscription-tier model. Default claude-opus-4-8 (regular, NOT the 1M
@@ -136,7 +137,8 @@ param(
 
     # #972: subscription Agent-SDK credit is the primary AFK tier by default
     # (Opus 4.8 @ medium effort, bills the $100/mo Max credit). DeepSeek stays
-    # wired as the credit-exhaustion fallback. Pass -SubscriptionPrimary:$false
+    # wired as the credit-exhaustion fallback. Pass -SubscriptionPrimary $false
+    # (space form — `:$false` colon syntax is a [bool]-binding error on PS 5.1)
     # to fall back to the legacy Tier-2-as-primary (DeepSeek) registration.
     [bool]$SubscriptionPrimary = $true,
 

--- a/scripts/sandcastle/Register-SandcastleTask.ps1
+++ b/scripts/sandcastle/Register-SandcastleTask.ps1
@@ -170,9 +170,10 @@ $ErrorActionPreference = 'Stop'
 
 function Get-ConfigDeviceName {
     param([string]$DeviceJsonPath)
-    # Guard empty/null path: Test-Path '' is a terminating parameter-binding
-    # error under Windows PowerShell 5.1 (tolerated in pwsh 7). An absent path
-    # means "no device.json" -> return null, never throw.
+    # Guard null/empty path. Under Windows PowerShell 5.1 a $null bound to
+    # Test-Path -Path throws NullNotAllowed (an empty string instead returns
+    # $false harmlessly). The `$DeviceJsonPath -and ...` short-circuit covers
+    # both: an absent path means "no device.json" -> return null, never throw.
     if ($DeviceJsonPath -and (Test-Path $DeviceJsonPath)) {
         try {
             return (Get-Content $DeviceJsonPath -Raw | ConvertFrom-Json).name

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -1207,7 +1207,10 @@ function Invoke-Watchdog {
                 -BaseUrl $tier2Primary.BaseUrl -AuthToken $tier2Primary.AuthToken `
                 -TargetIssue ''
             $tierUsed = "tier2:$($tier2Primary.Provider)"
-            $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+            # Same null-guard as the subscription path: a failed run returns
+            # result=$null — harmless under default strictness, a PropertyNotFound
+            # throw under a future Set-StrictMode. Guard all three call sites.
+            $targetIssue = if ($invocation.result) { Get-IssueFromBranch -Branch $invocation.result.branch } else { $null }
             $oomDetected = $false
         } else {
             # ----- Tier 0: primary Ollama model -----
@@ -1215,7 +1218,7 @@ function Invoke-Watchdog {
                 -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
                 -TargetIssue ''
             $tierUsed = 'tier0'
-            $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+            $targetIssue = if ($invocation.result) { Get-IssueFromBranch -Branch $invocation.result.branch } else { $null }
             $oomDetected = (-not $invocation.ok) -and (Test-IsOOM -Reason $invocation.reason -LogFile $logFile)
         }
 
@@ -1226,7 +1229,7 @@ function Invoke-Watchdog {
                 -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
                 -TargetIssue ([string]$targetIssue)
             $tierUsed = 'tier1'
-            if (-not $targetIssue) {
+            if (-not $targetIssue -and $invocation.result) {
                 $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
             }
         }

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -317,9 +317,12 @@ function Invoke-Sandcastle {
     if ($BaseUrl)     { $env:SANDCASTLE_AGENT_BASE_URL   = $BaseUrl }
     if ($AuthToken)   { $env:SANDCASTLE_AGENT_AUTH_TOKEN = $AuthToken }
     # AuthMode always set (defaults 'endpoint') — the real-money guard. Effort
-    # only when supplied (subscription tier); empty => main.mts default.
+    # only when supplied (subscription tier); when omitted, CLEAR it so a prior
+    # run's value (or a host-set SANDCASTLE_AGENT_EFFORT) can't leak into this
+    # child — an endpoint tier must reach main.mts with no effort override.
     $env:SANDCASTLE_AGENT_AUTH_MODE = $AuthMode
-    if ($Effort)      { $env:SANDCASTLE_AGENT_EFFORT      = $Effort }
+    if ($Effort) { $env:SANDCASTLE_AGENT_EFFORT = $Effort }
+    else         { Remove-Item Env:SANDCASTLE_AGENT_EFFORT -ErrorAction SilentlyContinue }
     # TargetIssue: pass empty string verbatim so retries can clear it.
     $env:SANDCASTLE_TARGET_ISSUE = "$TargetIssue"
 

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -1024,10 +1024,12 @@ function Invoke-Watchdog {
     $supabaseKey = $envVars['SUPABASE_KEY']
     $tgToken     = $envVars['TELEGRAM_BOT_TOKEN']
     $tgChatId    = $envVars['TELEGRAM_CHAT_ID']
-    if ($env:SUPABASE_URL)        { $supabaseUrl = $env:SUPABASE_URL }
-    if ($env:SUPABASE_KEY)        { $supabaseKey = $env:SUPABASE_KEY }
-    if ($env:TELEGRAM_BOT_TOKEN)  { $tgToken     = $env:TELEGRAM_BOT_TOKEN }
-    if ($env:TELEGRAM_CHAT_ID)    { $tgChatId    = $env:TELEGRAM_CHAT_ID }
+    $oauthToken  = $envVars['CLAUDE_CODE_OAUTH_TOKEN']
+    if ($env:SUPABASE_URL)            { $supabaseUrl = $env:SUPABASE_URL }
+    if ($env:SUPABASE_KEY)            { $supabaseKey = $env:SUPABASE_KEY }
+    if ($env:TELEGRAM_BOT_TOKEN)      { $tgToken     = $env:TELEGRAM_BOT_TOKEN }
+    if ($env:TELEGRAM_CHAT_ID)        { $tgChatId    = $env:TELEGRAM_CHAT_ID }
+    if ($env:CLAUDE_CODE_OAUTH_TOKEN) { $oauthToken  = $env:CLAUDE_CODE_OAUTH_TOKEN }
 
     $windowEndDt = Resolve-WindowEnd -WindowEnd $WindowEnd
 
@@ -1165,7 +1167,12 @@ function Invoke-Watchdog {
                 -AuthMode 'subscription' -Effort $SubscriptionEffort `
                 -TargetIssue ''
             $tierUsed = 'subscription'
-            $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+            # Guard the property access: a failed run returns result=$null. This is
+            # harmless under default strictness (PS returns $null for $null.branch),
+            # but a future Set-StrictMode would turn it into a PropertyNotFound throw
+            # *before* the fallback block below — silently bypassing the DeepSeek
+            # safety net on credit exhaustion. Keep it explicit.
+            $targetIssue = if ($invocation.result) { Get-IssueFromBranch -Branch $invocation.result.branch } else { $null }
             $oomDetected = $false
 
             # Fallback: ANY subscription failure (credit exhausted -> hard-stop
@@ -1181,7 +1188,7 @@ function Invoke-Watchdog {
                     -BaseUrl $subscriptionFallback.BaseUrl -AuthToken $subscriptionFallback.AuthToken `
                     -AuthMode 'endpoint' -TargetIssue ([string]$targetIssue)
                 $tierUsed = "tier2:$($subscriptionFallback.Provider)"
-                if (-not $targetIssue) {
+                if (-not $targetIssue -and $invocation.result) {
                     $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
                 }
             }
@@ -1276,8 +1283,10 @@ function Invoke-Watchdog {
                 # signals (e.g. error_class=AgentError + provider_billing=true).
                 $errClass = ''
             }
-            $tier2Secrets = @($tier2Primary.AuthToken, $tier2.AuthToken) | Where-Object { $_ }
-            $logTail  = Protect-LogTail -Text $logTail -Secrets (@($supabaseKey, $supabaseUrl, $tgToken) + $tier2Secrets)
+            # #972: also redact the subscription OAuth token when present (tier2Primary
+            # and tier2 cover the DeepSeek/endpoint path; $oauthToken covers subscription).
+            $extraSecrets = @($tier2Primary.AuthToken, $tier2.AuthToken, $oauthToken) | Where-Object { $_ }
+            $logTail  = Protect-LogTail -Text $logTail -Secrets (@($supabaseKey, $supabaseUrl, $tgToken) + $extraSecrets)
             # Full chain failure: label the issue if we know which one was attempted.
             # Skip labeling on billing failures -- "too-large-for-local" means the
             # model is too small, not that the provider account is drained.

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -49,6 +49,24 @@ param(
     # the OOM-escalation chain stays available when this flag is off.
     [switch]$Tier2AsPrimary,
 
+    # 2026-06-15 (#972): run the Anthropic subscription Agent SDK credit as the
+    # PRIMARY tier and skip Ollama entirely. Bills the monthly Max Agent-SDK
+    # credit via CLAUDE_CODE_OAUTH_TOKEN (set in .sandcastle/.env), NOT the
+    # metered API. On any subscription-tier failure (credit exhausted ->
+    # hard-stop, or a transient API error) the run falls back to the DeepSeek
+    # Tier 2 endpoint for that iteration. Senior to -Tier2AsPrimary: when both
+    # are set, subscription is primary and DeepSeek becomes the fallback.
+    [switch]$SubscriptionPrimary,
+
+    # Subscription-tier model + effort. claude-opus-4-8 (regular, NOT 1M --
+    # extra billing) at medium effort: model = task depth, effort = task width;
+    # AFK slices are single sharpened verticals so depth-heavy / width-bounded
+    # is the right trade (decision rationale, #972).
+    [string]$SubscriptionModel = 'claude-opus-4-8',
+
+    [ValidateSet('low', 'medium', 'high', 'max')]
+    [string]$SubscriptionEffort = 'medium',
+
     # Runtime-dir retention: keep the N most-recent .sandcastle/runtime/<stamp>/
     # directories on watchdog entry, prune older ones. -1 disables the sweep.
     # Env var SANDCASTLE_RUNTIME_RETENTION overrides this if set (#572).
@@ -261,6 +279,15 @@ function Invoke-Sandcastle {
         # defaults via OLLAMA_BASE_URL / "ollama" auth.
         [string]$BaseUrl,
         [string]$AuthToken,
+        # Auth mode (#972). Default 'endpoint' is the REAL-MONEY GUARD: every
+        # Ollama/DeepSeek caller is auto-pinned to ANTHROPIC_BASE_URL/TOKEN, so
+        # the presence of CLAUDE_CODE_OAUTH_TOKEN in .env can never silently
+        # bill the subscription credit. Only the subscription tier passes
+        # -AuthMode subscription explicitly.
+        [ValidateSet('endpoint', 'subscription')]
+        [string]$AuthMode = 'endpoint',
+        # Effort (#972), subscription tier only. Empty => main.mts default.
+        [string]$Effort,
         # Forced-target issue (escalation retries). Empty => agent free-picks.
         [string]$TargetIssue
     )
@@ -277,6 +304,8 @@ function Invoke-Sandcastle {
         SANDCASTLE_AGENT_MODEL      = $env:SANDCASTLE_AGENT_MODEL
         SANDCASTLE_AGENT_BASE_URL   = $env:SANDCASTLE_AGENT_BASE_URL
         SANDCASTLE_AGENT_AUTH_TOKEN = $env:SANDCASTLE_AGENT_AUTH_TOKEN
+        SANDCASTLE_AGENT_AUTH_MODE  = $env:SANDCASTLE_AGENT_AUTH_MODE
+        SANDCASTLE_AGENT_EFFORT     = $env:SANDCASTLE_AGENT_EFFORT
         SANDCASTLE_TARGET_ISSUE     = $env:SANDCASTLE_TARGET_ISSUE
         OLLAMA_MODEL                = $env:OLLAMA_MODEL
     }
@@ -287,6 +316,10 @@ function Invoke-Sandcastle {
                         $env:OLLAMA_MODEL                = $Model }
     if ($BaseUrl)     { $env:SANDCASTLE_AGENT_BASE_URL   = $BaseUrl }
     if ($AuthToken)   { $env:SANDCASTLE_AGENT_AUTH_TOKEN = $AuthToken }
+    # AuthMode always set (defaults 'endpoint') — the real-money guard. Effort
+    # only when supplied (subscription tier); empty => main.mts default.
+    $env:SANDCASTLE_AGENT_AUTH_MODE = $AuthMode
+    if ($Effort)      { $env:SANDCASTLE_AGENT_EFFORT      = $Effort }
     # TargetIssue: pass empty string verbatim so retries can clear it.
     $env:SANDCASTLE_TARGET_ISSUE = "$TargetIssue"
 
@@ -304,6 +337,8 @@ function Invoke-Sandcastle {
         $env:SANDCASTLE_AGENT_MODEL      = $prev.SANDCASTLE_AGENT_MODEL
         $env:SANDCASTLE_AGENT_BASE_URL   = $prev.SANDCASTLE_AGENT_BASE_URL
         $env:SANDCASTLE_AGENT_AUTH_TOKEN = $prev.SANDCASTLE_AGENT_AUTH_TOKEN
+        $env:SANDCASTLE_AGENT_AUTH_MODE  = $prev.SANDCASTLE_AGENT_AUTH_MODE
+        $env:SANDCASTLE_AGENT_EFFORT     = $prev.SANDCASTLE_AGENT_EFFORT
         $env:SANDCASTLE_TARGET_ISSUE     = $prev.SANDCASTLE_TARGET_ISSUE
         $env:OLLAMA_MODEL                = $prev.OLLAMA_MODEL
     }
@@ -952,6 +987,13 @@ function Invoke-Watchdog {
         # ollama_bench_must_measure_tool_use_fidelity. Default $false preserves
         # the original OOM-escalation chain used by existing tests.
         [switch]$Tier2AsPrimary,
+        # #972: run the Anthropic subscription Agent SDK credit as the primary
+        # tier (skips Ollama like -Tier2AsPrimary) with DeepSeek as fallback.
+        # Senior to -Tier2AsPrimary when both are set.
+        [switch]$SubscriptionPrimary,
+        [string]$SubscriptionModel = 'claude-opus-4-8',
+        [ValidateSet('low', 'medium', 'high', 'max')]
+        [string]$SubscriptionEffort = 'medium',
         # #572: runtime-dir retention; env var SANDCASTLE_RUNTIME_RETENTION wins.
         [int]$RuntimeRetention = 30
     )
@@ -1058,8 +1100,27 @@ function Invoke-Watchdog {
         }
     }
 
-    # 3. Ollama (skipped when Tier 2 is primary — no local model will be invoked)
-    if (-not $tier2Primary) {
+    # 2b. Subscription primary (#972). The Anthropic Max Agent-SDK credit runs
+    #     as the primary tier (bills CLAUDE_CODE_OAUTH_TOKEN, NOT the metered
+    #     API) and Ollama is skipped — same rationale as Tier-2-primary. Senior
+    #     to -Tier2AsPrimary: when both are set, subscription is primary and the
+    #     configured Tier 2 (DeepSeek) becomes the credit-exhaustion fallback.
+    $subscriptionFallback = $null
+    if ($SubscriptionPrimary) {
+        $tier2Primary = $null   # subscription supersedes Tier-2-as-primary
+        $fallbackProvider = if ($Tier2Provider) { $Tier2Provider } else { 'deepseek' }
+        $subscriptionFallback = Resolve-Tier2Config -Provider $fallbackProvider -Issue 0 `
+            -RepoSlug $repoSlug -EnvVars $envVars
+        if ($subscriptionFallback -and $subscriptionFallback.AuthToken) {
+            Write-Host "[watchdog] Subscription ($SubscriptionModel, effort=$SubscriptionEffort) is primary — Ollama disabled; fallback=$($subscriptionFallback.Provider):$($subscriptionFallback.Model)."
+        } else {
+            $subscriptionFallback = $null
+            Write-Host "[watchdog] Subscription ($SubscriptionModel, effort=$SubscriptionEffort) is primary — Ollama disabled; no DeepSeek fallback configured (key missing)."
+        }
+    }
+
+    # 3. Ollama (skipped when Tier 2 or subscription is primary — no local model)
+    if (-not $tier2Primary -and -not $SubscriptionPrimary) {
         if (-not (Test-OllamaRunning)) {
             Write-Host "[watchdog] Ollama not running -- autostarting."
             Start-OllamaServer
@@ -1077,7 +1138,7 @@ function Invoke-Watchdog {
     $iter = 0
     $partialReason = $null
     $queueDrained = $false     # agent emitted the completion signal (queue empty)
-    $tierCompleted = $null    # 'tier0' | 'tier1' | 'tier2:deepseek' | 'tier2:claude'
+    $tierCompleted = $null    # 'subscription' | 'tier0' | 'tier1' | 'tier2:deepseek' | 'tier2:claude'
 
     while ($iter -lt $MaxIterations) {
         if (Test-WindowExpired -WindowEnd $windowEndDt) {
@@ -1088,7 +1149,36 @@ function Invoke-Watchdog {
         $iter++
         Write-Host "[watchdog] iteration $iter/$MaxIterations"
 
-        if ($tier2Primary) {
+        if ($SubscriptionPrimary) {
+            # ----- Subscription primary: Anthropic Max Agent-SDK credit -----
+            # -AuthMode subscription => main.mts injects ONLY the OAuth token; no
+            # BaseUrl/AuthToken (those would route to the metered API).
+            $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $SubscriptionModel `
+                -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
+                -AuthMode 'subscription' -Effort $SubscriptionEffort `
+                -TargetIssue ''
+            $tierUsed = 'subscription'
+            $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+            $oomDetected = $false
+
+            # Fallback: ANY subscription failure (credit exhausted -> hard-stop
+            # when overflow is disabled, or a transient API error) drops to the
+            # DeepSeek endpoint for this iteration. One bounded retry; self-heals
+            # transient failures, mild waste if the credit is truly exhausted.
+            # NB the exact credit-exhaustion signature is not yet characterized
+            # (mirror of the DeepSeek-402 silent-failure note) — monitor (#972).
+            if (-not $invocation.ok -and $subscriptionFallback) {
+                Write-Host "[watchdog] subscription tier failed ($($invocation.reason)) -- falling back to $($subscriptionFallback.Provider):$($subscriptionFallback.Model)"
+                $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $subscriptionFallback.Model `
+                    -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
+                    -BaseUrl $subscriptionFallback.BaseUrl -AuthToken $subscriptionFallback.AuthToken `
+                    -AuthMode 'endpoint' -TargetIssue ([string]$targetIssue)
+                $tierUsed = "tier2:$($subscriptionFallback.Provider)"
+                if (-not $targetIssue) {
+                    $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
+                }
+            }
+        } elseif ($tier2Primary) {
             # ----- Tier 2 primary: remote Anthropic-compat endpoint (DeepSeek / Anthropic API) -----
             $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $tier2Primary.Model `
                 -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
@@ -1108,7 +1198,7 @@ function Invoke-Watchdog {
         }
 
         # ----- Tier 1: smaller Ollama model on OOM/crash (only when Tier 2 is NOT primary) -----
-        if (-not $tier2Primary -and -not $invocation.ok -and $Tier1Model -and $oomDetected) {
+        if (-not $tier2Primary -and -not $SubscriptionPrimary -and -not $invocation.ok -and $Tier1Model -and $oomDetected) {
             Write-Host "[watchdog] Tier 0 OOM detected -- escalating to Tier 1 model: $Tier1Model"
             $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $Tier1Model `
                 -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
@@ -1124,7 +1214,7 @@ function Invoke-Watchdog {
         # and the chain still hasn't recovered. Tier 1 may have been skipped
         # entirely (no $Tier1Model) or it may have run and failed for any
         # reason -- both qualify per AC #3 ("persistent failure after Tier 1").
-        if (-not $tier2Primary -and -not $invocation.ok -and $oomDetected -and $Tier2Provider) {
+        if (-not $tier2Primary -and -not $SubscriptionPrimary -and -not $invocation.ok -and $oomDetected -and $Tier2Provider) {
             $tier2 = Resolve-Tier2Config -Provider $Tier2Provider -Issue $targetIssue `
                 -RepoSlug $repoSlug -EnvVars $envVars
             if ($tier2 -and $tier2.AuthToken) {
@@ -1297,5 +1387,7 @@ if (-not $NoExecute -and $Repo) {
         -OllamaTimeoutSec $OllamaTimeoutSec `
         -Tier1Model $Tier1Model -Tier2Provider $Tier2Provider `
         -Tier2AsPrimary:$Tier2AsPrimary `
+        -SubscriptionPrimary:$SubscriptionPrimary `
+        -SubscriptionModel $SubscriptionModel -SubscriptionEffort $SubscriptionEffort `
         -RuntimeRetention $RuntimeRetention
 }

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -1153,6 +1153,13 @@ function Invoke-Watchdog {
             # ----- Subscription primary: Anthropic Max Agent-SDK credit -----
             # -AuthMode subscription => main.mts injects ONLY the OAuth token; no
             # BaseUrl/AuthToken (those would route to the metered API).
+            # -TargetIssue '' (free-pick) is intentional and matches the tier0 /
+            # tier2Primary primaries below: each *iteration* lets the agent grab a
+            # fresh AFK-queue issue. A within-iteration escalation (the fallback
+            # block just below) pins to $targetIssue so the SAME issue is retried;
+            # iteration N+1 only runs after iteration N succeeded (a failure throws
+            # at the shared handler below), so re-using the prior issue would
+            # re-attempt one that already has a PR.
             $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $SubscriptionModel `
                 -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
                 -AuthMode 'subscription' -Effort $SubscriptionEffort `
@@ -1178,6 +1185,11 @@ function Invoke-Watchdog {
                     $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
                 }
             }
+            # No explicit `else { throw }` for the no-fallback case: a failed
+            # $invocation with $subscriptionFallback = $null falls through to the
+            # shared failure handler below (`if (-not $invocation.ok)`), which
+            # records the 'failure' outcome AND throws. Throwing early here would
+            # skip that Record write — fail-fast is intentional, not accidental.
         } elseif ($tier2Primary) {
             # ----- Tier 2 primary: remote Anthropic-compat endpoint (DeepSeek / Anthropic API) -----
             $invocation = Invoke-Sandcastle -RepoRoot $repoRoot -Model $tier2Primary.Model `

--- a/scripts/sandcastle/Run-Sandcastle.ps1
+++ b/scripts/sandcastle/Run-Sandcastle.ps1
@@ -1190,7 +1190,11 @@ function Invoke-Watchdog {
                     -MaxIterations 1 -ResultFile $resultFile -LogFile $logFile -RunId $runId `
                     -BaseUrl $subscriptionFallback.BaseUrl -AuthToken $subscriptionFallback.AuthToken `
                     -AuthMode 'endpoint' -TargetIssue ([string]$targetIssue)
-                $tierUsed = "tier2:$($subscriptionFallback.Provider)"
+                # Compound attribution: a bare "tier2:deepseek" would hide that the
+                # subscription tier was attempted first, so a Supabase trace on a
+                # double-failure run could not tell "DeepSeek-primary failed" from
+                # "subscription failed THEN DeepSeek failed". Preserve both.
+                $tierUsed = "subscription>tier2:$($subscriptionFallback.Provider)"
                 if (-not $targetIssue -and $invocation.result) {
                     $targetIssue = Get-IssueFromBranch -Branch $invocation.result.branch
                 }

--- a/tests/sandcastle/Register-SandcastleTask.Tests.ps1
+++ b/tests/sandcastle/Register-SandcastleTask.Tests.ps1
@@ -174,9 +174,24 @@ Describe 'Format-SandcastleActionArgs' {
         ($args -contains '-Tier2AsPrimary') | Should Be $true
     }
 
-    It 'default: subscription primary emits -SubscriptionPrimary + model/effort, DeepSeek as fallback, NOT -Tier2AsPrimary' {
+    It 'default (no flag): DeepSeek is primary -- emits -Tier2AsPrimary, NOT -SubscriptionPrimary' {
+        # 2026-06-17: default reverted to DeepSeek-primary (#972). Anthropic
+        # shelved the separate Agent-SDK automation quota at launch, so the
+        # subscription path is dormant opt-in code, not the default tier.
         $args = Format-SandcastleActionArgs -WatchdogPath 'w.ps1' -Repo 'jarvis' -Model 'm' `
             -Tier1Model '' -Tier2Provider 'deepseek' -MaxIterations 3 -WindowEnd '01:00'
+        ($args -contains '-SubscriptionPrimary') | Should Be $false
+        ($args -contains '-SubscriptionModel')   | Should Be $false
+        $tIdx = [array]::IndexOf($args, '-Tier2Provider')
+        $tIdx | Should Not Be -1
+        $args[$tIdx + 1] | Should Be 'deepseek'
+        ($args -contains '-Tier2AsPrimary') | Should Be $true
+    }
+
+    It 'opt-in: -SubscriptionPrimary $true emits -SubscriptionPrimary + model/effort, DeepSeek as fallback, NOT -Tier2AsPrimary' {
+        $args = Format-SandcastleActionArgs -WatchdogPath 'w.ps1' -Repo 'jarvis' -Model 'm' `
+            -Tier1Model '' -Tier2Provider 'deepseek' -MaxIterations 3 -WindowEnd '01:00' `
+            -SubscriptionPrimary $true
         ($args -contains '-SubscriptionPrimary') | Should Be $true
         $mIdx = [array]::IndexOf($args, '-SubscriptionModel')
         $mIdx | Should Not Be -1
@@ -192,10 +207,10 @@ Describe 'Format-SandcastleActionArgs' {
         ($args -contains '-Tier2AsPrimary') | Should Be $false
     }
 
-    It 'default: subscription model/effort overridable' {
+    It 'opt-in: subscription model/effort overridable' {
         $args = Format-SandcastleActionArgs -WatchdogPath 'w.ps1' -Repo 'jarvis' -Model 'm' `
             -Tier1Model '' -Tier2Provider 'deepseek' -MaxIterations 3 -WindowEnd '01:00' `
-            -SubscriptionModel 'claude-sonnet-4-6' -SubscriptionEffort 'high'
+            -SubscriptionPrimary $true -SubscriptionModel 'claude-sonnet-4-6' -SubscriptionEffort 'high'
         $mIdx = [array]::IndexOf($args, '-SubscriptionModel')
         $args[$mIdx + 1] | Should Be 'claude-sonnet-4-6'
         $eIdx = [array]::IndexOf($args, '-SubscriptionEffort')

--- a/tests/sandcastle/Register-SandcastleTask.Tests.ps1
+++ b/tests/sandcastle/Register-SandcastleTask.Tests.ps1
@@ -8,7 +8,12 @@
 #   Invoke-Pester -Path tests/sandcastle/Register-SandcastleTask.Tests.ps1
 
 $script:TaskPath = Join-Path $PSScriptRoot '..\..\scripts\sandcastle\Register-SandcastleTask.ps1'
-. $script:TaskPath -NoExecute
+# -Repo is mandatory in the default 'Sandcastle' parameter set; supply it at
+# load so the script dot-sources under Windows PowerShell 5.1 / Pester 3.4
+# (where an unsatisfied mandatory param blocks the load). -NoExecute short-
+# circuits before any scheduler call, and the helper functions take -Repo
+# explicitly, so this load-time value never leaks into a test assertion.
+. $script:TaskPath -Repo jarvis -NoExecute
 
 # ---------------------------------------------------------------------------
 # Per-repo defaults
@@ -120,22 +125,24 @@ Describe 'Get-PowerShellExe' {
 
 Describe 'Format-SandcastleActionArgs' {
     It 'builds minimal args for jarvis (no tiers)' {
+        # -SubscriptionPrimary:$false isolates the base arg shape from the
+        # default subscription block (covered separately below).
         $args = Format-SandcastleActionArgs -WatchdogPath 'D:\repo\scripts\sandcastle\Run-Sandcastle.ps1' `
             -Repo 'jarvis' -Model 'qwen3-coder:30b' -Tier1Model '' -Tier2Provider '' `
-            -MaxIterations 5 -WindowEnd '01:00'
+            -MaxIterations 5 -WindowEnd '01:00' -SubscriptionPrimary $false
         $args[0] | Should Be '-NoProfile'
         $args[2] | Should Be 'Bypass'
         $args[3] | Should Be '-File'
         $args[4] | Should Be '"D:\repo\scripts\sandcastle\Run-Sandcastle.ps1"'
         $args[5] | Should Be '-Repo'
         $args[6] | Should Be 'jarvis'
-        $args[8] | Should Be '-Model'
-        $args[9] | Should Be 'qwen3-coder:30b'
-        $args[10] | Should Be '-MaxIterations'
-        $args[11] | Should Be 5
-        $args[12] | Should Be '-WindowEnd'
-        $args[13] | Should Be '01:00'
-        $args.Count | Should Be 14   # 7 parameter pairs
+        $args[7] | Should Be '-Model'
+        $args[8] | Should Be 'qwen3-coder:30b'
+        $args[9] | Should Be '-MaxIterations'
+        $args[10] | Should Be 5
+        $args[11] | Should Be '-WindowEnd'
+        $args[12] | Should Be '01:00'
+        $args.Count | Should Be 13   # lone -NoProfile switch + 6 parameter pairs
     }
 
     It 'includes -Tier1Model when specified' {
@@ -146,22 +153,53 @@ Describe 'Format-SandcastleActionArgs' {
         $args[$idx + 1] | Should Be 'qwen2.5-coder:7b'
     }
 
-    It 'includes -Tier2Provider and -Tier2AsPrimary when provider is set' {
+    It 'legacy: -SubscriptionPrimary:$false + provider set -> -Tier2Provider and -Tier2AsPrimary' {
         $args = Format-SandcastleActionArgs -WatchdogPath 'w.ps1' -Repo 'jarvis' -Model 'm' `
-            -Tier1Model '' -Tier2Provider 'deepseek' -MaxIterations 3 -WindowEnd '01:00'
+            -Tier1Model '' -Tier2Provider 'deepseek' -MaxIterations 3 -WindowEnd '01:00' `
+            -SubscriptionPrimary $false
         $idx = [array]::IndexOf($args, '-Tier2Provider')
         $idx | Should Not Be -1
         $args[$idx + 1] | Should Be 'deepseek'
-        ($args -contains '-Tier2AsPrimary') | Should Be $true
+        ($args -contains '-Tier2AsPrimary')    | Should Be $true
+        ($args -contains '-SubscriptionPrimary') | Should Be $false
     }
 
-    It 'uses claude as Tier2 provider when specified' {
+    It 'legacy: uses claude as Tier2 provider when specified (-SubscriptionPrimary:$false)' {
         $args = Format-SandcastleActionArgs -WatchdogPath 'w.ps1' -Repo 'jarvis' -Model 'm' `
-            -Tier1Model '' -Tier2Provider 'claude' -MaxIterations 3 -WindowEnd '01:00'
+            -Tier1Model '' -Tier2Provider 'claude' -MaxIterations 3 -WindowEnd '01:00' `
+            -SubscriptionPrimary $false
         $idx = [array]::IndexOf($args, '-Tier2Provider')
         $idx | Should Not Be -1
         $args[$idx + 1] | Should Be 'claude'
         ($args -contains '-Tier2AsPrimary') | Should Be $true
+    }
+
+    It 'default: subscription primary emits -SubscriptionPrimary + model/effort, DeepSeek as fallback, NOT -Tier2AsPrimary' {
+        $args = Format-SandcastleActionArgs -WatchdogPath 'w.ps1' -Repo 'jarvis' -Model 'm' `
+            -Tier1Model '' -Tier2Provider 'deepseek' -MaxIterations 3 -WindowEnd '01:00'
+        ($args -contains '-SubscriptionPrimary') | Should Be $true
+        $mIdx = [array]::IndexOf($args, '-SubscriptionModel')
+        $mIdx | Should Not Be -1
+        $args[$mIdx + 1] | Should Be 'claude-opus-4-8'
+        $eIdx = [array]::IndexOf($args, '-SubscriptionEffort')
+        $eIdx | Should Not Be -1
+        $args[$eIdx + 1] | Should Be 'medium'
+        # DeepSeek stays wired as fallback...
+        $tIdx = [array]::IndexOf($args, '-Tier2Provider')
+        $tIdx | Should Not Be -1
+        $args[$tIdx + 1] | Should Be 'deepseek'
+        # ...but NOT promoted to primary.
+        ($args -contains '-Tier2AsPrimary') | Should Be $false
+    }
+
+    It 'default: subscription model/effort overridable' {
+        $args = Format-SandcastleActionArgs -WatchdogPath 'w.ps1' -Repo 'jarvis' -Model 'm' `
+            -Tier1Model '' -Tier2Provider 'deepseek' -MaxIterations 3 -WindowEnd '01:00' `
+            -SubscriptionModel 'claude-sonnet-4-6' -SubscriptionEffort 'high'
+        $mIdx = [array]::IndexOf($args, '-SubscriptionModel')
+        $args[$mIdx + 1] | Should Be 'claude-sonnet-4-6'
+        $eIdx = [array]::IndexOf($args, '-SubscriptionEffort')
+        $args[$eIdx + 1] | Should Be 'high'
     }
 
     It 'builds redrobot args with correct repo value' {
@@ -193,7 +231,7 @@ Describe 'Format-QuotaProbeActionArgs' {
         $args[4] | Should Be '"D:\repo\scripts\sandcastle\Quota-Probe.ps1"'
         $args[5] | Should Be '-CacheTTLMinutes'
         $args[6] | Should Be 35
-        $args.Count | Should Be 8   # 4 parameter pairs
+        $args.Count | Should Be 7   # lone -NoProfile switch + 3 parameter pairs
     }
 
     It 'accepts custom interval-based cache TTL' {

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -388,6 +388,17 @@ Describe 'Protect-LogTail' {
         $out | Should Not Match 'sk-ddd'
         $out | Should Match 'API-KEY-REDACTED'
     }
+    It 'redacts the subscription OAuth token passed explicitly in -Secrets' {
+        # The failure handler passes $oauthToken in -Secrets (Run-Sandcastle.ps1
+        # ~L1173). Even though the OAuth token also matches the sk-ant pattern,
+        # the literal-secret path must redact it so a credit-exhaustion log tail
+        # never persists the Agent-SDK credential to Supabase. Built at runtime
+        # so the token shape never appears as a source literal (gitleaks).
+        $oauth = 'sk-ant-oat01-' + ('z' * 40)
+        $out = Protect-LogTail -Text "CLAUDE_CODE_OAUTH_TOKEN=$oauth exhausted" -Secrets @($oauth)
+        $out | Should Not Match 'sk-ant-oat01-z'
+        $out | Should Match 'REDACTED'
+    }
     It 'returns empty string on empty input' {
         Protect-LogTail -Text '' | Should Be ''
     }
@@ -1173,8 +1184,11 @@ Describe 'Invoke-Watchdog subscription-primary (Anthropic Max Agent-SDK credit, 
         Assert-MockCalled Invoke-Sandcastle -Times 2 -Exactly -Scope It
         $script:calls[0].Mode | Should Be 'subscription'
         $script:calls[1].Mode | Should Be 'endpoint'
+        # The failure record must attribute the run to the tier that actually
+        # ran last (the DeepSeek fallback), not the subscription primary — so
+        # the outcome row is greppable by the tier that consumed the budget.
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
-            -ParameterFilter { $Status -eq 'failure' }
+            -ParameterFilter { $Status -eq 'failure' -and $LlmMetrics.tier -eq 'tier2:deepseek' }
     }
 
     It 'AC: -SubscriptionPrimary supersedes -Tier2AsPrimary (both set -> subscription wins)' {

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -1153,6 +1153,30 @@ Describe 'Invoke-Watchdog subscription-primary (Anthropic Max Agent-SDK credit, 
         $script:calls[0].Mode | Should Be 'subscription'
     }
 
+    It 'AC: subscription failure AND DeepSeek fallback also fails -> records failure + throws' {
+        # Both tiers down: subscription credit exhausted *and* DeepSeek 402/down.
+        # Must not silently swallow — the shared no-result handler records a
+        # 'failure' outcome and rethrows so the iteration is visibly broken.
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Mode = $AuthMode }
+            # ok=$false on BOTH the subscription call and the DeepSeek fallback.
+            [pscustomobject]@{ ok = $false; exitCode = 1; reason = 'exit=1'; result = $null }
+        }
+        Mock Test-IsOOM { $false }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+              -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -SubscriptionPrimary `
+              -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        # Subscription first, then the DeepSeek fallback — two attempts, both failed.
+        Assert-MockCalled Invoke-Sandcastle -Times 2 -Exactly -Scope It
+        $script:calls[0].Mode | Should Be 'subscription'
+        $script:calls[1].Mode | Should Be 'endpoint'
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'failure' }
+    }
+
     It 'AC: -SubscriptionPrimary supersedes -Tier2AsPrimary (both set -> subscription wins)' {
         $script:calls = @()
         Mock Invoke-Sandcastle {

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -1633,6 +1633,23 @@ Describe 'Invoke-Sandcastle' {
         $script:seen.Model  | Should Be 'claude-opus-4-8'
     }
 
+    It 'leaves SANDCASTLE_AGENT_EFFORT unset in the child when -Effort is omitted' {
+        # A prior run's value must not leak: omitting -Effort means the child
+        # process sees no effort override, not a stale carry-over from $env.
+        $env:SANDCASTLE_AGENT_EFFORT = 'stale-leak'
+        $script:seenEffort = 'sentinel'
+        Mock Invoke-NpmSandcastle {
+            $script:seenEffort = $env:SANDCASTLE_AGENT_EFFORT
+            [pscustomobject]@{ cmdNotFound = $false; exitCode = 0 }
+        }
+        Invoke-Sandcastle -RepoRoot $script:tmpRoot -Model 'qwen-large' -MaxIterations 1 `
+            -ResultFile $script:resultFile -LogFile $script:logFile -RunId 'no-eff' `
+            -BaseUrl 'http://ollama' -TargetIssue '' | Out-Null
+        $script:seenEffort | Should BeNullOrEmpty
+        # And the prior host value is restored afterwards (save/restore symmetry).
+        $env:SANDCASTLE_AGENT_EFFORT | Should Be 'stale-leak'
+    }
+
     It 'defaults AUTH_MODE to endpoint (real-money guard) when -AuthMode is omitted' {
         # Any Ollama/DeepSeek caller that does NOT pass -AuthMode must be pinned
         # to endpoint so the presence of CLAUDE_CODE_OAUTH_TOKEN in .env cannot

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -1094,6 +1094,46 @@ Describe 'Invoke-Watchdog subscription-primary (Anthropic Max Agent-SDK credit, 
             -ParameterFilter { $Status -eq 'success' -and $LlmMetrics.tier -eq 'subscription' }
     }
 
+    It 'AC: subscription primary across 2 iterations -> re-invokes subscription each iter, accumulates usage' {
+        # Guards the multi-iteration loop state for the subscription path: with
+        # no completionSignal the watchdog must re-run the subscription tier on
+        # iteration 2 (a fresh free-pick), and $totalUsage must accumulate across
+        # both iterations rather than reset. A regression in iteration-N reuse or
+        # token accumulation would otherwise pass silently (all other subscription
+        # tests use MaxIterations=1).
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Mode = $AuthMode; Target = $TargetIssue }
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{
+                    branch = "feat/90$($script:calls.Count)-iter"; commits = @('c'); iterations = @(
+                        [pscustomobject]@{ usage = [pscustomobject]@{
+                            inputTokens = 10; outputTokens = 5
+                            cacheReadInputTokens = 0; cacheCreationInputTokens = 0 } }
+                    )
+                    # no completionSignal -> loop continues to iteration 2
+                }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 2 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -SubscriptionPrimary `
+            -SubscriptionModel 'claude-opus-4-8' -SubscriptionEffort 'medium' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 2 -Exactly -Scope It
+        $script:calls[0].Mode | Should Be 'subscription'
+        $script:calls[1].Mode | Should Be 'subscription'   # iteration 2 stays on the subscription primary
+        # Usage accumulated across both iterations (10+10 in, 5+5 out), tier preserved.
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter {
+                $Status -eq 'success' -and $LlmMetrics.tier -eq 'subscription' -and
+                $LlmMetrics.input_tokens -eq 20 -and $LlmMetrics.output_tokens -eq 10
+            }
+    }
+
     It 'AC: subscription primary skips Ollama daemon check (Ollama down does not matter)' {
         Mock Test-OllamaRunning { $false }
         Mock Invoke-Sandcastle {
@@ -1135,8 +1175,11 @@ Describe 'Invoke-Watchdog subscription-primary (Anthropic Max Agent-SDK credit, 
         $script:calls[1].Mode    | Should Be 'endpoint'
         $script:calls[1].Token   | Should Be 'ds-key'
         $script:calls[1].BaseUrl | Should Be 'https://api.deepseek.com/anthropic'
+        # Compound tier: the subscription tier was attempted first, then the
+        # DeepSeek fallback succeeded -- the outcome row must show BOTH so a
+        # trace can distinguish this from a pure DeepSeek-primary success.
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
-            -ParameterFilter { $Status -eq 'success' -and $LlmMetrics.tier -eq 'tier2:deepseek' }
+            -ParameterFilter { $Status -eq 'success' -and $LlmMetrics.tier -eq 'subscription>tier2:deepseek' }
     }
 
     It 'AC: subscription failure with no DeepSeek fallback configured -> throws (no silent skip)' {
@@ -1184,11 +1227,12 @@ Describe 'Invoke-Watchdog subscription-primary (Anthropic Max Agent-SDK credit, 
         Assert-MockCalled Invoke-Sandcastle -Times 2 -Exactly -Scope It
         $script:calls[0].Mode | Should Be 'subscription'
         $script:calls[1].Mode | Should Be 'endpoint'
-        # The failure record must attribute the run to the tier that actually
-        # ran last (the DeepSeek fallback), not the subscription primary — so
-        # the outcome row is greppable by the tier that consumed the budget.
+        # The failure record must carry the COMPOUND tier so the outcome row
+        # shows subscription was attempted first THEN the DeepSeek fallback ran
+        # — a bare "tier2:deepseek" would be indistinguishable from a plain
+        # DeepSeek-primary double-failure (the round-5 reviewer's point).
         Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
-            -ParameterFilter { $Status -eq 'failure' -and $LlmMetrics.tier -eq 'tier2:deepseek' }
+            -ParameterFilter { $Status -eq 'failure' -and $LlmMetrics.tier -eq 'subscription>tier2:deepseek' }
     }
 
     It 'AC: -SubscriptionPrimary supersedes -Tier2AsPrimary (both set -> subscription wins)' {

--- a/tests/sandcastle/Run-Sandcastle.Tests.ps1
+++ b/tests/sandcastle/Run-Sandcastle.Tests.ps1
@@ -1029,6 +1029,151 @@ Describe 'Invoke-Watchdog Tier 2-as-primary (AFK quota split, 2026-05-14)' {
     }
 }
 
+Describe 'Invoke-Watchdog subscription-primary (Anthropic Max Agent-SDK credit, #972)' {
+    # When -SubscriptionPrimary is set, the watchdog runs the subscription tier
+    # (AuthMode=subscription, no BaseUrl/Token) as primary, skips Ollama, and
+    # falls back to the DeepSeek endpoint on any subscription failure.
+    BeforeEach {
+        Mock Test-DockerRunning { $true }
+        Mock Test-OllamaRunning { $true }
+        Mock Start-DockerDesktop { }
+        Mock Start-OllamaServer  { }
+        Mock Get-RepoRoot { $env:TEMP }
+        Mock Read-DotEnvFile {
+            @{
+                SUPABASE_URL       = 'https://x'
+                SUPABASE_KEY       = 'k'
+                TELEGRAM_BOT_TOKEN = 't'
+                TELEGRAM_CHAT_ID   = '1'
+                DEEPSEEK_API_KEY   = 'ds-key'
+            }
+        }
+        Mock New-RuntimeDir { Join-Path $env:TEMP "sandcastle-subprimary-$([guid]::NewGuid())" }
+        Mock Invoke-RuntimeSweep { @() }
+        Mock Write-OutcomeRecord { 'mocked' }
+        Mock Send-TelegramAlert  { 'mocked' }
+        Mock Add-IssueLabel      { $true }
+        Mock Get-IssueLabels     { @() }
+    }
+
+    It 'AC: subscription primary -> single call with AuthMode=subscription, no BaseUrl/Token, no Ollama' {
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Model = $Model; Mode = $AuthMode; Effort = $Effort; BaseUrl = $BaseUrl; Token = $AuthToken }
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/900-sub'; commits = @(); iterations = @() }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -SubscriptionPrimary `
+            -SubscriptionModel 'claude-opus-4-8' -SubscriptionEffort 'medium' `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 1 -Exactly -Scope It
+        $script:calls[0].Model   | Should Be 'claude-opus-4-8'
+        $script:calls[0].Mode    | Should Be 'subscription'
+        $script:calls[0].Effort  | Should Be 'medium'
+        $script:calls[0].BaseUrl | Should BeNullOrEmpty
+        $script:calls[0].Token   | Should BeNullOrEmpty
+        Assert-MockCalled Start-OllamaServer -Times 0 -Exactly -Scope It
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' -and $LlmMetrics.tier -eq 'subscription' }
+    }
+
+    It 'AC: subscription primary skips Ollama daemon check (Ollama down does not matter)' {
+        Mock Test-OllamaRunning { $false }
+        Mock Invoke-Sandcastle {
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/901-no-ollama'; commits = @(); iterations = @() }
+            }
+        }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -SubscriptionPrimary `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Start-OllamaServer -Times 0 -Exactly -Scope It
+        Assert-MockCalled Invoke-Sandcastle  -Times 1 -Exactly -Scope It
+    }
+
+    It 'AC: subscription failure -> falls back to DeepSeek for that iteration' {
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Model = $Model; Mode = $AuthMode; BaseUrl = $BaseUrl; Token = $AuthToken }
+            if ($AuthMode -eq 'subscription') {
+                [pscustomobject]@{ ok = $false; exitCode = 1; reason = 'exit=1'; result = $null }
+            } else {
+                [pscustomobject]@{
+                    ok = $true; exitCode = 0; reason = $null
+                    result = [pscustomobject]@{ branch = 'feat/902-fallback'; commits = @(); iterations = @() }
+                }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -SubscriptionPrimary `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 2 -Exactly -Scope It
+        $script:calls[0].Mode    | Should Be 'subscription'
+        $script:calls[1].Mode    | Should Be 'endpoint'
+        $script:calls[1].Token   | Should Be 'ds-key'
+        $script:calls[1].BaseUrl | Should Be 'https://api.deepseek.com/anthropic'
+        Assert-MockCalled Write-OutcomeRecord -Times 1 -Exactly -Scope It `
+            -ParameterFilter { $Status -eq 'success' -and $LlmMetrics.tier -eq 'tier2:deepseek' }
+    }
+
+    It 'AC: subscription failure with no DeepSeek fallback configured -> throws (no silent skip)' {
+        Mock Read-DotEnvFile {
+            @{
+                SUPABASE_URL       = 'https://x'
+                SUPABASE_KEY       = 'k'
+                TELEGRAM_BOT_TOKEN = 't'
+                TELEGRAM_CHAT_ID   = '1'
+                # no DEEPSEEK_API_KEY -> no fallback
+            }
+        }
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Mode = $AuthMode }
+            [pscustomobject]@{ ok = $false; exitCode = 1; reason = 'exit=1'; result = $null }
+        }
+        Mock Test-IsOOM { $false }
+
+        { Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+              -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -SubscriptionPrimary `
+              -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5 } | Should Throw
+
+        Assert-MockCalled Invoke-Sandcastle -Times 1 -Exactly -Scope It
+        $script:calls[0].Mode | Should Be 'subscription'
+    }
+
+    It 'AC: -SubscriptionPrimary supersedes -Tier2AsPrimary (both set -> subscription wins)' {
+        $script:calls = @()
+        Mock Invoke-Sandcastle {
+            $script:calls += @{ Model = $Model; Mode = $AuthMode }
+            [pscustomobject]@{
+                ok = $true; exitCode = 0; reason = $null
+                result = [pscustomobject]@{ branch = 'feat/903-super'; commits = @(); iterations = @() }
+            }
+        }
+        Mock Test-IsOOM { $false }
+
+        Invoke-Watchdog -Repo 'jarvis' -MaxIterations 1 -Model 'qwen-large' `
+            -Tier1Model 'qwen-small' -Tier2Provider 'deepseek' -Tier2AsPrimary -SubscriptionPrimary `
+            -WindowEnd '' -DockerTimeoutSec 5 -OllamaTimeoutSec 5
+
+        Assert-MockCalled Invoke-Sandcastle -Times 1 -Exactly -Scope It
+        $script:calls[0].Mode  | Should Be 'subscription'
+        $script:calls[0].Model | Should Be 'claude-opus-4-8'
+    }
+}
+
 Describe 'Invoke-Watchdog daemon-state matrix' {
     BeforeEach {
         Mock Start-DockerDesktop { }
@@ -1422,20 +1567,61 @@ Describe 'Invoke-Sandcastle' {
         $env:SANDCASTLE_AGENT_MODEL      = 'prev-model'
         $env:SANDCASTLE_AGENT_BASE_URL   = 'prev-url'
         $env:SANDCASTLE_AGENT_AUTH_TOKEN = 'prev-token'
+        $env:SANDCASTLE_AGENT_AUTH_MODE  = 'prev-mode'
+        $env:SANDCASTLE_AGENT_EFFORT     = 'prev-effort'
         $env:SANDCASTLE_TARGET_ISSUE     = 'prev-target'
         $env:OLLAMA_MODEL                = 'prev-ollama'
         Mock Invoke-NpmSandcastle { [pscustomobject]@{ cmdNotFound = $false; exitCode = 0 } }
         Invoke-Sandcastle -RepoRoot $script:tmpRoot -Model 'new-m' -MaxIterations 5 `
             -ResultFile $script:resultFile -LogFile $script:logFile -RunId 'new-run' `
-            -BaseUrl 'http://new' -AuthToken 'new-tok' -TargetIssue '42' | Out-Null
+            -BaseUrl 'http://new' -AuthToken 'new-tok' -AuthMode 'subscription' `
+            -Effort 'max' -TargetIssue '42' | Out-Null
         $env:SANDCASTLE_RESULT_FILE      | Should Be 'prev-result'
         $env:SANDCASTLE_MAX_ITERATIONS   | Should Be 'prev-max'
         $env:SANDCASTLE_RUN_ID           | Should Be 'prev-run'
         $env:SANDCASTLE_AGENT_MODEL      | Should Be 'prev-model'
         $env:SANDCASTLE_AGENT_BASE_URL   | Should Be 'prev-url'
         $env:SANDCASTLE_AGENT_AUTH_TOKEN | Should Be 'prev-token'
+        $env:SANDCASTLE_AGENT_AUTH_MODE  | Should Be 'prev-mode'
+        $env:SANDCASTLE_AGENT_EFFORT     | Should Be 'prev-effort'
         $env:SANDCASTLE_TARGET_ISSUE     | Should Be 'prev-target'
         $env:OLLAMA_MODEL                | Should Be 'prev-ollama'
+    }
+
+    It 'injects AUTH_MODE=subscription + EFFORT during a subscription-tier call' {
+        # The real-money guard inverted: when -AuthMode subscription is passed,
+        # main.mts must see SANDCASTLE_AGENT_AUTH_MODE=subscription and the
+        # effort value -- assert via Invoke-NpmSandcastle observing live env.
+        $script:seen = $null
+        Mock Invoke-NpmSandcastle {
+            $script:seen = @{
+                Mode   = $env:SANDCASTLE_AGENT_AUTH_MODE
+                Effort = $env:SANDCASTLE_AGENT_EFFORT
+                Model  = $env:SANDCASTLE_AGENT_MODEL
+            }
+            [pscustomobject]@{ cmdNotFound = $false; exitCode = 0 }
+        }
+        Invoke-Sandcastle -RepoRoot $script:tmpRoot -Model 'claude-opus-4-8' -MaxIterations 1 `
+            -ResultFile $script:resultFile -LogFile $script:logFile -RunId 'sub' `
+            -AuthMode 'subscription' -Effort 'medium' -TargetIssue '' | Out-Null
+        $script:seen.Mode   | Should Be 'subscription'
+        $script:seen.Effort | Should Be 'medium'
+        $script:seen.Model  | Should Be 'claude-opus-4-8'
+    }
+
+    It 'defaults AUTH_MODE to endpoint (real-money guard) when -AuthMode is omitted' {
+        # Any Ollama/DeepSeek caller that does NOT pass -AuthMode must be pinned
+        # to endpoint so the presence of CLAUDE_CODE_OAUTH_TOKEN in .env cannot
+        # silently bill the subscription credit.
+        $script:seenMode = $null
+        Mock Invoke-NpmSandcastle {
+            $script:seenMode = $env:SANDCASTLE_AGENT_AUTH_MODE
+            [pscustomobject]@{ cmdNotFound = $false; exitCode = 0 }
+        }
+        Invoke-Sandcastle -RepoRoot $script:tmpRoot -Model 'qwen-large' -MaxIterations 1 `
+            -ResultFile $script:resultFile -LogFile $script:logFile -RunId 'ep' `
+            -BaseUrl 'http://ollama' -TargetIssue '' | Out-Null
+        $script:seenMode | Should Be 'endpoint'
     }
 
     It 'returns json-parse-error when result.json is malformed' {


### PR DESCRIPTION
## Status update (2026-06-17) — subscription path landed but **dormant**

Anthropic cancelled the separate Agent-SDK automation quota at the last minute, so
this PR ships the subscription auth path **as opt-in, not as the default**. The AFK
loop stays on metered **DeepSeek API (Tier 2 primary)**; the subscription code below
is retained, fully tested, and selectable via `-SubscriptionPrimary` /
`SANDCASTLE_AGENT_AUTH_MODE=subscription` for whenever the owner re-enables it.

## What

Adds the subscription auth path to the **canonical** sandcastle module (`.sandcastle/main.mts`) so the AFK loop *can* run on the Max subscription's monthly Agent SDK credit (Opus 4.8 @ medium effort) instead of the metered DeepSeek API — DeepSeek/Ollama retained as fallback tiers. Per the status note above, DeepSeek remains the **active** primary; subscription is opt-in.

`SANDCASTLE_AGENT_AUTH_MODE` selects between two **mutually exclusive** env paths:

| mode | injects | bills |
|---|---|---|
| `endpoint` (default for watchdog-driven / no-token runs) | `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` | Ollama (Tier 0/1) or DeepSeek/Claude API (Tier 2) |
| `subscription` | **only** `CLAUDE_CODE_OAUTH_TOKEN` | Max Agent SDK credit (API rates, hard-stop on exhaustion) |

**Resolution:** explicit `SANDCASTLE_AGENT_AUTH_MODE` wins (a blank value is treated as unset); else `endpoint` when the watchdog drives a tier (`SANDCASTLE_AGENT_BASE_URL` set) or no OAuth token is present; `subscription` only for an un-driven manual run carrying `CLAUDE_CODE_OAUTH_TOKEN`. Nightly Ollama/DeepSeek tiers stay **byte-for-byte unchanged** even if a token sits in `.env`. Ollama default (`qwen3-coder:30b`) and rework mode (`SANDCASTLE_TARGET_PR`) preserved.

## Real-money guard

`ANTHROPIC_*` outrank `CLAUDE_CODE_OAUTH_TOKEN` in Claude Code's auth order — if both were set the subscription path would silently bill **paid** pay-per-token. The two modes never share env keys, and explicit `subscription` without a token **throws before `run()`**.

## Verification

Ran `main.mts` through `tsx` across every branch (throws at the `GH_TOKEN` guard, before `run()`):

- endpoint default (no token) → `auth=endpoint model=qwen3-coder:30b` — unchanged
- token + no base-url → `auth=subscription model=claude-opus-4-8 effort=medium billing=max-agent-sdk-credit`
- token present **but** watchdog drives `SANDCASTLE_AGENT_BASE_URL` → stays `auth=endpoint` (backward-compat)
- blank `SANDCASTLE_AGENT_AUTH_MODE` → falls through to auto-detect (no opaque `got ""` throw)
- bad effort / explicit subscription without token → both throw clearly

Pester: `Run-Sandcastle.Tests.ps1` 139 passed / 6 pre-existing environmental failures (git `origin/main...feat/test` ambiguous-revision + real-FS `Get-RelatedTestFiles`/`Invoke-PytestGate`); `Register-SandcastleTask.Tests.ps1` 22/22 pass.

## Scope

Canonical module change; `redrobot/.sandcastle/main.mts` mirrors it in [redrobot#1174](https://github.com/SergazyNarynov/redrobot/pull/1174). The watchdog tier-reorder (`Run-Sandcastle.ps1` / `Register-SandcastleTask.ps1`) is included here behind the opt-in `-SubscriptionPrimary` flag.

Closes #972

## Re-registration note

`Register-SandcastleTask.ps1` defaults `-SubscriptionPrimary = $false` — i.e. existing
and newly-registered scheduled tasks run **DeepSeek-primary (`-Tier2AsPrimary`)**, matching
the dormant-subscription decision above. To activate the subscription tier on a device,
re-run the registration **with** `-SubscriptionPrimary` (elevated PowerShell) — this only
updates the scheduled-task definition, no code change.
