### PR TITLE
test(#922): behavioral LISTEN-wiring test for PsycopgEventQueue [no-issue]

### DIFF
--- a/agents/wake_driver.py
+++ b/agents/wake_driver.py
@@ -430,8 +430,9 @@ class PsycopgEventQueue:
     PostgREST (supabase-py) cannot ``LISTEN``, so this is the one place the
     agents reach Postgres directly.
 
-    Not unit-tested (needs a live DB); kept thin so the tested loop above
-    carries the logic.
+    The RPC methods need a live DB and are not unit-tested; the constructor's
+    LISTEN wiring is (a recording conn, no DB). Kept thin so the tested loop
+    above carries the logic.
     """
 
     def __init__(self, conn: psycopg.Connection, *, claimer: str = CLAIMER) -> None:

--- a/tests/test_wake_driver.py
+++ b/tests/test_wake_driver.py
@@ -972,12 +972,40 @@ def test_run_forwards_task_read_usage_to_the_drain():
 # --- #922: task_queue NOTIFY channel for cap-freed task dispatch --------
 
 
-def test_psycopg_event_queue_listens_on_task_queue_channel():
-    """AC1: PsycopgEventQueue must LISTEN on task_queue channel for
-    cap-freed capacity signals (distinct channel from events)."""
-    # This test validates the channel name and listen mechanics.
-    # We can't live-test psycopg LISTEN without a live DB, but we can
-    # verify the constant is defined and distinct.
-    assert hasattr(wake_driver, "TASK_QUEUE_CHANNEL")
+def test_task_queue_channel_constant_distinct_from_events():
+    """AC1: the task_queue NOTIFY channel constant exists and is distinct
+    from the events channel (cap-freed signals must not collide)."""
     assert wake_driver.TASK_QUEUE_CHANNEL == "task_queue"
     assert wake_driver.TASK_QUEUE_CHANNEL != wake_driver.EVENTS_CHANNEL
+
+
+class _RecordingConn:
+    """Minimal psycopg.Connection stand-in that records execute() SQL.
+
+    PsycopgEventQueue.__init__ only calls conn.execute(...) + conn.commit();
+    no live DB is needed to verify the LISTEN wiring it issues at construction.
+    """
+
+    def __init__(self):
+        self.executed: list[str] = []
+        self.commits = 0
+
+    def execute(self, sql, *args):
+        self.executed.append(sql)
+        return self
+
+    def commit(self):
+        self.commits += 1
+
+
+def test_psycopg_event_queue_listens_on_both_channels_at_construction():
+    """AC2: constructing PsycopgEventQueue issues LISTEN on BOTH the events
+    channel and the task_queue channel, then commits — so a cap-freed NOTIFY
+    actually wakes the loop. Behavioral check, not just constant existence."""
+    conn = _RecordingConn()
+
+    wake_driver.PsycopgEventQueue(conn)
+
+    assert f"LISTEN {wake_driver.EVENTS_CHANNEL}" in conn.executed
+    assert f"LISTEN {wake_driver.TASK_QUEUE_CHANNEL}" in conn.executed
+    assert conn.commits >= 1


### PR DESCRIPTION
## Summary
Post-merge follow-up to #1007 (#922). The merged AC2 test (`test_psycopg_event_queue_listens_on_task_queue_channel`) only asserted `TASK_QUEUE_CHANNEL` exists and is distinct from `EVENTS_CHANNEL` — it never verified the constructor actually issues `LISTEN task_queue`. A regression dropping the LISTEN line would have passed CI.

#1007 auto-merged on the weak version before this strengthening pushed to the branch, so it lands as a separate PR.

## Changes
- Replace the constant-only test with `test_psycopg_event_queue_listens_on_both_channels_at_construction`: a `_RecordingConn` stand-in records `execute()` calls; the test asserts both `LISTEN events` and `LISTEN task_queue` execute at construction and the conn commits. No live DB needed.
- Keep a trimmed constant-distinctness test (`test_task_queue_channel_constant_distinct_from_events`) for AC1.
- Correct the `PsycopgEventQueue` docstring — the constructor's LISTEN wiring IS now unit-tested; only the RPC methods need a live DB.

## Verification
`pytest tests/test_wake_driver.py` → 37 passed. No behavior change — test-only + docstring.

`[no-issue]` — strengthens already-merged #922; per Fix > track (#428) a 5-min test improvement to freshly-merged code doesn't warrant a tracking issue.