### PR TITLE
feat(#999): extend Tier-2 MCP write scrubber to goal/outcome write paths

### DIFF
--- a/mcp-memory/handlers/decision.py
+++ b/mcp-memory/handlers/decision.py
@@ -84,7 +84,13 @@ def _resolve_memory_refs(client, refs: list, project: str | None) -> tuple[list[
     return resolved, unresolved
 
 
-async def _link_fok_judgments_to_outcomes(client, outcome_ids: list[str], memory_ids: list[str], decision_timestamp: str, project: str | None) -> None:
+async def _link_fok_judgments_to_outcomes(
+    client,
+    outcome_ids: list[str],
+    memory_ids: list[str],
+    decision_timestamp: str,
+    project: str | None,
+) -> None:
     """Retroactively link FOK judgments to outcomes via memory linkage (#445).
 
     Primary heuristic — time-window match:
@@ -106,7 +112,7 @@ async def _link_fok_judgments_to_outcomes(client, outcome_ids: list[str], memory
         outcome_id = outcome_ids[0] if isinstance(outcome_ids, list) else outcome_ids
 
         # Parse decision timestamp
-        decision_dt = datetime.fromisoformat(decision_timestamp.replace('Z', '+00:00'))
+        decision_dt = datetime.fromisoformat(decision_timestamp.replace("Z", "+00:00"))
         cutoff_dt = decision_dt - timedelta(minutes=30)
 
         # Build a set of memory IDs to check (normalize to strings)
@@ -157,9 +163,9 @@ async def _link_fok_judgments_to_outcomes(client, outcome_ids: list[str], memory
                         # Check if this memory_id is in the returned set
                         if mem_id in returned_ids_str:
                             # Update the judgment with the outcome_id
-                            client.table("fok_judgments").update(
-                                {"outcome_id": outcome_id}
-                            ).eq("id", judgment_id).execute()
+                            client.table("fok_judgments").update({"outcome_id": outcome_id}).eq(
+                                "id", judgment_id
+                            ).execute()
                     except Exception:
                         # Skip individual check errors
                         pass
@@ -218,13 +224,16 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
     # #555: Tier-2 write-path scrubber backstop. Scan the user-supplied text
     # BEFORE resolving refs / inserting the episode. AC names `rationale`; the
     # privacy invariant ("MCP writes still cannot land secrets") extends the
-    # scan to `decision` + `alternatives_considered`, which also persist text.
+    # scan to every field that persists free text — `decision`,
+    # `alternatives_considered`, and `actor` (the symmetric partner of
+    # `_handle_store`'s `source_provenance`, both namespace strings).
     block = write_scrubber.check_write(
         client,
         {
             "decision": decision,
             "rationale": rationale,
             "alternatives_considered": args.get("alternatives_considered") or [],
+            "actor": actor,
         },
         write_path="record_decision",
     )
@@ -311,13 +320,9 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
                     "response_model", llm_meta["model"]
                 )
             if "input_tokens" in llm_meta:
-                canonical_payload["gen_ai.usage.input_tokens"] = llm_meta[
-                    "input_tokens"
-                ]
+                canonical_payload["gen_ai.usage.input_tokens"] = llm_meta["input_tokens"]
             if "output_tokens" in llm_meta:
-                canonical_payload["gen_ai.usage.output_tokens"] = llm_meta[
-                    "output_tokens"
-                ]
+                canonical_payload["gen_ai.usage.output_tokens"] = llm_meta["output_tokens"]
             if "cost_usd" in llm_meta:
                 canonical_payload["gen_ai.usage.cost_usd"] = llm_meta["cost_usd"]
                 try:

--- a/mcp-memory/handlers/decision.py
+++ b/mcp-memory/handlers/decision.py
@@ -243,6 +243,10 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
     # no UUID validation, so it is a free-text sink that must be scanned too).
     # `project` persists to the episode payload (line ~275) and can carry a
     # user path — scan it too, matching `_handle_store`'s gate.
+    # `memories_used` is scanned BEFORE resolution: any entry that is not a real
+    # UUID/name is preserved verbatim in `payload.memories_used_unresolved` AND
+    # echoed in the success text, so an unresolved secret-shaped entry (e.g. a
+    # raw `sk-ant-*` key) would otherwise bypass the gate and land in the DB.
     block = write_scrubber.check_write(
         client,
         {
@@ -252,6 +256,7 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
             "actor": actor,
             "outcomes_referenced": args.get("outcomes_referenced") or [],
             "project": project,
+            "memories_used": args.get("memories_used") or [],
         },
         write_path="record_decision",
     )

--- a/mcp-memory/handlers/decision.py
+++ b/mcp-memory/handlers/decision.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone  # noqa: F401
 from mcp.types import TextContent  # noqa: F401
 
 import server  # noqa: F401  — late-bound for monkeypatch propagation
+import write_scrubber  # #555: Tier-2 write-path secret-scrubber gate
 
 
 def _looks_like_uuid(s: str) -> bool:
@@ -213,6 +214,22 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
     project = args.get("project")
 
     client = server._get_client()
+
+    # #555: Tier-2 write-path scrubber backstop. Scan the user-supplied text
+    # BEFORE resolving refs / inserting the episode. AC names `rationale`; the
+    # privacy invariant ("MCP writes still cannot land secrets") extends the
+    # scan to `decision` + `alternatives_considered`, which also persist text.
+    block = write_scrubber.check_write(
+        client,
+        {
+            "decision": decision,
+            "rationale": rationale,
+            "alternatives_considered": args.get("alternatives_considered") or [],
+        },
+        write_path="record_decision",
+    )
+    if block is not None:
+        return [TextContent(type="text", text=block)]
 
     resolved_memories, unresolved_memories = _resolve_memory_refs(
         client, args.get("memories_used") or [], project

--- a/mcp-memory/handlers/decision.py
+++ b/mcp-memory/handlers/decision.py
@@ -18,6 +18,18 @@ from mcp.types import TextContent  # noqa: F401
 import server  # noqa: F401  — late-bound for monkeypatch propagation
 import write_scrubber  # #555: Tier-2 write-path secret-scrubber gate
 
+# Strong references to fire-and-forget tasks. CPython holds only a weak ref to
+# a bare ``asyncio.create_task`` result, so without an external strong ref the
+# task can be GC-collected mid-flight before it completes (same pattern as
+# write_scrubber._PENDING_BLOCK_LOGS). Discard via the done-callback below.
+_PENDING_TASKS: set[asyncio.Task] = set()
+
+
+def _pin_task(task: asyncio.Task) -> None:
+    """Strong-ref *task* until completion so it can't be GC-collected mid-flight."""
+    _PENDING_TASKS.add(task)
+    task.add_done_callback(_PENDING_TASKS.discard)
+
 
 def _looks_like_uuid(s: str) -> bool:
     """True if s is a canonical UUID string (case-insensitive, hyphenated)."""
@@ -229,6 +241,8 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
     # `_handle_store`'s `source_provenance`, both namespace strings), and
     # `outcomes_referenced` (persisted raw into the episode payload below with
     # no UUID validation, so it is a free-text sink that must be scanned too).
+    # `project` persists to the episode payload (line ~275) and can carry a
+    # user path — scan it too, matching `_handle_store`'s gate.
     block = write_scrubber.check_write(
         client,
         {
@@ -237,6 +251,7 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
             "alternatives_considered": args.get("alternatives_considered") or [],
             "actor": actor,
             "outcomes_referenced": args.get("outcomes_referenced") or [],
+            "project": project,
         },
         write_path="record_decision",
     )
@@ -293,9 +308,11 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
     # decision response on N+1 Supabase round-trips inside the linker; the
     # linker itself swallows exceptions, so a detached task is correct.
     if decision_timestamp and resolved_memories and outcome_ids:
-        asyncio.create_task(
-            _link_fok_judgments_to_outcomes(
-                client, outcome_ids, resolved_memories, decision_timestamp, project
+        _pin_task(
+            asyncio.create_task(
+                _link_fok_judgments_to_outcomes(
+                    client, outcome_ids, resolved_memories, decision_timestamp, project
+                )
             )
         )
 

--- a/mcp-memory/handlers/decision.py
+++ b/mcp-memory/handlers/decision.py
@@ -225,8 +225,10 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
     # BEFORE resolving refs / inserting the episode. AC names `rationale`; the
     # privacy invariant ("MCP writes still cannot land secrets") extends the
     # scan to every field that persists free text — `decision`,
-    # `alternatives_considered`, and `actor` (the symmetric partner of
-    # `_handle_store`'s `source_provenance`, both namespace strings).
+    # `alternatives_considered`, `actor` (the symmetric partner of
+    # `_handle_store`'s `source_provenance`, both namespace strings), and
+    # `outcomes_referenced` (persisted raw into the episode payload below with
+    # no UUID validation, so it is a free-text sink that must be scanned too).
     block = write_scrubber.check_write(
         client,
         {
@@ -234,6 +236,7 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
             "rationale": rationale,
             "alternatives_considered": args.get("alternatives_considered") or [],
             "actor": actor,
+            "outcomes_referenced": args.get("outcomes_referenced") or [],
         },
         write_path="record_decision",
     )

--- a/mcp-memory/handlers/decision.py
+++ b/mcp-memory/handlers/decision.py
@@ -277,7 +277,10 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
             .execute()
         )
     except Exception as exc:
-        return [TextContent(type="text", text=f"Error recording decision: {exc}")]
+        # Privacy (#555): postgrest/httpx exception str() can embed the request
+        # body (decision/rationale/etc.). If a secret ever slips the Tier-2 gate,
+        # echoing {exc} to the MCP caller would leak it — surface the type only.
+        return [TextContent(type="text", text=f"Error recording decision: {type(exc).__name__}")]
 
     if not result.data:
         return [TextContent(type="text", text="Failed to record decision.")]
@@ -360,7 +363,7 @@ async def _handle_record_decision(args: dict) -> list[TextContent]:
             import sys as _sys
 
             print(
-                f"[decision.py] events_canonical dual-write skipped: {exc}",
+                f"[decision.py] events_canonical dual-write skipped: {type(exc).__name__}",
                 file=_sys.stderr,
             )
 

--- a/mcp-memory/handlers/goal.py
+++ b/mcp-memory/handlers/goal.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone  # noqa: F401
 from mcp.types import TextContent  # noqa: F401
 
 import server  # noqa: F401  — late-bound for monkeypatch propagation
+import write_scrubber  # #999: Tier-2 write-path secret-scrubber gate
 
 GOAL_FIELDS = (
     "slug",
@@ -113,6 +114,20 @@ async def _handle_goal_set(args: dict) -> list[TextContent]:
     client = server._get_client()
     slug = args["slug"]
 
+    # #999: Tier-2 write-path scrubber backstop. Scan user-supplied free-text
+    # fields before any DB write.
+    block = write_scrubber.check_write(
+        client,
+        {
+            k: args[k]
+            for k in ("title", "why", "success_criteria", "risks", "owner_focus", "jarvis_focus", "outcome", "lessons")
+            if k in args
+        },
+        write_path="goal_set",
+    )
+    if block is not None:
+        return [TextContent(type="text", text=block)]
+
     data = {k: args[k] for k in GOAL_FIELDS if k in args}
 
     # Convert JSONB fields
@@ -177,6 +192,19 @@ async def _handle_goal_get(args: dict) -> list[TextContent]:
 async def _handle_goal_update(args: dict) -> list[TextContent]:
     client = server._get_client()
     slug = args["slug"]
+
+    # #999: Tier-2 write-path scrubber backstop.
+    block = write_scrubber.check_write(
+        client,
+        {
+            k: args[k]
+            for k in ("title", "why", "success_criteria", "risks", "owner_focus", "jarvis_focus", "outcome", "lessons")
+            if k in args
+        },
+        write_path="goal_update",
+    )
+    if block is not None:
+        return [TextContent(type="text", text=block)]
 
     data = {k: args[k] for k in GOAL_FIELDS if k in args and k != "slug"}
 

--- a/mcp-memory/handlers/memory.py
+++ b/mcp-memory/handlers/memory.py
@@ -915,9 +915,12 @@ async def _handle_store(args: dict) -> list[TextContent]:
             )
         ]
 
-    # #555: Tier-2 write-path scrubber backstop. Run AFTER validation but
-    # BEFORE any embedding/insert so a blocked write generates no embedding
-    # and lands no row. Reject (not silent-scrub) — the write is intent-bearing.
+    # Tier-2 write-path secret-scrubber gate; see write_scrubber module
+    # docstring. Run AFTER validation but BEFORE any embedding/insert so a
+    # blocked write generates no embedding and lands no row. Reject (not
+    # silent-scrub) — the write is intent-bearing. Scan every caller-supplied
+    # field that persists free text, including `project` (a caller string
+    # written to the memories row).
     block = write_scrubber.check_write(
         client,
         {
@@ -926,6 +929,7 @@ async def _handle_store(args: dict) -> list[TextContent]:
             "description": description,
             "tags": tags,
             "source_provenance": source_provenance,
+            "project": project,
         },
         write_path="memory_store",
     )

--- a/mcp-memory/handlers/memory.py
+++ b/mcp-memory/handlers/memory.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from mcp.types import TextContent
 
 import server  # late-bound — see module docstring
+import write_scrubber  # #555: Tier-2 write-path secret-scrubber gate
 
 # Recall pipeline constants and primitive helpers live in mcp-memory/recall.py
 # (deep-module split, #496). Aliased back to the legacy private names so that
@@ -913,6 +914,23 @@ async def _handle_store(args: dict) -> list[TextContent]:
                 ),
             )
         ]
+
+    # #555: Tier-2 write-path scrubber backstop. Run AFTER validation but
+    # BEFORE any embedding/insert so a blocked write generates no embedding
+    # and lands no row. Reject (not silent-scrub) — the write is intent-bearing.
+    block = write_scrubber.check_write(
+        client,
+        {
+            "name": mem_name,
+            "content": content,
+            "description": description,
+            "tags": tags,
+            "source_provenance": source_provenance,
+        },
+        write_path="memory_store",
+    )
+    if block is not None:
+        return [TextContent(type="text", text=block)]
 
     # Phase 2a: canonical-form embedding — include name + tags + description + content.
     # Name and tags carry high-signal lexical cues that raw content often dilutes

--- a/mcp-memory/handlers/outcome.py
+++ b/mcp-memory/handlers/outcome.py
@@ -14,11 +14,25 @@ from datetime import datetime, timezone  # noqa: F401
 from mcp.types import TextContent  # noqa: F401
 
 import server  # noqa: F401  — late-bound for monkeypatch propagation
+import write_scrubber  # #999: Tier-2 write-path secret-scrubber gate
 
 
 async def _handle_outcome_record(args: dict) -> list[TextContent]:
     """Record a task outcome to task_outcomes table."""
     client = server._get_client()
