### PR TITLE
fix(memory): pin fire-and-forget tasks in handlers/memory.py [no-issue]

### DIFF
--- a/mcp-memory/handlers/memory.py
+++ b/mcp-memory/handlers/memory.py
@@ -91,6 +91,22 @@ GAP_THRESHOLD = 0.45  # known-unknowns: log gaps when top_similarity < this
 GAP_DEDUP_SIM = 0.9
 
 
+# Strong references to fire-and-forget tasks. CPython holds only a weak ref to
+# a bare ``asyncio.create_task`` result, so without an external strong ref the
+# task can be GC-collected mid-flight before it completes (same pattern as
+# write_scrubber._PENDING_BLOCK_LOGS and decision._PENDING_TASKS). Every
+# detached task in this module — recall touch/backfill/recall-event, store-path
+# auto-link/known-unknown resolution — is pinned here. Discard via the
+# done-callback below.
+_PENDING_TASKS: set[asyncio.Task] = set()
+
+
+def _pin_task(task: asyncio.Task) -> None:
+    """Strong-ref *task* until completion so it can't be GC-collected mid-flight."""
+    _PENDING_TASKS.add(task)
+    task.add_done_callback(_PENDING_TASKS.discard)
+
+
 async def _upsert_known_unknown(
     client,
     query: str,
@@ -245,7 +261,7 @@ async def _handle_recall(args: dict) -> list[TextContent]:
                     if "always_load" not in (row.get("tags") or [])
                 ]
                 if ids_to_touch:
-                    asyncio.create_task(_touch_memories(client, ids_to_touch))
+                    _pin_task(asyncio.create_task(_touch_memories(client, ids_to_touch)))
             return results
 
     # Fallback: keyword-only search (embed failure or empty hybrid result).
@@ -264,7 +280,7 @@ async def _handle_recall(args: dict) -> list[TextContent]:
 
     # Lazily backfill embeddings for records missing them (fire-and-forget)
     if os.environ.get("VOYAGE_API_KEY"):
-        asyncio.create_task(_backfill_missing_embeddings(client, project))
+        _pin_task(asyncio.create_task(_backfill_missing_embeddings(client, project)))
 
     return results
 
@@ -352,7 +368,7 @@ async def _hybrid_recall(
         "type_filter": mem_type,
         "show_history": show_history,
     }
-    asyncio.create_task(_emit_recall_event(client, payload))
+    _pin_task(asyncio.create_task(_emit_recall_event(client, payload)))
 
     # Touch fans out across the whole displayed set (direct + linked) so
     # access-frequency boost matches what the user actually saw.
@@ -1034,13 +1050,15 @@ async def _handle_store(args: dict) -> list[TextContent]:
                     "content": content,
                     "tags": tags,
                 }
