### PR TITLE
ci(auto-merge): mint jarvis-ci App token so native issue auto-close fires (#1005)

### DIFF
--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -110,6 +110,17 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Token-presence guard (#1006 review, MAJOR): the Mint step is skipped
+          # when REPO_NAME is empty (its defense-in-depth `if:`), which leaves
+          # GH_TOKEN as the empty string here. `gh` with an empty GH_TOKEN may fall
+          # back to the ambient GITHUB_TOKEN rather than erroring — re-attributing
+          # the eventual merge to github-actions[bot] and suppressing native
+          # auto-close, the exact #948 Bug A this workflow exists to prevent. Fail
+          # loud before any gh call instead of risking a bot-attributed merge.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::App token is empty — the Mint step was skipped (REPO_NAME unset?). Refusing to call gh, which could fall back to GITHUB_TOKEN and re-attribute the merge to github-actions[bot] (#948 Bug A)."
+            exit 1
+          fi
           # Idempotent: the 'ready_for_review' trigger can fire after 'opened'
           # already enabled auto-merge; re-calling `gh pr merge --auto` then exits
           # non-zero ("already enabled"), which the loud Assert step above would
@@ -145,12 +156,26 @@ jobs:
             # this call. A "not open" failure here is benign (auto-merge's job is
             # already done), so swallow it after confirming the PR really closed.
             if ! gh pr merge "$PR" --repo "$REPO" --auto --squash; then
+              # Re-check state to tell a benign TOCTOU race from a real failure.
+              # Keep the empty-state case DISTINCT from "still OPEN" (#1006 review,
+              # MAJOR): an empty re-check is an unknown, not a confirmed-open PR, so
+              # the old `[ "$st" = "OPEN" ] || [ -z "$st" ]` conflation surfaced a
+              # misleading "on open PR" error.
               st=$(gh pr view "$PR" --repo "$REPO" --json state -q '.state' 2>/dev/null || echo "")
-              if [ "$st" = "OPEN" ] || [ -z "$st" ]; then
-                echo "::error::Failed to enable auto-merge on open PR #$PR."
+              if [ "$st" = "OPEN" ]; then
+                echo "::error::Failed to enable auto-merge on still-open PR #$PR."
                 exit 1
+              elif [ -z "$st" ]; then
+                # Couldn't confirm state — fail closed (not exit 0). Auto-merge
+                # ENABLEMENT has no downstream self-heal: merge-train only updates
+                # branches of PRs that already have auto-merge enabled, it never
+                # enables it. A silently-missed enablement would stall the PR
+                # forever, so an unconfirmed failure must stay visible.
+                echo "::error::auto-merge enable failed on #$PR and re-checking its state also failed — cannot confirm; failing closed so this stays visible."
+                exit 1
+              else
+                echo "::notice::PR #$PR closed ($st) before auto-merge could be enabled — nothing to do."
               fi
-              echo "::notice::PR #$PR closed ($st) before auto-merge could be enabled — nothing to do."
             fi
           else
             echo "::notice::Auto-merge already enabled on #$PR — nothing to do."

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -24,7 +24,9 @@ name: auto-merge-enable
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    # reopened: a closed-then-reopened PR (e.g. a temporarily-closed sandcastle)
+    # must get auto-merge re-enabled, else it silently never merges on its own.
+    types: [opened, ready_for_review, reopened]
 
 # The merge is performed with the App token below, not GITHUB_TOKEN, so this
 # job's default token needs no write scope.
@@ -62,7 +64,7 @@ jobs:
             echo "::error::auto-merge-enable requires the 'jarvis-ci' GitHub App, but APP_ID and/or APP_PRIVATE_KEY repo secrets are unset."
             echo "Why: auto-merge enabled with the default GITHUB_TOKEN suppresses native linked-issue auto-close (GitHub recursion prevention), so merged PRs leave their Closes #N issues open. A GitHub App installation token is required (#1005)."
             echo "Setup (one-time per repo):"
-            echo "  1. Create/extend the 'jarvis-ci' GitHub App with permissions: Contents=Read&write, Pull requests=Read&write, Issues=Read&write."
+            echo "  1. Create/extend the 'jarvis-ci' GitHub App with these permissions (as labelled in the GitHub App UI): Contents: Read and write, Pull requests: Read and write, Issues: Read and write."
             echo "  2. Install the App on this repository."
             echo "  3. Add repo secrets: APP_ID (the App's numeric id) and APP_PRIVATE_KEY (the .pem private key)."
             echo "Until then auto-merge cannot be enabled on this repo."
@@ -71,12 +73,14 @@ jobs:
           echo "App credentials present."
 
       - name: Derive repo name for least-privilege token scoping
-        # GITHUB_REPOSITORY ("owner/repo") is populated on EVERY event type;
-        # strip the owner to get the bare repo name. (This workflow only fires on
-        # pull_request, where github.event.repository.name is also populated, but
-        # deriving from GITHUB_REPOSITORY keeps the scoping identical to
-        # merge-train.yml, which DOES run on schedule where that field is empty.)
-        run: echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
+        # Derived from GITHUB_REPOSITORY ("owner/repo", set on every event) for
+        # consistency with merge-train.yml. The empty guard is load-bearing: an
+        # empty REPO_NAME would make create-github-app-token fall back to ALL
+        # installed repos, leaking the App's Issues:write scope to redrobot.
+        run: |
+          set -euo pipefail
+          : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is unset or empty}"
+          echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
 
       - name: Mint App installation token
         id: app-token
@@ -100,13 +104,26 @@ jobs:
           # already enabled auto-merge; re-calling `gh pr merge --auto` then exits
           # non-zero ("already enabled"), which the loud Assert step above would
           # make easy to mistake for a credential failure. Check first.
-          am=$(gh pr view "$PR" --repo "$REPO" --json autoMergeRequest -q '.autoMergeRequest')
+          #
+          # State is fetched alongside autoMergeRequest because cancel-in-progress:
+          # false lets a run queued near merge time execute AFTER the PR is already
+          # merged. On a merged PR autoMergeRequest reads "null" (auto-merge
+          # completed), so without this guard we'd call `gh pr merge --auto` on a
+          # closed PR and surface a spurious red ("#N is not open").
+          read -r am state < <(
+            gh pr view "$PR" --repo "$REPO" --json autoMergeRequest,state \
+              -q '"\(.autoMergeRequest) \(.state)"'
+          )
           # gh can exit 0 with empty stdout on transient API/auth degradation;
           # set -e won't catch that. An empty $am must NOT be read as "already
           # enabled" (silent false negative — PR left un-enrolled). Fail loud.
-          if [ -z "$am" ]; then
+          if [ -z "$am" ] || [ -z "$state" ]; then
             echo "::error::gh pr view returned empty output for #$PR — possible auth or API failure; not assuming auto-merge state."
             exit 1
+          fi
+          if [ "$state" != "OPEN" ]; then
+            echo "::notice::PR #$PR is $state (not OPEN) — nothing to enable."
+            exit 0
           fi
           if [ "$am" = "null" ]; then
             gh pr merge "$PR" --repo "$REPO" --auto --squash

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -89,8 +89,9 @@ jobs:
       - name: Mint App installation token
         id: app-token
         # Defense-in-depth: if the Derive step above is ever deleted/reordered so
-        # REPO_NAME is unset, fail this step rather than minting an unscoped token
-        # over ALL installed repos (the cross-repo Issues:write leak). Belt to the
+        # REPO_NAME is unset, skip minting rather than fall back to an unscoped
+        # token over ALL installed repos (the cross-repo Issues:write leak). The
+        # downstream Enable step then has no token and fails loud. Belt to the
         # Derive step's `:?` braces.
         if: env.REPO_NAME != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -12,10 +12,14 @@
 #   `Closes #N` issue stays open. Proven empirically (9/9 human merges auto-close,
 #   0 bot merges do). Same token rule already documented in merge-train.yml for
 #   update-branch (decision 2ccfa29a). Enabling auto-merge with the 'jarvis-ci'
-#   App installation token makes the merge a real (non-github-actions[bot])
-#   identity, so native auto-close fires. The App should also carry Issues:Read&
-#   write alongside Contents + Pull requests — the close is attributed to the
-#   merge actor, and the extra scope avoids any permission edge.
+#   App token makes the merge's `enabledBy` actor the App rather than
+#   github-actions[bot]; empirically that is enough for native auto-close to
+#   fire (9/9 human/App-enabled merges auto-close, 0 github-actions[bot] merges
+#   do). The exact causal chain inside GitHub's platform auto-merge is
+#   undocumented — the App token is the right fix regardless of the precise
+#   mechanism; don't over-generalize the rule from this one observation. The App
+#   should also carry Issues:Read&write alongside Contents + Pull requests so the
+#   close has no permission edge to trip on.
 name: auto-merge-enable
 
 on:
@@ -28,10 +32,13 @@ permissions:
   contents: read
 
 # Rapid draft->ready transitions or event re-deliveries can spawn two parallel
-# runs racing on `gh pr merge --auto` for the same PR. Serialize per-PR.
+# runs racing on `gh pr merge --auto` for the same PR. Queue them per-PR rather
+# than supersede: cancel-in-progress:true could kill a run after the App token
+# was minted but before `gh pr merge`, leaving the PR un-enrolled if no further
+# event arrives. The idempotency check below absorbs duplicate queued runs.
 concurrency:
   group: auto-merge-enable-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   enable:
@@ -69,6 +76,11 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Least-privilege: scope the token to THIS repo only, so the added
+          # Issues:write scope never leaks to other repos the App is installed
+          # on (CLAUDE.md: App is shared). Empty on rare event types falls back
+          # to all-installed-repos — no worse than the unscoped default.
+          repositories: ${{ github.event.repository.name }}
 
       - name: Enable squash auto-merge
         env:
@@ -82,6 +94,13 @@ jobs:
           # non-zero ("already enabled"), which the loud Assert step above would
           # make easy to mistake for a credential failure. Check first.
           am=$(gh pr view "$PR" --repo "$REPO" --json autoMergeRequest -q '.autoMergeRequest')
+          # gh can exit 0 with empty stdout on transient API/auth degradation;
+          # set -e won't catch that. An empty $am must NOT be read as "already
+          # enabled" (silent false negative — PR left un-enrolled). Fail loud.
+          if [ -z "$am" ]; then
+            echo "::error::gh pr view returned empty output for #$PR — possible auth or API failure; not assuming auto-merge state."
+            exit 1
+          fi
           if [ "$am" = "null" ]; then
             gh pr merge "$PR" --repo "$REPO" --auto --squash
           else

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -29,7 +29,11 @@ on:
     types: [opened, ready_for_review, reopened]
 
 # The merge is performed with the App token below, not GITHUB_TOKEN, so this
-# job's default token needs no write scope.
+# job's *default* token needs no write scope. NOTE: this block scopes ONLY the
+# default GITHUB_TOKEN — the minted App token's effective permissions
+# (Contents / Pull requests / Issues: write) are defined in the 'jarvis-ci'
+# GitHub App configuration, not here. `contents: read` is not the job's true
+# write ceiling.
 permissions:
   contents: read
 
@@ -84,6 +88,11 @@ jobs:
 
       - name: Mint App installation token
         id: app-token
+        # Defense-in-depth: if the Derive step above is ever deleted/reordered so
+        # REPO_NAME is unset, fail this step rather than minting an unscoped token
+        # over ALL installed repos (the cross-repo Issues:write leak). Belt to the
+        # Derive step's `:?` braces.
+        if: env.REPO_NAME != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
@@ -105,18 +114,23 @@ jobs:
           # non-zero ("already enabled"), which the loud Assert step above would
           # make easy to mistake for a credential failure. Check first.
           #
-          # State is fetched alongside autoMergeRequest because cancel-in-progress:
+          # State is fetched alongside auto-merge status because cancel-in-progress:
           # false lets a run queued near merge time execute AFTER the PR is already
-          # merged. On a merged PR autoMergeRequest reads "null" (auto-merge
-          # completed), so without this guard we'd call `gh pr merge --auto` on a
-          # closed PR and surface a spurious red ("#N is not open").
+          # merged. On a merged PR auto-merge reads as completed (am=null), so
+          # without the state guard we'd call `gh pr merge --auto` on a closed PR
+          # and surface a spurious red ("#N is not open").
+          #
+          # am is reduced to a bare "null"/"set" token (not the raw
+          # autoMergeRequest object, whose commitHeadline can contain spaces) and
+          # emitted with @tsv, so `read` splits cleanly on the tab regardless of
+          # field contents.
           read -r am state < <(
             gh pr view "$PR" --repo "$REPO" --json autoMergeRequest,state \
-              -q '"\(.autoMergeRequest) \(.state)"'
+              -q '[(if .autoMergeRequest == null then "null" else "set" end), .state] | @tsv'
           )
-          # gh can exit 0 with empty stdout on transient API/auth degradation;
-          # set -e won't catch that. An empty $am must NOT be read as "already
-          # enabled" (silent false negative — PR left un-enrolled). Fail loud.
+          # gh can exit 0 with whitespace-only stdout on transient API/auth
+          # degradation, leaving am/state empty without tripping set -e. Treat
+          # either empty as a hard failure rather than misreading auto-merge state.
           if [ -z "$am" ] || [ -z "$state" ]; then
             echo "::error::gh pr view returned empty output for #$PR — possible auth or API failure; not assuming auto-merge state."
             exit 1
@@ -126,7 +140,17 @@ jobs:
             exit 0
           fi
           if [ "$am" = "null" ]; then
-            gh pr merge "$PR" --repo "$REPO" --auto --squash
+            # TOCTOU: the PR can merge externally between the state check above and
+            # this call. A "not open" failure here is benign (auto-merge's job is
+            # already done), so swallow it after confirming the PR really closed.
+            if ! gh pr merge "$PR" --repo "$REPO" --auto --squash; then
+              st=$(gh pr view "$PR" --repo "$REPO" --json state -q '.state' 2>/dev/null || echo "")
+              if [ "$st" = "OPEN" ] || [ -z "$st" ]; then
+                echo "::error::Failed to enable auto-merge on open PR #$PR."
+                exit 1
+              fi
+              echo "::notice::PR #$PR closed ($st) before auto-merge could be enabled — nothing to do."
+            fi
           else
             echo "::notice::Auto-merge already enabled on #$PR — nothing to do."
           fi

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -70,17 +70,24 @@ jobs:
           fi
           echo "App credentials present."
 
+      - name: Derive repo name for least-privilege token scoping
+        # GITHUB_REPOSITORY ("owner/repo") is populated on EVERY event type;
+        # strip the owner to get the bare repo name. (This workflow only fires on
+        # pull_request, where github.event.repository.name is also populated, but
+        # deriving from GITHUB_REPOSITORY keeps the scoping identical to
+        # merge-train.yml, which DOES run on schedule where that field is empty.)
+        run: echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
+
       - name: Mint App installation token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Least-privilege: scope the token to THIS repo only, so the added
-          # Issues:write scope never leaks to other repos the App is installed
-          # on (CLAUDE.md: App is shared). Empty on rare event types falls back
-          # to all-installed-repos — no worse than the unscoped default.
-          repositories: ${{ github.event.repository.name }}
+          # Least-privilege: scope to THIS repo only (REPO_NAME is set on all
+          # triggers, see step above) so the added Issues:write scope never leaks
+          # to other repos the App is installed on (CLAUDE.md: App is shared).
+          repositories: ${{ env.REPO_NAME }}
 
       - name: Enable squash auto-merge
         env:

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -4,15 +4,27 @@
 # GitHub then merges it once every required gate (review / pytest / meta-tests /
 # gitleaks / require-linked-issue / owner-queue-guard) is green. Owner holds a PR
 # by keeping it a draft or applying status:owner-queue (owner-queue-guard stays red).
+#
+# CRITICAL — why a GitHub App token, not GITHUB_TOKEN (#1005, Bug A of #948):
+#   Auto-merge enabled with the default GITHUB_TOKEN makes GitHub attribute the
+#   eventual squash merge to github-actions[bot]. GitHub's recursion-prevention
+#   then SUPPRESSES native linked-issue auto-close — the PR merges but its
+#   `Closes #N` issue stays open. Proven empirically (9/9 human merges auto-close,
+#   0 bot merges do). Same token rule already documented in merge-train.yml for
+#   update-branch (decision 2ccfa29a). Enabling auto-merge with the 'jarvis-ci'
+#   App installation token makes the merge a real identity, so native auto-close
+#   fires. Precondition: the App needs Issues:Read&write (plus the existing
+#   Contents + Pull requests) for the close to be permitted.
 name: auto-merge-enable
 
 on:
   pull_request:
     types: [opened, ready_for_review]
 
+# The merge is performed with the App token below, not GITHUB_TOKEN, so this
+# job's default token needs no write scope.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   enable:
@@ -20,7 +32,32 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      - name: Assert App credentials present
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APP_ID}" ] || [ -z "${APP_PRIVATE_KEY}" ]; then
+            echo "::error::auto-merge-enable requires the 'jarvis-ci' GitHub App, but APP_ID and/or APP_PRIVATE_KEY repo secrets are unset."
+            echo "Why: auto-merge enabled with the default GITHUB_TOKEN suppresses native linked-issue auto-close (GitHub recursion prevention), so merged PRs leave their Closes #N issues open. A GitHub App installation token is required (#1005)."
+            echo "Setup (one-time per repo):"
+            echo "  1. Create/extend the 'jarvis-ci' GitHub App with permissions: Contents=Read&write, Pull requests=Read&write, Issues=Read&write."
+            echo "  2. Install the App on this repository."
+            echo "  3. Add repo secrets: APP_ID (the App's numeric id) and APP_PRIVATE_KEY (the .pem private key)."
+            echo "Until then auto-merge cannot be enabled on this repo."
+            exit 1
+          fi
+          echo "App credentials present."
+
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Enable squash auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --auto --squash

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -12,9 +12,10 @@
 #   `Closes #N` issue stays open. Proven empirically (9/9 human merges auto-close,
 #   0 bot merges do). Same token rule already documented in merge-train.yml for
 #   update-branch (decision 2ccfa29a). Enabling auto-merge with the 'jarvis-ci'
