### PR TITLE
fix(installer): bound MCP/env subprocess calls + line-buffer progress

### DIFF
--- a/scripts/install/installer.py
+++ b/scripts/install/installer.py
@@ -33,6 +33,14 @@ import yaml
 
 DEFAULT_MANIFEST = "install-manifest.yaml"
 
+# Bound external-command calls so a child that inherits the capture pipe and
+# never exits can't hang the installer forever (latent grandchild-pipe hang —
+# `capture_output=True` keeps reading until every writer closes the fd). The
+# health check already uses a 30s bound; `claude mcp add` may spin up Node and
+# hit the network, so it gets more headroom than the instant local `setx`.
+_MCP_SUBPROCESS_TIMEOUT = 120
+_ENV_SUBPROCESS_TIMEOUT = 30
+
 
 # ---------- data model ----------
 
@@ -405,11 +413,20 @@ def _register_mcp_user(name: str, spec: dict[str, Any]) -> None:
     `--` is safe.
     """
     claude = _resolve_claude_cli()
-    subprocess.run(
-        [claude, "mcp", "remove", "-s", "user", name],
-        check=False,
-        capture_output=True,
-    )
+    try:
+        subprocess.run(
+            [claude, "mcp", "remove", "-s", "user", name],
+            check=False,
+            capture_output=True,
+            timeout=_MCP_SUBPROCESS_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        # Best-effort cleanup — a hung remove must not block the add below.
+        print(
+            f"  warn: `claude mcp remove {name}` timed out "
+            f"after {_MCP_SUBPROCESS_TIMEOUT}s; continuing",
+            file=sys.stderr,
+        )
     cmd: list[str] = [claude, "mcp", "add", "-s", "user"]
     transport = spec.get("type")
     if transport in {"http", "sse"}:
@@ -426,7 +443,18 @@ def _register_mcp_user(name: str, spec: dict[str, Any]) -> None:
         for ek, ev in (spec.get("env") or {}).items():
             cmd += ["-e", f"{ek}={ev}"]
         cmd += ["--", spec["command"], *spec.get("args", [])]
-    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_MCP_SUBPROCESS_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"claude mcp add timed out after {_MCP_SUBPROCESS_TIMEOUT}s for {name!r}"
+        ) from exc
     if result.returncode != 0:
         raise RuntimeError(
             f"claude mcp add failed for {name!r}: {result.stderr.strip() or result.stdout.strip()}"
@@ -737,7 +765,19 @@ def _merge_json_file(
 
 def _set_env(name: str, value: str, platform: str) -> None:
     if platform == "windows":
-        result = subprocess.run(["setx", name, value], check=False, capture_output=True)
+        try:
+            result = subprocess.run(
+                ["setx", name, value],
+                check=False,
+                capture_output=True,
+                timeout=_ENV_SUBPROCESS_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            print(
+                f"setx {name} timed out after {_ENV_SUBPROCESS_TIMEOUT}s",
+                file=sys.stderr,
+            )
+            return
         if result.returncode != 0:
             stderr_msg = result.stderr.decode(errors="replace").strip()
             print(f"setx {name} failed (rc={result.returncode}): {stderr_msg}", file=sys.stderr)
@@ -1021,6 +1061,16 @@ def format_plan(plan: Plan) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Line-buffer stdout/stderr so per-action progress shows in real time even
+    # when output is captured through a pipe (install.ps1 tees it). Otherwise
+    # Python block-buffers a piped stdout and the whole run appears only at
+    # exit — which reads as a hang on slow steps like `claude mcp add`.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(line_buffering=True)
+        except (AttributeError, ValueError):
+            pass  # replaced/non-TextIOWrapper stream (e.g. pytest capture)
+
     parser = argparse.ArgumentParser(
         prog="jarvis-installer",
         description="Install/sync Jarvis agent machinery into ~/.claude/.",

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1344,6 +1344,84 @@ def test_register_mcp_user_raises_on_add_failure(monkeypatch) -> None:
         installer._register_mcp_user("x", {"command": "y", "args": []})
 
 
+def test_register_mcp_user_passes_timeout(monkeypatch) -> None:
+    """Both the remove and add calls must carry a timeout so a child that
+    inherits the capture pipe and never exits can't hang the installer."""
+    timeouts: list[float | None] = []
+
+    def fake_run(cmd, **kwargs):
+        timeouts.append(kwargs.get("timeout"))
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    monkeypatch.setattr(installer, "_resolve_claude_cli", lambda: "claude")
+    installer._register_mcp_user("memory", {"command": "python", "args": ["/abs/run.py"]})
+
+    assert timeouts == [installer._MCP_SUBPROCESS_TIMEOUT, installer._MCP_SUBPROCESS_TIMEOUT]
+
+
+def test_register_mcp_user_raises_on_add_timeout(monkeypatch) -> None:
+    """A hung `claude mcp add` surfaces as RuntimeError, not a silent hang."""
+
+    def fake_run(cmd, **kwargs):
+        # remove (no `add` token) succeeds; the add call times out.
+        if "add" in cmd:
+            raise installer.subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    monkeypatch.setattr(installer, "_resolve_claude_cli", lambda: "claude")
+    with pytest.raises(RuntimeError, match="claude mcp add timed out"):
+        installer._register_mcp_user("x", {"command": "y", "args": []})
+
+
+def test_register_mcp_user_tolerates_remove_timeout(monkeypatch) -> None:
+    """A hung idempotent-remove must not block the add that follows it."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if "remove" in cmd:
+            raise installer.subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    monkeypatch.setattr(installer, "_resolve_claude_cli", lambda: "claude")
+    # Should NOT raise — the add still runs after the remove times out.
+    installer._register_mcp_user("simple", {"command": "uvx", "args": ["foo-mcp"]})
+    assert any("add" in c for c in calls), "add must still run after remove timeout"
+
+
+def test_set_env_tolerates_setx_timeout(monkeypatch, capsys) -> None:
+    """A hung `setx` is reported and skipped, not propagated as a crash."""
+
+    def fake_run(cmd, **kwargs):
+        raise installer.subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    # Must not raise.
+    installer._set_env("FOO", "bar", "windows")
+    assert "timed out" in capsys.readouterr().err
+
+
 def test_resolve_claude_cli_uses_pathext_when_available(monkeypatch, tmp_path) -> None:
     """Regression: bare ``claude`` (no extension) on Windows breaks
     ``CreateProcessW`` when a sibling ``claude.CMD`` also exists; resolver must


