### PR TITLE
fix(#993): verdict guard anchors on head SHA — stale prior-SHA comment no longer a verdict

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -145,8 +145,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Freshness anchor (#993): a /code-review comment is a verdict only for
+          # the CURRENT head commit. The review action sometimes errors on turn 1
+          # (is_error, ~$0 cost, no comment posted for this SHA). Without a
+          # freshness check the selection below falls back to a STALE comment
+          # from a PRIOR head SHA — wrongly BLOCKING a clean head (a stale MAJOR
+          # lingers) or, worse, wrongly PASSING a dirty head (a stale "No issues
+          # found." green-lights code the plugin never saw). So we anchor on the
+          # head commit's committer time and treat any comment older than it as
+          # not-a-verdict-for-this-head. ISO-8601 UTC timestamps (…Z) from the
+          # API compare correctly as plain strings.
+          HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
+          HEAD_TIME=$(gh api "repos/$REPO/commits/$HEAD_SHA" -q .commit.committer.date)
+
           # Selection happens in standalone jq, not gh's --jq:
           #   - gh rejects `--slurp` combined with `--jq` (despite the help
           #     text), and without slurping, --jq runs per page so `.[-1]`
@@ -157,14 +171,33 @@ jobs:
           #     only. The (^|\n) anchor is line-anchored in every engine —
           #     keep it even under Oniguruma jq, so the pattern survives
           #     being moved between the two.
-          body=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" --paginate \
-            | jq -rs 'add | map(select(.body | test("(^|\\n)#{1,6}[ \\t]*(Claude[ \\t]+)?Code[ \\t]+Review"; "i"))) | (.[-1].body // "")')
+          # `total` = all code-review-titled comments (any age); `freshBody` =
+          # body of the latest one created at/after the head commit ($head).
+          sel=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            | jq -rs --arg head "$HEAD_TIME" 'add
+                | map(select(.body | test("(^|\\n)#{1,6}[ \\t]*(Claude[ \\t]+)?Code[ \\t]+Review"; "i")))
+                | { total: length,
+                    freshBody: ( map(select(.created_at >= $head)) | (.[-1].body // "") ) }
+                | @json')
+          total=$(jq -r '.total' <<<"$sel")
+          body=$(jq -r '.freshBody' <<<"$sel")
 
-          if [ -z "$body" ]; then
-            # Plugin skipped (draft / closed / already reviewed / not-eligible).
-            # No new verdict — leave merge gating to the eligibility logic upstream.
+          if [ "$total" -eq 0 ]; then
+            # No /code-review comment at all — the plugin legitimately skipped
+            # this PR (draft / closed / already reviewed / not-eligible). No
+            # verdict expected; leave merge gating to the eligibility logic
+            # upstream. (No regression: skipped PRs still pass.)
             echo "::notice::No /code-review comment present; plugin likely skipped. Treating as pass."
             exit 0
+          fi
+
+          if [ -z "$body" ]; then
+            # The plugin HAS reviewed this PR before, but no comment is newer
+            # than the current head commit — the latest review run errored or
+            # never posted for $HEAD_SHA. A stale prior-SHA comment is not a
+            # verdict for this head (#993). Fail closed; re-run code-review.
+            echo "::error::/code-review has prior comments on this PR but none newer than head commit $HEAD_SHA ($HEAD_TIME) — the latest review likely errored. Failing closed; re-run code-review."
+            exit 1
           fi
 
           # Two-gate model (#988): the MERGE gate blocks ONLY on a real merge-

--- a/tests/ci/test_code_review_verdict_guard.py
+++ b/tests/ci/test_code_review_verdict_guard.py
@@ -100,6 +100,35 @@ def verdict(comment_bodies: list[str]) -> str:
     return "fail"  # unrecognized review comment — fail closed
 
 
+def verdict_fresh(comments: list[tuple[str, str]], head_time: str) -> str:
+    """Mirror of the verdict step INCLUDING the #993 freshness gate.
+
+    A /code-review comment is a verdict only for the CURRENT head commit. The
+    review action sometimes errors on turn 1 and posts nothing for the head SHA;
+    a stale comment from a PRIOR head SHA must not be consumed as this head's
+    verdict (it would wrongly block a clean head or wrongly pass a dirty one).
+
+    Args:
+        comments: ``(body, created_at)`` pairs, oldest→newest (issue-comments API
+            order). ``created_at`` is an ISO-8601 UTC string (…Z), comparable as
+            a plain string against ``head_time``.
+        head_time: committer time of the current head commit (ISO-8601 UTC).
+
+    Returns 'pass' (exit 0) or 'fail' (exit 1). Three-way disambiguation:
+      - no code-review comment at all → 'pass' (plugin legitimately skipped);
+      - code-review comment(s) exist but ALL predate the head commit →
+        'fail' (latest review errored / never posted for this SHA — #993);
+      - a fresh code-review comment exists → existing two-gate content verdict.
+    """
+    review = [(b, t) for (b, t) in comments if TITLE_RE.search(b)]
+    if not review:
+        return "pass"  # no review comment at all — plugin skipped (no regression)
+    fresh = [b for (b, t) in review if t >= head_time]
+    if not fresh:
+        return "fail"  # only stale prior-SHA comment(s) — fail closed (#993)
+    return verdict([fresh[-1]])  # latest fresh comment → content verdict
+
+
 # The literal shape that false-passed the gate on PR #957: MAJOR + MINOR
 # sections. MAJOR still blocks.
 PR_957_COMMENT = """\
@@ -354,6 +383,80 @@ class TestVerdictLogic:
         assert verdict(["### Code review\n"]) == "fail"
 
 
+class TestFreshnessLogic:
+    """#993: a comment is a verdict only for the current head SHA.
+
+    The review action errors on turn 1 sometimes (is_error, ~$0, num_turns=1)
+    and posts NO comment for the head SHA. Without anchoring on the head commit
+    time the verdict step consumes a STALE prior-SHA comment — false-blocking a
+    clean head (stale MAJOR) or false-PASSING a dirty head (stale clean). The
+    second direction is the dangerous one: it auto-merges code the plugin never
+    reviewed. The gate fails closed when no comment is fresh for the head.
+    """
+
+    HEAD = "2026-06-18T12:00:00Z"  # current head commit's committer time
+    OLD = "2026-06-17T00:00:00Z"  # a comment from a prior head SHA
+    NEW = "2026-06-18T12:30:00Z"  # a comment posted for the current head SHA
+
+    def test_stale_major_only_fails_closed(self):
+        # False-BLOCK direction: a stale MAJOR from a prior SHA must NOT be
+        # consumed as this head's verdict. With no fresh comment → fail closed.
+        assert verdict_fresh([(BLOCKING_COMMENT, self.OLD)], self.HEAD) == "fail"
+
+    def test_stale_clean_only_fails_closed(self):
+        # False-PASS direction (the dangerous one, #993): a stale "No issues
+        # found." from a prior SHA must NOT pass the current (possibly dirty)
+        # head. Pre-fix this returned a PASS and auto-merged unreviewed code.
+        assert verdict_fresh([(CANONICAL_CLEAN_SPEC, self.OLD)], self.HEAD) == "fail"
+
+    def test_fresh_clean_passes(self):
+        assert verdict_fresh([(CANONICAL_CLEAN_SPEC, self.NEW)], self.HEAD) == "pass"
+
+    def test_fresh_major_fails(self):
+        assert verdict_fresh([(BLOCKING_COMMENT, self.NEW)], self.HEAD) == "fail"
+
+    def test_no_review_comment_at_all_passes(self):
+        # Plugin legitimately skipped — no regression vs. the pre-#993 behavior.
+        assert verdict_fresh([("LGTM, merging", self.NEW)], self.HEAD) == "pass"
+        assert verdict_fresh([], self.HEAD) == "pass"
+
+    def test_comment_at_exactly_head_time_is_fresh(self):
+        # created_at == head_time is treated as fresh (>=), not stale.
+        assert verdict_fresh([(CANONICAL_CLEAN_SPEC, self.HEAD)], self.HEAD) == "pass"
+
+    def test_fresh_wins_over_stale(self):
+        # Stale MAJOR + fresh clean → use the fresh comment → pass (the stale
+        # MAJOR from the prior SHA is correctly ignored).
+        assert (
+            verdict_fresh(
+                [(BLOCKING_COMMENT, self.OLD), (CANONICAL_CLEAN_SPEC, self.NEW)],
+                self.HEAD,
+            )
+            == "pass"
+        )
+        # Stale clean + fresh MAJOR → use the fresh comment → fail.
+        assert (
+            verdict_fresh(
+                [(CANONICAL_CLEAN_SPEC, self.OLD), (BLOCKING_COMMENT, self.NEW)],
+                self.HEAD,
+            )
+            == "fail"
+        )
+
+    def test_latest_fresh_comment_wins_among_fresh(self):
+        # Two fresh comments: the newest (last) decides, matching the bash
+        # `map(select(.created_at >= $head)) | .[-1].body`.
+        early_fresh = "2026-06-18T12:10:00Z"
+        late_fresh = "2026-06-18T12:40:00Z"
+        assert (
+            verdict_fresh(
+                [(BLOCKING_COMMENT, early_fresh), (CANONICAL_CLEAN_SPEC, late_fresh)],
+                self.HEAD,
+            )
+            == "pass"
+        )
+
+
 # -- Workflow wiring ----------------------------------------------------------
 
 
@@ -416,9 +519,13 @@ class TestVerdictStepWiring:
     def test_selector_slurps_pagination_via_standalone_jq(self, verdict_step):
         run = verdict_step["run"]
         assert "--paginate" in run
-        assert "jq -rs 'add" in run, (
+        # Pages must be slurped (-s) and flattened (add) in standalone jq so the
+        # latest review comment is the global-latest, not per-page. The freshness
+        # gate (#993) threads `--arg head` between `-rs` and the program, so the
+        # `add` flatten is no longer adjacent to `jq -rs` — match it tolerantly.
+        assert re.search(r"jq -rs\b.*'add", run), (
             "Pages must be slurped (-s) and flattened (add) in standalone jq "
-            "so .[-1] is the global-latest review comment, not per-page."
+            "so the latest review comment is the global-latest, not per-page."
         )
         code_lines = "\n".join(
             line for line in run.splitlines() if not line.lstrip().startswith("#")
@@ -513,4 +620,56 @@ class TestVerdictStepWiring:
         assert verdict_step["run"].strip().endswith("exit 1"), (
             "Unrecognized verdict format must fail closed (exit 1), not fall "
             "through to success — that fall-through is how #957 auto-merged."
+        )
+
+
+class TestFreshnessGateWiring:
+    """#993: the verdict step must anchor on the head commit and reject stale
+    prior-SHA comments. A SHA-agnostic selector consumes a leftover comment when
+    the latest review errors and posts nothing — false-block or false-pass."""
+
+    def test_resolves_head_commit_and_committer_time(self, verdict_step):
+        run = verdict_step["run"]
+        assert "headRefOid" in run, (
+            "Must resolve the PR head SHA (gh pr view --json headRefOid) to "
+            "anchor comment freshness."
+        )
+        assert ".commit.committer.date" in run, (
+            "Must read the head commit's committer time as the freshness "
+            "anchor (a comment older than the head commit is not its verdict)."
+        )
+
+    def test_selection_filters_comments_to_fresh_only(self, verdict_step):
+        run = verdict_step["run"]
+        assert ".created_at >= $head" in run, (
+            "The jq selection must drop comments created before the head "
+            "commit (stale prior-SHA comments are not this head's verdict)."
+        )
+
+    def test_no_comment_at_all_still_passes(self, verdict_step):
+        # total == 0 (plugin skipped) must remain a pass — no regression.
+        run = verdict_step["run"]
+        marker = 'if [ "$total" -eq 0 ]; then'
+        assert marker in run, (
+            "Must distinguish 'no review comment at all' (total 0 → pass) from "
+            "'comment(s) exist but all stale' (→ fail closed)."
+        )
+        skip_branch = run[run.index(marker) : run.index(marker) + 400]
+        assert "exit 0" in skip_branch, (
+            "No review comment at all = legitimate skip → pass (no regression)."
+        )
+
+    def test_stale_only_fails_closed(self, verdict_step):
+        # total > 0 but no fresh body ($body empty) → fail closed (#993).
+        run = verdict_step["run"]
+        marker = 'if [ -z "$body" ]; then'
+        assert marker in run, (
+            "Must have a stale-only branch: review comment(s) exist but none "
+            "is newer than the head commit."
+        )
+        stale_branch = run[run.index(marker) : run.index(marker) + 600]
+        assert "exit 1" in stale_branch and "exit 0" not in stale_branch, (
+            "Stale-only (no comment fresh for the head SHA) must FAIL CLOSED "
+            "(exit 1) — the latest review errored; do not consume a prior-SHA "
+            "verdict (#993)."
         )


### PR DESCRIPTION
## Problem (#993)

The `Verify review verdict` step in `code-review.yml` selected the global-latest `/code-review` comment **SHA-agnostically**. When the review action errors on turn 1 (`is_error`, ~$0 cost, `num_turns=1`) and posts **no** comment for the current head SHA, the guard fell back to a **stale comment from a prior SHA**:

- stale `### MAJOR` → **false-block** a now-clean head, or
- stale `No issues found.` → **false-pass** a dirty head — auto-merging code the plugin never reviewed (the dangerous direction).

## Fix

Anchor on the head commit's committer time and treat older comments as not-a-verdict-for-this-head:

1. `HEAD_SHA=$(gh pr view "$PR" --json headRefOid …)`; `HEAD_TIME=$(gh api repos/$REPO/commits/$HEAD_SHA -q .commit.committer.date)`.
2. jq selection now emits `{ total, freshBody }` — `freshBody` = latest comment with `created_at >= $head` (ISO-8601 UTC compares as strings).
3. Three-way disambiguation:
   - **no code-review comment at all** (`total == 0`) → **pass** (plugin legitimately skipped a draft/trivial/ineligible PR — no regression);
   - **comment(s) exist but all stale** (`freshBody` empty) → **fail closed** (the latest review errored — re-run code-review);
   - **fresh comment exists** → existing two-gate content verdict, unchanged.

Happy path is unchanged: the freshest comment is the one this run just posted, so it is fresh and evaluated exactly as before. The new behavior only bites when the latest review produced no comment for the current SHA — exactly the error case.

## Tests

- `TestFreshnessLogic` — `verdict_fresh(comments, head_time)` mirror: stale-MAJOR-only **and** stale-clean-only both fail closed (proving neither false-block nor false-pass survives); fresh wins over stale; `created_at == head_time` is fresh; no-review-comment-at-all still passes.
- `TestFreshnessGateWiring` — asserts the step resolves `headRefOid` + `.commit.committer.date`, filters on `.created_at >= $head`, keeps `total == 0 → pass`, and makes the stale-only branch fail closed.
- Retargeted `test_selector_slurps_pagination_via_standalone_jq` (the `--arg head` now threads between `jq -rs` and the program).

51 passed locally.

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)
