### PR TITLE
test(agents): make _resolve_claude_binary not-found test host-independent

### DIFF
--- a/tests/test_agents_executor.py
+++ b/tests/test_agents_executor.py
@@ -152,10 +152,18 @@ def test_resolve_claude_binary_raises_with_actionable_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import shutil as _shutil
+
+    import agents.executor as _executor
     from agents.executor import _resolve_claude_binary
 
     monkeypatch.delenv("JARVIS_CLAUDE_BIN", raising=False)
     monkeypatch.setattr(_shutil, "which", lambda _name: None)
+    # On Windows the 4th resolution step probes documented install paths
+    # (#385). On a dev box where `claude` lives at one of those defaults,
+    # the function would return that path instead of raising — a local-only
+    # false failure. Neutralize the fallback so all four steps fail
+    # regardless of host OS / installed binaries.
+    monkeypatch.setattr(_executor, "_CLAUDE_DEFAULT_WINDOWS_PATHS", ())
 
     with pytest.raises(FileNotFoundError, match="JARVIS_CLAUDE_BIN"):
         _resolve_claude_binary()


### PR DESCRIPTION
## What

`tests/test_agents_executor.py::test_resolve_claude_binary_raises_with_actionable_message` had a Windows-local false failure. `_resolve_claude_binary()`'s 4th resolution step probes documented Windows install paths (#385), so on a dev box where `claude` lives at one of those defaults the function returns that path instead of raising `FileNotFoundError` — the test fails locally though it passes in CI.

## Fix

Monkeypatch `_CLAUDE_DEFAULT_WINDOWS_PATHS` to `()` in the test so all four resolution steps fail regardless of host OS / installed binaries. Test-only change.

## Verification

`python -m pytest tests/test_agents_executor.py -q` → 20 passed.

[no-issue] — trivial, reversible, test-only fix (#428 fix-inline class); no parent issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)