### PR TITLE
feat(#1018): /status skill — deterministic L3 render + --deep + anchored routing

### DIFF
--- a/.claude-userlevel/skills/status/SKILL.md
+++ b/.claude-userlevel/skills/status/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: status
+model: claude-haiku-4-5
+description: "User-facing repo-state read. Calls the status_digest MCP tool and renders it deterministically (0 LLM tokens on the default path) — health line + ranked 'Куда смотреть' + 'Аномалии' across all tracked repos. `--deep` adds the full picture + LLM narration. Anchored routing: only `статус` / `status` / `статус <repo>` fire it."
+---
+
+# Status
+
+The owner-facing **read** side of status-synthesis (milestone #53). Several-times-a-day call, so the default surface is **deterministic Python — no LLM narration, no tokens spent on rendering**. The judgment already happened upstream: `status_digest` (#1017) wraps `gather() → status_engine.analyze()` and hands back a fully-decided `{health, detector_hits, ranking, provenance}` digest. This skill's only job is to surface it.
+
+**Boundary:** this skill reads and renders. It does not investigate, open issues, comment, rework, or act on findings — those belong to the owner and the sandcastle orchestrator (#531). Surfacing "куда смотреть" is the whole contract; what to do about it is the reader's call.
+
+**Anchored routing (CLAUDE.md skill-routing table, #1018 AC6/AC7).** Only the exact triggers `статус`, `status`, or `статус <repo>` route here. A sentence that merely contains the word — "какой статус у PR #123", "status code 500", a quoted error — is a normal in-context request, NOT a command to run a status investigation. Do not self-fire on incidental uses of the word. This closes the original failure mode where a bare "статус" was over-read as "go investigate everything".
+
+## Step 1 — Call the digest tool
+
+```
+mcp__status__status_digest(jarvis_home="<JARVIS_HOME or empty to auto-detect>")
+```
+
+Pass `jarvis_home` when `JARVIS_HOME` is set (cron / non-repo CWD); leave it empty to let the server auto-detect from CWD via `git rev-parse`. The tool returns the digest as a JSON text block:
+
+```json
+{
+  "health": {"ok": false, "reason": "..."},
+  "detector_hits": [{"detector": "...", "severity": "...", "repo": "...", "issue_number": 42, "title": "...", "description": "..."}],
+  "ranking": [{"rank": 1, "detector_hit": {...}, "reason": "..."}],
+  "provenance": {"jarvis": {"ran": true, "ok": true, "input_rows": 12, "age": 120.0}, "redrobot": {...}}
+}
+```
+
+One call covers **both repos** (jarvis + redrobot) — the gather is repo-fanned and the provenance block carries one stamp per source. Don't loop per repo.
+
+If the tool response begins with `Error in status_digest:` — surface that verbatim to the owner and stop. A failed gather must read as suspicious, never as "all clear".
+
+## Step 2 — Render deterministically (default path, 0 LLM tokens)
+
+Do **not** narrate, summarize, or reformat the digest yourself — that would spend tokens and drift from the snapshot test. Pipe the exact JSON from Step 1 through the pure renderer and print its output verbatim:
+
+```bash
+# Write the digest JSON from Step 1 to a temp file (via the Write tool or a
+# heredoc), then:
+python "${JARVIS_HOME:-.}/scripts/status_render.py" < /tmp/status_digest.json
+```
+
+`scripts/status_render.py` ([renderer](../../../scripts/status_render.py)) is a pure function over the digest. It emits:
+
+```
+<health line>          🟢 only when every source ran ok + is fresh; 🔴 otherwise
+
+Куда смотреть:          ranked top-N from the engine (omitted when nothing ranked)
+  1. ...
+
+Аномалии:               detector hits grouped by repo (omitted when none)
+  Osasuwu/jarvis:
+    • [MAJOR] stale-in-progress #42
+```
+
+**Provenance contract (#1018 AC3) — load-bearing.** The renderer re-derives freshness from `provenance` itself and refuses a green health line unless *every* source `ran`, is `ok`, and is within `FRESHNESS_AGE_SECONDS` — even if `health.ok` is `true`. A silently-failed or stale gather surfaces as degraded, not clear. This is defense-in-depth against a malformed digest; do not "fix" a red line by trusting `health.ok`.
+
+Print the renderer's stdout exactly. That is the default deliverable.
+
+## Step 3 — `--deep` (gated; adds LLM narration)
+
+When the owner passes `--deep` (e.g. `статус --deep`, `/status --deep`):
+
+1. Run the renderer with `--deep` for the deterministic **full picture** — every hit's full `description` plus a `Провенанс:` table:
+
+   ```bash
+   python "${JARVIS_HOME:-.}/scripts/status_render.py" --deep < /tmp/status_digest.json
+   ```
+
+2. **Then** layer LLM narration on top: read the full descriptions + provenance, and write a short cause/FYI paragraph per ranked item — what likely caused it, what to look at first, any cross-repo pattern. This is the only path that spends LLM tokens. Cause/FYI detail lives here exclusively; it must never leak onto the default surface.
+
+Default (no flag) ends at Step 2. `--deep` is a superset — the deterministic blocks are identical, with the provenance table and narration appended.
+
+## Failure modes
+
+- `status_digest` returns an `Error in ...` text → surface verbatim, stop. Never substitute a synthesized "looks fine".
+- Renderer exits non-zero (rc 2 = invalid digest JSON on stdin) → the JSON written to the temp file is malformed; re-capture the tool output exactly (do not hand-edit it) and retry. Don't paper over it with a prose summary.
+- `JARVIS_HOME` unset and CWD outside the repo → `${JARVIS_HOME:-.}` resolves to `.`; if `scripts/status_render.py` isn't found, the owner is in the wrong directory — say so rather than guessing a path.
+- Health line is 🔴 with a `источники деградировали` reason → a gather source failed or is stale; that IS the finding. Surface it; do not retry hoping for green.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Use skills — don't reinvent with raw tools.
 | "почисти память", "memory hygiene", /curate, after 2+ recall complaints | `/curate` (owner-invoked weekly; M45 S3 — host-only, deterministic surfacer, per-row owner confirm) |
 | "review memories", "drain queue", "проверь кандидаты", weekly memory-review, volume-event fire, /learn --status | `/learn` (M42 always-gate review surface; drains classifier + Deriver/Dreamer queues, hard cap 20, idempotent, no defer/accept_all) |
 | "last sprint report", "what did we ship", "milestone closeout", pre-sweep brief | `/last-work-report` (skeleton — #606) |
+| `статус` / `status` / `статус <repo>` — **anchored, only these exact triggers** | `/status` (deterministic L3 render over `status_digest`, 0 LLM tokens by default; `--deep` adds full picture + LLM narration; milestone #53, #1018) |
 | "zoom out", unfamiliar code area, need higher-level map | `/zoom-out` |
 | Issue triage / state machine / "ready for agent" | `/triage` |
 | Author/edit a skill | `/write-a-skill` |
@@ -110,6 +111,7 @@ Rules:
 - **Grill trigger checkbox is mandatory** — every `/implement` and `/delegate` invocation runs the SOUL.md checkbox at start. ≥1 yes ⇒ `/grill` first, no exceptions on "small task" basis. Output goes to AC + CONTEXT.md + memory.
 - **`/reason` (optional, intuition-stage) → `/grill` → `/to-prd` → `/to-issues` → `/implement` (or `/delegate`)** is the canonical chain for new features. TDD-mode engages inside `/implement` and `/delegate` per the SOUL.md grill-me checkbox — there is no standalone `/tdd` skill. Each phase in a fresh session if context is heavy. Skip `/reason` when you already have a plan to validate ("оркестратор можно лучше — не знаю как" → start with `/reason`; "вот план X, проверь" → skip to `/grill`).
 - If unsure → use the skill. Overhead near zero, cost of skipping is lost structure.
+- **`/status` is anchored routing — bare/unrelated uses of the word do NOT fire it.** Only the exact triggers `статус`, `status`, or `статус <repo>` (the word as a standalone command, optionally naming a tracked repo) route to `/status`. A sentence that merely contains the word — "какой статус у PR #123", "статус деплоя в логах", "status code 500", a quoted error string — is a normal request, answered in-context; it must NOT be treated as a command to run a repo-state investigation. This anchoring closes the original failure mode where a bare "статус" was over-eagerly read as "go investigate everything".
 
 ### Responsibility split — interactive · `/delegate` · reactive-core orchestrator
 

--- a/scripts/status_render.py
+++ b/scripts/status_render.py
@@ -1,0 +1,182 @@
+"""Deterministic /status renderer (#1018).
+
+Pure function over the `status_digest` MCP JSON
+(`{health, detector_hits, ranking, provenance}` — see mcp-status/server.py).
+The default render is 0-LLM deterministic Python: a health line, a ranked
+top-N "Куда смотреть" list, and an "Аномалии" block. `--deep` adds the
+deterministic full picture (every hit + a provenance table) for the
+/status skill session to layer LLM narration onto — the renderer itself
+never calls an LLM.
+
+Provenance contract (issue #1018 AC3): the renderer is forbidden from
+emitting a green health line unless *every* source ran ok and is fresh.
+It re-derives that independently from `provenance` rather than trusting
+`health.ok` alone, so a malformed digest (ok=True but a source silently
+failed/stale) still reads as suspicious, not "all clear".
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Single source of truth for the freshness threshold — mirror the engine.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from status_engine import FRESHNESS_AGE_SECONDS
+except Exception:  # pragma: no cover - defensive fallback if engine unavailable
+    FRESHNESS_AGE_SECONDS = 86400
+
+GREEN = "🟢"
+RED = "🔴"
+
+
+def _provenance_issues(provenance: dict) -> list[str]:
+    """Return human-readable descriptions of every degraded/stale source.
+
+    A source is degraded if it did not run, reported ok=False, or is older
+    than the freshness threshold. Empty list ⇒ every source is ok + fresh.
+    """
+    issues: list[str] = []
+    for name, prov in sorted((provenance or {}).items()):
+        ran = prov.get("ran", False)
+        ok = prov.get("ok", False)
+        age = prov.get("age", 0.0) or 0.0
+        if not ran:
+            issues.append(f"{name}: did not run")
+        elif not ok:
+            issues.append(f"{name}: failed (ok=False)")
+        elif age > FRESHNESS_AGE_SECONDS:
+            issues.append(f"{name}: stale ({age:.0f}s > {FRESHNESS_AGE_SECONDS}s)")
+    return issues
+
+
+def _health_line(digest: dict) -> str:
+    """Render the one-line health verdict.
+
+    Green ONLY when health.ok AND no provenance source is degraded/stale.
+    """
+    health = digest.get("health", {}) or {}
+    prov_issues = _provenance_issues(digest.get("provenance", {}))
+
+    if health.get("ok") and not prov_issues:
+        reason = health.get("reason") or "Все источники свежие, аномалий нет"
+        return f"{GREEN} Всё чисто — {reason}"
+
+    if health.get("ok"):
+        # health claims ok but provenance disagrees — surface the degradation.
+        reason = "источники деградировали: " + "; ".join(prov_issues)
+    else:
+        reason = health.get("reason") or "состояние неизвестно"
+        if prov_issues:
+            reason = f"{reason}; источники: " + "; ".join(prov_issues)
+    return f"{RED} {reason}"
+
+
+def _kuda_smotret(digest: dict) -> list[str]:
+    """Ranked top-N action list — straight from the engine's ranking."""
+    ranking = digest.get("ranking") or []
+    if not ranking:
+        return []
+    lines = ["Куда смотреть:"]
+    for item in ranking:
+        rank = item.get("rank", "?")
+        reason = item.get("reason", "")
+        lines.append(f"  {rank}. {reason}")
+    return lines
+
+
+def _anomalies(digest: dict, deep: bool) -> list[str]:
+    """Аномалии block — detector hits, grouped by repo so both repos show.
+
+    Default surface is symptom-level (one line per hit). `deep` adds the
+    full description text for each hit.
+    """
+    hits = digest.get("detector_hits") or []
+    if not hits:
+        return []
+    lines = ["Аномалии:"]
+    by_repo: dict[str, list[dict]] = {}
+    for hit in hits:
+        by_repo.setdefault(hit.get("repo", "?"), []).append(hit)
+    for repo in sorted(by_repo):
+        lines.append(f"  {repo}:")
+        for hit in by_repo[repo]:
+            sev = (hit.get("severity") or "").upper()
+            detector = hit.get("detector", "?")
+            num = hit.get("issue_number")
+            ref = f" #{num}" if num else ""
+            lines.append(f"    • [{sev}] {detector}{ref}")
+            if deep and hit.get("description"):
+                lines.append(f"        {hit['description']}")
+    return lines
+
+
+def _provenance_table(digest: dict) -> list[str]:
+    """Deep-only: per-source provenance table."""
+    provenance = digest.get("provenance") or {}
+    if not provenance:
+        return ["Провенанс: (нет источников)"]
+    lines = ["Провенанс:"]
+    for name, prov in sorted(provenance.items()):
+        lines.append(
+            f"  {name}: ran={prov.get('ran')} ok={prov.get('ok')} "
+            f"input_rows={prov.get('input_rows', 0)} age={prov.get('age', 0.0):.0f}s"
+        )
+    return lines
+
+
+def render(digest: dict, deep: bool = False) -> str:
+    """Render a status digest to deterministic text.
+
+    Args:
+        digest: the status_digest MCP JSON dict.
+        deep: when True, append the deterministic full picture (full hit
+            descriptions + a provenance table). The default (False) path is
+            the cheap several-times-a-day surface and is unaffected by deep.
+
+    Returns:
+        A newline-joined string. Never calls an LLM.
+    """
+    blocks: list[list[str]] = [[_health_line(digest)]]
+
+    kuda = _kuda_smotret(digest)
+    if kuda:
+        blocks.append(kuda)
+
+    anomalies = _anomalies(digest, deep)
+    if anomalies:
+        blocks.append(anomalies)
+
+    if deep:
+        blocks.append(_provenance_table(digest))
+
+    return "\n\n".join("\n".join(block) for block in blocks)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: read a status_digest JSON from stdin, print the render.
+
+    Usage: status_digest (MCP) | python scripts/status_render.py [--deep]
+    """
+    argv = sys.argv[1:] if argv is None else argv
+    deep = "--deep" in argv
+    # Health emoji are non-cp1251; force UTF-8 so the CLI never crashes on a
+    # Windows console (cp1251 default). render() itself returns a plain str.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):  # pragma: no cover - non-reconfigurable stream
+        pass
+    raw = sys.stdin.read()
+    try:
+        digest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"status_render: invalid digest JSON on stdin: {exc}\n")
+        return 2
+    print(render(digest, deep=deep))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_status_render.py
+++ b/tests/test_status_render.py
@@ -1,0 +1,242 @@
+"""Tests for scripts/status_render.py — the deterministic /status renderer (#1018).
+
+The renderer is a pure function over the status_digest MCP JSON
+({health, detector_hits, ranking, provenance}). The default path is
+0-LLM deterministic; --deep adds the deterministic full picture for the
+skill to layer LLM narration onto. Every test traces to an AC bullet of
+issue #1018.
+"""
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from status_render import render  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — digests in the exact shape mcp-status/server.py emits
+# ---------------------------------------------------------------------------
+
+
+def _hit(detector, severity, repo, num, title, desc):
+    return {
+        "detector": detector,
+        "severity": severity,
+        "repo": repo,
+        "issue_number": num,
+        "title": title,
+        "description": desc,
+    }
+
+
+DIGEST_UNHEALTHY = {
+    "health": {
+        "ok": False,
+        "reason": "Unhealthy: 2 detector hit(s) (0 critical, 2 major)",
+    },
+    "detector_hits": [
+        _hit(
+            "stale-in-progress",
+            "major",
+            "Osasuwu/jarvis",
+            42,
+            "Fix foo",
+            "Issue #42 has been in-progress for 5.0 days (threshold: 3d)",
+        ),
+        _hit(
+            "blocker-cascade",
+            "major",
+            "SergazyNarynov/redrobot",
+            7,
+            "Root blocker",
+            "Issue #7 transitively blocks 3 other issues",
+        ),
+    ],
+    "ranking": [
+        {
+            "rank": 1,
+            "detector_hit": _hit(
+                "stale-in-progress",
+                "major",
+                "Osasuwu/jarvis",
+                42,
+                "Fix foo",
+                "Issue #42 has been in-progress for 5.0 days (threshold: 3d)",
+            ),
+            "reason": "[MAJOR] stale-in-progress — Osasuwu/jarvis — #42",
+        },
+        {
+            "rank": 2,
+            "detector_hit": _hit(
+                "blocker-cascade",
+                "major",
+                "SergazyNarynov/redrobot",
+                7,
+                "Root blocker",
+                "Issue #7 transitively blocks 3 other issues",
+            ),
+            "reason": "[MAJOR] blocker-cascade — SergazyNarynov/redrobot — #7",
+        },
+    ],
+    "provenance": {
+        "jarvis": {"ran": True, "ok": True, "input_rows": 12, "age": 120.0},
+        "redrobot": {"ran": True, "ok": True, "input_rows": 4, "age": 300.0},
+    },
+}
+
+
+DIGEST_GREEN = {
+    "health": {"ok": True, "reason": "All sources fresh, no anomalies detected"},
+    "detector_hits": [],
+    "ranking": [],
+    "provenance": {
+        "jarvis": {"ran": True, "ok": True, "input_rows": 10, "age": 60.0},
+        "redrobot": {"ran": True, "ok": True, "input_rows": 3, "age": 90.0},
+    },
+}
+
+
+# health.ok=True but a source did not run — the renderer must refuse green.
+DIGEST_FALSE_GREEN = {
+    "health": {"ok": True, "reason": "All sources fresh, no anomalies detected"},
+    "detector_hits": [],
+    "ranking": [],
+    "provenance": {
+        "jarvis": {"ran": True, "ok": True, "input_rows": 10, "age": 60.0},
+        "redrobot": {"ran": False, "ok": False, "input_rows": 0, "age": 0.0},
+    },
+}
+
+
+# health.ok=True but a source is stale (age beyond freshness) — refuse green.
+DIGEST_STALE_GREEN = {
+    "health": {"ok": True, "reason": "All sources fresh, no anomalies detected"},
+    "detector_hits": [],
+    "ranking": [],
+    "provenance": {
+        "jarvis": {"ran": True, "ok": True, "input_rows": 10, "age": 999999.0},
+        "redrobot": {"ran": True, "ok": True, "input_rows": 3, "age": 90.0},
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# AC1 — default render is deterministic Python: health line + ranked top-N
+#       "Куда смотреть" + "Аномалии"
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultRender:
+    def test_has_health_line_and_both_blocks(self):
+        out = render(DIGEST_UNHEALTHY)
+        assert "🔴" in out
+        assert "Куда смотреть" in out
+        assert "Аномалии" in out
+
+    def test_ranked_items_present(self):
+        out = render(DIGEST_UNHEALTHY)
+        assert "stale-in-progress" in out
+        assert "blocker-cascade" in out
+        assert "#42" in out
+        assert "#7" in out
+
+    def test_is_deterministic(self):
+        assert render(DIGEST_UNHEALTHY) == render(DIGEST_UNHEALTHY)
+
+    def test_no_blocks_when_green(self):
+        out = render(DIGEST_GREEN)
+        assert "Куда смотреть" not in out
+        assert "Аномалии" not in out
+
+
+# ---------------------------------------------------------------------------
+# AC2 — --deep adds the full picture; default path unchanged when flag absent
+# ---------------------------------------------------------------------------
+
+
+class TestDeepFlag:
+    def test_default_equals_explicit_false(self):
+        assert render(DIGEST_UNHEALTHY) == render(DIGEST_UNHEALTHY, deep=False)
+
+    def test_deep_is_superset_of_default(self):
+        default = render(DIGEST_UNHEALTHY, deep=False)
+        deep = render(DIGEST_UNHEALTHY, deep=True)
+        assert deep != default
+        # every non-empty default line still appears in deep output
+        for line in default.splitlines():
+            if line.strip():
+                assert line in deep
+
+    def test_deep_adds_provenance_table(self):
+        default = render(DIGEST_UNHEALTHY, deep=False)
+        deep = render(DIGEST_UNHEALTHY, deep=True)
+        assert "Провенанс" not in default
+        assert "Провенанс" in deep
+        assert "input_rows" in deep or "rows=" in deep
+
+
+# ---------------------------------------------------------------------------
+# AC3 — green health line ONLY when provenance all ok + fresh
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceContract:
+    def test_green_when_healthy_and_fresh(self):
+        out = render(DIGEST_GREEN)
+        assert "🟢" in out
+        assert "🔴" not in out
+
+    def test_no_green_when_unhealthy(self):
+        assert "🟢" not in render(DIGEST_UNHEALTHY)
+
+    def test_no_green_when_source_did_not_run(self):
+        out = render(DIGEST_FALSE_GREEN)
+        assert "🟢" not in out
+        assert "redrobot" in out
+
+    def test_no_green_when_source_stale(self):
+        out = render(DIGEST_STALE_GREEN)
+        assert "🟢" not in out
+        assert "jarvis" in out
+
+
+# ---------------------------------------------------------------------------
+# AC4 — covers both repos in one invocation
+# ---------------------------------------------------------------------------
+
+
+class TestBothRepos:
+    def test_both_repos_appear(self):
+        out = render(DIGEST_UNHEALTHY)
+        assert "jarvis" in out
+        assert "redrobot" in out
+
+
+# ---------------------------------------------------------------------------
+# AC5 — snapshot test pins the deterministic render against a fixture digest
+# ---------------------------------------------------------------------------
+
+
+# Frozen deterministic render of DIGEST_UNHEALTHY — any format change must
+# update this deliberately (that is the regression signal this test exists for).
+SNAPSHOT_UNHEALTHY = (
+    "🔴 Unhealthy: 2 detector hit(s) (0 critical, 2 major)\n"
+    "\n"
+    "Куда смотреть:\n"
+    "  1. [MAJOR] stale-in-progress — Osasuwu/jarvis — #42\n"
+    "  2. [MAJOR] blocker-cascade — SergazyNarynov/redrobot — #7\n"
+    "\n"
+    "Аномалии:\n"
+    "  Osasuwu/jarvis:\n"
+    "    • [MAJOR] stale-in-progress #42\n"
+    "  SergazyNarynov/redrobot:\n"
+    "    • [MAJOR] blocker-cascade #7"
+)
+
+
+class TestSnapshot:
+    def test_render_matches_snapshot(self):
+        assert render(DIGEST_UNHEALTHY) == SNAPSHOT_UNHEALTHY

--- a/tests/test_status_routing_doc.py
+++ b/tests/test_status_routing_doc.py
@@ -1,0 +1,55 @@
+"""Pins the /status anchored-routing contract in CLAUDE.md (#1018 AC6/AC7).
+
+The /status skill is routed by an *anchored* trigger set — only the exact
+words `статус` / `status` / `статус <repo>` fire it. A bare/unrelated use of
+the word must not be read as a command to run a repo-state investigation
+(the original failure mode this slice closes). These are documentation
+guards: if someone edits the routing table and drops the anchor language,
+red CI forces the contract back into the doc rather than letting routing
+silently widen.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAUDE_MD = (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC6 — routing table maps ONLY статус / status / статус <repo> to /status
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingRow:
+    def test_status_row_present(self):
+        # the skill-routing table has a row pointing at the /status skill
+        assert "`/status`" in CLAUDE_MD
+
+    def test_row_lists_all_three_anchored_triggers(self):
+        # the row must enumerate every anchored trigger so the mapping is explicit
+        for trigger in ("статус", "status", "статус <repo>"):
+            assert trigger in CLAUDE_MD, f"missing anchored trigger: {trigger}"
+
+    def test_row_marks_routing_as_anchored(self):
+        # the word "anchored" must appear so the constraint is not lost on edit
+        assert "anchored" in CLAUDE_MD.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC7 — anchored-routing behavior documented: a bare unrelated use of the
+#       word does NOT trigger an investigation
+# ---------------------------------------------------------------------------
+
+
+class TestAntiInvestigationNote:
+    def test_anti_investigation_rule_documented(self):
+        # there is a prose rule stating bare/unrelated word use does not fire /status
+        lowered = CLAUDE_MD.lower()
+        assert "do not fire it" in lowered or "do not fire" in lowered
+        # and it must name the over-eager-investigation failure mode it closes
+        assert "investigation" in lowered
+
+    def test_rule_names_the_skill(self):
+        # the anti-investigation note is explicitly about /status, not generic
+        assert "`/status` is anchored routing" in CLAUDE_MD


### PR DESCRIPTION
## Summary
Adds the owner-facing **read** side of status-synthesis (milestone #53, finisher slice): a pure-function renderer over the `status_digest` MCP JSON, a thin `/status` skill that calls the tool and renders deterministically, and anchored routing in `CLAUDE.md`. The default `/status` path spends **0 LLM tokens** — judgment already happened upstream in `status_engine`; this slice only surfaces it. `--deep` is the one path that adds LLM narration.

## Why
Milestone #53 needed a user-facing surface for the engine (#1013/#1015) + MCP (#1017) work. The owner calls `/status` several times a day, so the default render must be cheap, stable, and free.
Closes #1018

## Decisions & Alternatives
Architecture decision `6f115fcd-0fe4-4c95-8dc7-17f2a48c3797` (3-layer status-synthesis; L3 deterministic render = 0 LLM). This slice's build decision: `47c24f15-08fd-48d7-9751-cdecc6356c2a`.
- **Pure-function renderer over the digest JSON** (`scripts/status_render.py`) — chosen over (a) adding render to `status_engine` (would couple the pure engine to presentation) and (b) rendering in skill prose (would spend tokens + drift from the snapshot test). The seam is a deterministic `render(digest, deep=False) -> str`.
- **Provenance contract re-derived independently** — the renderer recomputes freshness from `provenance` and refuses a green health line unless every source `ran` + `ok` + fresh, even when `health.ok` is `true`. Defense-in-depth: a malformed/silently-failed digest reads as suspicious, not "all clear" (AC3).
- **Anchored routing** — only `статус` / `status` / `статус <repo>` fire `/status`; an incidental use of the word stays an in-context request. Closes the original over-eager-investigation failure mode (AC6/AC7).

## Risk Assessment
- **LOW**: `scripts/status_render.py` (new, pure, fully unit-tested), the two new test files.
- **MEDIUM [PROTECTED]**: `CLAUDE.md` — skill-routing table row + anti-investigation rule note. Protected path; edited inline with principal approval (HITL per the issue). Reviewed with owner before merge.
- **MEDIUM [PROTECTED]**: `.claude-userlevel/skills/status/SKILL.md` — new skill under the protected user-level skills tree.

## Testing
- `pytest tests/test_status_render.py tests/test_status_routing_doc.py tests/test_status_engine.py -q` → **72 passed**.
- `ruff check` / `ruff format` → clean.
- **§4c E2E smoke**: ran `python scripts/status_render.py` (default + `--deep` + bad-JSON) as a real CLI subprocess. Default omits descriptions/provenance table; `--deep` adds both; provenance contract surfaces a `ran=false` source as degraded (no green line); rc=2 on malformed stdin JSON. Confirmed the Windows cp1251 console emoji crash is fixed via `sys.stdout.reconfigure(encoding="utf-8")`.
- Snapshot test pins the exact deterministic render against a fixture digest (AC5).

## Files Changed
- `scripts/status_render.py` — new pure renderer over the digest JSON; `render(digest, deep)` + CLI `main()`.
- `tests/test_status_render.py` — 13 tests, every one AC-mapped (AC1–AC5), incl. the frozen snapshot.
- `tests/test_status_routing_doc.py` — pins the anchored-routing contract in `CLAUDE.md` (AC6/AC7).
- `CLAUDE.md` **[PROTECTED]** — `/status` routing row (anchored triggers only) + anti-investigation rule note.
- `.claude-userlevel/skills/status/SKILL.md` **[PROTECTED]** — thin `/status` skill: call `status_digest` → render; `--deep` adds narration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)