### PR TITLE
docs(adoption): wire /triage + /to-issues to reactive-core event/task states (#752)

### DIFF
--- a/.claude-userlevel/skills/to-issues/SKILL.md
+++ b/.claude-userlevel/skills/to-issues/SKILL.md
@@ -49,6 +49,8 @@ This checklist is the upstream pair of the `/delegate` pre-dispatch gate. The ga
 
 Record the AFK decision per slice (yes/no + the one question that flipped it, when applicable) so the quiz in §4 can show the owner *why* a slice is HITL.
 
+**The AFK-fit verdict is the single source of AFK-truth — for manual *and* automated emission.** The `/delegate` pre-dispatch gate is not the only consumer: any **automated task emitter** the project runs must honor the same verdict rather than trust a label blindly. In jarvis this is the reactive-core orchestrator's `emit_task` route — an orchestrator-emitted `task_queue` row carries the same AFK-fit semantics as a manually-triaged slice: AFK-safe ⇒ `assignee=sandcastle` (auto-spawned by the task-dispatch loop), AFK-unsafe ⇒ `assignee=owner` (routed for owner attention, never auto-spawned), mirroring the `status:owner-queue` landing zone where a refused `/delegate` parks. The binding (event/task state vocabulary, who enqueues with what priority) lives in the project's CLAUDE.md *Responsibility split* and CONTEXT.md `task_queue` glossary — not here, so this checklist stays project-agnostic.
+
 ### 4. Quiz the user
 
 Present the proposed breakdown as a numbered list. For each slice, show:

--- a/.claude-userlevel/skills/triage/SKILL.md
+++ b/.claude-userlevel/skills/triage/SKILL.md
@@ -39,6 +39,10 @@ These are canonical role names — the actual label strings used in the issue tr
 
 State transitions: an unlabeled issue normally goes to `needs-triage` first; from there it moves to `needs-info`, `ready-for-agent`, `ready-for-human`, or `wontfix`. `needs-info` returns to `needs-triage` once the reporter replies. The maintainer can override at any time — flag transitions that look unusual and ask before proceeding.
 
+### Downstream: how triaged state feeds an AFK loop
+
+`ready-for-agent` is the state an automated AFK loop consumes — the maintainer's signal that an unattended agent may pick the issue up. In a project with a reactive-core event/task substrate (jarvis: `events` → `task_queue`), triaged issues and automatically-emitted tasks share the **same** AFK-fit gate (`/to-issues` §3a): an issue that passes routes to an autonomous agent, one that fails lands in `ready-for-human` (jarvis: also the `status:owner-queue` label when a dispatch was refused). Triage never enqueues a task itself — it sets the issue **state**; the project's dispatcher/orchestrator is what turns a `ready-for-agent` issue into a running task, and that is also where work *enters* the loop and where loop-closure happens. The concrete state vocabulary and fill-rules live in the project's CLAUDE.md / CONTEXT.md, not in this skill.
+
 ## Invocation
 
 The maintainer invokes `/triage` and describes what they want in natural language. Interpret the request and act. Examples:


### PR DESCRIPTION
## Summary
Closes out the #44 adoption slice by landing the two items PR #771 explicitly deferred: edges from the `/to-issues` and `/triage` skills to the reactive-core event/task substrate. Adds a note to `/to-issues` §3a that the AFK-fit verdict governs *automated* task emission (not just `/delegate`), and a "Downstream: how triaged state feeds an AFK loop" subsection to `/triage`.

## Why
#752 is the close-gate for milestone #44. #771 landed AC1/AC2/AC4 (CLAUDE.md Responsibility split, CONTEXT.md event/task glossary, SOUL-shared invariant) but deferred the skill edits and the AC5 validation pass because they "need the running system to describe." The orchestrator has since shipped (`agents/wake_driver.py`, `orchestrator.py`, `task_queue.py`, `task_dispatch.py` + `events`/`task_queue` schema), so the dependency is cleared.

Closes #752

## Decisions & Alternatives
- **Generic-framed edits, jarvis binding via pointer.** Both skills are user-level/cross-project (they also run on redrobot). The edits reference the downstream *automated task emitter* generically and defer the concrete reactive-core vocabulary to project CLAUDE.md/CONTEXT.md — so the shared skill doesn't leak jarvis internals into redrobot runs. Rejected: hardcoding reactive-core internals into the skills.
- **AC5 validated, not re-written.** CLAUDE.md *Responsibility split* (`events arrive → wake_driver → three dispositions → executor.spawn → Path A closure`) plus the CONTEXT.md glossary already let a naive reader answer "how does work enter the orchestrator and what happens next." Adding a synthesis paragraph would only create a drift surface. Rejected: new CONTEXT.md prose.
- Decision: `4d44723c-5ddc-4fd5-a55e-9a151713513a` (close-out scope). Upstream: `88425008` (#771 partial-vs-full), lesson `capability_needs_adoption_slice` (`adda0a22`).

## Risk Assessment
- **LOW**: documentation-only. Two SKILL.md bodies, +6 lines. No code, no schema, no tests touched. No file in `config/protected-paths.json` is edited (skill source files are not protected; reviewed PR is the gate).

## Testing
- `git diff --stat` confirms scope: only the two SKILL.md files (the `.claude-userlevel/settings.json` modification in the working tree is a pre-existing unrelated change and was deliberately excluded from the commit).
- No test parses these SKILL.md bodies (`rg` over `tests/` — no hits), so no behavioral test applies. Prose-only.

## Files Changed
- `.claude-userlevel/skills/to-issues/SKILL.md` — §3a: AFK-fit verdict is the single source of AFK-truth for automated emission too (orchestrator `emit_task` carries same sandcastle/owner semantics).
- `.claude-userlevel/skills/triage/SKILL.md` — new "Downstream: how triaged state feeds an AFK loop" subsection.