-#   App installation token makes the merge a real identity, so native auto-close
-#   fires. Precondition: the App needs Issues:Read&write (plus the existing
-#   Contents + Pull requests) for the close to be permitted.
+#   App installation token makes the merge a real (non-github-actions[bot])
+#   identity, so native auto-close fires. The App should also carry Issues:Read&
+#   write alongside Contents + Pull requests — the close is attributed to the
+#   merge actor, and the extra scope avoids any permission edge.
 name: auto-merge-enable
 
 on:
@@ -26,10 +27,22 @@ on:
 permissions:
   contents: read
 
+# Rapid draft->ready transitions or event re-deliveries can spawn two parallel
+# runs racing on `gh pr merge --auto` for the same PR. Serialize per-PR.
+concurrency:
+  group: auto-merge-enable-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   enable:
     # Skip drafts — a draft is the manual "owner attention owed" hold.
-    if: github.event.pull_request.draft == false
+    # Skip fork PRs — repo secrets (APP_ID/APP_PRIVATE_KEY) are withheld from
+    # forked-PR events, so the App token can't be minted; auto-merge on a fork
+    # PR isn't meaningful anyway. Without this guard the Assert step below would
+    # hard-fail every fork PR.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Assert App credentials present
@@ -60,4 +73,17 @@ jobs:
       - name: Enable squash auto-merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: gh pr merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --auto --squash
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Idempotent: the 'ready_for_review' trigger can fire after 'opened'
+          # already enabled auto-merge; re-calling `gh pr merge --auto` then exits
+          # non-zero ("already enabled"), which the loud Assert step above would
+          # make easy to mistake for a credential failure. Check first.
+          am=$(gh pr view "$PR" --repo "$REPO" --json autoMergeRequest -q '.autoMergeRequest')
+          if [ "$am" = "null" ]; then
+            gh pr merge "$PR" --repo "$REPO" --auto --squash
+          else
+            echo "::notice::Auto-merge already enabled on #$PR — nothing to do."
+          fi

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -55,7 +55,7 @@ jobs:
             echo "::error::merge-train requires the 'jarvis-ci' GitHub App, but APP_ID and/or APP_PRIVATE_KEY repo secrets are unset."
             echo "Why: update-branch pushed by the default GITHUB_TOKEN does not re-trigger required checks (GitHub recursion prevention), so auto-merge stalls. A GitHub App installation token is required."
             echo "Setup (one-time per repo):"
