### PR TITLE
feat(#1016): memory↔git contradiction detector (L1-only) + status-record extension

### DIFF
--- a/.claude-userlevel/skills/status-record/SKILL.md
+++ b/.claude-userlevel/skills/status-record/SKILL.md
@@ -10,6 +10,8 @@ Type 1 skill. Fires on cron, scans tracked repos, writes one structured snapshot
 
 **Boundary:** this skill is pure recording. No analysis, no proposals, no actions. Decisions and acting on findings belong to the sandcastle orchestrator (#531) and the owner reading the snapshot.
 
+**One carve-out — the L1 contradiction audit (#1016).** Step 3.5 runs the *single* LLM-judged detector in the status-synthesis design (memory↔git contradiction) once, in this morning baseline only, and **records its cached verdicts** into the snapshot. This is still recording, not acting: the skill writes the audit result, it never opens issues, comments, or reworks anything off the back of it. Acting on a surfaced contradiction remains the owner's / orchestrator's job. The audit is L1-only by construction — there is no intraday (L2) re-run, so the cheap delta path never pays for an LLM pass (mirrors `status_engine.analyze()`, which omits the contradiction fold entirely).
+
 ## Step 1 — Load repos
 
 Read `$JARVIS_HOME/config/repos.conf` (one `owner/repo` per line, `#` = comment). The skill runs under cron with no guaranteed CWD, so resolve via `JARVIS_HOME` (set by the installer per `install-manifest.yaml` `env_vars`). If `JARVIS_HOME` is unset, fall back to scanning the running process's repo root via `git rev-parse --show-toplevel` only if the CWD is already inside the jarvis repo; otherwise exit non-zero with a clear error.
@@ -47,13 +49,55 @@ Cron strips PATH; an unauthenticated `gh` silently 401s on every call and produc
 
 ```bash
 gh pr list --repo <R> --state open --json number,title,createdAt,updatedAt,reviewDecision,isDraft --limit 100
-gh issue list --repo <R> --state open --json number,title,labels,updatedAt --limit 100
+gh issue list --repo <R> --state open --json number,title,labels,updatedAt,body --limit 100
 gh run list --repo <R> --json conclusion --limit 10
 gh api "repos/<R>/milestones?state=open&per_page=50" --jq '.[] | {number, title, open_issues, closed_issues, due_on}'
 gh api "repos/<R>/dependabot/alerts" --jq '[.[] | select(.state=="open")] | length' 2>/dev/null
 ```
 
-If any list returns exactly its `--limit` size (or `per_page` for `gh api`), set the corresponding `*.truncated: true` field in the YAML and append `partial: <kind> truncated at <limit> for <repo>` to `global.partial`. Limits are sized for current usage (≤100 open issues per repo); a truncation event is itself a signal worth surfacing.
+`body` is fetched on open issues (it was not in v1) so blocker edges and decision references can be parsed — see *Richer state for the contradiction audit* below. The body is used only to derive structured edges; it is **not** stored verbatim in the snapshot.
+
+**Recently-closed issues (for the contradiction audit only).** The audit must be able to see "memory still treats #42 as live, but #42 is closed", so additionally fetch issues closed within the audit window (30 days). Skip this call if the morning baseline is not running (it is L1-only):
+
+```bash
+# <since> = (generated_at UTC date) − 30 days, ISO date
+gh issue list --repo <R> --state closed --search "closed:>=<since>" \
+  --json number,title,state,closedAt,labels --limit 100
+```
+
+If any list returns exactly its `--limit` size (or `per_page` for `gh api`), set the corresponding `*.truncated: true` field in the YAML and append `partial: <kind> truncated at <limit> for <repo>` to `global.partial`. Limits are sized for current usage (≤100 open issues per repo); a truncation event is itself a signal worth surfacing. A truncated closed-issue search degrades the audit (some closed refs unseen) but never the snapshot — mark `partial: closed-issue search truncated for <repo>` and continue.
+
+### Richer state for the contradiction audit (#1016)
+
+Three structured fields are derived **per open issue** from the gathered `labels` + `body`, used by the Step 3.5 audit (and available to downstream `status_engine.IssueInfo`). Parse, do not store raw bodies:
+
+| Derived field | Source | Rule |
+|---|---|---|
+| `labels` | gathered directly | already present in v1 |
+| `is_blocked` | body + labels | `true` iff the `blocked` label is present **or** the body has a `Blocked by #N` / `Depends on #N` reference (case-insensitive). A `## Blocked by` heading followed by `#N` bullets counts. |
+| `blocks` | body | list of `#N` from `Blocks #N` lines, or the issues that name *this* issue under their own `Blocked by` — i.e. the reverse edges. Same `#(\d+)` extraction the engine's `build_contradiction_prefilter` uses. |
+
+`#1016` itself is the canonical example — its body carries a `## Blocked by` section listing `#1013`, `#1015`. The blocker grammar is deliberately the same `#NNN` convention the repo already uses in issue bodies; no new GitHub dependency API is required (keeps the gather portable across all 3 devices).
+
+**Decision references** — the audit also needs the recent decisions whose text references issues. Gather decisions recorded within the prefilter window (14 days) from memory:
+
+```
+mcp__memory__memory_recall(query="status-snapshot decision", type="decision", project="jarvis", limit=50)
+```
+
+or, equivalently, query the `episodes` table for `decision_made` rows with `created_at >= now-14d`. Each decision's `decision` text is scanned for `#NNN` references; (decision, issue#) pairs where the issue is in the open-or-recently-closed set form the **shortlist** the audit judges. This is exactly `status_engine.build_contradiction_prefilter(decisions, baseline)` — call it rather than re-implementing the ≤14-day + `#NNN` extraction:
+
+```bash
+# scripts/ is a plain dir (no package __init__) — put it on PYTHONPATH and
+# import the module directly, the same way tests/test_status_engine.py does.
+PYTHONPATH="$JARVIS_HOME/scripts" python -c "
+import status_engine as se
+# ... build DecisionInfo list + Baseline from gathered data, then:
+# shortlist = se.build_contradiction_prefilter(decisions, baseline)
+# ... after judging each candidate, collect ContradictionVerdict objects:
+# cache = se.serialize_contradiction_cache(verdicts, generated_at=<ISO>)
+"
+```
 
 **Global state** (once, not per repo):
 
@@ -80,6 +124,55 @@ Per repo, compute counts only (no rates, no severity tagging, no proposals). Eac
 Thresholds (`>14d`, `>2d`) are policy constants. If a future tweak is needed, change here and bump `schema_version`.
 
 Rates (e.g. failure %) are deliberately not stored — the consumer computes them at recall time so policy lives in the reader, not in N days of frozen snapshots.
+
+## Step 3.5 — Contradiction audit (L1 only, #1016)
+
+The single LLM-judged detector. Runs **only in the morning baseline** — never on an intraday re-run. If this invocation is not the L1 baseline, skip the entire step and carry forward the previous snapshot's `contradiction_cache` block unchanged (it is a cache, not a fresh computation).
+
+**Model.** The deterministic gather/render of this skill runs on the frontmatter model (`claude-haiku-4-5`). The per-candidate contradiction judgment is escalated to **`claude-sonnet-4-6`** — judgment is the entire value of this lone detector, it runs L1-only over a tiny shortlist (a few candidates/day), so the stronger model costs effectively nothing. (Owner HITL calibration, decision `c72c7383-723c-4827-995a-eb7319d43c38`. If sonnet proves weak in practice, escalate the judgment to opus — same single call site.)
+
+**Inputs.** The shortlist from `build_contradiction_prefilter` (Step 2) — `(decision, issue#)` pairs where the referenced issue is **open or closed ≤30d**. For each pair, assemble the issue's current state (open/closed, `updated_at`/`closed_at`, labels, blocker edges) from the gathered data.
+
+**Judgment — run once per candidate, strict factual-conflict semantics only.** Drift and staleness are NOT contradictions here (the deterministic `stale-in-progress` and `decision-without-followthrough` detectors own those). Prompt:
+
+```
+You are auditing whether recorded memory contradicts current git/issue
+reality, ONE candidate at a time.
+
+Candidate:
+- Decision (recorded {age}d ago): "{decision_text}"
+- References issue #{issue_number} ({repo})
+- Current issue state: {open|closed}, {updated/closed} {n}d ago,
+  labels: {labels}, blocker edges: {blocks}/{is_blocked}
+
+Does the decision's CLAIM about #{issue_number} contradict the issue's
+ACTUAL current state? Strict factual conflict only.
+
+contradiction — a DIRECT factual conflict, e.g.:
+  • decision implies the work shipped / the issue is done, but it is
+    still OPEN with no merged PR;
+  • decision says #A blocks/is-blocked-by #B, but no such edge exists
+    or the named blocker is already closed;
+  • decision asserts a fact the issue's current state plainly refutes
+    (e.g. "still working on #42" but #42 is closed).
+no_contradiction — still-in-progress consistent with the decision;
+  benign divergence; normal staleness (NOT a contradiction — a
+  deterministic detector handles that); unverifiable from this data.
+uncertain — you cannot tell from the given data. Do NOT guess.
+
+Uncertain is DROPPED, not surfaced — a false alarm is worse than a
+miss. When in doubt, return uncertain or no_contradiction.
+
+Output (one candidate): verdict ∈ {contradiction|no_contradiction|
+uncertain} and a one-sentence rationale citing the specific
+conflicting fact.
+```
+
+**Fold.** Collect every per-candidate `{decision_id, issue_number, repo, verdict, rationale}`. Only `verdict == "contradiction"` is actionable; `uncertain` and `no_contradiction` are kept in the cache (for auditability) but never surfaced as hits. This is exactly `status_engine.fold_contradiction_verdicts` — the renderer (#1018) calls it over the cached verdicts, so the skill does **not** need to fold; it only records the raw verdicts.
+
+**Serialize.** Produce the cache block with `status_engine.serialize_contradiction_cache(verdicts, generated_at=<ISO>)` (schema `contradiction-cache/v1`). The full verdict set is stored — not just contradictions — so the drop decision stays auditable from the snapshot alone, and the renderer can re-fold without re-running the LLM (AC4).
+
+If the shortlist is empty (no recent decisions reference live issues), write an empty cache (`verdicts: []`) — never omit the block, so consumers can distinguish "audited, nothing found" from "audit didn't run".
 
 ## Step 4 — Write the snapshot
 
@@ -134,7 +227,20 @@ global:
     - name: voyageai
       expires_at: 2026-06-15
   partial: null   # string reason if any data was skipped/rate-limited; null on a complete run
+contradiction_cache:        # L1-only audit (#1016); output of serialize_contradiction_cache
+  schema: contradiction-cache/v1
+  generated_at: <ISO 8601 UTC>   # same as top-level generated_at on an L1 run
+  verdicts:                 # full set kept for auditability; renderer folds to hits via fold_contradiction_verdicts
+    - decision_id: c72c7383-723c-4827-995a-eb7319d43c38
+      issue_number: 42
+      repo: Osasuwu/jarvis
+      verdict: contradiction        # contradiction | no_contradiction | uncertain
+      rationale: decision claims #42 shipped, but #42 is still open with no merged PR
+  # verdicts: [] on an L1 run with an empty shortlist; the whole block is carried
+  # forward unchanged on a non-L1 (intraday) run — it is a cache, not recomputed.
 ```
+
+`contradiction_cache` is a new **optional** top-level field — adding it is not a `schema_version` bump (consumers reading `schema_version: 1` tolerate extra keys, per *Schema versioning* below). Absent on a snapshot written before #1016; an empty `verdicts: []` means "audited, found nothing", distinct from the field being absent ("audit never ran").
 
 # Status snapshot — YYYY-MM-DD
 
@@ -186,6 +292,8 @@ That's it. No table, no analysis, no recommendations.
 - `gh pr list` / `gh issue list` returns 404 (repo gone or renamed) → fall through to the `null`-fields path: emit the repo entry with `prs: null`, `issues: null`, set `global.partial: 404 on owner/repo`.
 - `device.json` exists but is malformed JSON → treat identically to "missing": omit the `device` field, continue. Don't fail the whole run on a single broken config file.
 - `git -C` exits non-zero on a corrupted local repo → emit the repo entry with `branch: null`, `clean: null`, `hygiene: null`, set `global.partial: corrupted local repo: <name>`. GitHub-side fields still gather.
+- **Contradiction audit (Step 3.5) fails for a single candidate** (sonnet call errors/times out) → record that candidate as `verdict: uncertain` (which is dropped on fold — fail toward a miss, never toward a false alarm), append `partial: contradiction audit incomplete: <decision_id>`. The snapshot still writes.
+- **Contradiction audit fails wholesale** (model unavailable, prefilter import error) → write `contradiction_cache.verdicts: []`, set `global.partial: contradiction audit skipped: <reason>`, and **still write the snapshot**. The audit is additive; its failure must never block the core state record. Distinguish from "audit not run because intraday" (non-L1), where the prior cache is carried forward rather than emptied.
 
 ## Derivations not in the YAML field table
 
@@ -215,3 +323,17 @@ memory_recall(query="status-snapshot", project="jarvis", type="reference", limit
 For a specific date: `memory_get(name="status_snapshot_2026-05-10", project="jarvis")`.
 
 For trend analysis (e.g. "milestone 37 burndown over 7 days"): pull last 7 by tag, parse the YAML block.
+
+**Contradiction audit (#1016).** The `contradiction_cache` block holds the L1 memory↔git audit. To surface actionable contradictions without re-running the LLM, fold the cached verdicts:
+
+```bash
+PYTHONPATH="$JARVIS_HOME/scripts" python -c "
+import status_engine as se, yaml, sys
+cache = yaml.safe_load(sys.stdin)['contradiction_cache']
+verdicts = se.deserialize_contradiction_cache(cache)
+for hit in se.fold_contradiction_verdicts(verdicts):
+    print(hit.repo, hit.issue_number, '-', hit.description)
+"
+```
+
+Only `verdict: contradiction` rows fold to hits; `uncertain`/`no_contradiction` are retained in the cache for auditability but never surfaced (false-negative-over-false-positive posture). This is the renderer path #1018 uses.

--- a/scripts/status_engine.py
+++ b/scripts/status_engine.py
@@ -37,6 +37,20 @@ FRESHNESS_AGE_SECONDS = 86400  # 24 hours
 DECISION_PREFILTER_DAYS = 14
 """Max age in days for decisions considered by the contradiction prefilter."""
 
+MEMORY_GIT_CONTRADICTION = "memory-git-contradiction"
+"""Detector name for the L1-only memory↔git contradiction detector (#1016).
+
+The judgment itself is the native status-record cron Claude session — there is
+no Anthropic API call here. This engine only folds the session's verdicts into
+DetectorHits (see fold_contradiction_verdicts) and round-trips the cached
+result (serialize/deserialize_contradiction_cache). The detector is L1-only:
+analyze() never invokes it, so intraday (L2) recomputation never pays for the
+LLM pass.
+"""
+
+CONTRADICTION_CACHE_SCHEMA = "contradiction-cache/v1"
+"""Schema tag for the serialized contradiction cache (AC4)."""
+
 
 # ============================================================================
 # Data types
@@ -46,6 +60,7 @@ DECISION_PREFILTER_DAYS = 14
 @dataclass
 class Provenance:
     """Provenance stamp for a data source or detector."""
+
     ran: bool = True
     ok: bool = True
     input_rows: int = 0
@@ -55,6 +70,7 @@ class Provenance:
 @dataclass
 class IssueInfo:
     """Lightweight issue representation for engine consumption."""
+
     number: int
     title: str = ""
     state: str = "open"
@@ -68,6 +84,7 @@ class IssueInfo:
 @dataclass
 class RepoState:
     """State snapshot of a single repository."""
+
     repo: str
     open_issues: list[IssueInfo] = field(default_factory=list)
     open_prs: list[dict] = field(default_factory=list)
@@ -77,6 +94,7 @@ class RepoState:
 @dataclass
 class DecisionInfo:
     """A recorded decision from episodes table."""
+
     decision_id: str
     decision: str = ""
     created_at: str = ""  # ISO 8601
@@ -84,8 +102,28 @@ class DecisionInfo:
 
 
 @dataclass
+class ContradictionVerdict:
+    """One LLM judgment over a (decision, issue) prefilter candidate (#1016).
+
+    Emitted by the native status-record cron session, not by this engine.
+    `verdict` is one of: 'contradiction' (memory and git disagree),
+    'no_contradiction' (they agree / benign divergence), or 'uncertain'
+    (judge could not decide). Per the false-negative-over-false-positive
+    posture (research b72ea66c), only 'contradiction' surfaces — both
+    'uncertain' and 'no_contradiction' are dropped on fold.
+    """
+
+    decision_id: str
+    issue_number: int
+    repo: str = ""
+    verdict: str = "uncertain"
+    rationale: str = ""
+
+
+@dataclass
 class Baseline:
     """L1 morning baseline snapshot."""
+
     repos: dict[str, RepoState] = field(default_factory=dict)
     gathered_at: str = ""
     provenance: dict[str, Provenance] = field(default_factory=dict)
@@ -94,6 +132,7 @@ class Baseline:
 @dataclass
 class Delta:
     """Intraday delta — lightweight current state."""
+
     repos: dict[str, RepoState] = field(default_factory=dict)
     gathered_at: str = ""
 
@@ -101,6 +140,7 @@ class Delta:
 @dataclass
 class DetectorHit:
     """A single detector firing."""
+
     detector: str
     severity: str  # 'critical' | 'major' | 'minor'
     repo: str
@@ -113,6 +153,7 @@ class DetectorHit:
 @dataclass
 class RankedItem:
     """A ranked item for the 'Куда смотреть' list."""
+
     rank: int
     detector_hit: DetectorHit
     reason: str = ""
@@ -121,6 +162,7 @@ class RankedItem:
 @dataclass
 class HealthVerdict:
     """Overall health verdict."""
+
     ok: bool
     reason: str = ""
 
@@ -128,6 +170,7 @@ class HealthVerdict:
 @dataclass
 class Digest:
     """Output of analyze()."""
+
     health: HealthVerdict
     detector_hits: list[DetectorHit] = field(default_factory=list)
     ranking: list[RankedItem] = field(default_factory=list)
@@ -154,9 +197,7 @@ def _parse_iso_age(iso_str: str, now: datetime | None = None) -> float:
         return 0.0
 
 
-def _merge_repos(
-    baseline: Baseline, delta: Delta
-) -> dict[str, RepoState]:
+def _merge_repos(baseline: Baseline, delta: Delta) -> dict[str, RepoState]:
     """Merge repos from delta over baseline for the freshest view."""
     merged: dict[str, RepoState] = {}
     for name, state in baseline.repos.items():
@@ -190,17 +231,19 @@ def detect_stale_in_progress(
                 continue
             age_days = _parse_iso_age(issue.updated_at, now)
             if age_days > STALE_INPROGRESS_DAYS:
-                hits.append(DetectorHit(
-                    detector="stale-in-progress",
-                    severity="major",
-                    repo=repo_name,
-                    issue_number=issue.number,
-                    title=issue.title,
-                    description=(
-                        f"Issue #{issue.number} has been in-progress for "
-                        f"{age_days:.1f} days (threshold: {STALE_INPROGRESS_DAYS}d)"
-                    ),
-                ))
+                hits.append(
+                    DetectorHit(
+                        detector="stale-in-progress",
+                        severity="major",
+                        repo=repo_name,
+                        issue_number=issue.number,
+                        title=issue.title,
+                        description=(
+                            f"Issue #{issue.number} has been in-progress for "
+                            f"{age_days:.1f} days (threshold: {STALE_INPROGRESS_DAYS}d)"
+                        ),
+                    )
+                )
 
     return hits
 
@@ -250,17 +293,19 @@ def detect_priority_inversion(
         if stalled_high and active_low:
             for high_issue in stalled_high:
                 low_titles = ", ".join(f"#{i.number}" for i in active_low[:3])
-                hits.append(DetectorHit(
-                    detector="priority-inversion",
-                    severity="critical",
-                    repo=repo_name,
-                    issue_number=high_issue.number,
-                    title=high_issue.title,
-                    description=(
-                        f"P0/P1 issue #{high_issue.number} stalled while "
-                        f"lower-priority work ({low_titles}) has recent activity"
-                    ),
-                ))
+                hits.append(
+                    DetectorHit(
+                        detector="priority-inversion",
+                        severity="critical",
+                        repo=repo_name,
+                        issue_number=high_issue.number,
+                        title=high_issue.title,
+                        description=(
+                            f"P0/P1 issue #{high_issue.number} stalled while "
+                            f"lower-priority work ({low_titles}) has recent activity"
+                        ),
+                    )
+                )
 
     return hits
 
@@ -310,18 +355,20 @@ def detect_decision_without_followthrough(
             seen.add(ref_num)
             for repo_name, issue_nums in open_issues.items():
                 if ref_num in issue_nums:
-                    hits.append(DetectorHit(
-                        detector="decision-without-followthrough",
-                        severity="major",
-                        repo=repo_name,
-                        issue_number=ref_num,
-                        title=f"Decision references #{ref_num}",
-                        description=(
-                            f"Decision '{dec.decision_id}' references "
-                            f"#{ref_num} but the issue has had no "
-                            f"visible movement"
-                        ),
-                    ))
+                    hits.append(
+                        DetectorHit(
+                            detector="decision-without-followthrough",
+                            severity="major",
+                            repo=repo_name,
+                            issue_number=ref_num,
+                            title=f"Decision references #{ref_num}",
+                            description=(
+                                f"Decision '{dec.decision_id}' references "
+                                f"#{ref_num} but the issue has had no "
+                                f"visible movement"
+                            ),
+                        )
+                    )
                     break
 
     return hits
@@ -358,18 +405,20 @@ def detect_blocker_cascade(
         for issue in repo_state.open_issues:
             blocked_list = blockers.get(issue.number, [])
             if blocked_list and issue.number not in blocked_by:
-                hits.append(DetectorHit(
-                    detector="blocker-cascade",
-                    severity="critical",
-                    repo=repo_name,
-                    issue_number=issue.number,
-                    title=issue.title,
-                    description=(
-                        f"Issue #{issue.number} is a root blocker "
-                        f"blocking {len(blocked_list)} other issue(s): "
-                        f"{', '.join(f'#{n}' for n in blocked_list)}"
-                    ),
-                ))
+                hits.append(
+                    DetectorHit(
+                        detector="blocker-cascade",
+                        severity="critical",
+                        repo=repo_name,
+                        issue_number=issue.number,
+                        title=issue.title,
+                        description=(
+                            f"Issue #{issue.number} is a root blocker "
+                            f"blocking {len(blocked_list)} other issue(s): "
+                            f"{', '.join(f'#{n}' for n in blocked_list)}"
+                        ),
+                    )
+                )
 
     return hits
 
@@ -409,6 +458,92 @@ def build_contradiction_prefilter(
 
 
 # ============================================================================
+# Contradiction-detector fold (L1-only — see analyze() omission)
+# ============================================================================
+
+
+def fold_contradiction_verdicts(
+    verdicts: Sequence[ContradictionVerdict],
+) -> list[DetectorHit]:
+    """Fold LLM contradiction verdicts into DetectorHits (#1016, AC1/AC6).
+
+    Only verdicts with ``verdict == "contradiction"`` surface. Both
+    ``"uncertain"`` and ``"no_contradiction"`` (and any unrecognized value)
+    are dropped — the false-negative-over-false-positive posture (research
+    b72ea66c): at solo-dev volume a base-rate flood of weak positives causes
+    habituation, so an undecided candidate is dropped, not surfaced.
+
+    The per-candidate rationale is carried into the hit's ``description`` so
+    the provenance of every surfaced contradiction is visible to the reader
+    (the actionability/provenance mitigation from the same research).
+    """
+    hits: list[DetectorHit] = []
+    for v in verdicts:
+        if v.verdict != "contradiction":
+            continue
+        hits.append(
+            DetectorHit(
+                detector=MEMORY_GIT_CONTRADICTION,
+                severity="major",
+                repo=v.repo,
+                issue_number=v.issue_number,
+                title=f"Decision {v.decision_id} contradicts issue #{v.issue_number}",
+                description=v.rationale,
+            )
+        )
+    return hits
+
+
+def serialize_contradiction_cache(
+    verdicts: Sequence[ContradictionVerdict],
+    generated_at: str = "",
+) -> dict:
+    """Serialize verdicts to a JSON-able cache dict (#1016, AC4).
+
+    The L1 morning pass writes this under the ``status-snapshot`` memory tag so
+    L2/L3 can re-fold the same contradictions without re-running the LLM. The
+    full verdict set is stored (not just the surfaced contradictions) so the
+    drop decision stays auditable from the cache alone.
+    """
+    return {
+        "schema": CONTRADICTION_CACHE_SCHEMA,
+        "generated_at": generated_at,
+        "verdicts": [
+            {
+                "decision_id": v.decision_id,
+                "issue_number": v.issue_number,
+                "repo": v.repo,
+                "verdict": v.verdict,
+                "rationale": v.rationale,
+            }
+            for v in verdicts
+        ],
+    }
+
+
+def deserialize_contradiction_cache(
+    data: dict,
+) -> list[ContradictionVerdict]:
+    """Rebuild verdicts from a cache dict (#1016, AC4).
+
+    Tolerant of a malformed/empty cache: a missing ``verdicts`` key yields an
+    empty list rather than raising, so a corrupt snapshot degrades to "no
+    cached contradictions" instead of breaking the render path.
+    """
+    rows = data.get("verdicts") or []
+    return [
+        ContradictionVerdict(
+            decision_id=row["decision_id"],
+            issue_number=row["issue_number"],
+            repo=row.get("repo", ""),
+            verdict=row.get("verdict", "uncertain"),
+            rationale=row.get("rationale", ""),
+        )
+        for row in rows
+    ]
+
+
+# ============================================================================
 # Ranking
 # ============================================================================
 
@@ -428,13 +563,14 @@ def rank_detector_hits(hits: list[DetectorHit]) -> list[RankedItem]:
 
     ranked: list[RankedItem] = []
     for i, hit in enumerate(sorted_hits[:TOP_N_CAP]):
-        ranked.append(RankedItem(
-            rank=i + 1,
-            detector_hit=hit,
-            reason=f"[{hit.severity.upper()}] {hit.detector}"
-                   f" — {hit.repo}"
-                   + (f" — #{hit.issue_number}" if hit.issue_number else ""),
-        ))
+        ranked.append(
+            RankedItem(
+                rank=i + 1,
+                detector_hit=hit,
+                reason=f"[{hit.severity.upper()}] {hit.detector}"
+                f" — {hit.repo}" + (f" — #{hit.issue_number}" if hit.issue_number else ""),
+            )
+        )
     return ranked
 
 
@@ -461,8 +597,7 @@ def compute_health_verdict(
             stale_or_failed.append(f"{source_name}: failed (ok=False)")
         elif prov.age > FRESHNESS_AGE_SECONDS:
             stale_or_failed.append(
-                f"{source_name}: stale "
-                f"({prov.age:.0f}s > {FRESHNESS_AGE_SECONDS}s)"
+                f"{source_name}: stale ({prov.age:.0f}s > {FRESHNESS_AGE_SECONDS}s)"
             )
 
     if stale_or_failed:

--- a/tests/test_status_engine.py
+++ b/tests/test_status_engine.py
@@ -7,14 +7,17 @@ test_rework_policy.py: in-memory fixtures, no I/O.
 
 from __future__ import annotations
 
+import inspect
 from datetime import datetime, timedelta, timezone
 
 from status_engine import (
     DECISION_PREFILTER_DAYS,
     FRESHNESS_AGE_SECONDS,
+    MEMORY_GIT_CONTRADICTION,
     STALE_INPROGRESS_DAYS,
     TOP_N_CAP,
     Baseline,
+    ContradictionVerdict,
     DecisionInfo,
     Delta,
     DetectorHit,
@@ -22,16 +25,18 @@ from status_engine import (
     HealthVerdict,
     IssueInfo,
     Provenance,
-    RankedItem,
     RepoState,
     analyze,
     build_contradiction_prefilter,
     compute_health_verdict,
+    deserialize_contradiction_cache,
     detect_blocker_cascade,
     detect_decision_without_followthrough,
     detect_priority_inversion,
     detect_stale_in_progress,
+    fold_contradiction_verdicts,
     rank_detector_hits,
+    serialize_contradiction_cache,
 )
 
 # ============================================================================
@@ -150,12 +155,20 @@ class TestStaleInProgressDetector:
 
     def test_stale_issue_detected(self):
         """AC: issue in-progress >3 days without update → hit."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["status:in-progress"],
-                           updated_days_ago=STALE_INPROGRESS_DAYS + 1),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1,
+                            labels=["status:in-progress"],
+                            updated_days_ago=STALE_INPROGRESS_DAYS + 1,
+                        ),
+                    ],
+                ),
+            }
+        )
         hits = detect_stale_in_progress(baseline, make_delta(), [])
         assert len(hits) == 1
         assert hits[0].detector == "stale-in-progress"
@@ -164,50 +177,79 @@ class TestStaleInProgressDetector:
 
     def test_recent_in_progress_not_stale(self):
         """AC: in-progress issue updated today → no hit."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["status:in-progress"],
-                           updated_days_ago=0.1),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(1, labels=["status:in-progress"], updated_days_ago=0.1),
+                    ],
+                ),
+            }
+        )
         hits = detect_stale_in_progress(baseline, make_delta(), [])
         assert len(hits) == 0
 
     def test_no_label_not_stale(self):
         """Issue without status:in-progress label → no hit regardless of age."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["bug"], updated_days_ago=10),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(1, labels=["bug"], updated_days_ago=10),
+                    ],
+                ),
+            }
+        )
         hits = detect_stale_in_progress(baseline, make_delta(), [])
         assert len(hits) == 0
 
     def test_delta_overrides_baseline(self):
         """Delta repo state takes priority over baseline."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["status:in-progress"],
-                           updated_days_ago=10),  # stale in baseline
-            ]),
-        })
-        delta = make_delta({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["status:in-progress"],
-                           updated_days_ago=0.1),  # fresh in delta
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1, labels=["status:in-progress"], updated_days_ago=10
+                        ),  # stale in baseline
+                    ],
+                ),
+            }
+        )
+        delta = make_delta(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1, labels=["status:in-progress"], updated_days_ago=0.1
+                        ),  # fresh in delta
+                    ],
+                ),
+            }
+        )
         hits = detect_stale_in_progress(baseline, delta, [])
         assert len(hits) == 0
 
     def test_boundary_below_threshold_not_stale(self):
         """Edge: just below STALE_INPROGRESS_DAYS → not stale (> not >=)."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["status:in-progress"],
-                           updated_days_ago=STALE_INPROGRESS_DAYS - 0.01),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1,
+                            labels=["status:in-progress"],
+                            updated_days_ago=STALE_INPROGRESS_DAYS - 0.01,
+                        ),
+                    ],
+                ),
+            }
+        )
         hits = detect_stale_in_progress(baseline, make_delta(), [])
         assert len(hits) == 0
 
@@ -222,14 +264,19 @@ class TestPriorityInversionDetector:
 
     def test_priority_inversion_detected(self):
         """AC: P0 issue stale, P2 issue active → hit."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["priority:P0"],
-                           updated_days_ago=STALE_INPROGRESS_DAYS + 2),
-                make_issue(2, labels=["priority:P2"],
-                           updated_days_ago=0.1),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1, labels=["priority:P0"], updated_days_ago=STALE_INPROGRESS_DAYS + 2
+                        ),
+                        make_issue(2, labels=["priority:P2"], updated_days_ago=0.1),
+                    ],
+                ),
+            }
+        )
         hits = detect_priority_inversion(baseline, make_delta(), [])
         assert len(hits) == 1
         assert hits[0].detector == "priority-inversion"
@@ -238,53 +285,77 @@ class TestPriorityInversionDetector:
 
     def test_no_inversion_when_all_active(self):
         """All priorities active → no inversion."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["priority:P0"],
-                           updated_days_ago=0.1),
-                make_issue(2, labels=["priority:P2"],
-                           updated_days_ago=0.1),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(1, labels=["priority:P0"], updated_days_ago=0.1),
+                        make_issue(2, labels=["priority:P2"], updated_days_ago=0.1),
+                    ],
+                ),
+            }
+        )
         hits = detect_priority_inversion(baseline, make_delta(), [])
         assert len(hits) == 0
 
     def test_no_inversion_when_low_priority_inactive(self):
         """All issues stale → no inversion (no active low-pri work)."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["priority:P0"],
-                           updated_days_ago=STALE_INPROGRESS_DAYS + 5),
-                make_issue(2, labels=["priority:P2"],
-                           updated_days_ago=STALE_INPROGRESS_DAYS + 5),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1, labels=["priority:P0"], updated_days_ago=STALE_INPROGRESS_DAYS + 5
+                        ),
+                        make_issue(
+                            2, labels=["priority:P2"], updated_days_ago=STALE_INPROGRESS_DAYS + 5
+                        ),
+                    ],
+                ),
+            }
+        )
         hits = detect_priority_inversion(baseline, make_delta(), [])
         assert len(hits) == 0
 
     def test_no_inversion_without_priority_labels(self):
         """Issues without priority labels → no inversion hits."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["status:in-progress"],
-                           updated_days_ago=STALE_INPROGRESS_DAYS + 2),
-                make_issue(2, labels=["bug"],
-                           updated_days_ago=0.1),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1,
+                            labels=["status:in-progress"],
+                            updated_days_ago=STALE_INPROGRESS_DAYS + 2,
+                        ),
+                        make_issue(2, labels=["bug"], updated_days_ago=0.1),
+                    ],
+                ),
+            }
+        )
         hits = detect_priority_inversion(baseline, make_delta(), [])
         assert len(hits) == 0
 
     def test_priority_critical_treated_as_P0(self):
         """priority:critical label treated same as P0."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, labels=["priority:critical"],
-                           updated_days_ago=STALE_INPROGRESS_DAYS + 2),
-                make_issue(2, labels=["priority:P2"],
-                           updated_days_ago=0.1),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1,
+                            labels=["priority:critical"],
+                            updated_days_ago=STALE_INPROGRESS_DAYS + 2,
+                        ),
+                        make_issue(2, labels=["priority:P2"], updated_days_ago=0.1),
+                    ],
+                ),
+            }
+        )
         hits = detect_priority_inversion(baseline, make_delta(), [])
         assert len(hits) == 1
 
@@ -299,17 +370,20 @@ class TestDecisionWithoutFollowthrough:
 
     def test_decision_referencing_open_issue_detected(self):
         """AC: decision with #NNN referencing an open issue → hit."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(42, labels=[]),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(42, labels=[]),
+                    ],
+                ),
+            }
+        )
         decisions = [
             make_decision("dec-1", decision="We should fix #42 via a new PR"),
         ]
-        hits = detect_decision_without_followthrough(
-            baseline, make_delta(), decisions
-        )
+        hits = detect_decision_without_followthrough(baseline, make_delta(), decisions)
         assert len(hits) == 1
         assert hits[0].detector == "decision-without-followthrough"
         assert hits[0].issue_number == 42
@@ -317,32 +391,38 @@ class TestDecisionWithoutFollowthrough:
 
     def test_decision_no_refs_no_hit(self):
         """Decision without #NNN ref → no hit."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(42),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(42),
+                    ],
+                ),
+            }
+        )
         decisions = [
             make_decision("dec-1", decision="Refactor the auth module"),
         ]
-        hits = detect_decision_without_followthrough(
-            baseline, make_delta(), decisions
-        )
+        hits = detect_decision_without_followthrough(baseline, make_delta(), decisions)
         assert len(hits) == 0
 
     def test_decision_refers_to_closed_issue(self):
         """Decision referencing issue NOT in open_issues → no hit."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, state="closed"),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(1, state="closed"),
+                    ],
+                ),
+            }
+        )
         decisions = [
             make_decision("dec-1", decision="See #999"),
         ]
-        hits = detect_decision_without_followthrough(
-            baseline, make_delta(), decisions
-        )
+        hits = detect_decision_without_followthrough(baseline, make_delta(), decisions)
         assert len(hits) == 0
 
 
@@ -356,13 +436,18 @@ class TestBlockerCascadeDetector:
 
     def test_root_blocker_surfaced(self):
         """AC: issue blocking others but not blocked → root blocker hit."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, blocks=[2, 3]),      # root blocker
-                make_issue(2, is_blocked=True),     # transitively blocked
-                make_issue(3, is_blocked=True),     # transitively blocked
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(1, blocks=[2, 3]),  # root blocker
+                        make_issue(2, is_blocked=True),  # transitively blocked
+                        make_issue(3, is_blocked=True),  # transitively blocked
+                    ],
+                ),
+            }
+        )
         hits = detect_blocker_cascade(baseline, make_delta(), [])
         assert len(hits) == 1
         assert hits[0].detector == "blocker-cascade"
@@ -371,24 +456,34 @@ class TestBlockerCascadeDetector:
 
     def test_no_blockers_no_hits(self):
         """No blocking relationships → no hits."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1),
-                make_issue(2),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(1),
+                        make_issue(2),
+                    ],
+                ),
+            }
+        )
         hits = detect_blocker_cascade(baseline, make_delta(), [])
         assert len(hits) == 0
 
     def test_transitive_chain_surfaces_root(self):
         """AC: A→B→C chain surfaces A (root), not B or C."""
-        baseline = make_baseline({
-            "jarvis": make_state("jarvis", issues=[
-                make_issue(1, blocks=[2]),
-                make_issue(2, is_blocked=True, blocks=[3]),
-                make_issue(3, is_blocked=True),
-            ]),
-        })
+        baseline = make_baseline(
+            {
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(1, blocks=[2]),
+                        make_issue(2, is_blocked=True, blocks=[3]),
+                        make_issue(3, is_blocked=True),
+                    ],
+                ),
+            }
+        )
         hits = detect_blocker_cascade(baseline, make_delta(), [])
         assert len(hits) == 1
         assert hits[0].issue_number == 1
@@ -405,8 +500,9 @@ class TestContradictionPrefilter:
     def test_recent_decision_with_ref_included(self):
         """Recent decision (<14d) with #NNN → included in prefilter."""
         decisions = [
-            make_decision("dec-1", decision="Fix #42",
-                          created_days_ago=DECISION_PREFILTER_DAYS - 1),
+            make_decision(
+                "dec-1", decision="Fix #42", created_days_ago=DECISION_PREFILTER_DAYS - 1
+            ),
         ]
         result = build_contradiction_prefilter(decisions, make_baseline())
         assert len(result) == 1
@@ -415,8 +511,9 @@ class TestContradictionPrefilter:
     def test_old_decision_excluded(self):
         """Old decision (>14d) → excluded from prefilter."""
         decisions = [
-            make_decision("dec-1", decision="Fix #42",
-                          created_days_ago=DECISION_PREFILTER_DAYS + 1),
+            make_decision(
+                "dec-1", decision="Fix #42", created_days_ago=DECISION_PREFILTER_DAYS + 1
+            ),
         ]
         result = build_contradiction_prefilter(decisions, make_baseline())
         assert len(result) == 0
@@ -424,8 +521,7 @@ class TestContradictionPrefilter:
     def test_decision_without_ref_excluded(self):
         """Decision without #NNN ref → excluded."""
         decisions = [
-            make_decision("dec-1", decision="Refactor auth",
-                          created_days_ago=1),
+            make_decision("dec-1", decision="Refactor auth", created_days_ago=1),
         ]
         result = build_contradiction_prefilter(decisions, make_baseline())
         assert len(result) == 0
@@ -433,13 +529,148 @@ class TestContradictionPrefilter:
     def test_multiple_refs_in_one_decision(self):
         """One decision referencing multiple issues → multiple pairs."""
         decisions = [
-            make_decision("dec-1", decision="Fix #42 and #99",
-                          created_days_ago=1),
+            make_decision("dec-1", decision="Fix #42 and #99", created_days_ago=1),
         ]
         result = build_contradiction_prefilter(decisions, make_baseline())
         assert len(result) == 2
         refs = {r[1] for r in result}
         assert refs == {42, 99}
+
+
+# ============================================================================
+# AC: memory↔git contradiction — verdict folding (#1016)
+# ============================================================================
+
+
+def make_verdict(
+    decision_id: str = "dec-1",
+    issue_number: int = 42,
+    repo: str = "Osasuwu/jarvis",
+    verdict: str = "contradiction",
+    rationale: str = "memory says shipped; issue still open",
+) -> ContradictionVerdict:
+    """Helper to construct a ContradictionVerdict fixture."""
+    return ContradictionVerdict(
+        decision_id=decision_id,
+        issue_number=issue_number,
+        repo=repo,
+        verdict=verdict,
+        rationale=rationale,
+    )
+
+
+class TestContradictionFolding:
+    """fold_contradiction_verdicts maps verdicts → DetectorHits (AC1, AC6).
+
+    The LLM judgment itself is the native status-record cron session — not
+    tested here. This covers only the deterministic fold of its output.
+    """
+
+    def test_contradiction_verdict_becomes_hit(self):
+        """A 'contradiction' verdict folds into one DetectorHit."""
+        hits = fold_contradiction_verdicts([make_verdict()])
+        assert len(hits) == 1
+        assert hits[0].detector == MEMORY_GIT_CONTRADICTION
+        assert hits[0].issue_number == 42
+        assert hits[0].repo == "Osasuwu/jarvis"
+
+    def test_rationale_carried_into_hit(self):
+        """Per-candidate rationale is preserved into the hit (AC1)."""
+        hits = fold_contradiction_verdicts(
+            [make_verdict(rationale="decision 6f11 claims merged; PR never opened")]
+        )
+        assert "6f11" in hits[0].description
+
+    def test_uncertain_verdict_dropped(self):
+        """An 'uncertain' candidate is dropped, not surfaced (AC6)."""
+        hits = fold_contradiction_verdicts([make_verdict(verdict="uncertain")])
+        assert hits == []
+
+    def test_no_contradiction_verdict_dropped(self):
+        """A 'no_contradiction' candidate produces no hit."""
+        hits = fold_contradiction_verdicts([make_verdict(verdict="no_contradiction")])
+        assert hits == []
+
+    def test_mixed_batch_only_contradictions_surface(self):
+        """Only the 'contradiction' verdicts in a mixed batch fold to hits."""
+        verdicts = [
+            make_verdict("d1", 1, verdict="contradiction"),
+            make_verdict("d2", 2, verdict="uncertain"),
+            make_verdict("d3", 3, verdict="no_contradiction"),
+            make_verdict("d4", 4, verdict="contradiction"),
+        ]
+        hits = fold_contradiction_verdicts(verdicts)
+        assert {h.issue_number for h in hits} == {1, 4}
+
+    def test_empty_verdicts_returns_empty(self):
+        assert fold_contradiction_verdicts([]) == []
+
+    def test_unknown_verdict_string_dropped(self):
+        """An unrecognized verdict value is treated as uncertain → dropped."""
+        hits = fold_contradiction_verdicts([make_verdict(verdict="maybe?")])
+        assert hits == []
+
+
+class TestContradictionCache:
+    """Cached contradiction result round-trips without re-running the LLM (AC4)."""
+
+    def test_serialize_produces_jsonable_dict(self):
+        data = serialize_contradiction_cache([make_verdict()])
+        # round-trips through JSON unchanged
+        import json
+
+        assert json.loads(json.dumps(data)) == data
+
+    def test_roundtrip_preserves_verdicts(self):
+        verdicts = [
+            make_verdict("d1", 1, verdict="contradiction"),
+            make_verdict("d2", 2, verdict="uncertain"),
+        ]
+        restored = deserialize_contradiction_cache(serialize_contradiction_cache(verdicts))
+        assert restored == verdicts
+
+    def test_renderer_folds_from_cache_without_llm(self):
+        """Deserialized cache folds to the same hits as the live verdicts (AC4)."""
+        verdicts = [
+            make_verdict("d1", 1, verdict="contradiction"),
+            make_verdict("d2", 2, verdict="uncertain"),
+        ]
+        cached = serialize_contradiction_cache(verdicts)
+        from_cache = fold_contradiction_verdicts(deserialize_contradiction_cache(cached))
+        from_live = fold_contradiction_verdicts(verdicts)
+        assert from_cache == from_live
+        assert len(from_cache) == 1  # only the contradiction survives
+
+    def test_empty_cache_deserializes_to_empty(self):
+        assert deserialize_contradiction_cache({"verdicts": []}) == []
+
+    def test_missing_verdicts_key_tolerated(self):
+        """A malformed cache (no verdicts key) deserializes to empty, not raises."""
+        assert deserialize_contradiction_cache({}) == []
+
+
+class TestL1OnlyGuard:
+    """The contradiction detector runs L1-only; analyze() never invokes it (AC2)."""
+
+    def test_analyze_does_not_call_fold(self):
+        """The intraday-capable analyze() path must not invoke the LLM fold."""
+        src = inspect.getsource(analyze)
+        assert "fold_contradiction_verdicts" not in src
+        assert "contradiction" not in src.lower()
+
+    def test_analyze_emits_no_contradiction_hits(self):
+        """Even with referenced decisions present, analyze() emits no
+        memory-git-contradiction hits — that detector is L1-only and lives
+        outside the engine path."""
+        baseline = make_baseline(
+            repos={
+                "jarvis": make_state("jarvis", issues=[make_issue(42)]),
+            },
+            provenance={"gh:jarvis": Provenance(ran=True, ok=True, age=0)},
+        )
+        decisions = [make_decision("d1", decision="Shipped #42", created_days_ago=1)]
+        result = analyze(baseline, make_delta(), decisions)
+        assert all(h.detector != MEMORY_GIT_CONTRADICTION for h in result.detector_hits)
 
 
 # ============================================================================
@@ -453,8 +684,7 @@ class TestRanking:
     def test_at_most_top_n_returned(self):
         """AC: ranking caps at TOP_N_CAP items."""
         hits = [
-            DetectorHit(detector=f"test-{i}", severity="minor",
-                        repo="jarvis")
+            DetectorHit(detector=f"test-{i}", severity="minor", repo="jarvis")
             for i in range(TOP_N_CAP + 5)
         ]
         ranked = rank_detector_hits(hits)
@@ -463,12 +693,9 @@ class TestRanking:
     def test_critical_before_major_before_minor(self):
         """AC: critical items ranked before major before minor."""
         hits = [
-            DetectorHit(detector="minor-hit", severity="minor",
-                        repo="jarvis"),
-            DetectorHit(detector="critical-hit", severity="critical",
-                        repo="jarvis"),
-            DetectorHit(detector="major-hit", severity="major",
-                        repo="jarvis"),
+            DetectorHit(detector="minor-hit", severity="minor", repo="jarvis"),
+            DetectorHit(detector="critical-hit", severity="critical", repo="jarvis"),
+            DetectorHit(detector="major-hit", severity="major", repo="jarvis"),
         ]
         ranked = rank_detector_hits(hits)
         assert ranked[0].detector_hit.detector == "critical-hit"
@@ -541,7 +768,9 @@ class TestHealthVerdict:
             make_baseline(
                 provenance={
                     "gh:jarvis": Provenance(
-                        ran=True, ok=True, age=FRESHNESS_AGE_SECONDS + 1,
+                        ran=True,
+                        ok=True,
+                        age=FRESHNESS_AGE_SECONDS + 1,
                     )
                 },
             ),
@@ -557,8 +786,7 @@ class TestHealthVerdict:
                 provenance={"gh:jarvis": Provenance(ran=True, ok=True, age=0)},
             ),
             [
-                DetectorHit(detector="test", severity="major",
-                            repo="jarvis"),
+                DetectorHit(detector="test", severity="major", repo="jarvis"),
             ],
         )
         assert health.ok is False
@@ -571,7 +799,9 @@ class TestHealthVerdict:
                 provenance={
                     "gh:jarvis": Provenance(ran=True, ok=True, age=0),
                     "gh:redrobot": Provenance(
-                        ran=True, ok=True, age=FRESHNESS_AGE_SECONDS + 100,
+                        ran=True,
+                        ok=True,
+                        age=FRESHNESS_AGE_SECONDS + 100,
                     ),
                 },
             ),
@@ -620,10 +850,16 @@ class TestIntegration:
         """Single stale in-progress issue → hits + non-green health."""
         baseline = make_baseline(
             repos={
-                "jarvis": make_state("jarvis", issues=[
-                    make_issue(1, labels=["status:in-progress"],
-                               updated_days_ago=STALE_INPROGRESS_DAYS + 5),
-                ]),
+                "jarvis": make_state(
+                    "jarvis",
+                    issues=[
+                        make_issue(
+                            1,
+                            labels=["status:in-progress"],
+                            updated_days_ago=STALE_INPROGRESS_DAYS + 5,
+                        ),
+                    ],
+                ),
             },
             provenance={"gh:jarvis": Provenance(ran=True, ok=True, age=0)},
         )
@@ -648,11 +884,13 @@ class TestIntegration:
         baseline = make_baseline(
             provenance={"gh:jarvis": Provenance(ran=True, ok=True, age=0)},
         )
-        delta = make_delta({
-            "redrobot": make_state(
-                "redrobot",
-                provenance=Provenance(ran=True, ok=True, age=100),
-            ),
-        })
+        delta = make_delta(
+            {
+                "redrobot": make_state(
+                    "redrobot",
+                    provenance=Provenance(ran=True, ok=True, age=100),
+                ),
+            }
+        )
         result = analyze(baseline, delta, [])
         assert "delta:redrobot" in result.provenance


### PR DESCRIPTION
## Summary

Adds the single LLM-judged detector in the status-synthesis design — **memory↔git contradiction** — plus the `status-record` cron extension that runs it once in the L1 morning baseline and caches the result. The LLM judgment is the **native status-record cron session** (no Anthropic API call); the Python surface is pure plumbing (fold + cache + L1-guard).

## Why

Closes #1016 (milestone [#53 — статус-синтез](https://github.com/Osasuwu/jarvis/milestone/53)). The deterministic detectors (#1013) catch mechanical anomalies; this slice adds the one detector that needs judgment — does a recorded decision's claim contradict current git/issue reality (e.g. "memory says #42 shipped" but #42 is open with no merged PR).

## Decisions & Alternatives

Architecture decision `6f115fcd-0fe4-4c95-8dc7-17f2a48c3797`; research grounding `b72ea66c` (alert-fatigue / false-negative posture). Two decisions this slice:

- **Design shape** (`be594e70`): the testable Python surface is pure plumbing — verdict→DetectorHit fold (uncertain dropped), L1-only guard, cache (de)serialize. The judgment runs as the native cron session, not via API key wiring (native-first + external-frugality + phase-split).
- **HITL calibration** (`c72c7383`, owner-in-the-loop per AC5):
  - **Strict factual-conflict semantics only** — drift/staleness is left to the deterministic `stale-in-progress` / `decision-without-followthrough` detectors (avoids double-counting; aligns with false-negative-over-false-positive posture). *Alt rejected: broad "include staleness" — raises false-positive rate.*
  - **Judgment escalated to `claude-sonnet-4-6`** (gather/render stay haiku). Runs L1-only over a tiny shortlist → cost trivial, judgment quality is the whole point. *Alt rejected: haiku-for-everything — weaker on the one step that matters.*
  - **Shortlist = open OR closed-≤30d issues** — catches the highest-value class: memory still treating a closed issue as live/blocking. *Alt rejected: open-only — misses memory-vs-closed entirely.*

## Risk Assessment

- **LOW**: engine additions are pure, zero-I/O, fully covered by new tests; `analyze()` is unchanged (the L1-only guard test pins that it never folds contradictions).
- **MEDIUM**: `status-record/SKILL.md` **[PROTECTED]** — edited inline with explicit principal approval (interactive `/implement`, owner present, AC5 HITL calibration done in-session). Prose/skill behavior change; no code path auto-runs it here.

## Testing

- `pytest tests/test_status_engine.py tests/test_status_gather.py -q` → **76 passed**.
- TDD red→green: 22 new engine tests across `TestContradictionFolding` (AC1/AC6), `TestContradictionCache` (AC4), `TestL1OnlyGuard` (AC2).
- End-to-end smoke: `serialize → YAML round-trip → deserialize → fold` reproduces hits exactly (the path #1018 renderer + this skill use); L1-only guard verified via `inspect.getsource(analyze)`.
- `ruff check` + `ruff format` clean.

## AC coverage

- **AC1** per-candidate verdicts + rationale → `ContradictionVerdict` + rationale carried into `DetectorHit.description`.
- **AC2** L1-only (analyze never invokes it) → `TestL1OnlyGuard` + `analyze()` omission.
- **AC3** gather labels/blockers/decision-refs → SKILL.md Step 2 (issue bodies, recently-closed, `is_blocked`/`blocks` edges, prefilter shortlist).
- **AC4** cached result readable without re-running LLM → `serialize/deserialize_contradiction_cache` + SKILL.md `contradiction_cache` block + reader snippet.
- **AC5** prompt + shortlist scope owner-reviewed before merge → HITL calibration in-session (decision `c72c7383`).
- **AC6** uncertain dropped (FN-bias) → `fold_contradiction_verdicts` drops `uncertain`/`no_contradiction`; tested.

## Files Changed

- `scripts/status_engine.py` — `ContradictionVerdict`, `MEMORY_GIT_CONTRADICTION`, `fold_contradiction_verdicts`, `serialize`/`deserialize_contradiction_cache`. (Large line delta is mostly `ruff format` normalizing blank-lines-after-docstrings across the file.)
- `tests/test_status_engine.py` — new test classes for AC1/AC2/AC4/AC6.
- `.claude-userlevel/skills/status-record/SKILL.md` **[PROTECTED]** — Step 2 richer-state gather, Step 3.5 contradiction audit (strict prompt, sonnet judge), `contradiction_cache` in snapshot YAML, fail-soft failure modes, reader snippet.