### PR TITLE
refactor: sync canon code-review.yml verdict to live two-gate + locale + freshness

### DIFF
--- a/scripts/repo_baseline/canon/code-review.yml
+++ b/scripts/repo_baseline/canon/code-review.yml
@@ -117,43 +117,135 @@ jobs:
     if: always() && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
     runs-on: {{ runs_on }}
     permissions:
+      contents: read
       pull-requests: read
     steps:
+      # Auto-merge MERGE gate (Gate 1 of the two-gate model, #988). This step
+      # turns the `review` check into a real verdict — without it the check is
+      # SUCCESS as long as the bot ran, so auto-merge can't tell "ran cleanly"
+      # from "found CRITICAL bugs".
+      #
+      # TWO-GATE MODEL: the MERGE gate blocks ONLY on a merge-blocking finding —
+      # an all-caps CRITICAL/MAJOR/BLOCKING severity heading. MINOR/NITPICK/LOW/
+      # INFO/MEDIUM and a bare "Found N issues:" line do NOT block, matching the
+      # REWORK-done gate (n_critical==0 AND n_major==0) so a clean-but-minor PR
+      # no longer ping-pongs between rework and the merge gate (#976).
+      #
+      # Hardened verdict contract (mirrors the jarvis reference workflow and
+      # tests/ci/test_code_review_verdict_guard.py):
+      #   - SELECT the latest comment whose body carries a code-review title
+      #     heading (1-6 #'s, optional "Claude", any case, anywhere in body).
+      #   - FRESHNESS (#993): a comment is a verdict only for the CURRENT head
+      #     commit. Anchor on the head commit's committer time; a comment older
+      #     than the head is not this head's verdict (the latest review may have
+      #     errored and posted nothing for this SHA). Fail closed on stale-only.
+      #   - BLOCK signal checked FIRST: all-caps CRITICAL/MAJOR/BLOCKING heading
+      #     (case-SENSITIVE grep -qE, NOT -qiE — title-case prose like "Blocking
+      #     issues — None" must not false-block, #976). MINOR is NOT in the
+      #     alternation (two-gate, #988).
+      #   - PASS signals (all exit 0; reached only when no block heading):
+      #     "No issues found." (clean), "Blocking issues — None" (#962 APPROVE),
+      #     "Found N issues:" (advisory, #956), and MINOR/NITPICK/LOW/INFO/
+      #     MEDIUM-only severity sections (#963).
+      #   - Selected-but-unrecognized comment → exit 1, fail-closed (#957).
+      #   - No selected comment at all → pass (plugin legitimately skipped).
       - name: Verify review verdict
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Selection happens in standalone jq, not gh's --jq:
-          # gh rejects --slurp with --jq, and without slurping --jq runs per
-          # page so .[-1] is per-page latest not global. Paginated arrays
-          # are flattened with add after slurping all pages.
-          body=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" --paginate \
-            | jq -rs 'add | map(select(.body | test("(^|\\n)#{1,6}[ \\t]*(Claude[ \\t]+)?Code[ \\t]+Review"; "i"))) | (.[-1].body // "")')
+          # Freshness anchor (#993): resolve the head commit's committer time and
+          # treat any comment older than it as not-a-verdict-for-this-head — else
+          # a stale prior-SHA comment wrongly BLOCKS a clean head or wrongly
+          # PASSES a dirty head when the latest review errored and posted nothing.
+          # ISO-8601 UTC timestamps (…Z) compare correctly as plain strings.
+          HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
+          HEAD_TIME=$(gh api "repos/$REPO/commits/$HEAD_SHA" -q .commit.committer.date)
 
