### PR TITLE
fix(ci): pr-merged.yml closes linked issues — native auto-close falsified for App merges (#1012)

### DIFF
--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -5,21 +5,30 @@
 # gitleaks / require-linked-issue / owner-queue-guard) is green. Owner holds a PR
 # by keeping it a draft or applying status:owner-queue (owner-queue-guard stays red).
 #
-# CRITICAL — why a GitHub App token, not GITHUB_TOKEN (#1005, Bug A of #948):
+# Why a GitHub App token, not GITHUB_TOKEN (#1005, #1012, Bug A of #948):
 #   Auto-merge enabled with the default GITHUB_TOKEN makes GitHub attribute the
-#   eventual squash merge to github-actions[bot]. GitHub's recursion-prevention
-#   then SUPPRESSES native linked-issue auto-close — the PR merges but its
-#   `Closes #N` issue stays open. Proven empirically (9/9 human merges auto-close,
-#   0 bot merges do). Same token rule already documented in merge-train.yml for
-#   update-branch (decision 2ccfa29a). Enabling auto-merge with the 'jarvis-ci'
-#   App token makes the merge's `enabledBy` actor the App rather than
-#   github-actions[bot]; empirically that is enough for native auto-close to
-#   fire (9/9 human/App-enabled merges auto-close, 0 github-actions[bot] merges
-#   do). The exact causal chain inside GitHub's platform auto-merge is
-#   undocumented — the App token is the right fix regardless of the precise
-#   mechanism; don't over-generalize the rule from this one observation. The App
-#   should also carry Issues:Read&write alongside Contents + Pull requests so the
-#   close has no permission edge to trip on.
+#   eventual squash merge to github-actions[bot]. That triggers GitHub's
+#   recursion-prevention, which (a) SUPPRESSES native linked-issue auto-close and
+#   (b) suppresses downstream `pull_request: closed` workflows — so neither the
+#   native close NOR a compensating closed-event workflow fires; the `Closes #N`
+#   issue stays open. Same token rule documented in merge-train.yml for
+#   update-branch (decision 2ccfa29a).
+#
+#   CORRECTION (#1012, decision 1b0cbbcc): minting the 'jarvis-ci' App token does
+#   NOT make native auto-close fire. Falsified live on 2026-06-21 — PR #1006
+#   merged with enabledBy/mergedBy = app/osasuwu-ci, valid `Closes #1005`, setting
+#   ON, closingIssuesReferences=[1005], yet #1005 stayed OPEN (no ClosedEvent 3h
+#   later). A GitHub App is a Bot-type actor, so native auto-close stays
+#   suppressed exactly as for github-actions[bot]. (The earlier "9/9 auto-close"
+#   proof was HUMAN merges only.)
+#
+#   What the App token DOES buy: the App-attributed merge is no longer a
+#   GITHUB_TOKEN merge, so the `pull_request: closed` event is NOT suppressed —
+#   pr-merged.yml fires and closes the linked issues EXPLICITLY (proven: it ran 9s
+#   after #1006 merged). So the close path is App-token merge (here) +
+#   explicit close (pr-merged.yml), not native auto-close. The App still needs
+#   Contents + Pull requests write to enable auto-merge; pr-merged.yml does the
+#   close with its own job-scoped issues:write GITHUB_TOKEN.
 name: auto-merge-enable
 
 on:

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -1,35 +1,77 @@
 name: PR Merged
 
+# Explicitly closes a merged PR's linked issues. GitHub's NATIVE linked-issue
+# auto-close does NOT fire for automated (bot / GitHub-App) merges — its
+# recursion-prevention suppresses the close even with a valid `Closes #N`, the
+# repo setting ON, and `closingIssuesReferences` populated (#948 Bug A; proven
+# live on #1006/#1005; decision 1b0cbbcc; memory
+# github_token_merge_suppresses_native_issue_autoclose). The App-token merge in
+# auto-merge-enable.yml un-suppresses THIS `pull_request: closed` event (a
+# GITHUB_TOKEN merge would suppress it too), so this workflow is the deterministic
+# close path. It uses the authoritative `closingIssuesReferences` linkage — the
+# exact set native auto-close would have closed — not a body regex.
+
 on:
   pull_request:
     types: [closed]
     branches: [main]
 
 jobs:
-  comment-on-linked-issues:
+  close-linked-issues:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+      MERGED_AT: ${{ github.event.pull_request.merged_at }}
     steps:
-      - uses: actions/github-script@v9
-        with:
-          script: |
-            const body = context.payload.pull_request.body || '';
-            const regex = /(?:closes|fixes|resolves)\s+#(\d+)/gi;
-            const issues = [...body.matchAll(regex)].map(m => parseInt(m[1]));
+      - name: Close linked issues
+        run: |
+          set -euo pipefail
+          : "${MERGED_AT:?merged_at missing on a merged PR event}"
 
-            const pr = context.payload.pull_request;
-            for (const issueNum of issues) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNum,
-                body: [
-                  `Closed via PR #${pr.number} (${pr.title})`,
-                  `Merge SHA: \`${pr.merge_commit_sha}\``,
-                  `Date: ${new Date().toISOString().split('T')[0]}`,
-                ].join('\n'),
-              });
-            }
+          # Authoritative closing linkage (same set GitHub's native auto-close
+          # targets) — not a body regex, so cross-repo/malformed refs can't leak in.
+          mapfile -t issues < <(
+            gh pr view "$PR_NUMBER" --repo "$REPO" \
+              --json closingIssuesReferences \
+              -q '.closingIssuesReferences[].number'
+          )
+          if [ "${#issues[@]}" -eq 0 ]; then
+            echo "::notice::PR #$PR_NUMBER has no closing issue references — nothing to close."
+            exit 0
+          fi
+
+          for n in "${issues[@]}"; do
+            state=$(gh issue view "$n" --repo "$REPO" --json state -q .state 2>/dev/null || echo "")
+            if [ -z "$state" ]; then
+              echo "::warning::Could not read issue #$n state — skipping."
+              continue
+            fi
+            if [ "$state" = "CLOSED" ]; then
+              echo "::notice::Issue #$n already closed — skipping (idempotent)."
+              continue
+            fi
+
+            # Reopen guard: respect a deliberate human reopen. If the issue was
+            # reopened AFTER this PR merged, leave it open — do not re-close.
+            latest_reopen=$(
+              gh api "repos/$REPO/issues/$n/timeline" --paginate \
+                -q '[.[] | select(.event=="reopened") | .created_at] | last // ""' \
+                2>/dev/null || echo ""
+            )
+            if [ -n "$latest_reopen" ] && [[ "$latest_reopen" > "$MERGED_AT" ]]; then
+              echo "::notice::Issue #$n reopened after PR #$PR_NUMBER merged ($MERGED_AT) — leaving open."
+              continue
+            fi
+
+            gh issue close "$n" --repo "$REPO" --reason completed \
+              --comment "$(printf 'Auto-closed on merge of #%s (%s).\nMerge SHA: `%s`\nNative linked-issue auto-close does not fire for automated merges (#948); closed here.' "$PR_NUMBER" "$PR_TITLE" "$MERGE_SHA")"
+            echo "::notice::Closed issue #$n (completed) via PR #$PR_NUMBER."
+          done