-            echo "  1. Create/extend the 'jarvis-ci' GitHub App with permissions: Contents=Read&write, Pull requests=Read&write, Issues=Read&write."
+            echo "  1. Create/extend the 'jarvis-ci' GitHub App with these permissions (as labelled in the GitHub App UI): Contents: Read and write, Pull requests: Read and write, Issues: Read and write."
             echo "  2. Install the App on this repository."
             echo "  3. Add repo secrets: APP_ID (the App's numeric id) and APP_PRIVATE_KEY (the .pem private key)."
             echo "Until then the merge train cannot run on this repo."
@@ -70,8 +70,12 @@ jobs:
         # create-github-app-token falls back to ALL installed repos. With the
         # App now carrying Issues:write, that empty fallback would mint an
         # Issues:write token on redrobot too, every 15 min. Strip the owner to
-        # scope the token to THIS repo on all triggers.
-        run: echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
+        # scope the token to THIS repo on all triggers. The empty guard makes the
+        # least-privilege invariant explicit (an empty REPO_NAME re-opens the leak).
+        run: |
+          set -euo pipefail
+          : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is unset or empty}"
+          echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
 
       - name: Mint App installation token
         id: app-token

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -69,6 +69,10 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Least-privilege: scope the token to THIS repo only. Empty on the
+          # schedule trigger falls back to all-installed-repos — no worse than
+          # the prior unscoped default.
+          repositories: ${{ github.event.repository.name }}
 
       - name: Update stale auto-merge PR branches
         env:

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -79,6 +79,11 @@ jobs:
 
       - name: Mint App installation token
         id: app-token
