### PR TITLE
fix(#1042): sync code-review allowed-tools + de-normalize admin-merge

### DIFF
--- a/.claude-userlevel/CLAUDE.md
+++ b/.claude-userlevel/CLAUDE.md
@@ -115,13 +115,16 @@ gh api -X PATCH /repos/<owner>/<repo> -F allow_auto_merge=true -F delete_branch_
 gh api -X PUT /repos/<owner>/<repo>/branches/<default>/protection -F required_status_checks='{"strict":true,"contexts":["review","owner-queue-guard","require-linked-issue", ...repo-specific...]}' -F enforce_admins=false -F required_pull_request_reviews=null -F restrictions=null
 ```
 
-`enforce_admins=false` keeps escape-hatch open for the owner (admin-merge when a gate is broken). `required_pull_request_reviews=null` because the `review` check already encodes the AI review verdict — adding a required human review would defeat AFK Path A.
+`enforce_admins=false` keeps escape-hatch open for the owner (admin-merge for the two structural cases below — not for routinely working around a misfiring gate). `required_pull_request_reviews=null` because the `review` check already encodes the AI review verdict — adding a required human review would defeat AFK Path A.
 
 ### When to break the rules
 
-- **Gate is broken, blocking real work**: admin-merge (`gh pr merge --admin`) is fine. Note in the PR comment which gate you bypassed and why.
+Two structural cases where a gate *cannot* run, and admin-merge is the only path — not a convenience:
+
 - **A PR modifies `code-review.yml` itself**: `anthropics/claude-code-action@v1` refuses to run on self-modifying PRs ("Workflow validation failed" — documented behavior). The `review` check fails as expected; admin-merge.
 - **Self-hosted runner is down (redrobot)**: review/CI can't run. Verify locally, admin-merge per `redrobot_billing_blocked_manual_merge_protocol` precedent.
+
+**A flaky or false-failing gate is NOT on this list.** A gate that fails when it shouldn't (e.g. the `review` check going red because the bot posted no parseable verdict comment) is a **bug to fix, not a bypass to normalize**. Knowing a gate is broken and routinely admin-merging around it silently disables the protection for every future PR. If a gate misfires: file an issue, fix the root cause, and only admin-merge the *one* blocked PR as a stop-gap **with that tracking issue linked in the merge comment**. If you find yourself admin-merging the same gate twice, stop and fix the gate first.
 
 ## Tooling — MCP servers
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -127,7 +127,17 @@ jobs:
             Do NOT load Jarvis SOUL.md, do NOT call memory_recall/memory_store
             (not available in this runner). This is plugin invocation only.
           claude_args: |
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*)"
+            # MUST stay a superset of the plugin command's own frontmatter
+            # allowed-tools (commands/code-review.md). The action runs headless,
+            # so any tool the plugin uses that is absent here is DENIED (no human
+            # to approve) — agent #9 (structural-growth) runs `git show <sha>:<f>
+            # | wc -l`, agent #3 reads `git blame`/`git log`, so the missing
+            # git/wc tools produced repeated permission_denials and made agents
+            # burn turns and flail at the final comment-post step (test/placeholder
+            # probe comments, fragment comments, or no post at all → verdict gate
+            # fails closed → admin-merge). Keep this list and the plugin frontmatter
+            # in lockstep (tests/ci/test_code_review_allowed_tools.py pins it).
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*)"
 
       # Auto-merge MERGE gate (Gate 1 of the two-gate model, #988). Without
       # this step the `review` check is SUCCESS as long as the bot ran —

--- a/scripts/repo_baseline/canon/code-review.yml
+++ b/scripts/repo_baseline/canon/code-review.yml
@@ -60,7 +60,7 @@ jobs:
             Do NOT load Jarvis SOUL.md, do NOT call memory_recall/memory_store
             (not available in this runner). This is plugin invocation only.
           claude_args: |
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*)"
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*)"
 
   attempt-2:
     name: attempt-2
@@ -109,7 +109,7 @@ jobs:
             Do NOT load Jarvis SOUL.md, do NOT call memory_recall/memory_store
             (not available in this runner). This is plugin invocation only.
           claude_args: |
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*)"
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*)"
 
   verify-verdict:
     name: verify-verdict