--- a/tests/ci/test_pr_merged_close_guard.py
+++ b/tests/ci/test_pr_merged_close_guard.py
@@ -1,0 +1,138 @@
+"""Meta-test for .github/workflows/pr-merged.yml.
+
+Reimplements the workflow's close/skip decision rule in Python and asserts it
+closes/skips the issues it promises, plus a config dimension keeping the YAML
+and this test in lockstep.
+
+Why this test exists (#948 Bug A, #1012): native linked-issue auto-close does
+NOT fire for automated (bot/App) merges — GitHub recursion-prevention suppresses
+it. The App-token merge (auto-merge-enable.yml) un-suppresses the
+`pull_request: closed` event, so pr-merged.yml is the deterministic close path.
+A silent drift here (back to comment-only, or dropping the reopen guard) would
+re-open Bug A with no red signal. pr-merged.yml is NOT path-filtered, so #326's
+*config* mandate doesn't strictly apply — but the close/skip rule is exactly the
+silent-drift class #326 targets, so the logic+config sibling test is warranted
+(same rationale as test_merge_train_guard.py).
+
+Decision rule mirrored here (see the bash loop in the YAML):
+  - issue already CLOSED                        -> skip (idempotent)
+  - issue reopened AFTER the PR's merged_at     -> skip (respect human reopen)
+  - otherwise                                   -> close (state_reason=completed)
+The candidate set is `closingIssuesReferences` (authoritative linkage), not a
+body regex.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "pr-merged.yml"
+)
+
+
+def decide(state: str, latest_reopen: str | None, merged_at: str) -> str:
+    """Mirror the workflow's per-issue close/skip rule.
+
+    Returns one of: "close", "skip-already-closed", "skip-reopened".
+    Timestamps are ISO-8601 Z strings; lexicographic comparison matches the
+    bash `[[ "$latest_reopen" > "$MERGED_AT" ]]` test.
+    """
+    if state == "CLOSED":
+        return "skip-already-closed"
+    if latest_reopen and latest_reopen > merged_at:
+        return "skip-reopened"
+    return "close"
+
+
+MERGED_AT = "2026-06-21T12:00:00Z"
+
+
+# ---- logic dimension --------------------------------------------------------
+
+
+def test_open_never_reopened_is_closed():
+    assert decide("OPEN", None, MERGED_AT) == "close"
+    assert decide("OPEN", "", MERGED_AT) == "close"
+
+
+def test_already_closed_is_skipped():
+    # Idempotent: a re-delivered event or a backstop must not re-close.
+    assert decide("CLOSED", None, MERGED_AT) == "skip-already-closed"
+
+
+def test_reopened_after_merge_is_skipped():
+    # Human reopened the issue after the PR merged -> respect it, leave open.
+    assert decide("OPEN", "2026-06-21T13:00:00Z", MERGED_AT) == "skip-reopened"
+
+
+def test_reopened_before_merge_is_closed():
+    # A reopen that predates this merge is stale w.r.t. this PR -> still close.
+    assert decide("OPEN", "2026-06-20T09:00:00Z", MERGED_AT) == "close"
+
+
+def test_reopen_exactly_at_merge_is_closed():
+    # Strict `>`: a reopen timestamped exactly at merge is not "after".
+    assert decide("OPEN", MERGED_AT, MERGED_AT) == "close"
+
+
+def test_closed_state_wins_over_reopen_signal():
+    # If the issue is currently CLOSED, skip regardless of any reopen history.
+    assert decide("CLOSED", "2026-06-21T13:00:00Z", MERGED_AT) == "skip-already-closed"
+
+
+# ---- config dimension (keep YAML and test in lockstep) ----------------------
+
+
+def test_workflow_exists():
+    assert WORKFLOW_PATH.is_file(), "pr-merged.yml missing"
+
+
+def test_workflow_triggers_on_pr_closed_to_main():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "pull_request:" in text and "closed" in text, "must trigger on pull_request closed."
+    assert "branches: [main]" in text, "must scope to merges into main."
+    assert "github.event.pull_request.merged == true" in text, (
+        "must act only on MERGED (not merely closed) PRs."
+    )
+
+
+def test_workflow_actually_closes_not_just_comments():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # The whole point of #1012: it must CLOSE, not only post a comment. A
+    # `gh issue close --reason completed` is the close; comment-only is the
+    # regression that left #1005 open with a false "Closed via" note.
+    assert "gh issue close" in text, "workflow must close linked issues, not just comment."
+    assert "--reason completed" in text, "closes must use state_reason=completed."
+
+
+def test_workflow_uses_authoritative_linkage_not_regex():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Use closingIssuesReferences (the set native auto-close targets), not a body
+    # regex — avoids cross-repo / malformed-ref leakage.
+    assert "closingIssuesReferences" in text, (
+        "candidate issues must come from closingIssuesReferences (authoritative linkage)."
+    )
+
+
+def test_workflow_has_reopen_guard():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # A deliberate human reopen after merge must not be re-closed.
+    assert "reopened" in text and "MERGED_AT" in text, (
+        "reopen-after-merge guard (compare reopened event time vs merged_at) drifted."
+    )
+
+
+def test_workflow_needs_issues_write():
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "issues: write" in text, "closing issues requires issues: write permission."
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Native GitHub linked-issue auto-close does **not** fire for automated (bot/App) merges — recursion-prevention suppresses it. `pr-merged.yml` now **closes** a merged PR's linked issues explicitly (instead of only commenting), using the authoritative `closingIssuesReferences` linkage and a reopen-after-merge guard.

## Why
Closes #1012. Refs #948 (Bug A / Mode 1).

#1006 enabled auto-merge via the `jarvis-ci` App token on the hypothesis that an App-attributed merge would make native auto-close fire. **Falsified live (2026-06-21):** #1006 merged with `enabledBy`/`mergedBy = app/osasuwu-ci`, body `Closes #1005`, `closingIssuesReferences=[1005]`, repo setting ON — yet #1005 stayed **OPEN** with no `ClosedEvent` 3h later. A GitHub App is a Bot-type actor, so native auto-close is suppressed exactly as for `github-actions[bot]`. (The original "9/9 auto-close" proof was *human* merges only.)

**Key insight that makes the fix trivial:** the App-token merge identity (not `GITHUB_TOKEN`) **un-suppresses** the `pull_request: closed` event — `pr-merged.yml` fired 9s after #1006 merged. So that workflow is the correct deterministic close path; it already had `issues: write` and the linkage, it just commented instead of closing.

## Decisions & Alternatives
- **Chose event-driven explicit close in `pr-merged.yml`** (decision `1b0cbbcc`). Alternatives:
  - *Keep relying on native auto-close via App token* — rejected: falsified live.
  - *Make the schedule reconciler #1010 the primary* — rejected as primary (polling lag); demoted to optional backstop. Its "why not pr-merged.yml" objection (closed event always suppressed) is invalidated by the App-token merge-identity change.
  - *Revert #1006* — rejected: the App token is still justified (un-suppresses the closed event + cleaner merge identity + merge-train precedent); only its *native-auto-close* rationale was wrong (corrected in this PR).
- **Candidate set = `closingIssuesReferences`**, not a body regex — the exact set native auto-close targets; no cross-repo/malformed-ref leakage.
- **Reopen guard**: skip an issue with a `reopened` event after the PR's `merged_at` — never re-close a deliberate human reopen.

## Risk Assessment
- **LOW/MEDIUM**: CI workflow + new test. The close uses the job-scoped `issues: write` `GITHUB_TOKEN`; idempotent (skips already-closed); bounded by one PR's linked issues.

## Testing
- `pytest tests/ci/` → 488 passed (12 new in `test_pr_merged_close_guard.py`).
- `bash -n` on the extracted run block → clean. Both workflows `yaml.safe_load` OK.

## Files Changed
- `.github/workflows/pr-merged.yml` — close (not comment) linked issues; reopen guard; authoritative linkage.
- `tests/ci/test_pr_merged_close_guard.py` — co-located meta-test (close/skip logic + config), mirrors `test_merge_train_guard.py`.
- `.github/workflows/auto-merge-enable.yml` — corrected the now-false "App token makes native auto-close fire" rationale.

## Follow-up
- #1005 will be closed manually with a corrective note (it shipped via #1006; the prior "Closed via" comment was posted while it stayed open) — this PR fixes the mechanism going forward.