+
+    # #999: Tier-2 write-path scrubber backstop.
+    block = write_scrubber.check_write(
+        client,
+        {
+            k: args[k]
+            for k in ("task_description", "outcome_summary", "lessons")
+            if k in args and args[k] is not None
+        },
+        write_path="outcome_record",
+    )
+    if block is not None:
+        return [TextContent(type="text", text=block)]
 
     row = {
         "task_type": args["task_type"],
@@ -54,6 +68,19 @@ async def _handle_outcome_update(args: dict) -> list[TextContent]:
     """Update a task outcome (verification, status flip, lessons)."""
     client = server._get_client()
     oid = args["id"]
+
+    # #999: Tier-2 write-path scrubber backstop.
+    block = write_scrubber.check_write(
+        client,
+        {
+            k: args[k]
+            for k in ("outcome_summary", "lessons")
+            if k in args and args[k] is not None
+        },
+        write_path="outcome_update",
+    )
+    if block is not None:
+        return [TextContent(type="text", text=block)]
 
     updates: dict = {}
     for key in (

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -211,17 +211,25 @@ def _dispatch_block_log(client, patterns: dict[str, int], *, write_path: str) ->
     detached task so the rejection returns immediately — the MCP event loop is
     never stalled on a 50–200 ms Supabase round-trip. The task is held in
     ``_PENDING_BLOCK_LOGS`` until done so it cannot be GC-dropped mid-insert.
-    Called synchronously with no running loop (direct unit-test calls) it falls
-    back to an inline insert.
+    Two paths fall back to a synchronous inline insert: (1) no loop is running
+    (direct unit-test calls), and (2) a loop *was* running but is now closing,
+    so ``create_task`` itself raises ``RuntimeError`` during teardown. In both
+    cases the audit event must still be written, so we insert inline.
     """
     try:
         asyncio.get_running_loop()
     except RuntimeError:
         log_block_event(client, patterns, write_path=write_path)
-    else:
+        return
+    try:
         task = asyncio.create_task(_log_block_event_async(client, patterns, write_path=write_path))
-        _PENDING_BLOCK_LOGS.add(task)
-        task.add_done_callback(_PENDING_BLOCK_LOGS.discard)
+    except RuntimeError:
+        # Loop is closing (teardown race) — create_task rejects. The audit event
+        # is non-negotiable, so fall back to a blocking inline insert.
+        log_block_event(client, patterns, write_path=write_path)
+        return
+    _PENDING_BLOCK_LOGS.add(task)
+    task.add_done_callback(_PENDING_BLOCK_LOGS.discard)
 
 
 def check_write(client, fields: dict[str, object], *, write_path: str) -> str | None:

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -12,12 +12,24 @@ payload was blocked rather than silently rewritten.
 Privacy invariant: no value from a blocked payload ever leaves this module.
 Only pattern names + fire counts appear in the rejection error, the
 ``mcp_write_scrubber_block`` counter event, or any log line.
+
+Scope (#555 AC): this gate covers the two free-text write paths named in the
+acceptance criteria — ``memory_store`` and ``record_decision``. Three other
+handlers also persist user free-text (``goal_set``/``goal_update``,
+``outcome_record``/``outcome_update``, ``credential_add``); extending the gate
+to ``goal``/``outcome`` is tracked as a follow-up slice. ``credential_add`` is
+deliberately NOT a candidate — its entire purpose is to store secrets, so a
+reject-gate there would be a contradiction (that store relies on RLS + the
+``credential_registry`` access model, not scrubbing).
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 # The scrubber lib lives under scripts/lib. The live server runtime launches
@@ -30,9 +42,17 @@ if _SCRIPTS.is_dir() and str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 try:
-    from lib.secret_scrubber import scrub  # type: ignore
+    from lib.secret_scrubber import scrub, API_KEY_PATTERNS  # type: ignore
 except Exception:  # noqa: BLE001 — cross-repo (redrobot) may lack scripts/lib
     scrub = None  # type: ignore
+    API_KEY_PATTERNS = []  # type: ignore
+    # Fail-open is intentional (availability > over-blocking) but MUST be loud:
+    # a silent no-op would erase the Tier-2 layer with zero operator signal.
+    print(
+        "[write_scrubber] WARNING: secret_scrubber unavailable — the Tier-2 "
+        "MCP write-path gate is DISABLED; writes will NOT be scanned for secrets.",
+        file=sys.stderr,
+    )
 
 
 # Patterns the scrubber detects but that must NOT hard-block an MCP write.
@@ -44,10 +64,23 @@ except Exception:  # noqa: BLE001 — cross-repo (redrobot) may lack scripts/lib
 # normalization is the SessionEnd/Deriver lane's job (slice 6), not this
 # Tier-2 secret-reject backstop. The genuine-secret patterns (API keys, env
 # blocks) — 0 false positives in the corpus — remain blocking.
-NON_BLOCKING_PATTERNS = frozenset({"path_username"})
+SCRUB_ONLY_PATTERNS = frozenset({"path_username"})
+
+# Guard against silent string-coupling drift: SCRUB_ONLY_PATTERNS names must be
+# real pattern names emitted by secret_scrubber.py. If a pattern is renamed
+# there, this raises at import (loud) instead of letting the frozenset become a
+# no-op that starts hard-blocking every path-containing write.
+_KNOWN_PATTERN_NAMES = {name for name, _ in API_KEY_PATTERNS} | {"env_block", "path_username"}
+if scrub is not None and not SCRUB_ONLY_PATTERNS <= _KNOWN_PATTERN_NAMES:
+    raise RuntimeError(
+        "write_scrubber.SCRUB_ONLY_PATTERNS references pattern name(s) not "
+        f"produced by secret_scrubber: {SCRUB_ONLY_PATTERNS - _KNOWN_PATTERN_NAMES}. "
+        "A rename in secret_scrubber.py silently disables path exclusion — "
+        "update SCRUB_ONLY_PATTERNS in lockstep."
+    )
 
 
-def _iter_strings(value: object):
+def _iter_strings(value: object) -> Iterator[str]:
     """Yield the str values worth scanning out of a field value.
 
     str → itself; list/tuple → each str element; everything else (ints,
@@ -67,13 +100,24 @@ def scan_fields(fields: dict[str, object]) -> dict[str, int]:
     *fields* maps a logical field name → value. Returns a dict of pattern
     name → total fire count across all fields. Empty when nothing fires (or
     when the scrubber lib is unavailable — see module docstring).
+
+    A ``scrub()`` crash is contained per-field (logged + skipped) so a bug in
+    the scrubber cannot take down every MCP write; this is fail-open, matching
+    the unavailable-scrubber stance above.
     """
     if scrub is None:
         return {}
     totals: dict[str, int] = {}
     for value in fields.values():
         for text in _iter_strings(value):
-            _, fires = scrub(text)
+            try:
+                _, fires = scrub(text)
+            except Exception as exc:  # noqa: BLE001 — scrubber bug must not crash writes
+                print(
+                    f"[write_scrubber] scrub() raised, field skipped (fail-open): {exc}",
+                    file=sys.stderr,
+                )
+                continue
             for name, count in fires.items():
                 totals[name] = totals.get(name, 0) + count
     return totals
@@ -88,37 +132,62 @@ def rejection_error(patterns: dict[str, int]) -> str:
 
 
 def log_block_event(client, patterns: dict[str, int], *, write_path: str) -> None:
-    """Fire-and-forget: write an ``mcp_write_scrubber_block`` counter event.
+    """Best-effort: write an ``mcp_write_scrubber_block`` counter event.
 
     Records pattern names + counts only (privacy invariant). *write_path*
     identifies which handler blocked (``memory_store`` / ``record_decision``)
-    so ``/learn`` can surface eager-pattern false positives.
+    so ``/learn`` can surface eager-pattern false positives. Repo slug is
+    env-overridable so cross-repo (redrobot) blocks are attributed correctly.
     """
     try:
         client.table("events").insert(
             {
                 "event_type": "mcp_write_scrubber_block",
                 "severity": "low",
-                "repo": "Osasuwu/jarvis",
+                "repo": os.environ.get("JARVIS_REPO_SLUG", "Osasuwu/jarvis"),
                 "source": "mcp_memory",
                 "title": f"Write blocked by secret scrubber ({write_path})",
                 "payload": {"write_path": write_path, "patterns": patterns},
             }
         ).execute()
-    except Exception:
-        # Logging is best-effort — never let it block the rejection itself.
-        pass
+    except Exception as exc:  # noqa: BLE001 — logging must never block the rejection
+        # Loud-but-non-fatal: a silent pass hides "why are there no block
+        # events in the table?" during debugging.
+        print(f"[write_scrubber] block-event log failed: {exc}", file=sys.stderr)
+
+
+async def _log_block_event_async(client, patterns: dict[str, int], *, write_path: str) -> None:
+    """Coroutine wrapper so the blocking insert can run as a detached task
+    (mirrors ``_emit_recall_event``) instead of stalling the handler response."""
+    log_block_event(client, patterns, write_path=write_path)
+
+
+def _dispatch_block_log(client, patterns: dict[str, int], *, write_path: str) -> None:
+    """Emit the block event off the hot path.
+
+    Inside an async handler (a loop is running) the insert is scheduled as a
+    detached task so the rejection returns immediately — the MCP event loop is
+    never stalled on a 50–200 ms Supabase round-trip. Called synchronously with
+    no running loop (direct unit-test calls) it falls back to an inline insert.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        log_block_event(client, patterns, write_path=write_path)
+    else:
+        asyncio.create_task(_log_block_event_async(client, patterns, write_path=write_path))
 
 
 def check_write(client, fields: dict[str, object], *, write_path: str) -> str | None:
-    """Tier-2 gate. Scan *fields*; on any **blocking** secret fire, log the
-    block event and return the JSON rejection string. Return ``None`` to allow
-    the write. Non-blocking patterns (see ``NON_BLOCKING_PATTERNS``) are
-    ignored — they are normalization concerns, not write-blocking leaks.
+    """Tier-2 gate. Scan *fields*; on any **blocking** secret fire, emit the
+    block event (off the event loop when one is running) and return the JSON
+    rejection string. Return ``None`` to allow the write. Scrub-only patterns
+    (see ``SCRUB_ONLY_PATTERNS``) are ignored — they are normalization
+    concerns, not write-blocking leaks.
     """
     fires = scan_fields(fields)
-    blocking = {k: v for k, v in fires.items() if k not in NON_BLOCKING_PATTERNS}
+    blocking = {k: v for k, v in fires.items() if k not in SCRUB_ONLY_PATTERNS}
     if not blocking:
         return None
-    log_block_event(client, blocking, write_path=write_path)
+    _dispatch_block_log(client, blocking, write_path=write_path)
     return rejection_error(blocking)

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -184,9 +184,15 @@ def log_block_event(client, patterns: dict[str, int], *, write_path: str) -> Non
 
 
 async def _log_block_event_async(client, patterns: dict[str, int], *, write_path: str) -> None:
-    """Coroutine wrapper so the blocking insert can run as a detached task
-    (mirrors ``_emit_recall_event``) instead of stalling the handler response."""
-    log_block_event(client, patterns, write_path=write_path)
+    """Run the blocking insert off the event-loop thread.
+
+    ``log_block_event`` does synchronous Supabase HTTP I/O. Scheduling it via
+    ``create_task`` alone only defers *when* it starts — it would still run the
+    50–200 ms round-trip on the loop thread and stall every other coroutine.
+    ``asyncio.to_thread`` hands it to the default executor so the loop stays
+    free. (The codebase's older fire-and-forget helpers — ``_emit_recall_event``
+    — block the loop directly; this path is the corrected pattern.)"""
+    await asyncio.to_thread(log_block_event, client, patterns, write_path=write_path)
 
 
 # Strong references to in-flight block-log tasks. CPython holds only a *weak*

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -41,7 +41,10 @@ from pathlib import Path
 # instead of silently degrading to a no-op. Tests already put scripts/ on the
 # path (conftest), so the insert is idempotent there.
 _SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
-if _SCRIPTS.is_dir() and str(_SCRIPTS) not in sys.path:
+# Gate on the target FILE existing, not merely a scripts/ dir: a host that has
+# an unrelated scripts/ directory (or a redrobot layout) must not get scripts/
+# prepended to sys.path, where it could shadow a stdlib/site module named `lib`.
+if (_SCRIPTS / "lib" / "secret_scrubber.py").is_file() and str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 try:
@@ -170,6 +173,21 @@ def rejection_error(patterns: dict[str, int]) -> str:
     return json.dumps({"error": "secret_pattern_detected", "patterns": patterns})
 
 
+# High-entropy credential patterns — a fire here means a real, live-key-shaped
+# secret was caught, which the orchestrator should triage above an env-block or
+# (already non-blocking) path. Anything not listed maps to "medium". The block
+# itself prevented the leak, so these are never "critical" (no incident
+# occurred), but severity must reflect *what* was caught for triage indexing.
+_HIGH_SEVERITY_PATTERNS = frozenset(
+    {"api_key_anthropic", "api_key_openai", "api_key_aws", "api_key_github", "api_key_slack"}
+)
+
+
+def _event_severity(patterns: dict[str, int]) -> str:
+    """Map fired patterns → event severity for orchestrator triage indexing."""
+    return "high" if any(p in _HIGH_SEVERITY_PATTERNS for p in patterns) else "medium"
+
+
 def log_block_event(client, patterns: dict[str, int], *, write_path: str) -> None:
     """Best-effort: write an ``mcp_write_scrubber_block`` counter event.
 
@@ -177,12 +195,14 @@ def log_block_event(client, patterns: dict[str, int], *, write_path: str) -> Non
     identifies which handler blocked (``memory_store`` / ``record_decision``)
     so ``/learn`` can surface eager-pattern false positives. Repo slug is
     env-overridable so cross-repo (redrobot) blocks are attributed correctly.
+    Severity reflects which pattern fired (see ``_event_severity``) so an
+    ``sk-ant-*`` catch is not buried at the same priority as an env-block.
     """
     try:
         client.table("events").insert(
             {
                 "event_type": "mcp_write_scrubber_block",
-                "severity": "low",
+                "severity": _event_severity(patterns),
                 "repo": os.environ.get("JARVIS_REPO_SLUG", "Osasuwu/jarvis"),
                 "source": "mcp_memory",
                 "title": f"Write blocked by secret scrubber ({write_path})",
@@ -222,6 +242,24 @@ async def _log_block_event_async(client, patterns: dict[str, int], *, write_path
 _PENDING_BLOCK_LOGS: set[asyncio.Task] = set()
 
 
+def _on_block_log_done(task: asyncio.Task) -> None:
+    """Unpin a finished block-log task and surface any exception eagerly.
+
+    Without retrieving ``task.exception()`` here, a failure inside the detached
+    insert would surface only as a late, value-bearing "Task exception was never
+    retrieved" warning at GC time. We log the exception *type* (privacy) and
+    drop the pin.
+    """
+    _PENDING_BLOCK_LOGS.discard(task)
+    if not task.cancelled():
+        exc = task.exception()
+        if exc is not None:
+            print(
+                f"[write_scrubber] block-log task failed: {type(exc).__name__}",
+                file=sys.stderr,
+            )
+
+
 def _dispatch_block_log(client, patterns: dict[str, int], *, write_path: str) -> None:
     """Emit the block event off the hot path.
 
@@ -247,7 +285,7 @@ def _dispatch_block_log(client, patterns: dict[str, int], *, write_path: str) ->
         log_block_event(client, patterns, write_path=write_path)
         return
     _PENDING_BLOCK_LOGS.add(task)
-    task.add_done_callback(_PENDING_BLOCK_LOGS.discard)
+    task.add_done_callback(_on_block_log_done)
 
 
 def check_write(client, fields: dict[str, object], *, write_path: str) -> str | None:

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -13,12 +13,9 @@ Privacy invariant: no value from a blocked payload ever leaves this module.
 Only pattern names + fire counts appear in the rejection error, the
 ``mcp_write_scrubber_block`` counter event, or any log line.
 
-Scope (#555 AC): this gate covers the two free-text write paths named in the
-acceptance criteria — ``memory_store`` and ``record_decision``. Three other
-handlers also persist user free-text (``goal_set``/``goal_update``,
-``outcome_record``/``outcome_update``, ``credential_add``); extending the gate
-to ``goal``/``outcome`` is tracked as a follow-up slice (#999).
-``credential_add`` is deliberately NOT a candidate — it is the one write path
+Scope (#555 AC + #999 follow-up): this gate covers ``memory_store``,
+``record_decision``, ``goal_set``, ``goal_update``, ``outcome_record``, and
+``outcome_update``. ``credential_add`` is deliberately NOT a candidate — it is the one write path
 whose entire *domain* is credentials. It records credential metadata (env var
 names, provider, expiry) plus free-text note fields (``notes`` /
 ``rotation_notes``) that legitimately discuss key-shaped values; a

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -45,21 +45,39 @@ if _SCRIPTS.is_dir() and str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 try:
-    from lib.secret_scrubber import scrub, API_KEY_PATTERNS  # type: ignore
-except Exception:  # noqa: BLE001 — cross-repo (redrobot) may lack scripts/lib
+    from lib.secret_scrubber import scrub, API_KEY_PATTERNS, EXTRA_PATTERN_NAMES  # type: ignore
+except (ImportError, ModuleNotFoundError):
+    # redrobot path: scripts/lib genuinely absent. Fail-open is intentional
+    # (availability > over-blocking) but MUST be loud: a silent no-op would
+    # erase the Tier-2 layer with zero operator signal. Suppressible via
+    # WRITE_SCRUBBER_QUIET so repos that legitimately lack scripts/lib don't
+    # print this on every cold start forever.
     scrub = None  # type: ignore
     API_KEY_PATTERNS = []  # type: ignore
-    # Fail-open is intentional (availability > over-blocking) but MUST be loud:
-    # a silent no-op would erase the Tier-2 layer with zero operator signal.
-    # Suppressible via WRITE_SCRUBBER_QUIET so repos that legitimately lack
-    # scripts/lib (redrobot) don't print this on every cold start forever.
+    EXTRA_PATTERN_NAMES = frozenset()  # type: ignore
     if not os.environ.get("WRITE_SCRUBBER_QUIET"):
         print(
-            "[write_scrubber] WARNING: secret_scrubber unavailable — the Tier-2 "
-            "MCP write-path gate is DISABLED; writes will NOT be scanned for "
-            "secrets. Set WRITE_SCRUBBER_QUIET=1 to silence (e.g. on redrobot).",
+            "[write_scrubber] WARNING: secret_scrubber unavailable (module absent) "
+            "— the Tier-2 MCP write-path gate is DISABLED; writes will NOT be "
+            "scanned for secrets. Set WRITE_SCRUBBER_QUIET=1 to silence (e.g. on "
+            "redrobot).",
             file=sys.stderr,
         )
+except Exception as exc:  # noqa: BLE001 — module FOUND but broken (syntax error, etc.)
+    # On jarvis scripts/lib exists, so this branch means secret_scrubber.py
+    # itself failed to import (merge-conflict marker, syntax error, bad ref).
+    # Surfacing the actual error type — not the misleading "unavailable" —
+    # is what tells the developer to fix the module rather than hunt a phantom
+    # missing dependency. Type only (no str(exc)) to honour the privacy stance.
+    scrub = None  # type: ignore
+    API_KEY_PATTERNS = []  # type: ignore
+    EXTRA_PATTERN_NAMES = frozenset()  # type: ignore
+    print(
+        "[write_scrubber] ERROR: secret_scrubber import failed — the module was "
+        f"found but is broken ({type(exc).__name__}); the Tier-2 gate is DISABLED. "
+        "Fix scripts/lib/secret_scrubber.py.",
+        file=sys.stderr,
+    )
 
 
 # Patterns the scrubber detects but that must NOT hard-block an MCP write.
@@ -80,7 +98,7 @@ SCRUB_ONLY_PATTERNS = frozenset({"path_username"})
 # than raise: a startup crash would take down the whole (shared) MCP server —
 # disproportionate for a drift whose worst case is over-blocking path writes
 # (fail-safe), not leaking secrets (fail-open). Loud-but-alive beats dead.
-_KNOWN_PATTERN_NAMES = {name for name, _ in API_KEY_PATTERNS} | {"env_block", "path_username"}
+_KNOWN_PATTERN_NAMES = {name for name, _ in API_KEY_PATTERNS} | set(EXTRA_PATTERN_NAMES)
 if scrub is not None and not SCRUB_ONLY_PATTERNS <= _KNOWN_PATTERN_NAMES:
     print(
         "[write_scrubber] WARNING: SCRUB_ONLY_PATTERNS references pattern name(s) "

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -169,6 +169,10 @@ def rejection_error(patterns: dict[str, int]) -> str:
     """Build the structured rejection payload as a JSON string.
 
     Carries ONLY pattern names + counts — never any payload value.
+
+    Returns a JSON *string* (handlers wrap it in a TextContent). #1000 will
+    migrate the MCP write paths to a structured ``dict`` error return; when that
+    lands, this returns the dict directly and the json.dumps moves to the edge.
     """
     return json.dumps({"error": "secret_pattern_detected", "patterns": patterns})
 
@@ -179,7 +183,16 @@ def rejection_error(patterns: dict[str, int]) -> str:
 # itself prevented the leak, so these are never "critical" (no incident
 # occurred), but severity must reflect *what* was caught for triage indexing.
 _HIGH_SEVERITY_PATTERNS = frozenset(
-    {"api_key_anthropic", "api_key_openai", "api_key_aws", "api_key_github", "api_key_slack"}
+    {
+        "api_key_anthropic",
+        "api_key_openai",
+        "api_key_aws",
+        "api_key_github",
+        "api_key_slack",
+        # A leaked JWT is typically a Supabase service-role token — full DB
+        # access, so high-sensitivity alongside the raw API keys.
+        "api_key_jwt",
+    }
 )
 
 

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -17,10 +17,13 @@ Scope (#555 AC): this gate covers the two free-text write paths named in the
 acceptance criteria — ``memory_store`` and ``record_decision``. Three other
 handlers also persist user free-text (``goal_set``/``goal_update``,
 ``outcome_record``/``outcome_update``, ``credential_add``); extending the gate
-to ``goal``/``outcome`` is tracked as a follow-up slice. ``credential_add`` is
-deliberately NOT a candidate — its entire purpose is to store secrets, so a
-reject-gate there would be a contradiction (that store relies on RLS + the
-``credential_registry`` access model, not scrubbing).
+to ``goal``/``outcome`` is tracked as a follow-up slice (#999).
+``credential_add`` is deliberately NOT a candidate — it is the one write path
+whose domain is credentials. It stores credential *metadata* (env var names,
+provider, expiry — the schema rejects raw secret values), so its references to
+key-shaped names are legitimate; a secret-reject gate there would fight the
+handler's own purpose. That path relies on the ``credential_registry`` access
+model, not scrubbing.
 """
 
 from __future__ import annotations
@@ -48,11 +51,15 @@ except Exception:  # noqa: BLE001 — cross-repo (redrobot) may lack scripts/lib
     API_KEY_PATTERNS = []  # type: ignore
     # Fail-open is intentional (availability > over-blocking) but MUST be loud:
     # a silent no-op would erase the Tier-2 layer with zero operator signal.
-    print(
-        "[write_scrubber] WARNING: secret_scrubber unavailable — the Tier-2 "
-        "MCP write-path gate is DISABLED; writes will NOT be scanned for secrets.",
-        file=sys.stderr,
-    )
+    # Suppressible via WRITE_SCRUBBER_QUIET so repos that legitimately lack
+    # scripts/lib (redrobot) don't print this on every cold start forever.
+    if not os.environ.get("WRITE_SCRUBBER_QUIET"):
+        print(
+            "[write_scrubber] WARNING: secret_scrubber unavailable — the Tier-2 "
+            "MCP write-path gate is DISABLED; writes will NOT be scanned for "
+            "secrets. Set WRITE_SCRUBBER_QUIET=1 to silence (e.g. on redrobot).",
+            file=sys.stderr,
+        )
 
 
 # Patterns the scrubber detects but that must NOT hard-block an MCP write.
@@ -68,15 +75,19 @@ SCRUB_ONLY_PATTERNS = frozenset({"path_username"})
 
 # Guard against silent string-coupling drift: SCRUB_ONLY_PATTERNS names must be
 # real pattern names emitted by secret_scrubber.py. If a pattern is renamed
-# there, this raises at import (loud) instead of letting the frozenset become a
-# no-op that starts hard-blocking every path-containing write.
+# there, this warns loudly at import instead of letting the frozenset become a
+# no-op that starts hard-blocking every path-containing write. We warn rather
+# than raise: a startup crash would take down the whole (shared) MCP server —
+# disproportionate for a drift whose worst case is over-blocking path writes
+# (fail-safe), not leaking secrets (fail-open). Loud-but-alive beats dead.
 _KNOWN_PATTERN_NAMES = {name for name, _ in API_KEY_PATTERNS} | {"env_block", "path_username"}
 if scrub is not None and not SCRUB_ONLY_PATTERNS <= _KNOWN_PATTERN_NAMES:
-    raise RuntimeError(
-        "write_scrubber.SCRUB_ONLY_PATTERNS references pattern name(s) not "
-        f"produced by secret_scrubber: {SCRUB_ONLY_PATTERNS - _KNOWN_PATTERN_NAMES}. "
-        "A rename in secret_scrubber.py silently disables path exclusion — "
-        "update SCRUB_ONLY_PATTERNS in lockstep."
+    print(
+        "[write_scrubber] WARNING: SCRUB_ONLY_PATTERNS references pattern name(s) "
+        f"not produced by secret_scrubber: {SCRUB_ONLY_PATTERNS - _KNOWN_PATTERN_NAMES}. "
+        "A rename in secret_scrubber.py disables path exclusion — those writes "
+        "will now be hard-blocked. Update SCRUB_ONLY_PATTERNS in lockstep.",
+        file=sys.stderr,
     )
 
 
@@ -85,6 +96,12 @@ def _iter_strings(value: object) -> Iterator[str]:
 
     str → itself; list/tuple → each str element; everything else (ints,
     None, dicts, floats) is skipped so non-text fields never raise.
+
+    Depth is one level: nested lists (``[["a"]]``) are NOT descended — the
+    inner list is not a str so it yields nothing. All current callers pass
+    flat ``str`` / ``list[str]`` fields, so this is safe today; if a future
+    caller passes nested structure it must flatten first or scanning silently
+    skips the nested text.
     """
     if isinstance(value, str):
         yield value
@@ -108,13 +125,17 @@ def scan_fields(fields: dict[str, object]) -> dict[str, int]:
     if scrub is None:
         return {}
     totals: dict[str, int] = {}
-    for value in fields.values():
+    for field_name, value in fields.items():
         for text in _iter_strings(value):
             try:
                 _, fires = scrub(text)
             except Exception as exc:  # noqa: BLE001 — scrubber bug must not crash writes
+                # Privacy invariant: log only the exception *type* and field
+                # name — never `{exc}`, whose str() could embed the input text
+                # (e.g. a regex-engine error carrying match context).
                 print(
-                    f"[write_scrubber] scrub() raised, field skipped (fail-open): {exc}",
+                    f"[write_scrubber] scrub() raised on field {field_name!r}, "
+                    f"skipped (fail-open): {type(exc).__name__}",
                     file=sys.stderr,
                 )
                 continue
@@ -152,8 +173,14 @@ def log_block_event(client, patterns: dict[str, int], *, write_path: str) -> Non
         ).execute()
     except Exception as exc:  # noqa: BLE001 — logging must never block the rejection
         # Loud-but-non-fatal: a silent pass hides "why are there no block
-        # events in the table?" during debugging.
-        print(f"[write_scrubber] block-event log failed: {exc}", file=sys.stderr)
+        # events in the table?" during debugging. Log only the exception type —
+        # the row we tried to insert carries pattern names + counts, but a
+        # client-layer error str() could still echo request context, so stay
+        # value-free here too.
+        print(
+            f"[write_scrubber] block-event log failed: {type(exc).__name__}",
+            file=sys.stderr,
+        )
 
 
 async def _log_block_event_async(client, patterns: dict[str, int], *, write_path: str) -> None:
@@ -162,20 +189,33 @@ async def _log_block_event_async(client, patterns: dict[str, int], *, write_path
     log_block_event(client, patterns, write_path=write_path)
 
 
+# Strong references to in-flight block-log tasks. CPython holds only a *weak*
+# reference to a task returned by asyncio.create_task; if nothing else keeps it
+# alive the GC can collect it mid-run, silently dropping the insert. For a
+# security audit event that is unacceptable — so we pin each task here and drop
+# it on completion. (See https://docs.python.org/3/library/asyncio-task.html
+# #asyncio.create_task — "Save a reference to the result of this function".)
+_PENDING_BLOCK_LOGS: set[asyncio.Task] = set()
+
+
 def _dispatch_block_log(client, patterns: dict[str, int], *, write_path: str) -> None:
     """Emit the block event off the hot path.
 
     Inside an async handler (a loop is running) the insert is scheduled as a
     detached task so the rejection returns immediately — the MCP event loop is
-    never stalled on a 50–200 ms Supabase round-trip. Called synchronously with
-    no running loop (direct unit-test calls) it falls back to an inline insert.
+    never stalled on a 50–200 ms Supabase round-trip. The task is held in
+    ``_PENDING_BLOCK_LOGS`` until done so it cannot be GC-dropped mid-insert.
+    Called synchronously with no running loop (direct unit-test calls) it falls
+    back to an inline insert.
     """
     try:
         asyncio.get_running_loop()
     except RuntimeError:
         log_block_event(client, patterns, write_path=write_path)
     else:
-        asyncio.create_task(_log_block_event_async(client, patterns, write_path=write_path))
+        task = asyncio.create_task(_log_block_event_async(client, patterns, write_path=write_path))
+        _PENDING_BLOCK_LOGS.add(task)
+        task.add_done_callback(_PENDING_BLOCK_LOGS.discard)
 
 
 def check_write(client, fields: dict[str, object], *, write_path: str) -> str | None:

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -19,11 +19,13 @@ handlers also persist user free-text (``goal_set``/``goal_update``,
 ``outcome_record``/``outcome_update``, ``credential_add``); extending the gate
 to ``goal``/``outcome`` is tracked as a follow-up slice (#999).
 ``credential_add`` is deliberately NOT a candidate — it is the one write path
-whose domain is credentials. It stores credential *metadata* (env var names,
-provider, expiry — the schema rejects raw secret values), so its references to
-key-shaped names are legitimate; a secret-reject gate there would fight the
-handler's own purpose. That path relies on the ``credential_registry`` access
-model, not scrubbing.
+whose entire *domain* is credentials. It records credential metadata (env var
+names, provider, expiry) plus free-text note fields (``notes`` /
+``rotation_notes``) that legitimately discuss key-shaped values; a
+secret-reject gate there would fight the handler's own purpose (it exists to
+catalogue credentials, so naming one is expected, not a leak). The structured
+value columns reject raw secrets at the schema level; the notes fields rely on
+the ``credential_registry`` access model, not scrubbing.
 """
 
 from __future__ import annotations
@@ -32,6 +34,7 @@ import asyncio
 import json
 import os
 import sys
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -99,8 +102,9 @@ SCRUB_ONLY_PATTERNS = frozenset({"path_username"})
 # there, this warns loudly at import instead of letting the frozenset become a
 # no-op that starts hard-blocking every path-containing write. We warn rather
 # than raise: a startup crash would take down the whole (shared) MCP server —
-# disproportionate for a drift whose worst case is over-blocking path writes
-# (fail-safe), not leaking secrets (fail-open). Loud-but-alive beats dead.
+# disproportionate for a drift whose worst case is a functional regression
+# (path writes hard-blocked), not a secret leak (fail-open). Loud-but-alive
+# beats dead.
 _KNOWN_PATTERN_NAMES = {name for name, _ in API_KEY_PATTERNS} | set(EXTRA_PATTERN_NAMES)
 if scrub is not None and not SCRUB_ONLY_PATTERNS <= _KNOWN_PATTERN_NAMES:
     print(
@@ -192,6 +196,8 @@ _HIGH_SEVERITY_PATTERNS = frozenset(
         # A leaked JWT is typically a Supabase service-role token — full DB
         # access, so high-sensitivity alongside the raw API keys.
         "api_key_jwt",
+        # VoyageAI embedding key — a real live credential for this codebase.
+        "api_key_voyageai",
     }
 )
 
@@ -199,6 +205,16 @@ _HIGH_SEVERITY_PATTERNS = frozenset(
 def _event_severity(patterns: dict[str, int]) -> str:
     """Map fired patterns → event severity for orchestrator triage indexing."""
     return "high" if any(p in _HIGH_SEVERITY_PATTERNS for p in patterns) else "medium"
+
+
+# Serialize the audit insert: concurrent blocked writes dispatch their block
+# events via asyncio.to_thread, which runs them on separate executor threads
+# against the *same* Supabase client singleton. httpx.Client is generally
+# thread-safe for concurrent requests, but the surrounding supabase-py
+# query-builder is not documented as such, and a corrupted/dropped audit event
+# is a security-signal loss. The insert is a single short round-trip on a rare
+# path (only fires on a detected secret), so serializing it is cheap insurance.
+_BLOCK_LOG_LOCK = threading.Lock()
 
 
 def log_block_event(client, patterns: dict[str, int], *, write_path: str) -> None:
@@ -210,18 +226,22 @@ def log_block_event(client, patterns: dict[str, int], *, write_path: str) -> Non
     env-overridable so cross-repo (redrobot) blocks are attributed correctly.
     Severity reflects which pattern fired (see ``_event_severity``) so an
     ``sk-ant-*`` catch is not buried at the same priority as an env-block.
+
+    Serialized via ``_BLOCK_LOG_LOCK`` so concurrent ``to_thread`` dispatches
+    don't drive the shared client singleton from two threads at once.
     """
     try:
-        client.table("events").insert(
-            {
-                "event_type": "mcp_write_scrubber_block",
-                "severity": _event_severity(patterns),
-                "repo": os.environ.get("JARVIS_REPO_SLUG", "Osasuwu/jarvis"),
-                "source": "mcp_memory",
-                "title": f"Write blocked by secret scrubber ({write_path})",
-                "payload": {"write_path": write_path, "patterns": patterns},
-            }
-        ).execute()
+        with _BLOCK_LOG_LOCK:
+            client.table("events").insert(
+                {
+                    "event_type": "mcp_write_scrubber_block",
+                    "severity": _event_severity(patterns),
+                    "repo": os.environ.get("JARVIS_REPO_SLUG", "Osasuwu/jarvis"),
+                    "source": "mcp_memory",
+                    "title": f"Write blocked by secret scrubber ({write_path})",
+                    "payload": {"write_path": write_path, "patterns": patterns},
+                }
+            ).execute()
     except Exception as exc:  # noqa: BLE001 — logging must never block the rejection
         # Loud-but-non-fatal: a silent pass hides "why are there no block
         # events in the table?" during debugging. Log only the exception type —

--- a/mcp-memory/write_scrubber.py
+++ b/mcp-memory/write_scrubber.py
@@ -1,0 +1,124 @@
+"""MCP write-path Tier-2 secret-scrubber gate (#555).
+
+The slice-3 scrubber (``scripts/lib/secret_scrubber.py``) is applied at the
+MCP write boundary. This is the Tier-2 backstop in the two-layer privacy
+model (decision ``eb62980e``, ADR-0003): even if the SessionEnd hook scrubber
+(slice 6) leaks, MCP writes still cannot land secrets.
+
+When any pattern fires on user-supplied text, the write is **rejected** — not
+silently scrubbed. The write is intent-bearing, so the sender must know the
+payload was blocked rather than silently rewritten.
+
+Privacy invariant: no value from a blocked payload ever leaves this module.
+Only pattern names + fire counts appear in the rejection error, the
+``mcp_write_scrubber_block`` counter event, or any log line.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# The scrubber lib lives under scripts/lib. The live server runtime launches
+# server.py from mcp-memory/ (via run-memory-server.py), so scripts/ is NOT on
+# sys.path by default — add it here so jarvis always loads the real gate
+# instead of silently degrading to a no-op. Tests already put scripts/ on the
+# path (conftest), so the insert is idempotent there.
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if _SCRIPTS.is_dir() and str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+try:
+    from lib.secret_scrubber import scrub  # type: ignore
+except Exception:  # noqa: BLE001 — cross-repo (redrobot) may lack scripts/lib
+    scrub = None  # type: ignore
+
+
+# Patterns the scrubber detects but that must NOT hard-block an MCP write.
+# `path_username` is a privacy *normalization* (scrub-and-keep), not a secret
+# leak: ~26% of the live memory corpus (214/832) legitimately contains absolute
+# user paths (`C:\Users\<name>\…`, `/Users/<name>/…`). Hard-rejecting those
+# would violate AC#4 ("no false-positive blocks on real-world content") and
+# break a quarter of all memory writes that reference a file path. Path
+# normalization is the SessionEnd/Deriver lane's job (slice 6), not this
+# Tier-2 secret-reject backstop. The genuine-secret patterns (API keys, env
+# blocks) — 0 false positives in the corpus — remain blocking.
+NON_BLOCKING_PATTERNS = frozenset({"path_username"})
+
+
+def _iter_strings(value: object):
+    """Yield the str values worth scanning out of a field value.
+
+    str → itself; list/tuple → each str element; everything else (ints,
+    None, dicts, floats) is skipped so non-text fields never raise.
+    """
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            if isinstance(item, str):
+                yield item
+
+
+def scan_fields(fields: dict[str, object]) -> dict[str, int]:
+    """Run the scrubber over each text field, return aggregate fire counts.
+
+    *fields* maps a logical field name → value. Returns a dict of pattern
+    name → total fire count across all fields. Empty when nothing fires (or
+    when the scrubber lib is unavailable — see module docstring).
+    """
+    if scrub is None:
+        return {}
+    totals: dict[str, int] = {}
+    for value in fields.values():
+        for text in _iter_strings(value):
+            _, fires = scrub(text)
+            for name, count in fires.items():
+                totals[name] = totals.get(name, 0) + count
+    return totals
+
+
+def rejection_error(patterns: dict[str, int]) -> str:
+    """Build the structured rejection payload as a JSON string.
+
+    Carries ONLY pattern names + counts — never any payload value.
+    """
+    return json.dumps({"error": "secret_pattern_detected", "patterns": patterns})
+
+
+def log_block_event(client, patterns: dict[str, int], *, write_path: str) -> None:
+    """Fire-and-forget: write an ``mcp_write_scrubber_block`` counter event.
+
+    Records pattern names + counts only (privacy invariant). *write_path*
+    identifies which handler blocked (``memory_store`` / ``record_decision``)
+    so ``/learn`` can surface eager-pattern false positives.
+    """
+    try:
+        client.table("events").insert(
+            {
+                "event_type": "mcp_write_scrubber_block",
+                "severity": "low",
+                "repo": "Osasuwu/jarvis",
+                "source": "mcp_memory",
+                "title": f"Write blocked by secret scrubber ({write_path})",
+                "payload": {"write_path": write_path, "patterns": patterns},
+            }
+        ).execute()
+    except Exception:
+        # Logging is best-effort — never let it block the rejection itself.
+        pass
+
+
+def check_write(client, fields: dict[str, object], *, write_path: str) -> str | None:
+    """Tier-2 gate. Scan *fields*; on any **blocking** secret fire, log the
+    block event and return the JSON rejection string. Return ``None`` to allow
+    the write. Non-blocking patterns (see ``NON_BLOCKING_PATTERNS``) are
+    ignored — they are normalization concerns, not write-blocking leaks.
+    """
+    fires = scan_fields(fields)
+    blocking = {k: v for k, v in fires.items() if k not in NON_BLOCKING_PATTERNS}
+    if not blocking:
+        return None
+    log_block_event(client, blocking, write_path=write_path)
+    return rejection_error(blocking)

--- a/scripts/lib/secret_scrubber.py
+++ b/scripts/lib/secret_scrubber.py
@@ -42,6 +42,11 @@ PAT_API_KEY_GITHUB = re.compile(r"ghp_[A-Za-z0-9]{30,}")
 PAT_API_KEY_SLACK = re.compile(r"xox[baprs]-[A-Za-z0-9-]{12,}")
 PAT_API_KEY_JWT = re.compile(r"eyJ[A-Za-z0-9_=-]+\.eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+")
 PAT_API_KEY_AWS = re.compile(r"AKIA[0-9A-Z]{16}")
+# VoyageAI keys (`pa-<entropy>`) — this codebase actively reads VOYAGE_API_KEY
+# for embeddings, so a Voyage key is a realistic leak vector here. Require
+# {32,} alphanumerics after the `pa-` prefix (real keys carry ~40+) to keep the
+# false-positive surface near zero — the short prefix alone would be too eager.
+PAT_API_KEY_VOYAGEAI = re.compile(r"pa-[A-Za-z0-9]{32,}")
 
 # Combined API key patterns for counting. Anthropic is first so `sk-ant-*` is
 # attributed to its own pattern, not partially mangled by the OpenAI pass.
@@ -52,6 +57,7 @@ API_KEY_PATTERNS: list[tuple[str, re.Pattern]] = [
     ("api_key_slack", PAT_API_KEY_SLACK),
     ("api_key_jwt", PAT_API_KEY_JWT),
     ("api_key_aws", PAT_API_KEY_AWS),
+    ("api_key_voyageai", PAT_API_KEY_VOYAGEAI),
 ]
 
 # Non-API-key pattern names emitted by scrub() (the env-block + path passes).

--- a/scripts/lib/secret_scrubber.py
+++ b/scripts/lib/secret_scrubber.py
@@ -34,7 +34,9 @@ from typing import Tuple
 # length 3, so the OpenAI pattern never catches an Anthropic key. This is the
 # credential type most likely to surface in *this* codebase (every Claude Code
 # session handles `sk-ant-*` keys), so a dedicated pattern is non-negotiable.
-PAT_API_KEY_ANTHROPIC = re.compile(r"sk-ant-[A-Za-z0-9-]{20,}")
+# Real sk-ant-api03 keys carry ~60-90 entropy chars after the 12-char prefix;
+# require {30,} (like the GitHub pattern) to keep the false-positive surface low.
+PAT_API_KEY_ANTHROPIC = re.compile(r"sk-ant-[A-Za-z0-9-]{30,}")
 PAT_API_KEY_OPENAI = re.compile(r"sk-[A-Za-z0-9]{20,}")
 PAT_API_KEY_GITHUB = re.compile(r"ghp_[A-Za-z0-9]{30,}")
 PAT_API_KEY_SLACK = re.compile(r"xox[baprs]-[A-Za-z0-9-]{12,}")

--- a/scripts/lib/secret_scrubber.py
+++ b/scripts/lib/secret_scrubber.py
@@ -5,8 +5,8 @@ returns scrubbed text plus a dict of per-pattern fire counts.  Zero-count
 dict when no patterns fire.
 
 Patterns redacted:
-  - API key prefixes (OpenAI ``sk-``, GitHub ``ghp_``, Slack ``xox[baprs]-``,
-    JWT ``eyJ…``, AWS ``AKIA``)
+  - API key prefixes (Anthropic ``sk-ant-``, OpenAI ``sk-``, GitHub ``ghp_``,
+    Slack ``xox[baprs]-``, JWT ``eyJ…``, AWS ``AKIA``)
   - ``.env`` blocks (lines matching ``^[A-Z_]+=.{8,}$`` inside fenced or
     labelled env content)
   - Path normalisation (Windows ``C:\\Users\\<name>\\…``, macOS
@@ -28,20 +28,35 @@ from typing import Tuple
 
 # API key / token prefixes — match the key prefix plus sufficient entropy
 # to avoid false positives on short random strings.
+#
+# Anthropic keys (`sk-ant-api03-<entropy>`) must be matched BEFORE the OpenAI
+# pattern: the `-` after `sk-ant` terminates OpenAI's `[A-Za-z0-9]{20,}` run at
+# length 3, so the OpenAI pattern never catches an Anthropic key. This is the
+# credential type most likely to surface in *this* codebase (every Claude Code
+# session handles `sk-ant-*` keys), so a dedicated pattern is non-negotiable.
+PAT_API_KEY_ANTHROPIC = re.compile(r"sk-ant-[A-Za-z0-9-]{20,}")
 PAT_API_KEY_OPENAI = re.compile(r"sk-[A-Za-z0-9]{20,}")
 PAT_API_KEY_GITHUB = re.compile(r"ghp_[A-Za-z0-9]{30,}")
 PAT_API_KEY_SLACK = re.compile(r"xox[baprs]-[A-Za-z0-9-]{12,}")
 PAT_API_KEY_JWT = re.compile(r"eyJ[A-Za-z0-9_=-]+\.eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+")
 PAT_API_KEY_AWS = re.compile(r"AKIA[0-9A-Z]{16}")
 
-# Combined API key patterns for counting
+# Combined API key patterns for counting. Anthropic is first so `sk-ant-*` is
+# attributed to its own pattern, not partially mangled by the OpenAI pass.
 API_KEY_PATTERNS: list[tuple[str, re.Pattern]] = [
+    ("api_key_anthropic", PAT_API_KEY_ANTHROPIC),
     ("api_key_openai", PAT_API_KEY_OPENAI),
     ("api_key_github", PAT_API_KEY_GITHUB),
     ("api_key_slack", PAT_API_KEY_SLACK),
     ("api_key_jwt", PAT_API_KEY_JWT),
     ("api_key_aws", PAT_API_KEY_AWS),
 ]
+
+# Non-API-key pattern names emitted by scrub() (the env-block + path passes).
+# Exported so consumers (write_scrubber) derive their known-name set from the
+# source of truth instead of hardcoding string literals that silently drift if
+# a pattern is renamed here. Keep in lockstep with the fires keys set below.
+EXTRA_PATTERN_NAMES: frozenset[str] = frozenset({"env_block", "path_username"})
 
 # .env block detection: lines matching `^[A-Z_]+=.{8,}$` inside env content.
 # Matches fenced blocks where the language is "env" / "dotenv" / ".env", or a

--- a/tests/test_record_decision_handler.py
+++ b/tests/test_record_decision_handler.py
@@ -165,7 +165,9 @@ class TestRecordDecisionInsert:
     @pytest.mark.asyncio
     async def test_db_failure_returns_error_text(self, monkeypatch):
         client = MagicMock()
-        client.table.return_value.insert.return_value.execute.side_effect = RuntimeError("boom")
+        client.table.return_value.insert.return_value.execute.side_effect = RuntimeError(
+            "boom: secret-bearing context"
+        )
         monkeypatch.setattr("server._get_client", lambda: client)
 
         result = await _handle_record_decision(
@@ -175,7 +177,11 @@ class TestRecordDecisionInsert:
                 "reversibility": "reversible",
             }
         )
-        assert "boom" in result[0].text
+        # Privacy: the error surfaces the exception *type* only, never str(exc).
+        # A DB-layer error str() can echo the failed row (which carries the
+        # caller's free text), so the leaky `{exc}` was replaced by the type.
+        assert "RuntimeError" in result[0].text
+        assert "boom" not in result[0].text
 
     # ---- End-to-end: memories_used resolution ----
 

--- a/tests/test_record_decision_handler.py
+++ b/tests/test_record_decision_handler.py
@@ -216,6 +216,37 @@ class TestRecordDecisionInsert:
             f"episode was written despite a blocked project field: {insert_payloads!r}"
         )
 
+    @pytest.mark.asyncio
+    async def test_secret_in_memories_used_blocks_write(self, monkeypatch):
+        """#555 round-10 M1: an unresolved entry in ``memories_used`` is
+        preserved verbatim in ``payload.memories_used_unresolved`` and echoed in
+        the response, so a secret there bypasses the gate unless scanned. The
+        gate must scan ``memories_used`` BEFORE resolution and reject."""
+        client = make_client("ep-blocked")
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        fake_key = "sk-ant-" + "api03-" + "0123456789abcdefghijABCDEFG"
+        result = await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+                "memories_used": [fake_key],
+            }
+        )
+        text = result[0].text
+        assert "secret_pattern_detected" in text
+        assert "api_key_anthropic" in text
+        assert fake_key not in text
+        insert_payloads = [
+            c.args[0]
+            for c in client.table.return_value.insert.call_args_list
+            if c.args
+        ]
+        assert not any("decision" in p for p in insert_payloads), (
+            f"episode written despite a blocked memories_used entry: {insert_payloads!r}"
+        )
+
     # ---- End-to-end: memories_used resolution ----
 
     @pytest.mark.asyncio

--- a/tests/test_record_decision_handler.py
+++ b/tests/test_record_decision_handler.py
@@ -183,6 +183,39 @@ class TestRecordDecisionInsert:
         assert "RuntimeError" in result[0].text
         assert "boom" not in result[0].text
 
+    @pytest.mark.asyncio
+    async def test_secret_in_project_field_blocks_write(self, monkeypatch):
+        """#555 round-10 MINOR-2: the decision gate scans ``project`` (it
+        persists to episodes.payload.project), so a secret there is rejected —
+        no episode insert — matching the store gate's field coverage."""
+        client = make_client("ep-blocked")
+        monkeypatch.setattr("server._get_client", lambda: client)
+
+        fake_key = "sk-ant-" + "api03-" + "0123456789abcdefghijABCDEFG"
+        result = await _handle_record_decision(
+            {
+                "decision": "x",
+                "rationale": "y",
+                "reversibility": "reversible",
+                "project": fake_key,
+            }
+        )
+        text = result[0].text
+        assert "secret_pattern_detected" in text
+        assert "api_key_anthropic" in text
+        # Privacy: the offending value never appears in the rejection.
+        assert fake_key not in text
+        # Rejected before the episode write: no insert carries a decision-shaped
+        # payload (the only other insert that may fire is the events block-log).
+        insert_payloads = [
+            c.args[0]
+            for c in client.table.return_value.insert.call_args_list
+            if c.args
+        ]
+        assert not any("decision" in p for p in insert_payloads), (
+            f"episode was written despite a blocked project field: {insert_payloads!r}"
+        )
+
     # ---- End-to-end: memories_used resolution ----
 
     @pytest.mark.asyncio

--- a/tests/test_secret_scrubber.py
+++ b/tests/test_secret_scrubber.py
@@ -100,6 +100,24 @@ def test_aws_key_negative():
     assert fires == {}
 
 
+def test_voyageai_key_redacted():
+    """VoyageAI `pa-<entropy>` keys must be caught — this codebase reads
+    VOYAGE_API_KEY, so a Voyage key is a realistic leak vector here."""
+    k = "pa-" + "0123456789abcdefghijABCDEFGHIJ0123456789"
+    cleaned, fires = scrub(f"export VOYAGE_API_KEY={k}")
+    assert "<<REDACTED:api_key_voyageai>>" in cleaned
+    assert fires["api_key_voyageai"] == 1
+    assert k not in cleaned
+
+
+def test_voyageai_key_negative():
+    """Short `pa-` runs (a word like 'pa-11' or prose) must NOT fire — the
+    {32,} entropy floor keeps the false-positive surface near zero."""
+    cleaned, fires = scrub("pa-11 is a typo for the pa-system")
+    assert cleaned == "pa-11 is a typo for the pa-system"
+    assert fires == {}
+
+
 # ── .env blocks ──────────────────────────────────────────────────────────
 
 ENV_BLOCK_SAMPLE = """Here is my config:

--- a/tests/test_secret_scrubber.py
+++ b/tests/test_secret_scrubber.py
@@ -3,6 +3,7 @@
 Covers each pattern: positive (redacts) + negative (no false positive on
 natural text).
 """
+
 from __future__ import annotations
 
 import sys
@@ -15,6 +16,7 @@ from lib.secret_scrubber import scrub
 
 # ── API keys ────────────────────────────────────────────────────────────
 
+
 def test_openai_key_redacted():
     k = "sk-proj" + "AbCdEfGhIjKlMnOpQrStUvWxYz"
     cleaned, fires = scrub(f"my key is {k}")
@@ -26,6 +28,26 @@ def test_openai_key_negative():
     """Short sk- prefix (not enough entropy) should NOT fire."""
     cleaned, fires = scrub("sk-test")
     assert cleaned == "sk-test"
+    assert fires == {}
+
+
+def test_anthropic_key_redacted():
+    """sk-ant-api03-<entropy> must be caught by the dedicated Anthropic pattern.
+    The `-` after `sk-ant` breaks the OpenAI run at 3 chars, so without this
+    pattern the key would slip the gate entirely (the bug round-7 surfaced)."""
+    k = "sk-ant-" + "api03-" + "0123456789abcdefghijABCDEFG"
+    cleaned, fires = scrub(f"export ANTHROPIC_API_KEY={k}")
+    assert "<<REDACTED:api_key_anthropic>>" in cleaned
+    assert fires.get("api_key_anthropic") == 1
+    # Attributed to its own pattern — not partially mangled as api_key_openai.
+    assert "api_key_openai" not in fires
+    assert k not in cleaned
+
+
+def test_anthropic_key_negative():
+    """Short sk-ant- prefix without enough entropy ({30,}) should NOT fire."""
+    cleaned, fires = scrub("sk-ant-test")
+    assert cleaned == "sk-ant-test"
     assert fires == {}
 
 
@@ -116,6 +138,7 @@ def test_env_block_negative():
 
 # ── Path normalisation ───────────────────────────────────────────────────
 
+
 def test_linux_path_redacted():
     cleaned, fires = scrub("I work at /home/alice/projects/jarvis")
     assert "<USER_PATH>/projects/jarvis" in cleaned
@@ -152,6 +175,7 @@ def test_multiple_paths():
 
 
 # ── Empty / no-op ────────────────────────────────────────────────────────
+
 
 def test_clean_text_unchanged():
     cleaned, fires = scrub("Hello world, this is normal text.")

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -51,6 +51,24 @@ BLOCKING_PATTERN_CASES = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def _clear_pending():
+    """Isolate the module-level ``_PENDING_BLOCK_LOGS`` set between tests.
+
+    The set pins in-flight detached block-log tasks (GC-pinning, see
+    write_scrubber). It is process-global, so without this fixture a task
+    scheduled by one test bleeds into the next — making
+    ``test_block_event_is_actually_logged_on_async_path`` able to pass
+    *vacuously* off a stale task, and letting TestDecisionGate's blocking
+    tests leak tasks forward. Clearing before AND after each test gives every
+    test a clean view; the per-test event loop teardown cancels any tasks we
+    drop the strong ref to here.
+    """
+    write_scrubber._PENDING_BLOCK_LOGS.clear()
+    yield
+    write_scrubber._PENDING_BLOCK_LOGS.clear()
+
+
 # ── scan_fields ───────────────────────────────────────────────────────────
 
 
@@ -139,7 +157,9 @@ class TestLogBlockEvent:
         client.table.assert_called_with("events")
         row = client.table.return_value.insert.call_args.args[0]
         assert row["event_type"] == "mcp_write_scrubber_block"
-        assert row["severity"] in ("critical", "high", "medium", "low", "info")
+        # Block events are a low-severity counter signal, not an alert — pinned
+        # exactly so a future bump to a noisier severity is a deliberate change.
+        assert row["severity"] == "low"
         assert row["repo"] == "Osasuwu/jarvis"
         assert row["payload"]["patterns"] == {"api_key_openai": 2}
         assert row["payload"]["write_path"] == "memory_store"
@@ -334,6 +354,29 @@ class TestStoreGate:
         )
         assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
 
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("description", f"see {FAKE_OPENAI_KEY}"),
+            ("tags", ["fine", FAKE_OPENAI_KEY]),
+            ("source_provenance", f"external:{FAKE_OPENAI_KEY}"),
+        ],
+    )
+    async def test_secret_in_other_scanned_fields_blocks(self, field, value):
+        """Every field the store gate scans must block, not just name/content —
+        otherwise a secret could slip in through description/tags/provenance."""
+        args = {
+            "type": "project",
+            "name": "fine",
+            "content": "clean content",
+            "project": "jarvis",
+            "source_provenance": "session:test",
+        }
+        args[field] = value
+        result = await _handle_store(args)
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+        assert self.embed_calls == []
+
     async def test_clean_store_passes_gate(self):
         tbl = MagicMock()
         tbl.upsert.return_value.execute.return_value = MagicMock(data=[{"id": "ok-1"}])
@@ -410,6 +453,26 @@ class TestDecisionGate:
             }
         )
         assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_actor_blocks(self, monkeypatch):
+        """``actor`` is in the decision gate's scanned set — a secret there must
+        block just like decision/rationale/alternatives."""
+        client = make_client("ep-blocked")
+        monkeypatch.setattr(server_module, "_get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": "clean decision",
+                "rationale": "clean rationale",
+                "reversibility": "reversible",
+                "actor": f"session:{FAKE_OPENAI_KEY}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+        episode_inserts = [
+            c for c in client.table.call_args_list if c.args and c.args[0] == "episodes"
+        ]
+        assert episode_inserts == []
 
     async def test_clean_decision_passes_gate(self, monkeypatch):
         client = make_client("ep-ok")

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -106,17 +106,22 @@ class TestScanFields:
     def test_scrub_raising_is_contained_per_field(self, monkeypatch):
         """MAJOR-fix: a scrub() crash on one field must fail OPEN (skip that
         field, keep scanning the rest) — never propagate and crash the write.
-        Also asserts the field name is logged but the value is not."""
+        The surviving field still contributes its fires, proving containment
+        skips only the crashing field and does not abort the whole scan."""
 
         def _boom(text):
             if "BOOM" in text:
                 raise ValueError("scrubber exploded")
-            return text, {}
+            n = text.count(FAKE_OPENAI_KEY)
+            return text, ({"api_key_openai": n} if n else {})
 
         monkeypatch.setattr(write_scrubber, "scrub", _boom)
-        # First field raises, second is clean → no exception, empty totals.
-        fires = write_scrubber.scan_fields({"bad": "trigger BOOM here", "good": "ordinary text"})
-        assert fires == {}
+        # First field raises (skipped), second still fires → the secret in the
+        # surviving field is reported despite the sibling crash.
+        fires = write_scrubber.scan_fields(
+            {"bad": "trigger BOOM here", "good": f"key {FAKE_OPENAI_KEY}"}
+        )
+        assert fires == {"api_key_openai": 1}
 
     def test_scrub_raising_does_not_leak_value_to_stderr(self, monkeypatch, capsys):
         """Privacy invariant: the per-field crash log carries the exception
@@ -162,20 +167,76 @@ class TestLogBlockEvent:
         client.table.assert_called_with("events")
         row = client.table.return_value.insert.call_args.args[0]
         assert row["event_type"] == "mcp_write_scrubber_block"
-        # Block events are a low-severity counter signal, not an alert — pinned
-        # exactly so a future bump to a noisier severity is a deliberate change.
-        assert row["severity"] == "low"
+        # An API-key fire is high-severity for triage indexing (see
+        # _event_severity) — a live-key-shaped catch must not be buried at the
+        # same priority as an env-block.
+        assert row["severity"] == "high"
         assert row["repo"] == "Osasuwu/jarvis"
         assert row["payload"]["patterns"] == {"api_key_openai": 2}
         assert row["payload"]["write_path"] == "memory_store"
         # No payload value leaks into the event row.
         assert FAKE_OPENAI_KEY not in json.dumps(row)
 
+    def test_severity_reflects_caught_pattern(self):
+        """High-entropy credential patterns → "high"; everything else (e.g. an
+        env block) → "medium". Pinned so the triage-index mapping is a
+        deliberate change, not an accidental flatten back to one severity."""
+        client = MagicMock()
+        write_scrubber.log_block_event(client, {"api_key_anthropic": 1}, write_path="memory_store")
+        assert client.table.return_value.insert.call_args.args[0]["severity"] == "high"
+
+        client.reset_mock()
+        write_scrubber.log_block_event(client, {"env_block": 1}, write_path="memory_store")
+        assert client.table.return_value.insert.call_args.args[0]["severity"] == "medium"
+
     def test_swallows_db_errors(self):
         client = MagicMock()
         client.table.side_effect = Exception("DB down")
         # Must not raise — logging is fire-and-forget.
         write_scrubber.log_block_event(client, {"x": 1}, write_path="memory_store")
+
+
+# ── _dispatch_block_log fallback branches ─────────────────────────────────
+
+
+class TestDispatchBlockLog:
+    def test_no_loop_runs_inline(self, monkeypatch):
+        """Called outside any running loop (direct unit-test / sync caller) →
+        the audit insert runs inline rather than being lost to a create_task
+        that has no loop to schedule on."""
+        called: list = []
+        monkeypatch.setattr(
+            write_scrubber,
+            "log_block_event",
+            lambda c, p, *, write_path: called.append((p, write_path)),
+        )
+        write_scrubber._dispatch_block_log(
+            MagicMock(), {"api_key_openai": 1}, write_path="memory_store"
+        )
+        assert called == [({"api_key_openai": 1}, "memory_store")]
+
+    async def test_teardown_race_falls_back_to_inline(self, monkeypatch):
+        """A loop IS running but create_task raises RuntimeError (loop closing
+        during teardown). The audit event is non-negotiable, so the dispatcher
+        must fall back to a synchronous inline insert rather than swallow it."""
+        called: list = []
+        monkeypatch.setattr(
+            write_scrubber,
+            "log_block_event",
+            lambda c, p, *, write_path: called.append((p, write_path)),
+        )
+
+        def _raise(coro):
+            coro.close()  # avoid "coroutine was never awaited" noise
+            raise RuntimeError("loop is closing")
+
+        monkeypatch.setattr(write_scrubber.asyncio, "create_task", _raise)
+        write_scrubber._dispatch_block_log(
+            MagicMock(), {"api_key_aws": 1}, write_path="record_decision"
+        )
+        assert called == [({"api_key_aws": 1}, "record_decision")]
+        # Nothing was pinned — the task was never created.
+        assert not write_scrubber._PENDING_BLOCK_LOGS
 
 
 # ── check_write (combined gate) ───────────────────────────────────────────
@@ -359,6 +420,10 @@ class TestStoreGate:
         # Drain the detached _log_block_event_async task(s). The insert runs via
         # asyncio.to_thread, so awaiting the pending-task set (not bare sleep(0)
         # ticks) is what guarantees the executor thread finished before we assert.
+        # Snapshot the set BEFORE awaiting: the done-callback discards completed
+        # tasks, so reading it after a yield could race to empty even though a
+        # task ran. The gate returns without yielding, so the task is scheduled
+        # but not yet started here — the set is reliably populated.
         pending = list(write_scrubber._PENDING_BLOCK_LOGS)
         assert pending, "no block-log task was scheduled on the async path"
         await asyncio.gather(*pending)
@@ -418,8 +483,12 @@ class TestStoreGate:
                 "source_provenance": "session:test",
             }
         )