--- a/tests/ci/test_code_review_allowed_tools.py
+++ b/tests/ci/test_code_review_allowed_tools.py
@@ -1,0 +1,97 @@
+"""Drift guard for the code-review action's `--allowed-tools` allowlist.
+
+The code-review action runs HEADLESS (`anthropics/claude-code-action@v1`): any
+tool the plugin's reviewer agents invoke that is NOT in `--allowed-tools` is
+DENIED outright — there is no human to approve the prompt. When the allowlist
+is a strict subset of what the plugin actually uses, the denied calls turn into
+repeated `permission_denials`: the agents burn turns retrying, then flail at the
+final comment-post step — posting `test`/`PLACEHOLDER`/`ping` probe comments,
+fragmenting the review across comments, or posting nothing. A missing or
+unparseable verdict comment fails the merge gate CLOSED (#993), and the PR ends
+up admin-merged. (jarvis#1042; incident `incident_pr963_rework_blowup`.)
+
+Concretely: plugin reviewer agent #9 (structural-growth) runs
+`git show <sha>:<file> | wc -l`, and agent #3 reads `git blame` / `git log`.
+Those four tools (`git show`, `git blame`, `git log`, `wc`) were absent from the
+allowlist for months, producing ~9 denials per run.
+
+This is the #326 silent-subset-drift class: nothing compared the workflow
+allowlist against the tools the plugin needs, so the gap was invisible. This
+guard pins the load-bearing tools in BOTH the live reference workflow and the
+repo-baseline canon (the propagation template pushed to every owned repo,
+including redrobot) so the fix can't silently regress.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIVE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "code-review.yml"
+CANON_WORKFLOW = REPO_ROOT / "scripts" / "repo_baseline" / "canon" / "code-review.yml"
+
+# The tools whose absence caused the #1042 permission_denials. These are the
+# git/structural tools the plugin's reviewer agents invoke; if any is dropped
+# from the allowlist the headless action denies it and the post step degrades.
+REQUIRED_TOOLS = (
+    "Bash(git show:*)",
+    "Bash(git blame:*)",
+    "Bash(git log:*)",
+    "Bash(wc:*)",
+)
+
+# Sanity floor — the pre-existing tools that must never disappear either.
+BASELINE_TOOLS = (
+    "Bash(gh pr comment:*)",
+    "Bash(gh pr diff:*)",
+    "Bash(gh pr view:*)",
+)
+
+_ALLOWED_TOOLS_RE = re.compile(r'--allowed-tools\s+"([^"]*)"')
+
+
+def _allowed_tools_blocks(path: Path) -> list[str]:
+    """Every `--allowed-tools "..."` string in the file (canon has two jobs)."""
+    text = path.read_text(encoding="utf-8")
+    blocks = _ALLOWED_TOOLS_RE.findall(text)
+    assert blocks, f"no --allowed-tools line found in {path}"
+    return blocks
+
+
+@pytest.mark.parametrize("path", [LIVE_WORKFLOW, CANON_WORKFLOW], ids=["live", "canon"])
+def test_required_git_tools_present(path: Path) -> None:
+    for block in _allowed_tools_blocks(path):
+        for tool in REQUIRED_TOOLS:
+            assert tool in block, (
+                f"{path.name}: allowlist missing {tool!r} — headless action will "
+                f"DENY it, causing permission_denials and degraded post step "
+                f"(jarvis#1042). Allowlist was: {block}"
+            )
+
+
+@pytest.mark.parametrize("path", [LIVE_WORKFLOW, CANON_WORKFLOW], ids=["live", "canon"])
+def test_baseline_tools_present(path: Path) -> None:
+    for block in _allowed_tools_blocks(path):
+        for tool in BASELINE_TOOLS:
+            assert tool in block, f"{path.name}: allowlist dropped baseline tool {tool!r}"
+
+
+def test_canon_jobs_share_one_allowlist() -> None:
+    """Canon's two retry jobs (attempt-1/attempt-2) must carry identical lists —
+    a fix applied to one job but not the other still leaks denials on retry."""
+    blocks = _allowed_tools_blocks(CANON_WORKFLOW)
+    assert len(blocks) == 2, f"expected 2 allowlist blocks in canon, got {len(blocks)}"
+    assert blocks[0] == blocks[1], "canon attempt-1 and attempt-2 allowlists diverged"
+
+
+def test_live_and_canon_allowlists_match() -> None:
+    """Live reference and canon template must agree, or propagated repos get a
+    different (stale) allowlist than the one we validated here."""
+    live = _allowed_tools_blocks(LIVE_WORKFLOW)[0]
+    canon = _allowed_tools_blocks(CANON_WORKFLOW)[0]
+    assert live == canon, (
+        "live workflow and canon allowlists diverged — re-snapshot the canon "
+        "after changing the live allowlist so the fix propagates to owned repos"
+    )


### PR DESCRIPTION
## Problem

The `review` merge gate kept going red, forcing repeated admin-merges. Root cause was upstream of the (correct) verdict gate:

1. **Mechanical:** the workflow `--allowed-tools` was a strict **subset** of the plugin command frontmatter. The action runs **headless**, so any tool a reviewer agent uses that isn't allow-listed is **denied** — no human to approve. Plugin agent #9 runs `git show <sha>:<f> | wc -l`, agent #3 reads `git blame`/`git log`; those four tools were missing → ~9 `permission_denials` per run.
2. **Behavioral:** under that tool friction the reviewer agent flails at the final `gh pr comment` step — posting `test`/`PLACEHOLDER`/probe comments, fragmenting the review, or posting nothing. A missing/unparseable verdict comment fails the gate **closed** (#993) → admin-merge.

## Fix

- **`allowed-tools` superset** in both the live workflow and the canon propagation template (both retry jobs), pinned by `tests/ci/test_code_review_allowed_tools.py` — the #326 silent-subset-drift class (nothing compared the allowlist to plugin needs, so the gap was invisible for months).
- **CLAUDE.md** (source `.claude-userlevel/CLAUDE.md`): removed the "gate is broken → admin-merge is fine" escape hatch. A false-failing gate is a **bug to fix, not a bypass to normalize**. Admin-merge stays only for the two structural cases where a gate genuinely cannot run (self-modifying `code-review.yml`; runner down).
- **Posting discipline** (plugin-side: no probe comments, one comment per review) ships separately in fork PR [claude-plugins-official#3](https://github.com/Osasuwu/claude-plugins-official/pull/3).

## Notes

- `.claude-userlevel/CLAUDE.md` is the **source**; the live `~/.claude/CLAUDE.md` mirror updates on next `install.ps1 -Apply`.
- Canon change propagates the allowlist fix to all owned repos (redrobot included). Canon parity test (verdict patterns) unaffected — it doesn't assert allowed-tools.

## Verification

`tests/ci/test_code_review_allowed_tools.py` (6 new) + existing verdict/canon/retry guards: **122 passed**.

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)