### PR DESCRIPTION
## What

Two installer health-check findings surfaced during the user-scope MCP cleanup pass:

1. **No subprocess timeout** on `_register_mcp_user` (the idempotent `remove` and the `add`) and `_set_env` (`setx`). With `capture_output=True`, the reader blocks until *every* writer closes the pipe — a grandchild that inherits the fd and never exits hangs the installer indefinitely. Now bounded:
   - `_MCP_SUBPROCESS_TIMEOUT=120` for `claude mcp add` (spins up Node + may hit the network)
   - `_ENV_SUBPROCESS_TIMEOUT=30` for local `setx`
   - A hung `add` → `RuntimeError`; a hung `remove`/`setx` → warned and skipped. Consistent with the existing 30s bound on the health check.

2. **Block-buffered progress.** `main()` now line-buffers stdout/stderr. Python block-buffers a piped stdout, so under `install.ps1` (which tees output) the whole run only appeared at exit — reading as a hang on slow steps like `claude mcp add`. `reconfigure()` is guarded for replaced/non-`TextIOWrapper` streams (pytest capture).

## Tests

4 new: timeout passthrough, add-timeout raises, remove-timeout tolerated, setx-timeout tolerated. Full installer suite **85 passed**, ruff clean.

## Notes

`[no-issue]` drive-by fix-inline — owner explicitly chose fix-over-file for these findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)