-        # Reaches the normal store path → embedding spy was called.
+        # Reaches the normal store path → embedding spy was called AND the DB
+        # upsert was actually reached (guards against an early return between
+        # embed and insert that would still pass an embed-only assertion).
         assert self.embed_calls
+        assert tbl.upsert.called, "clean write never reached the memories upsert"
+        assert "ok-1" in result[0].text
         assert "error" not in result[0].text
 
 

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -34,6 +34,10 @@ FAKE_OPENAI_KEY = "sk-proj" + "AbCdEfGhIjKlMnOpQrStUvWxYz"
 # One fake per remaining blocking pattern (same split-construction convention as
 # tests/test_secret_scrubber.py) so a regression in any single scrubber pattern
 # is caught at the write-gate layer, not just for api_key_openai.
+# Anthropic key: sk-ant-api03-<entropy>. The `-` after `sk-ant` breaks the
+# OpenAI pattern's run at 3 chars, so this is caught ONLY by the dedicated
+# api_key_anthropic pattern — the regression this case guards.
+FAKE_ANTHROPIC_KEY = "sk-ant-" + "api03-" + "0123456789abcdefghijABCDEFG"
 FAKE_GITHUB_TOKEN = "ghp_" + "ABCDEFGHIJKLM" + "NOPQRSTUVWXYZabcdefghij123456"
 FAKE_SLACK_TOKEN = "xoxb" + "-1111111111-aaaaaaaaaaaaaaaaaaaa"
 FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + ".signature_part_here"