-          if [ -z "$body" ]; then
+          # Selection happens in standalone jq, not gh's --jq: gh rejects --slurp
+          # combined with --jq, and without slurping --jq runs per page so .[-1]
+          # is per-page latest, not global. `gh api --paginate` emits one array
+          # per page; `jq -s` slurps them and `add` flattens to one comment list.
+          # gh's --jq is gojq where ^ matches string start only; the (^|\n) anchor
+          # is line-anchored in every engine — keep it under either jq.
+          # `total` = all code-review-titled comments (any age); `freshBody` =
+          # body of the latest one created at/after the head commit ($head).
+          sel=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            | jq -rs --arg head "$HEAD_TIME" 'add
+                | map(select(.body | test("(^|\\n)#{1,6}[ \\t]*(Claude[ \\t]+)?Code[ \\t]+Review"; "i")))
+                | { total: length,
+                    freshBody: ( map(select(.created_at >= $head)) | (.[-1].body // "") ) }
+                | @json')
+          total=$(jq -r '.total' <<<"$sel")
+          body=$(jq -r '.freshBody' <<<"$sel")
+
+          if [ "$total" -eq 0 ]; then
+            # No /code-review comment at all — the plugin legitimately skipped
+            # this PR (draft / closed / already reviewed / not-eligible).
             echo "::notice::No /code-review comment present; plugin likely skipped. Treating as pass."
             exit 0
           fi
 
-          # Findings checks run before clean check: a findings comment may
-          # contain incidental "No issues found." — pass must never shadow fail.
-          if grep -qiE '^#{1,6}[^[:alnum:]]*(CRITICAL|MAJOR|MINOR|BLOCKING)\b' <<<"$body"; then
-            echo "::error::Code review posted severity findings sections (CRITICAL/MAJOR/MINOR/BLOCKING); blocking auto-merge until addressed."
+          if [ -z "$body" ]; then
+            # The plugin reviewed this PR before, but no comment is newer than the
+            # current head commit — the latest review errored or never posted for
+            # $HEAD_SHA. A stale prior-SHA comment is not a verdict for this head
+            # (#993). Fail closed; re-run code-review.
+            echo "::error::/code-review has prior comments on this PR but none newer than head commit $HEAD_SHA ($HEAD_TIME) — the latest review likely errored. Failing closed; re-run code-review."
             exit 1
           fi
 
-          if grep -qE 'Found [0-9]+ issues?:' <<<"$body"; then
-            count=$(grep -oE 'Found [0-9]+ issues?:' <<<"$body" | head -1 | grep -oE '[0-9]+')
-            echo "::error::Code review found $count issue(s); blocking auto-merge until addressed."
+          # Severity greps below classify heading decoration via the POSIX class
+          # [^[:alnum:]]. Under the runner's default LANG=C.UTF-8 a multibyte
+          # decoration (emoji "### 🔴 BLOCKING", #954) is read as ONE alnum-
+          # ambiguous rune that [^[:alnum:]] does NOT consume, so the block check
+          # silently misses and a coexisting "### MINOR" can flip the gate to
+          # PASS. Forcing the C locale makes grep treat every decoration byte
+          # individually (non-alnum), restoring the emoji-heading match (#996).
+          # Set AFTER the jq body extraction so JSON decoding stays UTF-8 aware.
+          export LC_ALL=C
+
+          # Two-gate model (#988): block ONLY on an all-caps CRITICAL/MAJOR/
+          # BLOCKING severity heading. Block check runs FIRST so no pass signal
+          # below can shadow it. grep -qE (NOT -qiE): case-SENSITIVE all-caps
+          # (#976). MINOR is DROPPED — minors never block merge.
+          if grep -qE '^#{1,6}[^[:alnum:]]*(CRITICAL|MAJOR|BLOCKING)\b' <<<"$body"; then
+            echo "::error::Code review posted blocking severity sections (CRITICAL/MAJOR/BLOCKING); blocking auto-merge until addressed."
             exit 1
           fi
 
+          # No blocking severity heading. Any recognized non-blocking shape is a
+          # positive pass (order among the pass checks is immaterial).
           if grep -qE '^No issues found\.' <<<"$body"; then
             echo "::notice::Code review clean."
             exit 0
           fi
 
+          # APPROVE summary "Blocking issues — None" (#962). Case-insensitive
+          # (title-case prose); only reached after the block check.
+          if grep -qiE 'blocking issues\b[^[:alnum:]]*none\b' <<<"$body"; then
+            echo "::notice::Code review reports no blocking issues."
+            exit 0
+          fi
+
+          # Findings present but none blocking: canonical "Found N issues:". A
+          # PASS under the two-gate model (#956); residual risk accepted per #988.
+          if grep -qE 'Found [0-9]+ issues?:' <<<"$body"; then
+            count=$(grep -oE 'Found [0-9]+ issues?:' <<<"$body" | head -1 | grep -oE '[0-9]+')
+            echo "::notice::Code review found $count non-blocking issue(s); not blocking auto-merge (two-gate model)."
+            exit 0
+          fi
+
+          # Non-blocking severity sections only: MINOR-only (#963) or MEDIUM/LOW/
+          # INFO/NITPICK advisories with no Found-N line.
+          if grep -qE '^#{1,6}[^[:alnum:]]*(MINOR|NITPICK|LOW|INFO|MEDIUM)\b' <<<"$body"; then
+            echo "::notice::Code review posted only non-blocking severity sections; not blocking auto-merge."
+            exit 0
+          fi
+
+          # Unrecognized format — fail closed so a malformed or deviant comment
+          # can't slip past auto-merge (cf. PR #957 false-pass).
           echo "::error::Could not parse /code-review verdict from latest review comment. Failing closed."
           exit 1

--- a/tests/ci/test_canon_code_review_verdict_parity.py
+++ b/tests/ci/test_canon_code_review_verdict_parity.py
@@ -1,0 +1,151 @@
+"""Canon↔live drift guard for the code-review verdict logic.
+
+The repo-baseline canon (`scripts/repo_baseline/canon/code-review.yml`) is the
+PROPAGATION template pushed to every owned repo. Its `verify-verdict` job must
+encode the SAME merge-gate decision logic as the live reference workflow
+(`.github/workflows/code-review.yml`), or propagated repos silently get an
+outdated gate that mis-merges PRs.
+
+This is exactly what happened pre-this-test: the canon verdict step lagged a
+full generation behind live —
+
+  - still `grep -qiE` (case-INsensitive) on the block check vs live `-qE` (#976);
+  - still blocked on MINOR (pre-two-gate) vs live's CRITICAL/MAJOR/BLOCKING
+    alternation (#988);
+  - lacked `export LC_ALL=C` so an emoji severity heading escaped the block
+    check (#996);
+  - lacked the #993 freshness anchor.
+
+Nothing compared the two, so the drift was invisible. This guard pins parity on
+the load-bearing verdict patterns. When the live workflow's verdict logic
+evolves, re-snapshot the canon (`scripts/repo_baseline/canon/code-review.yml`)
+and this test goes green again — that's the guard working.
+
+Structural note: the canon and live workflows are intentionally NOT byte-equal —
+canon is a 3-job retry-wrapper (attempt-1 → attempt-2 → verify-verdict) with
+`{{ axis }}` placeholders, live is a single `review` job. So this test compares
+the *verdict-decision patterns*, not the whole file.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.repo_baseline import Manifest, Renderer
+from scripts.repo_baseline.canon import load_canon_template
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIVE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "code-review.yml"
+
+# Patterns that carry the merge-gate decision. Each must appear, verbatim, in
+# BOTH the live verdict step and the rendered canon verdict step. Drift on any
+# one is the class of bug this guard exists to catch.
+VERDICT_INVARIANTS = [
+    # case-SENSITIVE all-caps block, MINOR dropped (#976/#988)
+    r"grep -qE '^#{1,6}[^[:alnum:]]*(CRITICAL|MAJOR|BLOCKING)",
+    # locale fix so emoji headings are consumed byte-wise (#996)
+    "export LC_ALL=C",
+    # non-blocking severity pass branch (two-gate, #963)
+    r"^#{1,6}[^[:alnum:]]*(MINOR|NITPICK|LOW|INFO|MEDIUM)\b",
+    # "Found N issues:" recognized (non-blocking pass under two-gate, #956)
+    "Found [0-9]+ issues?:",
+    # "Blocking issues — None" APPROVE pass (#962)
+    "blocking issues",
+    # clean signal, not end-anchored
+    r"^No issues found\.",
+    # freshness anchor (#993)
+    "headRefOid",
+    ".commit.committer.date",
+    ".created_at >= $head",
+]
+
+# Anti-patterns: the OLD/buggy shapes. Must appear in NEITHER verdict step.
+VERDICT_ANTIPATTERNS = [
+    # case-INsensitive block — the #962 false-block bug
+    r"grep -qiE '^#{1,6}[^[:alnum:]]*(CRITICAL",
+    # MINOR in the block alternation — pre-two-gate (#988)
+    "(CRITICAL|MAJOR|MINOR|BLOCKING)",
+]
+
+
+def _verdict_run(run_steps: list[dict]) -> str:
+    step = next(s for s in run_steps if s.get("name") == "Verify review verdict")
+    return step["run"]
+
+
+@pytest.fixture(scope="module")
+def live_verdict_run() -> str:
+    doc = yaml.safe_load(LIVE_WORKFLOW.read_text(encoding="utf-8"))
+    return _verdict_run(doc["jobs"]["review"]["steps"])
+
+
+@pytest.fixture(scope="module")
+def canon_verdict_run() -> str:
+    template = load_canon_template(".github/workflows/code-review.yml")
+    assert template is not None, "canon code-review.yml template must exist"
+    manifest = Manifest.from_dict(
+        {
+            "repo": "Osasuwu/jarvis",
+            "profile": "full",
+            "required_check_contexts": ["verify-verdict"],
+        }
+    )
+    rendered = Renderer().render(template, manifest)
+    doc = yaml.safe_load(rendered)
+    return _verdict_run(doc["jobs"]["verify-verdict"]["steps"])
+
+
+class TestCanonVerdictParity:
+    @pytest.mark.parametrize("pattern", VERDICT_INVARIANTS)
+    def test_invariant_present_in_canon(self, canon_verdict_run, pattern):
+        assert pattern in canon_verdict_run, (
+            f"Canon verdict step is missing the load-bearing pattern {pattern!r}. "
+            f"Re-snapshot scripts/repo_baseline/canon/code-review.yml from the live "
+            f".github/workflows/code-review.yml verdict step."
+        )
+
+    @pytest.mark.parametrize("pattern", VERDICT_INVARIANTS)
+    def test_invariant_present_in_live(self, live_verdict_run, pattern):
+        # If live drops a pattern, the invariant list is stale — update both.
+        assert pattern in live_verdict_run, (
+            f"Live verdict step no longer contains {pattern!r}. If the live "
+            f"verdict logic changed intentionally, update VERDICT_INVARIANTS and "
+            f"re-snapshot the canon to match."
+        )
+
+    @pytest.mark.parametrize("pattern", VERDICT_ANTIPATTERNS)
+    def test_antipattern_absent_from_canon(self, canon_verdict_run, pattern):
+        assert pattern not in canon_verdict_run, (
+            f"Canon verdict step contains the buggy/outdated shape {pattern!r}."
+        )
+
+    @pytest.mark.parametrize("pattern", VERDICT_ANTIPATTERNS)
+    def test_antipattern_absent_from_live(self, live_verdict_run, pattern):
+        assert pattern not in live_verdict_run, (
+            f"Live verdict step contains the buggy/outdated shape {pattern!r}."
+        )
+
+    def test_canon_block_check_runs_before_pass_checks(self, canon_verdict_run):
+        run = canon_verdict_run
+        block_at = run.index("(CRITICAL|MAJOR|BLOCKING)")
+        for later in (r"^No issues found\.", "Found [0-9]+ issues?:",
+                      "(MINOR|NITPICK|LOW|INFO|MEDIUM)"):
+            assert block_at < run.index(later), (
+                f"Block check must precede pass signal {later!r} so no pass can "
+                f"shadow a CRITICAL/MAJOR/BLOCKING heading."
+            )
+
+    def test_canon_locale_exported_before_block(self, canon_verdict_run):
+        run = canon_verdict_run
+        assert run.index("export LC_ALL=C") < run.index("(CRITICAL|MAJOR|BLOCKING)"), (
+            "LC_ALL=C must be exported before the first severity grep (#996)."
+        )
+
+    def test_canon_verdict_fails_closed(self, canon_verdict_run):
+        assert canon_verdict_run.strip().endswith("exit 1"), (
+            "Unrecognized verdict format must fail closed (exit 1), not fall "
+            "through to success (cf. #957)."
+        )


### PR DESCRIPTION
## Summary

The repo-baseline **canon** (`scripts/repo_baseline/canon/code-review.yml`) is the propagation template pushed to every owned repo. Its `verify-verdict` step had silently drifted a **full generation** behind the live reference workflow (`.github/workflows/code-review.yml`). Because nothing compared canon vs live, the drift was invisible.

### Drift fixed (canon `verify-verdict` → live parity)

| Axis | Canon (was) | Live (now matched) |
|---|---|---|
| Block grep case | `grep -qiE` (case-insensitive) | `grep -qE` (case-sensitive all-caps) — #976 |
| Block alternation | `CRITICAL\|MAJOR\|MINOR\|BLOCKING` (MINOR blocks) | `CRITICAL\|MAJOR\|BLOCKING` (two-gate) — #988 |
| Locale | _(none)_ | `export LC_ALL=C` before severity greps — #996 |
| Freshness | _(none)_ | head-SHA committer-time anchor — #993 |
| Found-N | blocked (exit 1) | non-blocking pass (two-gate) — #956 |
| Minor-only sections | fell through to fail-closed | explicit non-blocking pass — #963 |

Kept the canon's intentional **3-job retry-wrapper** structure and the `verify-verdict` job name (pinned by `test_canon_required_checks_guard`). Added `contents: read` to the `verify-verdict` job for the freshness commit API.

### Drift guard added

`tests/ci/test_canon_code_review_verdict_parity.py` pins the load-bearing `grep` decision patterns in **both** canon and live. When the live verdict logic evolves, this test goes red until the canon is re-snapshotted — closing the "nobody compares the two" hole that allowed this drift. Runs in the `meta-tests` gate.

### Other canon files — checked, not stale

`owner-queue-guard.yml`, `pr-body-check.yml`, `ci-meta.yml` are logic-identical to live (only comments terser, `{{ runs_on }}` is the intended placeholder). `dependabot.yml` (REPO_CUSTOM escape hatch documented), `task.yml` (live's jarvis-specific Phase dropdown), `config.yml` (`{{ repo }}` placeholder), and `PULL_REQUEST_TEMPLATE.md` (deliberately minimal baseline) differ for intentional templating/repo-specific reasons — none harmfully stale.

## Test plan

- `pytest tests/ci/` — **450 passed** (includes the new parity test + the existing live verdict guard + required-checks guard)
- Rendered canon validated: valid YAML, no leftover `{{ }}` placeholders, `verify-verdict` job + `contents: read`; verdict bash passes `bash -n`.

`[no-issue]` — structural snapshot sync of the propagation baseline; no parent issue needed (CLAUDE.md "Fix > track" / refactor bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