-                asyncio.create_task(
-                    _create_auto_links(
-                        client,
-                        stored_id,
-                        similar_rows,
-                        mem_type,
-                        candidate=candidate_for_classifier,
+                _pin_task(
+                    asyncio.create_task(
+                        _create_auto_links(
+                            client,
+                            stored_id,
+                            similar_rows,
+                            mem_type,
+                            candidate=candidate_for_classifier,
+                        )
                     )
                 )
 
@@ -1070,7 +1088,7 @@ async def _handle_store(args: dict) -> list[TextContent]:
 
         # Resolve known unknowns: if stored memory matches any open unknown > 0.7 similarity,
         # mark as resolved (fire-and-forget, best-effort)
-        asyncio.create_task(_resolve_known_unknowns(client, embedding, stored_id))
+        _pin_task(asyncio.create_task(_resolve_known_unknowns(client, embedding, stored_id)))
 
     # #658: structured envelope. `stored=True` is the unambiguous success
     # signal; callers must not infer success/failure from `message` prose.

--- a/tests/test_memory_task_pinning.py
+++ b/tests/test_memory_task_pinning.py
@@ -1,0 +1,138 @@
+"""Fire-and-forget task pinning in mcp-memory/handlers/memory.py.
+
+CPython holds only a *weak* reference to the task returned by
+``asyncio.create_task``; without an external strong ref the GC can collect a
+detached task mid-flight, silently dropping its work. memory.py routes every
+fire-and-forget task (recall touch/backfill/recall-event, store-path
+auto-link/known-unknown resolution) through ``_pin_task`` so the task is held
+in ``_PENDING_TASKS`` until it completes.
+
+This mirrors write_scrubber._PENDING_BLOCK_LOGS and decision._PENDING_TASKS.
+Pre-existing tech debt surfaced during #555 review (sibling-grep).
+
+conftest.py stubs the MCP SDK + Supabase before ``handlers.memory`` imports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Import ``server`` first so the server <-> handlers.memory import chain is
+# fully initialised before we grab the handler module directly (importing
+# handlers.memory first triggers a partially-initialised circular import —
+# the same reason sibling tests import ``from server import ...``).
+import server  # noqa: F401
+import handlers.memory as mem
+from recall import RecallHit
+
+
+# ---------------------------------------------------------------------------
+# _pin_task contract: pinned task survives GC and is discarded on completion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pin_task_holds_until_completion_then_discards():
+    gate = asyncio.Event()
+    completed = asyncio.Event()
+
+    async def _gated():
+        await gate.wait()
+        completed.set()
+
+    mem._PENDING_TASKS.clear()
+    # Pin the task, then drop the only local strong ref and force a GC pass.
+    # Without pinning, the task would be collectable here; with it, the
+    # module-level set keeps it alive.
+    mem._pin_task(asyncio.create_task(_gated()))
+    del _gated
+    gc.collect()
+
+    assert len(mem._PENDING_TASKS) == 1, "task must be strong-reffed while in flight"
+
+    # Release the gate and let the task run to completion.
+    gate.set()
+    await asyncio.wait_for(completed.wait(), timeout=1.0)
+    # The done-callback runs on the loop after the task finishes; yield to it.
+    await asyncio.sleep(0)
+
+    assert mem._PENDING_TASKS == set(), "completed task must be unpinned by the done-callback"
+
+
+# ---------------------------------------------------------------------------
+# Handler-level: _hybrid_recall's recall-event emit (the legacy fire-and-forget
+# anti-pattern, memory.py:354) is now pinned rather than bare-detached.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hybrid_recall_pins_emit_recall_event(monkeypatch):
+    gate = asyncio.Event()
+
+    async def _gated_emit(_client, _payload):
+        await gate.wait()
+
+    async def _stub_recall(*_args, **_kwargs):
+        return [
+            RecallHit(
+                memory={
+                    "id": "mem-1",
+                    "name": "m",
+                    "type": "project",
+                    "description": "d",
+                    "content": "c",
+                    "updated_at": "2026-06-19T00:00:00+00:00",
+                    "similarity": 0.9,
+                },
+                semantic_score=0.9,
+                keyword_score=0.0,
+                rrf_score=0.5,
+                temporal_score=0.5,
+                final_score=0.5,
+                source="semantic",
+            )
+        ]
+
+    monkeypatch.setattr(mem, "recall", _stub_recall)
+    monkeypatch.setattr(mem, "_emit_recall_event", _gated_emit)
+
+    mem._PENDING_TASKS.clear()
+    await mem._hybrid_recall(
+        MagicMock(), query_text="anything", project="jarvis", mem_type=None, limit=5
+    )
+
+    # The emit task is still gated (pending) — it must be pinned, not GC-droppable.
+    gc.collect()
+    assert len(mem._PENDING_TASKS) == 1
+
+    gate.set()
+    # Drain the pinned task so it doesn't leak into other tests.
+    await asyncio.gather(*list(mem._PENDING_TASKS))
+    await asyncio.sleep(0)
+    assert mem._PENDING_TASKS == set()
+
+
+# ---------------------------------------------------------------------------
+# Source guard: no bare asyncio.create_task survives in memory.py. Every call
+# must be wrapped by _pin_task so the GC-drop regression can't silently return
+# (sibling-grep discipline — see CLAUDE.md "No silent caps").
+# ---------------------------------------------------------------------------
+
+
+def test_every_create_task_is_pinned():
+    src = (Path(mem.__file__)).read_text(encoding="utf-8")
+
+    total = len(re.findall(r"asyncio\.create_task\(", src))
+    pinned = len(re.findall(r"_pin_task\(\s*asyncio\.create_task\(", src))
+
+    assert total >= 5, f"expected >=5 detached tasks in memory.py, found {total}"
+    assert pinned == total, (
+        f"{total - pinned} bare asyncio.create_task call(s) in memory.py are not "
+        "wrapped by _pin_task — they can be GC-collected mid-flight. Wrap them."
+    )


### PR DESCRIPTION
## Summary

`mcp-memory/handlers/memory.py` fired several fire-and-forget `asyncio.create_task(...)` calls (recall touch/backfill/recall-event, store-path auto-link/known-unknown resolution) without retaining a strong reference. CPython holds only a *weak* ref to a bare `create_task` result, so the GC can collect a detached task mid-flight before it completes — silently dropping the side effect (touch not recorded, embedding not backfilled, recall event not emitted).

This pins every detached task in the module in a module-level `_PENDING_TASKS` set via a `_pin_task()` helper that discards on completion — the same pattern already used by `write_scrubber._PENDING_BLOCK_LOGS` and `decision._PENDING_TASKS`.

## Test

`tests/test_memory_task_pinning.py` — 3 cases asserting tasks stay strongly-referenced until completion. All pass.

`[no-issue]` — drive-by correctness fix adjacent to the #555/#999 scrubber work; sibling pattern already established in two other handlers.