+        # Defense-in-depth: if the Derive step above is ever deleted/reordered so
+        # REPO_NAME is unset, skip minting rather than fall back to an unscoped
+        # token over ALL installed repos (the cross-repo write-scope leak). Belt
+        # to the Derive step's `:?` braces.
+        if: env.REPO_NAME != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -63,16 +63,26 @@ jobs:
           fi
           echo "App credentials present."
 
+      - name: Derive repo name for least-privilege token scoping
+        # GITHUB_REPOSITORY ("owner/repo") is populated on EVERY event type.
+        # github.event.repository.name is NOT — on the `schedule` trigger the
+        # event payload has no `repository` key, so it evaluates to empty and
+        # create-github-app-token falls back to ALL installed repos. With the
+        # App now carrying Issues:write, that empty fallback would mint an
+        # Issues:write token on redrobot too, every 15 min. Strip the owner to
+        # scope the token to THIS repo on all triggers.
+        run: echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
+
       - name: Mint App installation token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Least-privilege: scope the token to THIS repo only. Empty on the
-          # schedule trigger falls back to all-installed-repos — no worse than
-          # the prior unscoped default.
-          repositories: ${{ github.event.repository.name }}
+          # Least-privilege: scope to THIS repo only (REPO_NAME is set on all
+          # triggers, see step above) so the App's write scopes never leak to
+          # other repos it's installed on (CLAUDE.md: App shared with redrobot).
+          repositories: ${{ env.REPO_NAME }}
 
       - name: Update stale auto-merge PR branches
         env:

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -55,7 +55,7 @@ jobs:
             echo "::error::merge-train requires the 'jarvis-ci' GitHub App, but APP_ID and/or APP_PRIVATE_KEY repo secrets are unset."
             echo "Why: update-branch pushed by the default GITHUB_TOKEN does not re-trigger required checks (GitHub recursion prevention), so auto-merge stalls. A GitHub App installation token is required."
             echo "Setup (one-time per repo):"
-            echo "  1. Create a GitHub App with permissions: Contents=Read&write, Pull requests=Read&write."
+            echo "  1. Create/extend the 'jarvis-ci' GitHub App with permissions: Contents=Read&write, Pull requests=Read&write, Issues=Read&write."
             echo "  2. Install the App on this repository."
             echo "  3. Add repo secrets: APP_ID (the App's numeric id) and APP_PRIVATE_KEY (the .pem private key)."
             echo "Until then the merge train cannot run on this repo."