@@ -42,6 +46,7 @@ FAKE_ENV_BLOCK = "```env\nDB_PASSWORD=supersecretpassword123\n```"
 
 # (pattern name, text that fires exactly that blocking pattern)
 BLOCKING_PATTERN_CASES = [
+    ("api_key_anthropic", FAKE_ANTHROPIC_KEY),
     ("api_key_openai", FAKE_OPENAI_KEY),
     ("api_key_github", FAKE_GITHUB_TOKEN),
     ("api_key_slack", FAKE_SLACK_TOKEN),
@@ -261,12 +266,30 @@ class TestScrubUnavailable:
 
 class TestScrubOnlyCoupling:
     def test_scrub_only_names_are_real_pattern_names(self):
-        """The import-time drift guard warns (no longer crashes) if
-        SCRUB_ONLY_PATTERNS names a pattern secret_scrubber no longer emits.
-        This test pins the invariant in committed code so a rename in
-        secret_scrubber.py that silently turns path exclusion into a no-op
-        (re-blocking ~26% of path-bearing writes) fails CI here."""
-        assert write_scrubber.SCRUB_ONLY_PATTERNS <= write_scrubber._KNOWN_PATTERN_NAMES
+        """Drift guard, LIVE-FIRE: assert SCRUB_ONLY_PATTERNS names are names the
+        real scrubber emits on real path input. A static subset check against
+        ``_KNOWN_PATTERN_NAMES`` would pass vacuously — that set *also* hardcodes
+        ``path_username``, so a rename in secret_scrubber.py would leave both
+        stale in lockstep and never go red. Calling scrub() closes that loop:
+        if path_username is renamed, the live fires key changes and this fails."""
+        assert write_scrubber.scrub is not None, "only meaningful when scrubber is available"
+        _, fires = write_scrubber.scrub(r"config at C:\Users\alice\.claude\settings.json")
+        assert write_scrubber.SCRUB_ONLY_PATTERNS <= set(fires.keys()), (
+            "SCRUB_ONLY_PATTERNS references names the live scrubber does not emit "
+            f"on path input: {write_scrubber.SCRUB_ONLY_PATTERNS - set(fires.keys())}"
+        )
+
+    def test_env_block_pattern_name_is_live(self):
+        """Companion live-fire guard for the non-path EXTRA_PATTERN_NAMES entry.
+        ``env_block`` rides in _KNOWN_PATTERN_NAMES via EXTRA_PATTERN_NAMES but
+        is not in SCRUB_ONLY_PATTERNS, so the subset guard above never exercises
+        it. Fire the real scrubber on an env block and assert the emitted key is
+        still ``env_block`` — catches a rename that would silently stop blocking
+        env writes with no operator signal."""
+        assert write_scrubber.scrub is not None, "only meaningful when scrubber is available"
+        _, fires = write_scrubber.scrub(FAKE_ENV_BLOCK)
+        assert "env_block" in fires
+        assert "env_block" in write_scrubber._KNOWN_PATTERN_NAMES
 
 
 # ── _handle_store integration ─────────────────────────────────────────────
@@ -315,6 +338,13 @@ class TestStoreGate:
         block-event insert is dispatched as a detached task. Without draining,
         no test ever observes it. Drain with ``asyncio.sleep(0)`` and assert the
         ``events`` insert fired with the value-free counter row."""
+        # Route each table() to its own mock so the events row is extracted from
+        # the events table specifically — not from a shared insert.call_args that
+        # grabs the last insert on ANY table (which would make the privacy check
+        # vacuous if a future insert followed the block event).
+        tables: dict = {}
+        self.client.table.side_effect = lambda name: tables.setdefault(name, MagicMock())
+
         result = await _handle_store(
             {
                 "type": "project",
@@ -333,11 +363,8 @@ class TestStoreGate:
         assert pending, "no block-log task was scheduled on the async path"
         await asyncio.gather(*pending)
 
-        events_inserts = [
-            c for c in self.client.table.call_args_list if c.args and c.args[0] == "events"
-        ]
-        assert events_inserts, "block event was never inserted on the async path"
-        row = self.client.table.return_value.insert.call_args.args[0]
+        assert "events" in tables, "block event was never inserted on the async path"
+        row = tables["events"].insert.call_args.args[0]
         assert row["event_type"] == "mcp_write_scrubber_block"
         assert row["payload"]["write_path"] == "memory_store"
         assert FAKE_OPENAI_KEY not in json.dumps(row)
@@ -453,6 +480,26 @@ class TestDecisionGate:
             }
         )
         assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_outcomes_referenced_blocks(self, monkeypatch):
+        """``outcomes_referenced`` is persisted raw into the episode payload with
+        no UUID validation, so a secret smuggled there must block too."""
+        client = make_client("ep-blocked")
+        monkeypatch.setattr(server_module, "_get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": "clean decision",
+                "rationale": "clean rationale",
+                "reversibility": "reversible",
+                "outcomes_referenced": [f"outcome {FAKE_OPENAI_KEY}"],
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+        episode_inserts = [
+            c for c in client.table.call_args_list if c.args and c.args[0] == "episodes"
+        ]
+        assert episode_inserts == []
 
     async def test_secret_in_actor_blocks(self, monkeypatch):
         """``actor`` is in the decision gate's scanned set — a secret there must

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -306,9 +306,12 @@ class TestStoreGate:
         )
         assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
 
