### PR TITLE
refactor(tests): move repo-baseline shared fakes to conftest (#980)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,11 +82,12 @@ testpaths = ["tests"]
 pythonpath = ["src", "."]
 asyncio_mode = "auto"
 # Pin prepend import mode (today's pytest default) explicitly: tests/ is not a
-# package, and sibling test modules import each other as top-level names (e.g.
-# `from test_repo_baseline_auditor import FakeRunner`). That only works while the
-# test file's own directory is on sys.path[0], which prepend mode guarantees. If
-# pytest ever changes its default to importlib, this keeps the cross-module
-# imports working. (#978 round-3 MINOR 6.)
+# package, and test modules import shared helpers as top-level names — both from
+# conftest (`from conftest import FakeRunner`, #980) and from sibling test
+# modules (`from test_utils import FakeClient`). That only works while the test
+# directory is on sys.path[0], which prepend mode guarantees. If pytest ever
+# changes its default to importlib, this keeps those imports working.
+# (#978 round-3 MINOR 6; #980.)
 addopts = "--import-mode=prepend"
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ helpers needed testing (see #254 rework).
 
 from __future__ import annotations
 
+import base64
 import os
 import sys
 import types
@@ -37,6 +38,7 @@ _mcp_types.Tool = MagicMock
 def _noop_decorator(*args, **kwargs):
     def decorator(fn):
         return fn
+
     return decorator
 
 
@@ -222,10 +224,129 @@ class _FakeTable:
 def make_mock_client():
     """Factory fixture: returns a function that creates a contract-style
     mock Supabase client with a _FakeTable wired to table()."""
+
     def _make(table_kwargs: dict | None = None):
         client = MagicMock()
         client._table = _FakeTable(**(table_kwargs or {}))
         client.table.return_value = client._table
         client.rpc.return_value.execute.return_value = MagicMock(data=[])
         return client
+
     return _make
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes for repo-baseline gh/REST shell tests (#980)
+# ---------------------------------------------------------------------------
+# Previously defined in test_repo_baseline_auditor.py and pulled in by
+# test_repo_baseline_generate_snapshots.py via
+# `from test_repo_baseline_auditor import ...` — a sibling-test coupling that
+# only worked under pytest prepend mode and broke silently on rename. Centralised
+# here (the established shared-test-infra home) as plain importable helpers, so
+# every call site stays `FakeRunner(...)` / `_jarvis_responses()` unchanged.
+
+# Imported after the sys.path setup above — `scripts/` must already be on
+# sys.path, so this cannot sit with the top-of-file imports (E402).
+from scripts.repo_baseline.auditor import GhNotFound  # noqa: E402
+
+
+class FakeRunner:
+    """Stand-in for the live ``gh api`` runner.
+
+    ``responses`` maps an api path → parsed JSON. Paths listed in
+    ``not_found`` raise ``GhNotFound`` (simulating a 404, e.g. a repo with
+    no branch protection or no dependabot.yml).
+
+    Records each invocation as a ``(path, paginate)`` tuple in ``self.calls``
+    so tests can assert the paginate flag was passed correctly per endpoint —
+    ``_read_labels`` MUST paginate, every other reader MUST NOT (#978 MAJOR 4).
+    ``raise_for`` maps a path → exception to raise (simulating a transient
+    failure on a specific repo, for the ``audit_all`` isolation tests).
+    """
+
+    def __init__(
+        self,
+        responses: dict,
+        not_found: set[str] | None = None,
+        raise_for: dict | None = None,
+    ):
+        self.responses = responses
+        self.not_found = set(not_found or ())
+        self.raise_for = dict(raise_for or {})
+        self.calls: list[tuple[str, bool]] = []
+
+    def __call__(self, path: str, *, paginate: bool = False):
+        self.calls.append((path, paginate))
+        if path in self.raise_for:
+            raise self.raise_for[path]
+        if path in self.not_found:
+            raise GhNotFound(path)
+        try:
+            return self.responses[path]
+        except KeyError:
+            raise KeyError(
+                f"FakeRunner: no response for {path!r}. Registered: {sorted(self.responses)}"
+            ) from None
+
+    def paths(self) -> list[str]:
+        """Just the called paths, dropping the paginate flag."""
+        return [p for p, _ in self.calls]
+
+    def paginate_for(self, path: str) -> bool:
+        """The paginate flag the last call for *path* was made with."""
+        for p, pag in reversed(self.calls):
+            if p == path:
+                return pag
+        raise KeyError(path)
+
+
+def _dependabot_b64(*ecosystems: str) -> dict:
+    updates = "\n".join(
+        f'  - package-ecosystem: "{e}"\n    directory: "/"\n    schedule:\n      interval: "weekly"'
+        for e in ecosystems
+    )
+    text = f"version: 2\nupdates:\n{updates}\n"
+    return {
+        "content": base64.b64encode(text.encode()).decode(),
+        "encoding": "base64",
+    }
+
+
+def _jarvis_responses() -> dict:
+    return {
+        "repos/Osasuwu/jarvis": {
+            "allow_auto_merge": True,
+            "allow_squash_merge": True,
+            "allow_merge_commit": False,
+            "allow_rebase_merge": False,
+            "delete_branch_on_merge": True,
+            "visibility": "public",
+            "default_branch": "main",
+        },
+        "repos/Osasuwu/jarvis/labels": [
+            {"name": "priority:critical", "color": "b60205", "description": "Hotfix"},
+            {"name": "status:in-progress", "color": "fbca04", "description": ""},
+        ],
+        "repos/Osasuwu/jarvis/actions/workflows?per_page=100": {
+            "workflows": [
+                {"name": "Code Review", "path": ".github/workflows/code-review.yml"},
+                {"name": "pytest", "path": ".github/workflows/pytest.yml"},
+            ]
+        },
+        "repos/Osasuwu/jarvis/branches/main/protection": {
+            "required_status_checks": {
+                "strict": True,
+                "contexts": ["review", "pytest"],
+            }
+        },
+        "repos/Osasuwu/jarvis/contents/.github/dependabot.yml": _dependabot_b64(
+            "pip", "github-actions"
+        ),
+    }
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr

--- a/tests/test_repo_baseline_auditor.py
+++ b/tests/test_repo_baseline_auditor.py
@@ -26,103 +26,7 @@ from scripts.repo_baseline.auditor import (
     seed_manifest,
 )
 
-
-# ── Test double: dict-backed gh runner ───────────────────────────────
-
-
-class FakeRunner:
-    """Stand-in for the live ``gh api`` runner.
-
-    ``responses`` maps an api path → parsed JSON. Paths listed in
-    ``not_found`` raise ``GhNotFound`` (simulating a 404, e.g. a repo with
-    no branch protection or no dependabot.yml).
-
-    Records each invocation as a ``(path, paginate)`` tuple in ``self.calls``
-    so tests can assert the paginate flag was passed correctly per endpoint —
-    ``_read_labels`` MUST paginate, every other reader MUST NOT (#978 MAJOR 4).
-    ``raise_for`` maps a path → exception to raise (simulating a transient
-    failure on a specific repo, for the ``audit_all`` isolation tests).
-    """
-
-    def __init__(
-        self,
-        responses: dict,
-        not_found: set[str] | None = None,
-        raise_for: dict | None = None,
-    ):
-        self.responses = responses
-        self.not_found = set(not_found or ())
-        self.raise_for = dict(raise_for or {})
-        self.calls: list[tuple[str, bool]] = []
-
-    def __call__(self, path: str, *, paginate: bool = False):
-        self.calls.append((path, paginate))
-        if path in self.raise_for:
-            raise self.raise_for[path]
-        if path in self.not_found:
-            raise GhNotFound(path)
-        try:
-            return self.responses[path]
-        except KeyError:
-            raise KeyError(
-                f"FakeRunner: no response for {path!r}. Registered: {sorted(self.responses)}"
-            ) from None
-
-    def paths(self) -> list[str]:
-        """Just the called paths, dropping the paginate flag."""
-        return [p for p, _ in self.calls]
-
-    def paginate_for(self, path: str) -> bool:
-        """The paginate flag the last call for *path* was made with."""
-        for p, pag in reversed(self.calls):
-            if p == path:
-                return pag
-        raise KeyError(path)
-
-
-def _dependabot_b64(*ecosystems: str) -> dict:
-    updates = "\n".join(
-        f'  - package-ecosystem: "{e}"\n    directory: "/"\n    schedule:\n      interval: "weekly"'
-        for e in ecosystems
-    )
-    text = f"version: 2\nupdates:\n{updates}\n"
-    return {
-        "content": base64.b64encode(text.encode()).decode(),
-        "encoding": "base64",
-    }
-
-
-def _jarvis_responses() -> dict:
-    return {
-        "repos/Osasuwu/jarvis": {
-            "allow_auto_merge": True,
-            "allow_squash_merge": True,
-            "allow_merge_commit": False,
-            "allow_rebase_merge": False,
-            "delete_branch_on_merge": True,
-            "visibility": "public",
-            "default_branch": "main",
-        },
-        "repos/Osasuwu/jarvis/labels": [
-            {"name": "priority:critical", "color": "b60205", "description": "Hotfix"},
-            {"name": "status:in-progress", "color": "fbca04", "description": ""},
-        ],
-        "repos/Osasuwu/jarvis/actions/workflows?per_page=100": {
-            "workflows": [
-                {"name": "Code Review", "path": ".github/workflows/code-review.yml"},
-                {"name": "pytest", "path": ".github/workflows/pytest.yml"},
-            ]
-        },
-        "repos/Osasuwu/jarvis/branches/main/protection": {
-            "required_status_checks": {
-                "strict": True,
-                "contexts": ["review", "pytest"],
-            }
-        },
-        "repos/Osasuwu/jarvis/contents/.github/dependabot.yml": _dependabot_b64(
-            "pip", "github-actions"
-        ),
-    }
+from conftest import FakeRunner, _FakeProc, _dependabot_b64, _jarvis_responses
 
 
 class TestRepoSnapshotParsing:
@@ -672,13 +576,6 @@ class TestAuditAll:
         # redrobot is NOT in the Osasuwu baseline scope — credential-blocked,
         # different owner, deferred to #940.
         assert not any("redrobot" in r for r in OSASUWU_REPOS)
-
-
-class _FakeProc:
-    def __init__(self, returncode=0, stdout="", stderr=""):
-        self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
 
 
 class TestGhRunner:

--- a/tests/test_repo_baseline_generate_snapshots.py
+++ b/tests/test_repo_baseline_generate_snapshots.py
@@ -13,9 +13,9 @@ contract is load-bearing:
 * **Round-trip** — the emitted manifest YAML must load back through
   :meth:`Manifest.from_dict` without massaging.
 
-Reuses ``FakeRunner`` + ``_jarvis_responses`` from the auditor test module
-(top-level importable — ``tests/`` is not a package, pytest prepend mode puts
-it on ``sys.path``) so the canned ``gh api`` JSON stays defined in one place.
+Reuses ``FakeRunner`` + ``_jarvis_responses`` from ``tests/conftest.py`` (the
+shared-test-infra home — importable as ``from conftest import ...``) so the
+canned ``gh api`` JSON stays defined in one place (#980).
 """
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ import yaml
 from scripts.repo_baseline import Manifest
 from scripts.repo_baseline import generate_snapshots as gen
 
-from test_repo_baseline_auditor import FakeRunner, _jarvis_responses
+from conftest import FakeRunner, _jarvis_responses
 
 
 def _generate_jarvis(tmp_path, *, repos=("Osasuwu/jarvis",)):


### PR DESCRIPTION
## Summary
Move the repo-baseline shared test fakes — `FakeRunner`, `_jarvis_responses`, `_dependabot_b64`, and `_FakeProc` — from `tests/test_repo_baseline_auditor.py` into `tests/conftest.py`, the established shared-test-infra home. `test_repo_baseline_generate_snapshots.py` now imports them from `conftest` instead of reaching into the sibling auditor test module.

## Why
`test_repo_baseline_generate_snapshots.py` depended on `from test_repo_baseline_auditor import FakeRunner, _jarvis_responses` — a top-level cross-test-module import that only resolves under pytest **prepend** import mode (because `tests/` is not a package, so the test dir lands on `sys.path[0]`). It is invisible coupling: renaming or restructuring the auditor test file would break the generator tests with a confusing `ModuleNotFoundError`, and nothing signals the dependency.

Closes #980

## Decisions & Alternatives
- **Chose plain importable helpers over pytest fixtures.** ~30 call sites construct the fakes with arguments (`FakeRunner(responses, not_found)`, `dict(_jarvis_responses())`). Fixtures would force a factory-fixture rewrite at every call site for zero behavioral gain; helpers keep all call sites byte-identical.
- **`conftest.py` over a new `tests/repo_baseline_fakes.py` module.** conftest is already the shared-infra home in this repo (it holds the memory-server stubs + `make_mock_client`), is auto-discovered, and is importable as `from conftest import ...` under the same prepend mode — consolidating rather than adding a fourth shared-helper location.
- `GhNotFound` is imported in conftest *after* the `sys.path` setup block (it needs `scripts/` on the path), so it carries `# noqa: E402` — consistent with the conditional-import exemptions already in the file.

## Risk Assessment
- **LOW**: test-only refactor. No production code touched. Pure move + import-rewire; same fakes, same assertions.

## Testing
- `python -m pytest tests/test_repo_baseline_auditor.py tests/test_repo_baseline_generate_snapshots.py -q` → **51 passed**
- `python -m pytest -q` → **2383 passed, 1 failed** — the single failure (`test_agents_executor.py::test_resolve_claude_binary_raises_with_actionable_message`) is a **pre-existing, Windows-local** failure unrelated to this PR: confirmed it fails identically with these changes stashed. It only fires on a Windows box where `claude` is installed at a default path (the test stubs `shutil.which` but not the `os.name==nt` default-path fallback); CI on Linux passes. Flagged separately for a dedicated fix.
- `python -m ruff check` + `ruff format` clean on all touched files.

## Files Changed
- `tests/conftest.py` — added the four shared fakes + `base64` and `GhNotFound` imports
- `tests/test_repo_baseline_auditor.py` — removed the four fakes (now imported from conftest); kept `base64`/`json`/`GhNotFound` which remain used by its own tests
- `tests/test_repo_baseline_generate_snapshots.py` — import from `conftest`; docstring updated
- `pyproject.toml` — refreshed the prepend-mode comment whose example cited the now-removed auditor-test import