### PR TITLE
fix(#992): force LC_ALL=C on severity-heading greps in both verdict gates

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -200,6 +200,16 @@ jobs:
             exit 1
           fi
 
+          # Severity greps below classify each byte of heading decoration via the
+          # POSIX class [^[:alnum:]]. Under the runner's default LANG=C.UTF-8 a
+          # multibyte decoration (emoji "### 🔴 BLOCKING", #954) is read as ONE
+          # alnum-ambiguous rune that [^[:alnum:]] does NOT consume, so the block
+          # check silently misses and a coexisting "### MINOR" can flip the gate
+          # to PASS. Forcing the C locale makes grep treat every decoration byte
+          # individually (non-alnum), restoring the emoji-heading match. Set after
+          # the jq body extraction so JSON decoding stays UTF-8 aware.
+          export LC_ALL=C
+
           # Two-gate model (#988): the MERGE gate blocks ONLY on a real merge-
           # blocking finding — an all-caps CRITICAL/MAJOR/BLOCKING severity
           # heading. The block check runs FIRST so no pass signal below can

--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -299,6 +299,15 @@ jobs:
           # Read comment body from the event payload (safe — no shell expansion of comment content)
           COMMENT_BODY="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
 
+          # Force the C locale for every grep below. The severity-heading greps
+          # classify decoration bytes with POSIX [^[:alnum:]]; under the runner's
+          # default LANG=C.UTF-8 a multibyte emoji ("### 🔴 BLOCKING", #954) is one
+          # rune that [^[:alnum:]] won't consume, so a genuinely blocking review
+          # fails to raise review_negative — diverging from the merge gate this
+          # parser is meant to mirror (#992). C locale makes grep byte-oriented so
+          # the emoji decoration matches. Set after jq so JSON stays UTF-8 aware.
+          export LC_ALL=C
+
           # Only act on the Claude code-review verdict comment. claude[bot]
           # posts other comment kinds (simplification opportunities, /rework
           # progress, orchestrator-watcher dispatches). Mirror the SAME title

--- a/tests/ci/test_code_review_verdict_guard.py
+++ b/tests/ci/test_code_review_verdict_guard.py
@@ -50,6 +50,13 @@ TITLE_RE = re.compile(r"^#{1,6}[ \t]*(?:Claude[ \t]+)?Code[ \t]+Review", re.I | 
 # prose ("### Blocking issues — None", #962) must NOT match. Decoration between
 # the #'s and the keyword is tolerated; the class excludes \n so the decoration
 # run cannot span lines under re.M (grep matches per-line).
+#
+# Locale faithfulness: Python's `[^A-Za-z0-9\n]` consumes a multibyte emoji
+# rune-by-rune, so this mirror matches "### 🔴 BLOCKING". The bash grep only
+# behaves the same once the verdict step exports LC_ALL=C — pinned by
+# test_severity_greps_run_under_c_locale. Without that export the bash diverges
+# (emoji match 0 while this mirror says 1), which is exactly the merge-gate hole
+# the locale fix closes; the pin keeps this mirror truthful at runtime.
 BLOCK_RE = re.compile(r"^#{1,6}[^A-Za-z0-9\n]*(?:CRITICAL|MAJOR|BLOCKING)\b", re.M)
 
 # Clean signal: line-start anchored, NO end anchor — the plugin spec's clean
@@ -545,6 +552,26 @@ class TestVerdictStepWiring:
             "MINOR must be DROPPED from the block alternation (two-gate, #988) "
             "— minors never block merge."
         )
+
+    def test_severity_greps_run_under_c_locale(self, verdict_step):
+        # The block/nonblock greps classify heading decoration with POSIX
+        # [^[:alnum:]]. Under the runner default LANG=C.UTF-8 a multibyte emoji
+        # ("### 🔴 BLOCKING", #954) is one rune that [^[:alnum:]] won't consume,
+        # so the block check misses and a coexisting "### MINOR" can flip the
+        # MERGE gate to PASS — auto-merging a PR the bot blocked. `export
+        # LC_ALL=C` (set after the jq body extraction so JSON stays UTF-8 aware)
+        # makes grep byte-oriented and restores the emoji match. Verified at
+        # runtime: LANG=C.UTF-8 → emoji match 0, LC_ALL=C → emoji match 1.
+        run = verdict_step["run"]
+        assert "export LC_ALL=C" in run, (
+            "Severity greps must run under LC_ALL=C — otherwise an emoji-"
+            "decorated CRITICAL/MAJOR/BLOCKING heading (#954) escapes the block "
+            "check under the runner's C.UTF-8 default and a coexisting MINOR "
+            "section flips the merge gate to a false PASS."
+        )
+        assert run.index("export LC_ALL=C") < run.index(
+            "(CRITICAL|MAJOR|BLOCKING)"
+        ), "LC_ALL=C must be exported before the first severity grep."
 
     def test_block_check_is_case_sensitive_allcaps(self, verdict_step):
         # #976: the block grep must be `-qE` (case-sensitive), NOT `-qiE` —

--- a/tests/ci/test_event_dispatch_review_parser.py
+++ b/tests/ci/test_event_dispatch_review_parser.py
@@ -50,6 +50,13 @@ TITLE_RE = re.compile(r"^#{1,6}[ \t]*(?:Claude[ \t]+)?Code[ \t]+Review", re.I | 
 # tests/ci/test_code_review_verdict_guard.py. Case-SENSITIVE (no re.I): real
 # plugin severity sections are all-caps; title-case prose ("### Blocking issues
 # — None", #962) must NOT match. MINOR dropped — minors never block.
+#
+# Locale faithfulness: Python's `[^A-Za-z0-9\n]` consumes a multibyte emoji
+# rune-by-rune, so this mirror matches "### 🔴 BLOCKING". The bash grep only
+# behaves the same once the step exports LC_ALL=C (test_severity_greps_run_
+# under_c_locale pins that). Without LC_ALL=C the bash would diverge — match 0
+# on the emoji while this mirror says 1 — so the locale pin is what keeps the
+# `test_emoji_decorated_blocking_emits` expectation truthful at runtime.
 BLOCK_RE = re.compile(r"^#{1,6}[^A-Za-z0-9\n]*(?:CRITICAL|MAJOR|BLOCKING)\b", re.M)
 
 # Back-compat count derivation (blocking-heading counts).
@@ -298,3 +305,20 @@ class TestParserWiring:
             "The blocking-heading gate must run before count derivation — "
             "counts are only meaningful once a block is confirmed."
         )
+
+    def test_severity_greps_run_under_c_locale(self, parser_run):
+        # The [^[:alnum:]] decoration class only consumes a multibyte emoji
+        # ("### 🔴 BLOCKING", #954) per-byte under the C locale; under the
+        # runner default LANG=C.UTF-8 it reads the emoji as one non-consumed
+        # rune and the block check silently misses. `export LC_ALL=C` must be
+        # set, AND it must precede the severity greps (after jq, so JSON stays
+        # UTF-8 aware). Verified at runtime: LANG=C.UTF-8 → emoji match 0,
+        # LC_ALL=C → emoji match 1.
+        assert "export LC_ALL=C" in parser_run, (
+            "Severity greps must run under LC_ALL=C — otherwise an emoji-"
+            "decorated CRITICAL/MAJOR/BLOCKING heading (#954) escapes the "
+            "block check under the runner's C.UTF-8 default."
+        )
+        assert parser_run.index("export LC_ALL=C") < parser_run.index(
+            "(CRITICAL|MAJOR|BLOCKING)"
+        ), "LC_ALL=C must be exported before the first severity grep."


### PR DESCRIPTION
## What

Follow-up completing #992. PR #995 aligned the event-dispatch `review_negative` parser to the merge-gate two-gate predicate, but both gates shared a latent **locale bug** in the shared block pattern `^#{1,6}[^[:alnum:]]*(CRITICAL|MAJOR|BLOCKING)\b`.

On `ubuntu-latest` the default `LANG=C.UTF-8` makes POSIX `[^[:alnum:]]` read a multibyte emoji (`### 🔴 BLOCKING`, #954) as a single rune it will **not** consume, so the block check silently misses. Verified at runtime:

```
LANG=C.UTF-8  -> emoji-heading match 0   (bug)
LC_ALL=C      -> emoji-heading match 1   (fixed)
```

## Why it mattered (real merge-gate hole, not just the mirror)

In `code-review.yml`, a review comment carrying `### 🔴 BLOCKING` **plus** a `### MINOR` section fell through the missed block check into the non-blocking-severity **PASS** branch — the MERGE gate would auto-merge a PR the bot actually blocked. `event-dispatch.yml` had the symmetric miss (failed to raise `review_negative`).

## Fix

`export LC_ALL=C` on the severity greps in **both** workflows (after the `jq` body extraction, so JSON stays UTF-8 aware) → grep is byte-oriented → emoji decoration matches per-byte. Case-sensitivity preserved: title-case prose (`Blocking issues — None`, #962) still does **not** block.

Meta-tests in both guards pin the directive (config dimension, #326) and document that the Python mirrors are only faithful to the bash once `LC_ALL=C` is set.

## Review note

Found by the local Opus review subagent on PR #995 (VERDICT: BLOCK) — sonnet quota exhausted until 2026-06-22, so CI `review` is substituted by a local Opus subagent per owner instruction, then admin-merge on green non-review checks. PR self-modifies `code-review.yml`, so the `review` action would refuse to run anyway (documented self-modifying-PR behavior).

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)