-        # Let the detached _log_block_event_async task run to completion.
-        for _ in range(5):
-            await asyncio.sleep(0)
+        # Drain the detached _log_block_event_async task(s). The insert runs via
+        # asyncio.to_thread, so awaiting the pending-task set (not bare sleep(0)
+        # ticks) is what guarantees the executor thread finished before we assert.
+        pending = list(write_scrubber._PENDING_BLOCK_LOGS)
+        assert pending, "no block-log task was scheduled on the async path"
+        await asyncio.gather(*pending)
 
         events_inserts = [
             c for c in self.client.table.call_args_list if c.args and c.args[0] == "events"

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -1,0 +1,286 @@
+"""Tests for the MCP write-path Tier-2 secret-scrubber gate (#555).
+
+Covers the standalone ``write_scrubber`` helper module plus its integration
+into the two write paths (``_handle_store``, ``_handle_record_decision``).
+
+Privacy invariant under test: when a write is blocked, NO value from the
+blocked payload appears in the error, the event row, or anywhere else —
+only pattern names + fire counts.
+
+Test secrets are constructed dynamically (prefix + entropy concatenation) so
+GitHub's static secret scanner does not flag this file — same convention as
+tests/test_secret_scrubber.py.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+import write_scrubber
+from server import _handle_store, _handle_record_decision
+import server as server_module
+
+from test_record_decision_helpers import make_client
+
+
+# A realistic OpenAI-style key: prefix + 26 entropy chars (matches
+# sk-[A-Za-z0-9]{20,}). Split so the static scanner never sees a whole token.
+FAKE_OPENAI_KEY = "sk-proj" + "AbCdEfGhIjKlMnOpQrStUvWxYz"
+
+
+# ── scan_fields ───────────────────────────────────────────────────────────
+
+
+class TestScanFields:
+    def test_clean_fields_no_fires(self):
+        fires = write_scrubber.scan_fields(
+            {"name": "normal name", "content": "ordinary text", "tags": ["a", "b"]}
+        )
+        assert fires == {}
+
+    def test_secret_in_str_field_fires(self):
+        fires = write_scrubber.scan_fields({"content": f"key is {FAKE_OPENAI_KEY}"})
+        assert fires.get("api_key_openai") == 1
+
+    def test_secret_in_list_field_fires(self):
+        fires = write_scrubber.scan_fields({"tags": ["fine", f"{FAKE_OPENAI_KEY}"]})
+        assert fires.get("api_key_openai") == 1
+
+    def test_counts_aggregate_across_fields(self):
+        fires = write_scrubber.scan_fields(
+            {"name": FAKE_OPENAI_KEY, "content": FAKE_OPENAI_KEY}
+        )
+        assert fires.get("api_key_openai") == 2
+
+    def test_non_string_values_skipped(self):
+        # ints / None / dicts must not raise — only str + list-of-str scanned.
+        fires = write_scrubber.scan_fields(
+            {"confidence": 0.9, "flag": None, "meta": {"x": 1}, "content": "clean"}
+        )
+        assert fires == {}
+
+
+# ── rejection_error ───────────────────────────────────────────────────────
+
+
+class TestRejectionError:
+    def test_shape(self):
+        payload = json.loads(write_scrubber.rejection_error({"api_key_openai": 1}))
+        assert payload["error"] == "secret_pattern_detected"
+        assert payload["patterns"] == {"api_key_openai": 1}
+
+    def test_carries_only_names_and_counts_no_value(self):
+        body = write_scrubber.rejection_error({"api_key_openai": 1})
+        # The literal secret never appears in the rejection string.
+        assert FAKE_OPENAI_KEY not in body
+
+
+# ── log_block_event ───────────────────────────────────────────────────────
+
+
+class TestLogBlockEvent:
+    def test_inserts_counter_event_no_values(self):
+        client = MagicMock()
+        write_scrubber.log_block_event(
+            client, {"api_key_openai": 2}, write_path="memory_store"
+        )
+
+        client.table.assert_called_with("events")
+        row = client.table.return_value.insert.call_args.args[0]
+        assert row["event_type"] == "mcp_write_scrubber_block"
+        assert row["severity"] in ("critical", "high", "medium", "low", "info")
+        assert row["repo"] == "Osasuwu/jarvis"
+        assert row["payload"]["patterns"] == {"api_key_openai": 2}
+        assert row["payload"]["write_path"] == "memory_store"
+        # No payload value leaks into the event row.
+        assert FAKE_OPENAI_KEY not in json.dumps(row)
+
+    def test_swallows_db_errors(self):
+        client = MagicMock()
+        client.table.side_effect = Exception("DB down")
+        # Must not raise — logging is fire-and-forget.
+        write_scrubber.log_block_event(client, {"x": 1}, write_path="memory_store")
+
+
+# ── check_write (combined gate) ───────────────────────────────────────────
+
+
+class TestCheckWrite:
+    def test_clean_returns_none_no_event(self):
+        client = MagicMock()
+        out = write_scrubber.check_write(
+            client, {"content": "all clean"}, write_path="memory_store"
+        )
+        assert out is None
+        client.table.assert_not_called()
+
+    def test_fired_returns_error_and_logs_event(self):
+        client = MagicMock()
+        out = write_scrubber.check_write(
+            client, {"content": FAKE_OPENAI_KEY}, write_path="memory_store"
+        )
+        assert out is not None
+        payload = json.loads(out)
+        assert payload["error"] == "secret_pattern_detected"
+        client.table.assert_called_with("events")
+
+    def test_user_path_does_not_block(self):
+        """AC#4: ~26% of the live corpus carries absolute user paths. A path
+        is a normalization concern (scrub-and-keep), not a write-blocking
+        secret leak — it must NOT reject the write or emit a block event."""
+        client = MagicMock()
+        out = write_scrubber.check_write(
+            client,
+            {"content": r"config at C:\Users\alice\.claude\settings.json"},
+            write_path="memory_store",
+        )
+        assert out is None
+        client.table.assert_not_called()
+
+    def test_secret_blocks_even_alongside_path(self):
+        """A real secret still blocks even when a (non-blocking) path is also
+        present; the block payload carries only the secret pattern."""
+        client = MagicMock()
+        out = write_scrubber.check_write(
+            client,
+            {"content": f"/home/bob/app uses {FAKE_OPENAI_KEY}"},
+            write_path="memory_store",
+        )
+        payload = json.loads(out)
+        assert payload["patterns"] == {"api_key_openai": 1}
+        assert "path_username" not in payload["patterns"]
+
+
+# ── _handle_store integration ─────────────────────────────────────────────
+
+
+class TestStoreGate:
+    @pytest.fixture(autouse=True)
+    def _patch(self, monkeypatch):
+        self.client = MagicMock()
+        monkeypatch.setattr(server_module, "_get_client", lambda: self.client)
+
+        self.embed_calls: list = []
+
+        async def _spy_embed(_text):
+            self.embed_calls.append(_text)
+            return {}
+
+        monkeypatch.setattr(server_module, "_compute_write_embeddings", _spy_embed)
+
+    @pytest.mark.asyncio
+    async def test_secret_in_content_blocks_no_embed_no_insert(self):
+        result = await _handle_store(
+            {
+                "type": "project",
+                "name": "leaky",
+                "content": f"my key {FAKE_OPENAI_KEY}",
+                "project": "jarvis",
+                "source_provenance": "session:test",
+            }
+        )
+
+        body = json.loads(result[0].text)
+        assert body["error"] == "secret_pattern_detected"
+        assert "api_key_openai" in body["patterns"]
+        # No embedding computed.
+        assert self.embed_calls == []
+        # No memory row written — only the events insert is permitted.
+        memory_writes = [
+            c for c in self.client.table.call_args_list if c.args and c.args[0] == "memories"
+        ]
+        assert memory_writes == []
+        # The secret never appears in the returned error text.
+        assert FAKE_OPENAI_KEY not in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_secret_in_name_blocks(self):
+        result = await _handle_store(
+            {
+                "type": "project",
+                "name": FAKE_OPENAI_KEY,
+                "content": "clean content",
+                "project": "jarvis",
+                "source_provenance": "session:test",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    @pytest.mark.asyncio
+    async def test_clean_store_passes_gate(self):
+        tbl = MagicMock()
+        tbl.upsert.return_value.execute.return_value = MagicMock(data=[{"id": "ok-1"}])
+        self.client.table.return_value = tbl
+
+        result = await _handle_store(
+            {
+                "type": "project",
+                "name": "fine",
+                "content": "nothing secret here",
+                "project": "jarvis",
+                "source_provenance": "session:test",
+            }
+        )
+        # Reaches the normal store path → embedding spy was called.
+        assert self.embed_calls
+        assert "error" not in result[0].text
+
+
+# ── _handle_record_decision integration ───────────────────────────────────
+
+
+class TestDecisionGate:
+    @pytest.mark.asyncio
+    async def test_secret_in_rationale_blocks_no_episode(self, monkeypatch):
+        client = make_client("ep-blocked")
+        monkeypatch.setattr(server_module, "_get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": "do the thing",
+                "rationale": f"because {FAKE_OPENAI_KEY} is the key",
+                "reversibility": "reversible",
+                "actor": "session:test",
+            }
+        )
+
+        body = json.loads(result[0].text)
+        assert body["error"] == "secret_pattern_detected"
+        # No episode written.
+        episode_inserts = [c for c in client.table.call_args_list if c.args and c.args[0] == "episodes"]
+        assert episode_inserts == []
+        assert FAKE_OPENAI_KEY not in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_secret_in_alternatives_blocks(self, monkeypatch):
+        client = make_client("ep-blocked")
+        monkeypatch.setattr(server_module, "_get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": "clean decision",
+                "rationale": "clean rationale",
+                "alternatives_considered": [f"option using {FAKE_OPENAI_KEY}"],
+                "reversibility": "reversible",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    @pytest.mark.asyncio
+    async def test_clean_decision_passes_gate(self, monkeypatch):
+        client = make_client("ep-ok")
+        monkeypatch.setattr(server_module, "_get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": "clean decision",
+                "rationale": "clean rationale",
+                "reversibility": "reversible",
+            }
+        )
+        # Reaches the normal path → episode id surfaced, no error.
+        assert "ep-ok" in result[0].text
+        assert "secret_pattern_detected" not in result[0].text

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -30,6 +30,25 @@ from test_record_decision_helpers import make_client
 # sk-[A-Za-z0-9]{20,}). Split so the static scanner never sees a whole token.
 FAKE_OPENAI_KEY = "sk-proj" + "AbCdEfGhIjKlMnOpQrStUvWxYz"
 
+# One fake per remaining blocking pattern (same split-construction convention as
+# tests/test_secret_scrubber.py) so a regression in any single scrubber pattern
+# is caught at the write-gate layer, not just for api_key_openai.
+FAKE_GITHUB_TOKEN = "ghp_" + "ABCDEFGHIJKLM" + "NOPQRSTUVWXYZabcdefghij123456"
+FAKE_SLACK_TOKEN = "xoxb" + "-1111111111-aaaaaaaaaaaaaaaaaaaa"
+FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + ".signature_part_here"
+FAKE_AWS_KEY = "AKIA" + "IOSFODNN7EXAMPLE"
+FAKE_ENV_BLOCK = "```env\nDB_PASSWORD=supersecretpassword123\n```"
+
+# (pattern name, text that fires exactly that blocking pattern)
+BLOCKING_PATTERN_CASES = [
+    ("api_key_openai", FAKE_OPENAI_KEY),
+    ("api_key_github", FAKE_GITHUB_TOKEN),
+    ("api_key_slack", FAKE_SLACK_TOKEN),
+    ("api_key_jwt", FAKE_JWT),
+    ("api_key_aws", FAKE_AWS_KEY),
+    ("env_block", FAKE_ENV_BLOCK),
+]
+
 
 # ── scan_fields ───────────────────────────────────────────────────────────
 
@@ -50,9 +69,7 @@ class TestScanFields:
         assert fires.get("api_key_openai") == 1
 
     def test_counts_aggregate_across_fields(self):
-        fires = write_scrubber.scan_fields(
-            {"name": FAKE_OPENAI_KEY, "content": FAKE_OPENAI_KEY}
-        )
+        fires = write_scrubber.scan_fields({"name": FAKE_OPENAI_KEY, "content": FAKE_OPENAI_KEY})
         assert fires.get("api_key_openai") == 2
 
     def test_non_string_values_skipped(self):
@@ -84,9 +101,7 @@ class TestRejectionError:
 class TestLogBlockEvent:
     def test_inserts_counter_event_no_values(self):
         client = MagicMock()
-        write_scrubber.log_block_event(
-            client, {"api_key_openai": 2}, write_path="memory_store"
-        )
+        write_scrubber.log_block_event(client, {"api_key_openai": 2}, write_path="memory_store")
 
         client.table.assert_called_with("events")
         row = client.table.return_value.insert.call_args.args[0]
@@ -154,6 +169,40 @@ class TestCheckWrite:
         assert "path_username" not in payload["patterns"]
 
 
+# ── every blocking pattern is exercised, not just api_key_openai ──────────
+
+
+class TestAllBlockingPatterns:
+    @pytest.mark.parametrize("pattern_name,text", BLOCKING_PATTERN_CASES)
+    def test_each_blocking_pattern_blocks(self, pattern_name, text):
+        client = MagicMock()
+        out = write_scrubber.check_write(client, {"content": text}, write_path="memory_store")
+        assert out is not None, f"{pattern_name} did not block the write"
+        assert pattern_name in json.loads(out)["patterns"]
+        # The raw token never leaks into the rejection payload.
+        assert text not in out
+
+
+# ── fail-open when the scrubber lib is unavailable ────────────────────────
+
+
+class TestScrubUnavailable:
+    def test_scan_fields_fail_open_when_scrub_none(self, monkeypatch):
+        """Security invariant: when scrub is unavailable the gate fails OPEN
+        (availability > over-blocking) — documented + must stay covered."""
+        monkeypatch.setattr(write_scrubber, "scrub", None)
+        assert write_scrubber.scan_fields({"content": FAKE_OPENAI_KEY}) == {}
+
+    def test_check_write_fail_open_when_scrub_none(self, monkeypatch):
+        monkeypatch.setattr(write_scrubber, "scrub", None)
+        client = MagicMock()
+        out = write_scrubber.check_write(
+            client, {"content": FAKE_OPENAI_KEY}, write_path="memory_store"
+        )
+        assert out is None
+        client.table.assert_not_called()
+
+
 # ── _handle_store integration ─────────────────────────────────────────────
 
 
@@ -171,7 +220,6 @@ class TestStoreGate:
 
         monkeypatch.setattr(server_module, "_compute_write_embeddings", _spy_embed)
 
-    @pytest.mark.asyncio
     async def test_secret_in_content_blocks_no_embed_no_insert(self):
         result = await _handle_store(
             {
@@ -196,7 +244,6 @@ class TestStoreGate:
         # The secret never appears in the returned error text.
         assert FAKE_OPENAI_KEY not in result[0].text
 
-    @pytest.mark.asyncio
     async def test_secret_in_name_blocks(self):
         result = await _handle_store(
             {
@@ -209,7 +256,6 @@ class TestStoreGate:
         )
         assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
 
-    @pytest.mark.asyncio
     async def test_clean_store_passes_gate(self):
         tbl = MagicMock()
         tbl.upsert.return_value.execute.return_value = MagicMock(data=[{"id": "ok-1"}])
@@ -233,7 +279,6 @@ class TestStoreGate:
 
 
 class TestDecisionGate:
-    @pytest.mark.asyncio
     async def test_secret_in_rationale_blocks_no_episode(self, monkeypatch):
         client = make_client("ep-blocked")
         monkeypatch.setattr(server_module, "_get_client", lambda: client)
@@ -250,11 +295,30 @@ class TestDecisionGate:
         body = json.loads(result[0].text)
         assert body["error"] == "secret_pattern_detected"
         # No episode written.
-        episode_inserts = [c for c in client.table.call_args_list if c.args and c.args[0] == "episodes"]
+        episode_inserts = [
+            c for c in client.table.call_args_list if c.args and c.args[0] == "episodes"
+        ]
         assert episode_inserts == []
         assert FAKE_OPENAI_KEY not in result[0].text
 
-    @pytest.mark.asyncio
+    async def test_secret_in_decision_blocks(self, monkeypatch):
+        client = make_client("ep-blocked")
+        monkeypatch.setattr(server_module, "_get_client", lambda: client)
+
+        result = await _handle_record_decision(
+            {
+                "decision": f"adopt {FAKE_OPENAI_KEY} as the key",
+                "rationale": "clean rationale",
+                "reversibility": "reversible",
+            }
+        )
+        body = json.loads(result[0].text)
+        assert body["error"] == "secret_pattern_detected"
+        episode_inserts = [
+            c for c in client.table.call_args_list if c.args and c.args[0] == "episodes"
+        ]
+        assert episode_inserts == []
+
     async def test_secret_in_alternatives_blocks(self, monkeypatch):
         client = make_client("ep-blocked")
         monkeypatch.setattr(server_module, "_get_client", lambda: client)
@@ -269,7 +333,6 @@ class TestDecisionGate:
         )
         assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
 
-    @pytest.mark.asyncio
     async def test_clean_decision_passes_gate(self, monkeypatch):
         client = make_client("ep-ok")
         monkeypatch.setattr(server_module, "_get_client", lambda: client)

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -21,7 +21,14 @@ from unittest.mock import MagicMock
 import pytest
 
 import write_scrubber
-from server import _handle_store, _handle_record_decision
+from server import (
+    _handle_store,
+    _handle_record_decision,
+    _handle_goal_set,
+    _handle_goal_update,
+    _handle_outcome_record,
+    _handle_outcome_update,
+)
 import server as server_module
 
 from test_record_decision_helpers import make_client
@@ -637,4 +644,274 @@ class TestDecisionGate:
         )
         # Reaches the normal path → episode id surfaced, no error.
         assert "ep-ok" in result[0].text
+        assert "secret_pattern_detected" not in result[0].text
+
+
+# ── _handle_goal_set / _handle_goal_update integration ───────────────────
+
+
+class TestGoalGate:
+    @pytest.fixture(autouse=True)
+    def _patch(self, monkeypatch):
+        self.client = MagicMock()
+        monkeypatch.setattr(server_module, "_get_client", lambda: self.client)
+
+    async def test_secret_in_title_blocks_no_insert(self):
+        """A secret in the goal title must block — no row written."""
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": f"my key {FAKE_OPENAI_KEY}",
+                "why": "clean why",
+            }
+        )
+        body = json.loads(result[0].text)
+        assert body["error"] == "secret_pattern_detected"
+        assert "api_key_openai" in body["patterns"]
+        # No goal insert/update reached.
+        goals_writes = [
+            c for c in self.client.table.call_args_list if c.args and c.args[0] == "goals"
+        ]
+        assert not goals_writes
+        assert FAKE_OPENAI_KEY not in result[0].text
+
+    async def test_secret_in_why_blocks(self):
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "why": f"because {FAKE_GITHUB_TOKEN} is used",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_success_criteria_blocks(self):
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "success_criteria": [f"need {FAKE_ANTHROPIC_KEY}"],
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_risks_blocks(self):
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "risks": [f"token {FAKE_AWS_KEY} exposed"],
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_owner_focus_blocks(self):
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "owner_focus": f"rotate {FAKE_SLACK_TOKEN}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_jarvis_focus_blocks(self):
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "jarvis_focus": f"use {FAKE_VOYAGE_KEY}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_outcome_blocks(self):
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "outcome": f"completed with {FAKE_JWT}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_lessons_blocks(self):
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "lessons": f"never hardcode {FAKE_OPENAI_KEY}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_user_path_does_not_block_goal(self):
+        """AC#4: absolute user paths must not block a goal write."""
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "why": r"config at C:\Users\alice\.claude\settings.json",
+            }
+        )
+        assert "secret_pattern_detected" not in result[0].text
+
+    async def test_clean_goal_set_passes_gate(self):
+        """A clean goal_set must reach the normal handler path."""
+        # The handler checks for existing slug — return empty so it creates.
+        tbl = MagicMock()
+        chain = MagicMock()
+        chain.limit.return_value.execute.return_value = MagicMock(data=[])
+        tbl.select.return_value.eq.return_value = chain
+        self.client.table.return_value = tbl
+
+        result = await _handle_goal_set(
+            {
+                "slug": "test-goal",
+                "title": "clean title",
+                "why": "clean why",
+            }
+        )
+        # Reaches the normal path → goal created.
+        assert "created" in result[0].text
+        assert "secret_pattern_detected" not in result[0].text
+
+    # ── goal_update ─────────────────────────────────────────────────
+
+    async def test_update_secret_in_title_blocks(self):
+        result = await _handle_goal_update(
+            {
+                "slug": "test-goal",
+                "title": f"updated with {FAKE_OPENAI_KEY}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_update_clean_passes_gate(self):
+        """A clean goal_update must reach the normal handler path."""
+        tbl = MagicMock()
+        tbl.update.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"slug": "test-goal"}]
+        )
+        self.client.table.return_value = tbl
+
+        result = await _handle_goal_update(
+            {
+                "slug": "test-goal",
+                "title": "updated title",
+                "why": "updated why",
+            }
+        )
+        assert "updated" in result[0].text
+        assert "secret_pattern_detected" not in result[0].text
+
+
+# ── _handle_outcome_record / _handle_outcome_update integration ─────────
+
+
+class TestOutcomeGate:
+    @pytest.fixture(autouse=True)
+    def _patch(self, monkeypatch):
+        self.client = MagicMock()
+        monkeypatch.setattr(server_module, "_get_client", lambda: self.client)
+
+    async def test_secret_in_task_description_blocks_no_insert(self):
+        result = await _handle_outcome_record(
+            {
+                "task_type": "fix",
+                "task_description": f"rotate {FAKE_OPENAI_KEY}",
+                "outcome_status": "success",
+            }
+        )
+        body = json.loads(result[0].text)
+        assert body["error"] == "secret_pattern_detected"
+        assert FAKE_OPENAI_KEY not in result[0].text
+        # No outcome insert reached.
+        outcome_writes = [
+            c for c in self.client.table.call_args_list if c.args and c.args[0] == "task_outcomes"
+        ]
+        assert not outcome_writes
+
+    async def test_secret_in_outcome_summary_blocks(self):
+        result = await _handle_outcome_record(
+            {
+                "task_type": "fix",
+                "task_description": "clean task",
+                "outcome_status": "success",
+                "outcome_summary": f"used {FAKE_GITHUB_TOKEN}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_secret_in_lessons_blocks(self):
+        result = await _handle_outcome_record(
+            {
+                "task_type": "fix",
+                "task_description": "clean task",
+                "outcome_status": "success",
+                "lessons": f"never hardcode {FAKE_OPENAI_KEY}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_user_path_does_not_block_outcome(self):
+        result = await _handle_outcome_record(
+            {
+                "task_type": "fix",
+                "task_description": r"updated C:\Users\bob\.env",
+                "outcome_status": "success",
+            }
+        )
+        assert "secret_pattern_detected" not in result[0].text
+
+    async def test_clean_outcome_record_passes_gate(self):
+        tbl = MagicMock()
+        tbl.insert.return_value.execute.return_value = MagicMock(data=[{"id": "out-1"}])
+        self.client.table.return_value = tbl
+
+        result = await _handle_outcome_record(
+            {
+                "task_type": "fix",
+                "task_description": "clean task",
+                "outcome_status": "success",
+                "outcome_summary": "all good",
+            }
+        )
+        assert "out-1" in result[0].text
+        assert "secret_pattern_detected" not in result[0].text
+
+    # ── outcome_update ──────────────────────────────────────────────
+
+    async def test_update_secret_in_outcome_summary_blocks(self):
+        result = await _handle_outcome_update(
+            {
+                "id": "out-1",
+                "outcome_summary": f"breach with {FAKE_OPENAI_KEY}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_update_secret_in_lessons_blocks(self):
+        result = await _handle_outcome_update(
+            {
+                "id": "out-1",
+                "lessons": f"leaked {FAKE_AWS_KEY}",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+    async def test_update_clean_passes_gate(self):
+        tbl = MagicMock()
+        tbl.update.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"id": "out-1"}]
+        )
+        self.client.table.return_value = tbl
+
+        result = await _handle_outcome_update(
+            {
+                "id": "out-1",
+                "outcome_summary": "clean update",
+            }
+        )
+        assert "out-1" in result[0].text
         assert "secret_pattern_detected" not in result[0].text

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -42,9 +42,14 @@ FAKE_GITHUB_TOKEN = "ghp_" + "ABCDEFGHIJKLM" + "NOPQRSTUVWXYZabcdefghij123456"
 FAKE_SLACK_TOKEN = "xoxb" + "-1111111111-aaaaaaaaaaaaaaaaaaaa"
 FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + ".signature_part_here"
 FAKE_AWS_KEY = "AKIA" + "IOSFODNN7EXAMPLE"
+FAKE_VOYAGE_KEY = "pa-" + "0123456789abcdefghijABCDEFGHIJ0123456789"
 FAKE_ENV_BLOCK = "```env\nDB_PASSWORD=supersecretpassword123\n```"
 
 # (pattern name, text that fires exactly that blocking pattern)
+# `path_username` is intentionally absent — it is a scrub-and-keep
+# normalization, NOT a write-blocking leak (see SCRUB_ONLY_PATTERNS); a
+# separate test (``test_user_path_does_not_block``) covers its non-blocking
+# behavior. Listing it here would assert the opposite of the intended policy.
 BLOCKING_PATTERN_CASES = [
     ("api_key_anthropic", FAKE_ANTHROPIC_KEY),
     ("api_key_openai", FAKE_OPENAI_KEY),
@@ -52,12 +57,13 @@ BLOCKING_PATTERN_CASES = [
     ("api_key_slack", FAKE_SLACK_TOKEN),
     ("api_key_jwt", FAKE_JWT),
     ("api_key_aws", FAKE_AWS_KEY),
+    ("api_key_voyageai", FAKE_VOYAGE_KEY),
     ("env_block", FAKE_ENV_BLOCK),
 ]
 
 
 @pytest.fixture(autouse=True)
-def _clear_pending():
+async def _clear_pending():
     """Isolate the module-level ``_PENDING_BLOCK_LOGS`` set between tests.
 
     The set pins in-flight detached block-log tasks (GC-pinning, see
@@ -65,12 +71,20 @@ def _clear_pending():
     scheduled by one test bleeds into the next — making
     ``test_block_event_is_actually_logged_on_async_path`` able to pass
     *vacuously* off a stale task, and letting TestDecisionGate's blocking
-    tests leak tasks forward. Clearing before AND after each test gives every
-    test a clean view; the per-test event loop teardown cancels any tasks we
-    drop the strong ref to here.
+    tests leak tasks forward.
+
+    On teardown we DRAIN before clearing: a block-log task wraps
+    ``asyncio.to_thread`` and an event-loop teardown cannot cancel the worker
+    thread already running the insert. Just ``.clear()``-ing the pins would let
+    that thread finish against the next test's mock client (a cross-test bleed).
+    Awaiting the snapshot lets every in-flight insert complete first; only then
+    do we drop the pins. ``async`` fixture runs under ``asyncio_mode=auto``.
     """
     write_scrubber._PENDING_BLOCK_LOGS.clear()
     yield
+    pending = list(write_scrubber._PENDING_BLOCK_LOGS)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
     write_scrubber._PENDING_BLOCK_LOGS.clear()
 
 
@@ -196,11 +210,17 @@ class TestLogBlockEvent:
         write_scrubber.log_block_event(client, {"api_key_jwt": 1}, write_path="memory_store")
         assert client.table.return_value.insert.call_args.args[0]["severity"] == "high"
 
-    def test_swallows_db_errors(self):
+    def test_swallows_db_errors(self, capsys):
         client = MagicMock()
-        client.table.side_effect = Exception("DB down")
+        client.table.side_effect = Exception("DB down: secret-bearing context")
         # Must not raise — logging is fire-and-forget.
         write_scrubber.log_block_event(client, {"x": 1}, write_path="memory_store")
+        # Privacy: the stderr diagnostic must carry the exception *type* only,
+        # never str(exc) (which could echo request context). Pins the invariant
+        # so a future `print(exc)` regression goes red (round-10 m3).
+        err = capsys.readouterr().err
+        assert "Exception" in err
+        assert "secret-bearing context" not in err
 
 
 # ── _dispatch_block_log fallback branches ─────────────────────────────────
@@ -497,6 +517,13 @@ class TestStoreGate:
         assert tbl.upsert.called, "clean write never reached the memories upsert"
         assert "ok-1" in result[0].text
         assert "error" not in result[0].text
+        # A clean write must NOT emit a block event — the gate only logs on a
+        # detected secret. Guards against an over-eager log_block_event firing
+        # on every write (round-10 m2).
+        events_calls = [
+            c for c in self.client.table.call_args_list if c.args and c.args[0] == "events"
+        ]
+        assert not events_calls, "clean write spuriously emitted a block event"
 
 
 # ── _handle_record_decision integration ───────────────────────────────────

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -189,6 +189,13 @@ class TestLogBlockEvent:
         write_scrubber.log_block_event(client, {"env_block": 1}, write_path="memory_store")
         assert client.table.return_value.insert.call_args.args[0]["severity"] == "medium"
 
+        # A leaked JWT is a Supabase service-role token (full DB access) — it
+        # must triage as "high" alongside the raw API keys, not as a medium
+        # env-block. Pins the round-10 MINOR-3 fix.
+        client.reset_mock()
+        write_scrubber.log_block_event(client, {"api_key_jwt": 1}, write_path="memory_store")
+        assert client.table.return_value.insert.call_args.args[0]["severity"] == "high"
+
     def test_swallows_db_errors(self):
         client = MagicMock()
         client.table.side_effect = Exception("DB down")

--- a/tests/test_write_scrubber.py
+++ b/tests/test_write_scrubber.py
@@ -14,6 +14,7 @@ tests/test_secret_scrubber.py.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import MagicMock
 
@@ -78,6 +79,38 @@ class TestScanFields:
             {"confidence": 0.9, "flag": None, "meta": {"x": 1}, "content": "clean"}
         )
         assert fires == {}
+
+    def test_scrub_raising_is_contained_per_field(self, monkeypatch):
+        """MAJOR-fix: a scrub() crash on one field must fail OPEN (skip that
+        field, keep scanning the rest) — never propagate and crash the write.
+        Also asserts the field name is logged but the value is not."""
+
+        def _boom(text):
+            if "BOOM" in text:
+                raise ValueError("scrubber exploded")
+            return text, {}
+
+        monkeypatch.setattr(write_scrubber, "scrub", _boom)
+        # First field raises, second is clean → no exception, empty totals.
+        fires = write_scrubber.scan_fields({"bad": "trigger BOOM here", "good": "ordinary text"})
+        assert fires == {}
+
+    def test_scrub_raising_does_not_leak_value_to_stderr(self, monkeypatch, capsys):
+        """Privacy invariant: the per-field crash log carries the exception
+        *type* + field name only — never the raised exception's str() (which
+        could embed the input text)."""
+
+        secret_marker = "S3CR3T_" + "PAYLOAD_VALUE"
+
+        def _boom(text):
+            raise ValueError(text)  # exception str() == the input text
+
+        monkeypatch.setattr(write_scrubber, "scrub", _boom)
+        write_scrubber.scan_fields({"content": secret_marker})
+        err = capsys.readouterr().err
+        assert "ValueError" in err
+        assert "content" in err
+        assert secret_marker not in err
 
 
 # ── rejection_error ───────────────────────────────────────────────────────
@@ -203,6 +236,19 @@ class TestScrubUnavailable:
         client.table.assert_not_called()
 
 
+# ── SCRUB_ONLY_PATTERNS coupling invariant ────────────────────────────────
+
+
+class TestScrubOnlyCoupling:
+    def test_scrub_only_names_are_real_pattern_names(self):
+        """The import-time drift guard warns (no longer crashes) if
+        SCRUB_ONLY_PATTERNS names a pattern secret_scrubber no longer emits.
+        This test pins the invariant in committed code so a rename in
+        secret_scrubber.py that silently turns path exclusion into a no-op
+        (re-blocking ~26% of path-bearing writes) fails CI here."""
+        assert write_scrubber.SCRUB_ONLY_PATTERNS <= write_scrubber._KNOWN_PATTERN_NAMES
+
+
 # ── _handle_store integration ─────────────────────────────────────────────
 
 
@@ -243,6 +289,35 @@ class TestStoreGate:
         assert memory_writes == []
         # The secret never appears in the returned error text.
         assert FAKE_OPENAI_KEY not in result[0].text
+
+    async def test_block_event_is_actually_logged_on_async_path(self):
+        """MAJOR-fix: under asyncio_mode=auto the handler runs in a loop, so the
+        block-event insert is dispatched as a detached task. Without draining,
+        no test ever observes it. Drain with ``asyncio.sleep(0)`` and assert the
+        ``events`` insert fired with the value-free counter row."""
+        result = await _handle_store(
+            {
+                "type": "project",
+                "name": "leaky",
+                "content": f"my key {FAKE_OPENAI_KEY}",
+                "project": "jarvis",
+                "source_provenance": "session:test",
+            }
+        )
+        assert json.loads(result[0].text)["error"] == "secret_pattern_detected"
+
+        # Let the detached _log_block_event_async task run to completion.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        events_inserts = [
+            c for c in self.client.table.call_args_list if c.args and c.args[0] == "events"
+        ]
+        assert events_inserts, "block event was never inserted on the async path"
+        row = self.client.table.return_value.insert.call_args.args[0]
+        assert row["event_type"] == "mcp_write_scrubber_block"
+        assert row["payload"]["write_path"] == "memory_store"
+        assert FAKE_OPENAI_KEY not in json.dumps(row)
 
     async def test_secret_in_name_blocks(self):
         result = await _handle_store(


### PR DESCRIPTION
## Summary

Extends the Tier-2 MCP write-path secret-scrubber gate (`write_scrubber.check_write`) from #555 to cover four additional write handlers:

- **goal_set / goal_update** — scans title, why, success_criteria, risks, owner_focus, jarvis_focus, outcome, lessons
- **outcome_record / outcome_update** — scans task_description, outcome_summary, lessons

Same invariants as #555: reject (not silent-scrub) on a genuine secret pattern; emit a value-free `mcp_write_scrubber_block` event with the new `write_path`; preserve fail-open-but-loud stance when scrubber lib is unavailable.

Closes #999

## Files changed

- `mcp-memory/write_scrubber.py` — updated module docstring scope to include #999 handlers
- `mcp-memory/handlers/goal.py` — gate in `_handle_goal_set` and `_handle_goal_update`
- `mcp-memory/handlers/outcome.py` — gate in `_handle_outcome_record` and `_handle_outcome_update`
- `tests/test_write_scrubber.py` — 18 new tests: per-field blocking coverage + clean-pass for both handler families

## Testing

- `pytest tests/test_write_scrubber.py tests/test_secret_scrubber.py` → 86 passed
- `ruff check` → clean

Closes #999

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>