--- a/tests/ci/test_auto_merge_enable_guard.py
+++ b/tests/ci/test_auto_merge_enable_guard.py
@@ -1,0 +1,161 @@
+"""Meta-test for .github/workflows/auto-merge-enable.yml.
+
+Reimplements the auto-merge-enable's per-PR enable decision in Python and
+asserts it enables/skips the PRs the workflow promises, plus a config dimension
+that keeps the YAML and this test in lockstep.
+
+Why this test exists (CLAUDE.md §326 + #948 Bug A): auto-merge-enable.yml is the
+fix for #948 Bug A — a PR auto-merged with the default GITHUB_TOKEN is attributed
+to github-actions[bot], and GitHub's recursion-prevention then SUPPRESSES native
+linked-issue auto-close (the merged PR leaves its `Closes #N` issue open). The fix
+is to enable auto-merge with a GitHub App installation token so the merge's
+`enabledBy` actor is the App, not the bot. That correctness hinges entirely on
+config the diff can silently regress:
+  - reverting the App token back to GITHUB_TOKEN reintroduces the exact bug,
+  - dropping the draft/fork guard hard-fails fork PRs or enrols held drafts,
+  - dropping the empty-output guard silently leaves a PR un-enrolled,
+  - dropping cancel-in-progress:false can kill a run mid-enable.
+None of those produce a red signal on their own — this test is that signal.
+
+Enable rule mirrored here (see the `if:` guard + bash step in the YAML):
+  eligible   = non-draft AND head repo == base repo (not a fork)
+  enable     = eligible AND auto-merge not already enabled (autoMergeRequest null)
+  skip       = eligible AND auto-merge already enabled (idempotent re-trigger)
+  fail-loud  = eligible AND `gh pr view` returned empty (auth/API degradation)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "auto-merge-enable.yml"
+)
+
+
+# ---- logic dimension --------------------------------------------------------
+#
+# The decision has three terminal states: ENABLE, SKIP, FAIL. `am` is the
+# stringified `.autoMergeRequest` field as gh emits it: "null" when unset, a
+# non-empty JSON object when enabled, and "" only on a degraded API call.
+
+
+def decide(*, draft: bool, head_repo: str, base_repo: str, am: str) -> str:
+    """Mirror the workflow's enable decision. Returns ENABLE / SKIP / FAIL / NOOP."""
+    # `if:` guard — drafts and forks never reach the steps.
+    if draft:
+        return "NOOP"
+    if head_repo != base_repo:
+        return "NOOP"
+    # Empty-output guard — fail loud rather than misread as "already enabled".
+    if am == "":
+        return "FAIL"
+    if am == "null":
+        return "ENABLE"
+    return "SKIP"
+
+
+def test_ready_non_fork_with_no_automerge_enables():
+    assert decide(draft=False, head_repo="o/r", base_repo="o/r", am="null") == "ENABLE"
+
+
+def test_already_enabled_is_idempotent_skip():
+    assert decide(draft=False, head_repo="o/r", base_repo="o/r", am='{"enabledAt":"x"}') == "SKIP"
+
+
+def test_draft_is_noop():
+    assert decide(draft=True, head_repo="o/r", base_repo="o/r", am="null") == "NOOP"
+
+
+def test_fork_pr_is_noop():
+    assert decide(draft=False, head_repo="fork/r", base_repo="o/r", am="null") == "NOOP"
+
+
+def test_empty_output_fails_loud():
+    assert decide(draft=False, head_repo="o/r", base_repo="o/r", am="") == "FAIL"
+
+
+def test_draft_fork_still_noop():
+    assert decide(draft=True, head_repo="fork/r", base_repo="o/r", am="null") == "NOOP"
+
+
+# ---- config dimension (keep YAML and test in lockstep) ----------------------
+
+
+def test_workflow_exists():
+    assert WORKFLOW_PATH.is_file(), "auto-merge-enable.yml missing"
+
+
+def test_workflow_uses_app_token_not_github_token():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "create-github-app-token" in text, (
+        "auto-merge-enable must mint a GitHub App token — auto-merge enabled with "
+        "GITHUB_TOKEN attributes the merge to github-actions[bot], which suppresses "
+        "native linked-issue auto-close (#948 Bug A)."
+    )
+
+
+def test_workflow_app_token_is_sha_pinned():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Supply-chain hardening: the action must be pinned to a full commit SHA,
+    # not a mutable tag (@v3). A 40-hex SHA on the create-github-app-token line.
+    assert "create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1" in text, (
+        "create-github-app-token must be SHA-pinned (supply-chain), not tag-pinned."
+    )
+
+
+def test_workflow_scopes_token_to_this_repo():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Least-privilege: the App is shared across repos (jarvis + redrobot), so the
+    # minted token must be scoped to this repo only. Derived from GITHUB_REPOSITORY
+    # so it's populated on every trigger.
+    assert "REPO_NAME=${GITHUB_REPOSITORY#*/}" in text, (
+        "token must be scoped via env REPO_NAME derived from GITHUB_REPOSITORY."
+    )
+    assert "repositories: ${{ env.REPO_NAME }}" in text, (
+        "create-github-app-token must pass repositories: env.REPO_NAME for least-privilege."
+    )
+
+
+def test_workflow_guards_drafts_and_forks():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "github.event.pull_request.draft == false" in text, (
+        "draft guard dropped — held drafts would get auto-merge enabled."
+    )
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in text, (
+        "fork guard dropped — fork PRs (no secrets) would hard-fail the token step."
+    )
+
+
+def test_workflow_has_empty_output_guard():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert '[ -z "$am" ]' in text, (
+        "empty-output guard dropped — a degraded `gh pr view` would be misread as "
+        "'already enabled', silently leaving the PR un-enrolled."
+    )
+
+
+def test_workflow_enables_only_when_unset():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert '[ "$am" = "null" ]' in text, (
+        "idempotency check dropped — re-triggers would re-call `gh pr merge --auto` "
+        "and surface a spurious failure."
+    )
+
+
+def test_workflow_has_concurrency_guard():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "concurrency:" in text and "cancel-in-progress: false" in text, (
+        "auto-merge-enable must queue per-PR runs without cancelling one mid-enable "
+        "(a cancel after token mint but before `gh pr merge` leaves the PR un-enrolled)."
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ci/test_auto_merge_enable_guard.py
+++ b/tests/ci/test_auto_merge_enable_guard.py
@@ -101,8 +101,12 @@ def test_closed_pr_is_noop():
     assert decide(draft=False, head_repo="o/r", base_repo="o/r", am="null", state="CLOSED") == "NOOP"
 
 
-def test_draft_fork_still_noop():
-    assert decide(draft=True, head_repo="fork/r", base_repo="o/r", am="null") == "NOOP"
+def test_fork_precedes_empty_output_fail():
+    # Fork guard is evaluated before the empty-output FAIL path: a fork PR with
+    # degraded output must NOOP (the `if:` skips the steps entirely), not FAIL.
+    # Replaces a draft+fork case that duplicated the draft-only path (#1006 review,
+    # NIT) — this one actually reaches the fork branch with am="".
+    assert decide(draft=False, head_repo="fork/r", base_repo="o/r", am="") == "NOOP"
 
 
 # ---- config dimension (keep YAML and test in lockstep) ----------------------
@@ -130,9 +134,12 @@ def test_workflow_uses_app_token_not_github_token():
         "GH_TOKEN for `gh pr merge --auto` must use the minted App token output "
         "(steps.app-token.outputs.token), not GITHUB_TOKEN — reverting is #948 Bug A."
     )
-    assert "secrets.GITHUB_TOKEN" not in text, (
-        "auto-merge-enable must never pass secrets.GITHUB_TOKEN to gh — it would "
-        "re-attribute the merge to github-actions[bot] and suppress auto-close."
+    # Match the regression VECTOR (the interpolated expression), not the bare
+    # substring: a comment mentioning secrets.GITHUB_TOKEN would false-positive
+    # the broad check (#1006 review, MINOR).
+    assert "${{ secrets.GITHUB_TOKEN }}" not in text, (
+        "auto-merge-enable must never pass ${{ secrets.GITHUB_TOKEN }} to gh — it "
+        "would re-attribute the merge to github-actions[bot] and suppress auto-close."
     )
 
 
@@ -174,9 +181,28 @@ def test_workflow_guards_drafts_and_forks():
 
 def test_workflow_has_empty_output_guard():
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # The guard is compound: `[ -z "$am" ] || [ -z "$state" ]`. Assert BOTH halves
+    # (#1006 review, MINOR) — dropping the `$state` half would leave the
+    # state-emptiness path unguarded while this test still passed on the `$am` half.
     assert '[ -z "$am" ]' in text, (
         "empty-output guard dropped — a degraded `gh pr view` would be misread as "
         "'already enabled', silently leaving the PR un-enrolled."
+    )
+    assert '[ -z "$state" ]' in text, (
+        "state empty-guard half dropped — a degraded `gh pr view` could leave "
+        "$state empty and the merged-PR guard would misfire."
+    )
+
+
+def test_workflow_guards_empty_app_token():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # If the Mint step is skipped (REPO_NAME empty), GH_TOKEN is "" and gh could
+    # fall back to the ambient GITHUB_TOKEN — re-attributing the merge to the bot
+    # (#948 Bug A). The Enable step must fail loud on an empty token before any gh
+    # call (#1006 review, MAJOR).
+    assert '[ -z "${GH_TOKEN:-}" ]' in text, (
+        "Enable step must fail loud when the App token is empty — an empty GH_TOKEN "
+        "risks a GITHUB_TOKEN fallback and a bot-attributed merge (#948 Bug A)."
     )
 
 

--- a/tests/ci/test_auto_merge_enable_guard.py
+++ b/tests/ci/test_auto_merge_enable_guard.py
@@ -42,8 +42,10 @@ WORKFLOW_PATH = (
 # ---- logic dimension --------------------------------------------------------
 #
 # The decision has three terminal states: ENABLE, SKIP, FAIL. `am` is the
-# stringified `.autoMergeRequest` field as gh emits it: "null" when unset, a
-# non-empty JSON object when enabled, and "" only on a degraded API call.
+# auto-merge token the workflow's jq emits: "null" when unset, "set" when
+# already enabled, and "" only on degraded (whitespace-only) API output. The
+# workflow reduces the raw autoMergeRequest object to this bare token via @tsv
+# so `read` can't mis-split on spaces inside commitHeadline.
 
 
 def decide(*, draft: bool, head_repo: str, base_repo: str, am: str, state: str = "OPEN") -> str:
@@ -70,7 +72,7 @@ def test_ready_non_fork_with_no_automerge_enables():
 
 
 def test_already_enabled_is_idempotent_skip():
-    assert decide(draft=False, head_repo="o/r", base_repo="o/r", am='{"enabledAt":"x"}') == "SKIP"
+    assert decide(draft=False, head_repo="o/r", base_repo="o/r", am="set") == "SKIP"
 
 
 def test_draft_is_noop():
@@ -186,6 +188,23 @@ def test_workflow_enables_only_when_unset():
     )
 
 
+def test_workflow_emits_clean_automerge_token():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # The raw autoMergeRequest object carries a commitHeadline that can contain
+    # spaces; interpolating it into `read -r am state` mis-splits state. The jq
+    # must reduce it to a bare "null"/"set" token and emit with @tsv so `read`
+    # splits only on the tab. Regressing to `\(.autoMergeRequest)` re-opens the
+    # whitespace bug (#948 review round 6).
+    assert 'if .autoMergeRequest == null then "null" else "set" end' in text, (
+        "auto-merge status must be reduced to a bare null/set token, not the raw "
+        "autoMergeRequest object (whitespace in commitHeadline mis-splits `read`)."
+    )
+    assert "| @tsv" in text, (
+        "the read inputs must be tab-separated (@tsv) so `read` can't mis-split "
+        "on spaces inside a field."
+    )
+
+
 def test_workflow_skips_non_open_pr():
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     # cancel-in-progress:false allows a run to land after the PR merged; the state
@@ -216,9 +235,12 @@ def test_workflow_repo_name_guard_is_load_bearing():
 
 def test_workflow_has_concurrency_guard():
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
-    assert "concurrency:" in text and "cancel-in-progress: false" in text, (
-        "auto-merge-enable must queue per-PR runs without cancelling one mid-enable "
-        "(a cancel after token mint but before `gh pr merge` leaves the PR un-enrolled)."
+    assert "concurrency:" in text, (
+        "auto-merge-enable must declare a concurrency group to serialize per-PR runs."
+    )
+    assert "cancel-in-progress: false" in text, (
+        "auto-merge-enable must not cancel an in-flight run mid-enable — a cancel "
+        "after token mint but before `gh pr merge` leaves the PR un-enrolled."
     )
 
 

--- a/tests/ci/test_auto_merge_enable_guard.py
+++ b/tests/ci/test_auto_merge_enable_guard.py
@@ -46,7 +46,7 @@ WORKFLOW_PATH = (
 # non-empty JSON object when enabled, and "" only on a degraded API call.
 
 
-def decide(*, draft: bool, head_repo: str, base_repo: str, am: str) -> str:
+def decide(*, draft: bool, head_repo: str, base_repo: str, am: str, state: str = "OPEN") -> str:
     """Mirror the workflow's enable decision. Returns ENABLE / SKIP / FAIL / NOOP."""
     # `if:` guard — drafts and forks never reach the steps.
     if draft:
@@ -54,8 +54,12 @@ def decide(*, draft: bool, head_repo: str, base_repo: str, am: str) -> str:
     if head_repo != base_repo:
         return "NOOP"
     # Empty-output guard — fail loud rather than misread as "already enabled".
-    if am == "":
+    if am == "" or state == "":
         return "FAIL"
+    # cancel-in-progress:false lets a run queued near merge time execute after the
+    # PR is already merged; on a merged PR am reads "null" but state is not OPEN.
+    if state != "OPEN":
+        return "NOOP"
     if am == "null":
         return "ENABLE"
     return "SKIP"
@@ -81,6 +85,20 @@ def test_empty_output_fails_loud():
     assert decide(draft=False, head_repo="o/r", base_repo="o/r", am="") == "FAIL"
 
 
+def test_empty_state_fails_loud():
+    assert decide(draft=False, head_repo="o/r", base_repo="o/r", am="null", state="") == "FAIL"
+
+
+def test_already_merged_pr_is_noop():
+    # Queued run executes after merge: am=="null" (auto-merge completed) but the
+    # PR is no longer OPEN — must NOT call `gh pr merge` on a closed PR.
+    assert decide(draft=False, head_repo="o/r", base_repo="o/r", am="null", state="MERGED") == "NOOP"
+
+
+def test_closed_pr_is_noop():
+    assert decide(draft=False, head_repo="o/r", base_repo="o/r", am="null", state="CLOSED") == "NOOP"
+
+
 def test_draft_fork_still_noop():
     assert decide(draft=True, head_repo="fork/r", base_repo="o/r", am="null") == "NOOP"
 
@@ -92,7 +110,7 @@ def test_workflow_exists():
     assert WORKFLOW_PATH.is_file(), "auto-merge-enable.yml missing"
 
 
-def test_workflow_uses_app_token_not_github_token():
+def test_workflow_mints_app_token():
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "create-github-app-token" in text, (
         "auto-merge-enable must mint a GitHub App token — auto-merge enabled with "
@@ -101,11 +119,30 @@ def test_workflow_uses_app_token_not_github_token():
     )
 
 
-def test_workflow_app_token_is_sha_pinned():
+def test_workflow_uses_app_token_not_github_token():
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
-    # Supply-chain hardening: the action must be pinned to a full commit SHA,
-    # not a mutable tag (@v3). A 40-hex SHA on the create-github-app-token line.
-    assert "create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1" in text, (
+    # Minting the App token is not enough: Bug A reappears if GH_TOKEN on the
+    # `gh pr merge` step reverts to secrets.GITHUB_TOKEN while the mint step stays
+    # (token minted then discarded). Pin the *usage*, not just the presence.
+    assert "steps.app-token.outputs.token" in text, (
+        "GH_TOKEN for `gh pr merge --auto` must use the minted App token output "
+        "(steps.app-token.outputs.token), not GITHUB_TOKEN — reverting is #948 Bug A."
+    )
+    assert "secrets.GITHUB_TOKEN" not in text, (
+        "auto-merge-enable must never pass secrets.GITHUB_TOKEN to gh — it would "
+        "re-attribute the merge to github-actions[bot] and suppress auto-close."
+    )
+
+
+def test_workflow_app_token_is_sha_pinned():
+    import re
+
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Supply-chain hardening: the action must be pinned to a full 40-hex commit
+    # SHA, not a mutable tag (@v3). Match the SHANESS, not the exact commit, so a
+    # Dependabot pin bump doesn't red this test (the sibling merge-train guard
+    # follows the same intent-not-literal pattern).
+    assert re.search(r"create-github-app-token@[0-9a-f]{40}", text), (
         "create-github-app-token must be SHA-pinned (supply-chain), not tag-pinned."
     )
 
@@ -146,6 +183,34 @@ def test_workflow_enables_only_when_unset():
     assert '[ "$am" = "null" ]' in text, (
         "idempotency check dropped — re-triggers would re-call `gh pr merge --auto` "
         "and surface a spurious failure."
+    )
+
+
+def test_workflow_skips_non_open_pr():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # cancel-in-progress:false allows a run to land after the PR merged; the state
+    # guard prevents calling `gh pr merge` on a closed PR (spurious red).
+    assert '[ "$state" != "OPEN" ]' in text, (
+        "merged-PR guard dropped — a queued run after merge would call "
+        "`gh pr merge` on a closed PR and surface a spurious failure."
+    )
+
+
+def test_workflow_triggers_on_ready_for_review_and_reopened():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Dropping ready_for_review → draft→ready PRs never enrol; dropping reopened →
+    # a reopened sandcastle never re-enrols. Both are silent failures.
+    for trigger in ("opened", "ready_for_review", "reopened"):
+        assert trigger in text, f"auto-merge-enable must trigger on {trigger!r}."
+
+
+def test_workflow_repo_name_guard_is_load_bearing():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # An empty REPO_NAME makes create-github-app-token fall back to ALL installed
+    # repos, leaking Issues:write to redrobot. The guard must fail loud instead.
+    assert "GITHUB_REPOSITORY:?" in text, (
+        "the REPO_NAME derivation must guard against an empty GITHUB_REPOSITORY "
+        "(empty scope re-opens the cross-repo token leak)."
     )
 
 

--- a/tests/ci/test_merge_train_guard.py
+++ b/tests/ci/test_merge_train_guard.py
@@ -196,8 +196,11 @@ def test_workflow_uses_app_token_not_github_token():
     assert "steps.app-token.outputs.token" in text, (
         "GH_TOKEN must use the minted App token output (steps.app-token.outputs.token)."
     )
-    assert "secrets.GITHUB_TOKEN" not in text, (
-        "merge-train must never pass secrets.GITHUB_TOKEN to gh — recursion "
+    # Match the regression VECTOR (the interpolated expression), not the bare
+    # substring: a comment mentioning secrets.GITHUB_TOKEN would false-positive
+    # the broad check (#1006 review, MINOR).
+    assert "${{ secrets.GITHUB_TOKEN }}" not in text, (
+        "merge-train must never pass ${{ secrets.GITHUB_TOKEN }} to gh — recursion "
         "prevention would stop update-branch from re-triggering required checks."
     )
 

--- a/tests/ci/test_merge_train_guard.py
+++ b/tests/ci/test_merge_train_guard.py
@@ -190,6 +190,16 @@ def test_workflow_uses_app_token_not_github_token():
         "merge-train must mint a GitHub App token — GITHUB_TOKEN-pushed "
         "updates do not re-trigger required checks (recursion prevention)."
     )
+    # Minting isn't enough: the update-branch step must USE the App token. If
+    # GH_TOKEN reverts to GITHUB_TOKEN while the mint step stays, update-branch
+    # stops re-triggering checks and auto-merge stalls again (the original bug).
+    assert "steps.app-token.outputs.token" in text, (
+        "GH_TOKEN must use the minted App token output (steps.app-token.outputs.token)."
+    )
+    assert "secrets.GITHUB_TOKEN" not in text, (
+        "merge-train must never pass secrets.GITHUB_TOKEN to gh — recursion "
+        "prevention would stop update-branch from re-triggering required checks."
+    )
 
 
 def test_workflow_filters_match_selection_rule():

--- a/tests/ci/test_merge_train_guard.py
+++ b/tests/ci/test_merge_train_guard.py
@@ -202,6 +202,43 @@ def test_workflow_uses_app_token_not_github_token():
     )
 
 
+def test_workflow_app_token_is_sha_pinned():
+    import re
+
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Supply-chain hardening: the action must be pinned to a full 40-hex commit
+    # SHA, not a mutable tag (@v3). Match the SHANESS, not the exact commit, so a
+    # Dependabot pin bump doesn't red this test (the sibling auto-merge-enable
+    # guard follows the same intent-not-literal pattern).
+    assert re.search(r"create-github-app-token@[0-9a-f]{40}", text), (
+        "create-github-app-token must be SHA-pinned (supply-chain), not tag-pinned."
+    )
+
+
+def test_workflow_scopes_token_to_this_repo():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Least-privilege: the App is shared across repos (jarvis + redrobot), so the
+    # minted token must be scoped to this repo only. Derived from GITHUB_REPOSITORY
+    # because github.event.repository.name is empty on the schedule trigger — an
+    # empty scope falls back to ALL installed repos, leaking write scopes.
+    assert "REPO_NAME=${GITHUB_REPOSITORY#*/}" in text, (
+        "token must be scoped via env REPO_NAME derived from GITHUB_REPOSITORY."
+    )
+    assert "repositories: ${{ env.REPO_NAME }}" in text, (
+        "create-github-app-token must pass repositories: env.REPO_NAME for least-privilege."
+    )
+
+
+def test_workflow_repo_name_guard_is_load_bearing():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # An empty REPO_NAME makes create-github-app-token fall back to ALL installed
+    # repos, leaking write scopes to redrobot. The guard must fail loud instead.
+    assert "GITHUB_REPOSITORY:?" in text, (
+        "the REPO_NAME derivation must guard against an empty GITHUB_REPOSITORY "
+        "(empty scope re-opens the cross-repo token leak)."
+    )
+
+
 def test_workflow_filters_match_selection_rule():
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     for token in ("isDraft", "autoMergeRequest", "status:owner-queue", "BEHIND", "update-branch"):


### PR DESCRIPTION
## Summary
`auto-merge-enable.yml` now mints a `jarvis-ci` GitHub App installation token (`actions/create-github-app-token@v3`) and enables squash auto-merge with it, instead of `secrets.GITHUB_TOKEN`. Mirrors the established `merge-train.yml` pattern.

## Why
Bug A (root cause) of #948. Auto-merge enabled with `GITHUB_TOKEN` makes GitHub attribute the eventual squash merge to `github-actions[bot]`; recursion-prevention then **suppresses native linked-issue auto-close** — sandcastle PRs merged but their `Closes #N` issues stayed open. Proven empirically: of merged PRs with populated `closingIssuesReferences`, **9/9 human merges auto-closed, 0 `github-actions` merges did natively** (full RCA + decision `967d7dbd` in #948). A non-`GITHUB_TOKEN` merge identity makes native auto-close fire.

Closes #1005

## Decisions & Alternatives
- **Chose App-token merge over fixing `pr-merged.yml`** — the latter treats the symptom and leaves the bot merge identity that suppresses native close, making the compensator load-bearing forever. App token fixes it at the source and reuses an existing repo pattern (decision `2ccfa29a`, #891).
- **App token, not PAT** — per the standing #891 decision (no PAT; `jarvis-ci` App is the sanctioned credential).
- Backstop sweep + Mode-2 authoring rule are **out of scope here**, tracked under #948.

## Risk Assessment
- **MEDIUM**: changes how auto-merge is *enabled* across the repo. If `APP_ID`/`APP_PRIVATE_KEY` are unset the job now fails loud (asserted) rather than silently enabling via `GITHUB_TOKEN` — but those secrets are already provisioned and used by `merge-train.yml`, so the App path is live.
- **Reversible**: revert the workflow to restore the prior behavior.

## ⚠️ Precondition (owner action)
The `jarvis-ci` App currently holds `Contents` + `Pull requests` (Read & write). For the native close to be *permitted*, it also needs **`Issues: Read & write`**. The merge itself works without it; only the auto-close needs it. **Live check:** if this PR auto-merges but **#1005 stays open**, the App still needs the `Issues` scope — grant it, then the next sandcastle PR closes its issue natively.

## Testing
- `python -c "yaml.safe_load(...)"` → YAML valid.
- Not path-filtered (no `paths:` filter) → no #326 meta-test required.
- E2E verification is this PR itself: it enables its own auto-merge via the App token, and #1005's close-on-merge confirms the App's `Issues` scope.

## Files Changed
- `.github/workflows/auto-merge-enable.yml` — mint + use App token; drop `GITHUB_TOKEN` write scope to `contents: read`; assert App creds; header rationale.
