### PR TITLE
feat(#1016): wire L1 contradiction cache through gather → engine → digest

### DIFF
--- a/mcp-status/server.py
+++ b/mcp-status/server.py
@@ -196,7 +196,7 @@ def _contradiction_verdicts_from_gather(gather_result):
     analyze() to fold (#1016 AC4). No cache → empty list, which is the
     intraday/L2 default that folds nothing.
     """
-    cache = getattr(gather_result, "contradiction_cache", None)
+    cache = gather_result.contradiction_cache
     if not cache:
         return []
     return deserialize_contradiction_cache(cache)

--- a/mcp-status/server.py
+++ b/mcp-status/server.py
@@ -61,7 +61,10 @@ from mcp.types import CallToolResult, TextContent, Tool  # noqa: E402
 
 # Import gather and engine modules
 from scripts.status_gather import gather  # noqa: E402
-from scripts.status_engine import analyze  # noqa: E402
+from scripts.status_engine import (  # noqa: E402
+    analyze,
+    deserialize_contradiction_cache,
+)
 
 # ============================================================================
 # MCP Server
@@ -183,6 +186,22 @@ def _convert_gather_to_engine_format(gather_result):
     return baseline, delta, decisions
 
 
+def _contradiction_verdicts_from_gather(gather_result):
+    """Deserialize the cached L1 contradiction verdicts from a GatherResult.
+
+    The L1 status-record audit ran the memory↔git contradiction LLM once and
+    stored its verdicts in the status-snapshot memory; gather() read that cache
+    back into `gather_result.contradiction_cache` (pure deserialization, no
+    LLM). Here we turn the cache dict into ContradictionVerdict objects for
+    analyze() to fold (#1016 AC4). No cache → empty list, which is the
+    intraday/L2 default that folds nothing.
+    """
+    cache = getattr(gather_result, "contradiction_cache", None)
+    if not cache:
+        return []
+    return deserialize_contradiction_cache(cache)
+
+
 @server.call_tool()
 async def call_tool(name: str, arguments: dict) -> list[TextContent] | CallToolResult:
     """Dispatch to the status_digest tool."""
@@ -196,8 +215,16 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent] | CallToolR
             # Convert gather result to engine format
             baseline, delta, decisions = _convert_gather_to_engine_format(gather_result)
 
+            # Fold the cached L1 memory↔git contradiction verdicts (if any).
+            # Reading the cache is pure deserialization — the LLM ran once in
+            # the L1 status-record audit, never here (#1016 AC2/AC4).
+            contradiction_verdicts = _contradiction_verdicts_from_gather(gather_result)
+
             # Analyze with engine
-            digest = analyze(baseline, delta, decisions)
+            digest = analyze(
+                baseline, delta, decisions,
+                contradiction_verdicts=contradiction_verdicts,
+            )
 
             # Build response: {health, detector_hits, ranking, provenance}
             response_data = {

--- a/mcp-status/server.py
+++ b/mcp-status/server.py
@@ -197,8 +197,10 @@ def _contradiction_verdicts_from_gather(gather_result):
     intraday/L2 default that folds nothing.
     """
     cache = gather_result.contradiction_cache
-    if not cache:
+    if cache is None:
         return []
+    # An empty-but-present dict still flows through deserialize (→ []); only a
+    # genuinely absent cache short-circuits. `is None` keeps the two distinct.
     return deserialize_contradiction_cache(cache)
 
 

--- a/scripts/status_engine.py
+++ b/scripts/status_engine.py
@@ -4,7 +4,7 @@ Zero I/O. Houses four deterministic detectors, provenance contract, and
 top-N ranking for the status-synthesis pipeline.
 
 Public interface:
-    analyze(baseline, delta, decisions) -> Digest
+    analyze(baseline, delta, decisions, contradiction_verdicts=()) -> Digest
 
 Constants (reversible knobs, tuned post-launch):
     STALE_INPROGRESS_DAYS = 3
@@ -629,17 +629,29 @@ def analyze(
     baseline: Baseline,
     delta: Delta,
     decisions: list[DecisionInfo],
+    contradiction_verdicts: Sequence[ContradictionVerdict] = (),
 ) -> Digest:
     """Synthesize status digest from baseline, delta, and decisions.
 
     Pure function — zero I/O, fully deterministic given the same inputs.
     This is the sole public interface of status_engine.
+
+    ``contradiction_verdicts`` carries the L1 memory↔git verdicts (already
+    judged upstream by the status-record cron, then read from the cached
+    status-snapshot — see deserialize_contradiction_cache). analyze() only
+    *folds* them; it never runs the LLM judgment itself. The default empty
+    tuple is the intraday/L2 path: no verdicts → no contradiction hit → no
+    LLM cost, satisfying the L1-only contract (#1016 AC2). Folding the cached
+    verdicts here (rather than after analyze) lets contradiction hits take
+    part in rank_detector_hits + compute_health_verdict, so they appear in
+    "Куда смотреть" and flip health red like any other detector hit (AC4).
     """
     hits: list[DetectorHit] = []
     hits.extend(detect_stale_in_progress(baseline, delta, decisions))
     hits.extend(detect_priority_inversion(baseline, delta, decisions))
     hits.extend(detect_decision_without_followthrough(baseline, delta, decisions))
     hits.extend(detect_blocker_cascade(baseline, delta, decisions))
+    hits.extend(fold_contradiction_verdicts(contradiction_verdicts))
 
     ranking = rank_detector_hits(hits)
     health = compute_health_verdict(baseline, hits)

--- a/scripts/status_engine.py
+++ b/scripts/status_engine.py
@@ -528,13 +528,24 @@ def deserialize_contradiction_cache(
 
     Tolerant of a malformed/empty cache: a missing ``verdicts`` key yields an
     empty list rather than raising, so a corrupt snapshot degrades to "no
-    cached contradictions" instead of breaking the render path.
+    cached contradictions" instead of breaking the render path. Individual
+    rows missing mandatory keys degrade per-field (not KeyError) for the same
+    reason (C2).
+
+    A cache stamped with an unrecognized ``schema`` version deserializes to
+    empty — a future v2 layout must not be silently misread as v1 (M2). A
+    cache with no ``schema`` key at all is accepted (legacy / hand-written).
     """
+    schema = data.get("schema")
+    if schema is not None and schema != CONTRADICTION_CACHE_SCHEMA:
+        return []
     rows = data.get("verdicts") or []
     return [
         ContradictionVerdict(
-            decision_id=row["decision_id"],
-            issue_number=row["issue_number"],
+            decision_id=row.get("decision_id", ""),
+            # YAML may emit issue_number as a float (42.0); coerce to int so it
+            # renders as #42, not #42.0.
+            issue_number=int(row.get("issue_number", 0) or 0),
             repo=row.get("repo", ""),
             verdict=row.get("verdict", "uncertain"),
             rationale=row.get("rationale", ""),
@@ -595,7 +606,10 @@ def compute_health_verdict(
             stale_or_failed.append(f"{source_name}: did not run")
         elif not prov.ok:
             stale_or_failed.append(f"{source_name}: failed (ok=False)")
-        elif prov.age > FRESHNESS_AGE_SECONDS:
+        elif prov.age is not None and prov.age > FRESHNESS_AGE_SECONDS:
+            # age is None ⇒ data age unknown (e.g. a status snapshot written
+            # without a parseable generated_at). Treat unknown age as not-stale
+            # rather than crashing the comparison (C1).
             stale_or_failed.append(
                 f"{source_name}: stale ({prov.age:.0f}s > {FRESHNESS_AGE_SECONDS}s)"
             )

--- a/scripts/status_gather.py
+++ b/scripts/status_gather.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -129,6 +130,7 @@ class GatherResult:
     provenance: dict[str, dict] = field(default_factory=dict)
     gathered_at: str = ""
     errors: list[str] = field(default_factory=list)
+    contradiction_cache: dict | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -138,6 +140,7 @@ class GatherResult:
             "provenance": self.provenance,
             "gathered_at": self.gathered_at,
             "errors": self.errors,
+            "contradiction_cache": self.contradiction_cache,
         }
 
 
@@ -462,6 +465,98 @@ def gather_decisions(
 
 
 # ============================================================================
+# Contradiction-cache gather (#1016 AC3/AC4)
+#
+# The L1 status-record audit runs the memory↔git contradiction LLM ONCE and
+# writes its verdicts into the `status-snapshot`-tagged memory as a fenced
+# yaml block (schema contradiction-cache/v1). gather() reads that block back
+# so the engine can FOLD the cached verdicts without re-running the LLM
+# (AC4). Reading is pure deserialization — no LLM, no network beyond the
+# single REST read that already fetches the snapshot row.
+# ============================================================================
+
+_YAML_FENCE_RE = re.compile(r"```ya?ml\s*\n(.*?)\n```", re.DOTALL)
+
+
+def _extract_contradiction_cache(content: str) -> dict | None:
+    """Pull the `contradiction_cache` dict out of a memory body.
+
+    Fully tolerant: any parse failure, a missing fence, or a fence whose yaml
+    has no `contradiction_cache` key returns None. Never raises.
+    """
+    if not content:
+        return None
+    import yaml
+
+    for match in _YAML_FENCE_RE.finditer(content):
+        block = match.group(1)
+        try:
+            data = yaml.safe_load(block)
+        except yaml.YAMLError:
+            continue
+        if isinstance(data, dict):
+            cache = data.get("contradiction_cache")
+            if isinstance(cache, dict):
+                return cache
+    return None
+
+
+def _parse_iso_epoch(iso_str: str) -> float | None:
+    """Parse an ISO 8601 timestamp to epoch seconds, or None on failure."""
+    if not iso_str:
+        return None
+    try:
+        s = iso_str.strip()
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        return datetime.fromisoformat(s).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def gather_contradiction_cache(
+    url: str,
+    key: str,
+    query_fn: QuerySupabaseFn,
+    now: float,
+) -> tuple[dict | None, Provenance]:
+    """Read the cached L1 contradiction verdicts from the latest status snapshot.
+
+    Queries the `memories` table for the most recent `status-snapshot`-tagged
+    jarvis memory, extracts its fenced contradiction-cache yaml block, and
+    returns it for the engine to fold. The cache's own `generated_at` drives
+    the provenance age (data age, not query latency) so the renderer's
+    freshness gate reflects when the LLM actually ran.
+
+    Returns (cache_dict, provenance). cache is None and ok=False when the
+    query fails, no snapshot exists, or the snapshot carries no cache block.
+    """
+    params = {
+        "tags": "cs.{status-snapshot}",
+        "project": "eq.jarvis",
+        "select": "name,content,created_at",
+        "order": "created_at.desc",
+        "limit": "1",
+    }
+    rows = query_fn(url, key, "memories", params)
+
+    if not rows:
+        # Query failed (None) or no snapshot row yet (empty) — both !ok.
+        return None, Provenance(ran=True, ok=False, input_rows=0, age=None)
+
+    content = str(rows[0].get("content", ""))
+    cache = _extract_contradiction_cache(content)
+    if cache is None:
+        return None, Provenance(ran=True, ok=False, input_rows=0, age=None)
+
+    verdicts = cache.get("verdicts") or []
+    gen_epoch = _parse_iso_epoch(str(cache.get("generated_at", "")))
+    age = (now - gen_epoch) if gen_epoch is not None else None
+    prov = Provenance(ran=True, ok=True, input_rows=len(verdicts), age=age)
+    return cache, prov
+
+
+# ============================================================================
 # Main gather orchestrator
 # ============================================================================
 
@@ -638,17 +733,30 @@ def gather(
             f"{SourceKind.SUPABASE_DECISIONS}: {SUPABASE_URL_ENV}/{SUPABASE_KEY_ENV} unset"
         )
 
-    # --- Step 5: Status-snapshot baselines (optional — tolerate gap) ---
-    # Baselines are read from memory. In a cron context where memory-MCP is
-    # not loaded, this will be None — the gather tolerates the gap and stamps
-    # provenance accordingly.
-    result.provenance[SourceKind.STATUS_SNAPSHOT] = Provenance(
-        ran=True, ok=False, input_rows=0,
-        age=_now() - gather_start,
-        # NOTE: baseline retrieval from memory-MCP requires the memory server.
-        # If unavailable (cron), this source is simply marked !ok and the
-        # engine/renderer treats it as stale/no-baseline.
-    ).to_dict()
+    # --- Step 5: Status-snapshot contradiction cache (optional — tolerate gap) ---
+    # The L1 status-record audit writes the cached memory↔git contradiction
+    # verdicts into the `status-snapshot`-tagged memory. We read them back here
+    # (pure deserialization, no LLM — #1016 AC4) so the engine can fold them.
+    # On first run, a non-cron device, or a missing snapshot, the read is !ok
+    # and the engine/renderer treats it as stale/no-baseline.
+    if supabase_url and supabase_key:
+        cache, snap_prov = gather_contradiction_cache(
+            supabase_url, supabase_key, _query_supabase, _now(),
+        )
+        result.contradiction_cache = cache
+        result.provenance[SourceKind.STATUS_SNAPSHOT] = snap_prov.to_dict()
+        if not snap_prov.ok:
+            result.errors.append(
+                f"{SourceKind.STATUS_SNAPSHOT}: no fresh status snapshot available"
+            )
+    else:
+        result.provenance[SourceKind.STATUS_SNAPSHOT] = Provenance(
+            ran=True, ok=False, input_rows=0,
+            age=_now() - gather_start,
+        ).to_dict()
+        result.errors.append(
+            f"{SourceKind.STATUS_SNAPSHOT}: {SUPABASE_URL_ENV}/{SUPABASE_KEY_ENV} unset"
+        )
 
     return result
 

--- a/scripts/status_gather.py
+++ b/scripts/status_gather.py
@@ -540,17 +540,40 @@ def gather_contradiction_cache(
         "select": "name,content,created_at",
         "order": "created_at.desc",
         "limit": "1",
+        # Live-row filter (mirrors memory recall): never fold a snapshot that
+        # was soft-deleted or expired/superseded out of belief.
+        "deleted_at": "is.null",
+        "expired_at": "is.null",
+        # Trust boundary (#542/#565 RLS): a sandcastle agent can only write
+        # rows whose source_provenance starts `sandcastle:`. An L1 baseline
+        # written by the principal never carries that prefix, so reject it to
+        # stop a sandcastle-poisoned snapshot from injecting forged verdicts.
+        # NULL provenance (legacy/principal writes) still passes.
+        "or": "(source_provenance.is.null,source_provenance.not.like.sandcastle:*)",
     }
     rows = query_fn(url, key, "memories", params)
 
-    if not rows:
-        # Query failed (None) or no snapshot row yet (empty) — both !ok.
-        return None, Provenance(ran=True, ok=False, input_rows=0, age=None)
+    # A transport failure (None) and an empty result ([]) must NOT collapse
+    # into the same provenance — a Supabase outage has to stay distinguishable
+    # from a first-run device that simply has no snapshot yet. Mirrors the
+    # gather_decisions None-vs-empty split.
+    _failed = Provenance(ran=True, ok=False, input_rows=0, age=None)
 
-    content = str(rows[0].get("content", ""))
+    if rows is None:
+        # Query failed entirely — transport/network error.
+        return None, _failed
+
+    if not rows:
+        # Query succeeded, no snapshot row yet (first run / intraday pre-L1).
+        # Empty is a legitimate non-error state, like gather_decisions.
+        return None, Provenance(ran=True, ok=True, input_rows=0, age=None)
+
+    content = rows[0].get("content") or ""
     cache = _extract_contradiction_cache(content)
     if cache is None:
-        return None, Provenance(ran=True, ok=False, input_rows=0, age=None)
+        # Snapshot exists but carries no parseable cache block — treat as a
+        # failed read of the cache, not an empty success.
+        return None, _failed
 
     verdicts = cache.get("verdicts") or []
     gen_epoch = _parse_iso_epoch(str(cache.get("generated_at", "")))

--- a/scripts/status_gather.py
+++ b/scripts/status_gather.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+import yaml
+
 # ============================================================================
 # Public constants
 # ============================================================================
@@ -475,7 +477,9 @@ def gather_decisions(
 # single REST read that already fetches the snapshot row.
 # ============================================================================
 
-_YAML_FENCE_RE = re.compile(r"```ya?ml\s*\n(.*?)\n```", re.DOTALL)
+# Tolerant of a fence info-string (```yaml title=...) and of a trailing blank
+# line before the closing fence — both are common Markdown emits (M1).
+_YAML_FENCE_RE = re.compile(r"```ya?ml[^\n]*\n(.*?)\n?```", re.DOTALL)
 
 
 def _extract_contradiction_cache(content: str) -> dict | None:
@@ -486,10 +490,9 @@ def _extract_contradiction_cache(content: str) -> dict | None:
     """
     if not content:
         return None
-    import yaml
 
     for match in _YAML_FENCE_RE.finditer(content):
-        block = match.group(1)
+        block = match.group(1).strip()
         try:
             data = yaml.safe_load(block)
         except yaml.YAMLError:
@@ -750,9 +753,10 @@ def gather(
                 f"{SourceKind.STATUS_SNAPSHOT}: no fresh status snapshot available"
             )
     else:
+        # No creds ⇒ nothing was gathered, so data age is undefined (None), not
+        # time-since-gather-start (m3). ok=False already signals the gap.
         result.provenance[SourceKind.STATUS_SNAPSHOT] = Provenance(
-            ran=True, ok=False, input_rows=0,
-            age=_now() - gather_start,
+            ran=True, ok=False, input_rows=0, age=None,
         ).to_dict()
         result.errors.append(
             f"{SourceKind.STATUS_SNAPSHOT}: {SUPABASE_URL_ENV}/{SUPABASE_KEY_ENV} unset"

--- a/tests/test_mcp_status_server.py
+++ b/tests/test_mcp_status_server.py
@@ -25,6 +25,7 @@ status_server = importlib.util.module_from_spec(_spec)
 sys.modules["status_server"] = status_server
 _spec.loader.exec_module(status_server)
 _convert_gather_to_engine_format = status_server._convert_gather_to_engine_format
+_contradiction_verdicts_from_gather = status_server._contradiction_verdicts_from_gather
 
 
 # ============================================================================
@@ -206,3 +207,88 @@ def test_end_to_end_gather_to_digest():
     # Provenance should include the sources from gather
     assert "repos_conf" in digest.provenance
     assert "supabase_decisions" in digest.provenance
+
+
+# ============================================================================
+# Test: Contradiction-cache deserialization + fold-through (#1016 AC4)
+#
+# The server reads the cached L1 verdicts from gather_result.contradiction_cache
+# and folds them into analyze() — WITHOUT re-running the LLM. The cached hit
+# must surface in the digest's detector_hits.
+# ============================================================================
+
+
+def _cache_with_contradiction():
+    """Build a serialized contradiction cache carrying one contradiction."""
+    from scripts.status_engine import (
+        ContradictionVerdict,
+        serialize_contradiction_cache,
+    )
+
+    verdicts = [
+        ContradictionVerdict(
+            decision_id="dec-9",
+            issue_number=77,
+            repo="Osasuwu/jarvis",
+            verdict="contradiction",
+            rationale="memory says shipped; issue #77 still open",
+        ),
+    ]
+    return serialize_contradiction_cache(verdicts, generated_at="2024-06-09T12:00:00+00:00")
+
+
+def test_contradiction_verdicts_from_gather_deserializes_cache():
+    """The server helper turns the cached dict back into verdict objects."""
+    gather_result = make_fixture_gather_result()
+    gather_result.contradiction_cache = _cache_with_contradiction()
+
+    verdicts = _contradiction_verdicts_from_gather(gather_result)
+    assert len(verdicts) == 1
+    assert verdicts[0].issue_number == 77
+    assert verdicts[0].verdict == "contradiction"
+
+
+def test_no_cache_yields_empty_verdicts():
+    """No contradiction_cache → empty verdicts (intraday/L2-safe default)."""
+    gather_result = make_fixture_gather_result()
+    gather_result.contradiction_cache = None
+    assert _contradiction_verdicts_from_gather(gather_result) == []
+
+
+def test_cached_contradiction_surfaces_in_digest_without_llm():
+    """End-to-end: cached verdict folds through analyze into detector_hits.
+
+    This is the #1016 AC4 proof — the renderer (digest consumer) sees the
+    contradiction with NO LLM call in this path.
+    """
+    from scripts.status_engine import MEMORY_GIT_CONTRADICTION, analyze
+
+    gather_result = make_fixture_gather_result()
+    gather_result.contradiction_cache = _cache_with_contradiction()
+
+    baseline, delta, decisions = _convert_gather_to_engine_format(gather_result)
+    verdicts = _contradiction_verdicts_from_gather(gather_result)
+    digest = analyze(baseline, delta, decisions, contradiction_verdicts=verdicts)
+
+    contradiction_hits = [
+        h for h in digest.detector_hits if h.detector == MEMORY_GIT_CONTRADICTION
+    ]
+    assert len(contradiction_hits) == 1
+    assert contradiction_hits[0].issue_number == 77
+
+
+def test_no_cache_means_no_contradiction_hit():
+    """Empty cache → analyze folds nothing → no contradiction hit (L2 path)."""
+    from scripts.status_engine import MEMORY_GIT_CONTRADICTION, analyze
+
+    gather_result = make_fixture_gather_result()
+    gather_result.contradiction_cache = None
+
+    baseline, delta, decisions = _convert_gather_to_engine_format(gather_result)
+    verdicts = _contradiction_verdicts_from_gather(gather_result)
+    digest = analyze(baseline, delta, decisions, contradiction_verdicts=verdicts)
+
+    contradiction_hits = [
+        h for h in digest.detector_hits if h.detector == MEMORY_GIT_CONTRADICTION
+    ]
+    assert contradiction_hits == []

--- a/tests/test_status_engine.py
+++ b/tests/test_status_engine.py
@@ -7,7 +7,6 @@ test_rework_policy.py: in-memory fixtures, no I/O.
 
 from __future__ import annotations
 
-import inspect
 from datetime import datetime, timedelta, timezone
 
 from status_engine import (
@@ -650,13 +649,123 @@ class TestContradictionCache:
 
 
 class TestL1OnlyGuard:
-    """The contradiction detector runs L1-only; analyze() never invokes it (AC2)."""
+    """The contradiction detector runs L1-only; analyze() never invokes the
+    LLM judgment on its own (AC2).
 
-    def test_analyze_does_not_call_fold(self):
-        """The intraday-capable analyze() path must not invoke the LLM fold."""
-        src = inspect.getsource(analyze)
-        assert "fold_contradiction_verdicts" not in src
-        assert "contradiction" not in src.lower()
+    Behavioral guard (replaces an earlier source-grep): the meaningful L1-only
+    contract is that ``analyze`` never *generates* contradiction verdicts — it
+    only folds verdicts handed to it explicitly. The LLM judgment lives in the
+    upstream L1 status-record cron; the intraday (L2) path calls ``analyze``
+    with the default empty ``contradiction_verdicts`` and therefore pays for no
+    LLM and surfaces no contradiction. Folding a *cached* verdict (already
+    computed in the morning) is deterministic and free, so it is allowed.
+    """
+
+    def test_analyze_default_param_folds_nothing(self):
+        """Calling analyze without the verdicts arg surfaces no contradiction
+        hit — the intraday/L2 signature is unchanged and LLM-free."""
+        base = make_baseline(
+            provenance={"jarvis": Provenance(ran=True, ok=True, age=0)},
+        )
+        digest = analyze(base, make_delta(), [])
+        assert all(
+            h.detector != MEMORY_GIT_CONTRADICTION for h in digest.detector_hits
+        )
+
+    def test_analyze_does_not_autodetect_contradictions(self):
+        """Even when a decision references an open issue, analyze with no
+        verdicts produces no contradiction hit — it never runs the detector
+        itself (the LLM judgment must arrive pre-computed from L1)."""
+        issue = make_issue(42, labels=["status:in-progress"])
+        state = make_state("Osasuwu/jarvis", issues=[issue])
+        base = make_baseline(
+            provenance={"jarvis": Provenance(ran=True, ok=True, age=0)},
+        )
+        delta = make_delta(repos={"Osasuwu/jarvis": state})
+        decisions = [make_decision("d1", decision="Shipped #42", created_days_ago=1)]
+        digest = analyze(base, delta, decisions)
+        assert all(
+            h.detector != MEMORY_GIT_CONTRADICTION for h in digest.detector_hits
+        )
+
+
+class TestAnalyzeFoldsContradictions:
+    """analyze() folds explicitly-passed cached verdicts into the digest so
+    they participate in ranking + health (AC4)."""
+
+    def _green_baseline(self) -> Baseline:
+        return make_baseline(
+            provenance={"jarvis": Provenance(ran=True, ok=True, age=0)},
+        )
+
+    def test_contradiction_verdict_surfaces_as_hit(self):
+        digest = analyze(
+            self._green_baseline(),
+            make_delta(),
+            [],
+            contradiction_verdicts=[make_verdict()],
+        )
+        hits = [h for h in digest.detector_hits if h.detector == MEMORY_GIT_CONTRADICTION]
+        assert len(hits) == 1
+        assert hits[0].issue_number == 42
+
+    def test_uncertain_verdict_not_folded(self):
+        digest = analyze(
+            self._green_baseline(),
+            make_delta(),
+            [],
+            contradiction_verdicts=[make_verdict(verdict="uncertain")],
+        )
+        assert all(
+            h.detector != MEMORY_GIT_CONTRADICTION for h in digest.detector_hits
+        )
+
+    def test_folded_hit_participates_in_ranking(self):
+        digest = analyze(
+            self._green_baseline(),
+            make_delta(),
+            [],
+            contradiction_verdicts=[make_verdict()],
+        )
+        ranked_detectors = {item.detector_hit.detector for item in digest.ranking}
+        assert MEMORY_GIT_CONTRADICTION in ranked_detectors
+
+    def test_folded_hit_flips_health(self):
+        """A folded contradiction on an otherwise-green baseline makes the
+        health verdict unhealthy — it is a real anomaly, not just metadata."""
+        green = analyze(self._green_baseline(), make_delta(), [])
+        assert green.health.ok is True
+        unhealthy = analyze(
+            self._green_baseline(),
+            make_delta(),
+            [],
+            contradiction_verdicts=[make_verdict()],
+        )
+        assert unhealthy.health.ok is False
+
+    def test_fold_is_deterministic(self):
+        args = (self._green_baseline(), make_delta(), [])
+        kw = {"contradiction_verdicts": [make_verdict()]}
+        assert analyze(*args, **kw).detector_hits == analyze(*args, **kw).detector_hits
+
+    def test_cached_cache_folds_through_analyze_without_llm(self):
+        """End-to-end AC4: serialize → deserialize → analyze surfaces the same
+        contradiction hit the live verdicts would, with no LLM in the path."""
+        verdicts = [
+            make_verdict("d1", 1, verdict="contradiction"),
+            make_verdict("d2", 2, verdict="uncertain"),
+        ]
+        cache = serialize_contradiction_cache(verdicts)
+        restored = deserialize_contradiction_cache(cache)
+        digest = analyze(
+            self._green_baseline(),
+            make_delta(),
+            [],
+            contradiction_verdicts=restored,
+        )
+        hits = [h for h in digest.detector_hits if h.detector == MEMORY_GIT_CONTRADICTION]
+        assert len(hits) == 1  # only the contradiction survives
+        assert hits[0].issue_number == 1
 
     def test_analyze_emits_no_contradiction_hits(self):
         """Even with referenced decisions present, analyze() emits no

--- a/tests/test_status_engine.py
+++ b/tests/test_status_engine.py
@@ -647,6 +647,70 @@ class TestContradictionCache:
         """A malformed cache (no verdicts key) deserializes to empty, not raises."""
         assert deserialize_contradiction_cache({}) == []
 
+    def test_row_missing_mandatory_keys_tolerated(self):
+        """A verdict row missing decision_id/issue_number degrades gracefully —
+        the 'tolerant' contract must not raise KeyError on a partial row (C2)."""
+        cache = {
+            "verdicts": [
+                {"repo": "o/r", "verdict": "contradiction", "rationale": "x"},
+            ]
+        }
+        restored = deserialize_contradiction_cache(cache)
+        assert len(restored) == 1
+        assert restored[0].decision_id == ""
+        assert restored[0].issue_number == 0
+
+    def test_float_issue_number_coerced_to_int(self):
+        """YAML can emit issue_number as a float (42.0); it must render as #42,
+        not #42.0 (C2)."""
+        cache = {
+            "verdicts": [
+                {
+                    "decision_id": "d1",
+                    "issue_number": 42.0,
+                    "repo": "o/r",
+                    "verdict": "contradiction",
+                    "rationale": "x",
+                },
+            ]
+        }
+        restored = deserialize_contradiction_cache(cache)
+        assert restored[0].issue_number == 42
+        assert isinstance(restored[0].issue_number, int)
+
+    def test_schema_mismatch_returns_empty(self):
+        """A cache stamped with an unrecognized schema version deserializes to
+        empty rather than silently producing wrong verdicts (M2)."""
+        cache = {
+            "schema": "contradiction-cache/v2",
+            "verdicts": [
+                {
+                    "decision_id": "d1",
+                    "issue_number": 1,
+                    "repo": "o/r",
+                    "verdict": "contradiction",
+                    "rationale": "x",
+                },
+            ],
+        }
+        assert deserialize_contradiction_cache(cache) == []
+
+    def test_absent_schema_key_tolerated(self):
+        """A cache with no schema key (legacy/hand-written) still deserializes —
+        only an explicit *mismatched* schema is rejected (M2)."""
+        cache = {
+            "verdicts": [
+                {
+                    "decision_id": "d1",
+                    "issue_number": 1,
+                    "repo": "o/r",
+                    "verdict": "contradiction",
+                    "rationale": "x",
+                },
+            ]
+        }
+        assert len(deserialize_contradiction_cache(cache)) == 1
+
 
 class TestL1OnlyGuard:
     """The contradiction detector runs L1-only; analyze() never invokes the
@@ -767,19 +831,9 @@ class TestAnalyzeFoldsContradictions:
         assert len(hits) == 1  # only the contradiction survives
         assert hits[0].issue_number == 1
 
-    def test_analyze_emits_no_contradiction_hits(self):
-        """Even with referenced decisions present, analyze() emits no
-        memory-git-contradiction hits — that detector is L1-only and lives
-        outside the engine path."""
-        baseline = make_baseline(
-            repos={
-                "jarvis": make_state("jarvis", issues=[make_issue(42)]),
-            },
-            provenance={"gh:jarvis": Provenance(ran=True, ok=True, age=0)},
-        )
-        decisions = [make_decision("d1", decision="Shipped #42", created_days_ago=1)]
-        result = analyze(baseline, make_delta(), decisions)
-        assert all(h.detector != MEMORY_GIT_CONTRADICTION for h in result.detector_hits)
+    # NOTE: the "analyze never autodetects contradictions" assertion lives in
+    # TestL1OnlyGuard.test_analyze_does_not_autodetect_contradictions — not
+    # duplicated here (N4).
 
 
 # ============================================================================
@@ -917,6 +971,21 @@ class TestHealthVerdict:
             [],
         )
         assert health.ok is False
+
+    def test_age_none_does_not_crash(self):
+        """A source with ran=True, ok=True, age=None (unknown data age — e.g. a
+        status snapshot written without a parseable generated_at) must not crash
+        the freshness comparison. age=None means 'age unknown', not stale (C1)."""
+        health = compute_health_verdict(
+            make_baseline(
+                provenance={
+                    "status_snapshot": Provenance(ran=True, ok=True, age=None),
+                },
+            ),
+            [],
+        )
+        # Does not raise; unknown age is treated as not-stale (lenient, non-crash).
+        assert health.ok is True
 
 
 # ============================================================================

--- a/tests/test_status_gather.py
+++ b/tests/test_status_gather.py
@@ -17,7 +17,9 @@ from scripts.status_gather import (
     SourceKind,
     parse_repos_conf,
     _make_decision_record,
+    _extract_contradiction_cache,
     gather,
+    gather_contradiction_cache,
 )
 
 
@@ -81,6 +83,57 @@ def _make_gh_empty() -> dict:
 def _make_gh_fail() -> dict:
     """Simulate a failed gh command."""
     return {"stdout": "", "stderr": "gh: not authenticated", "returncode": 1}
+
+
+def _fixture_query_by_table(table_rows: dict) -> callable:
+    """Return a table-AWARE query_supabase_fn.
+
+    The default `_fixture_query_supabase` is table-blind (same rows for every
+    table); that conflates the `episodes` (decisions) and `memories`
+    (status-snapshot) queries. This fixture keys returned rows by table name so
+    a test can supply a snapshot for `memories` without polluting `episodes`.
+    A table absent from the mapping yields [] (empty-but-successful).
+    """
+    def _query(url: str, key: str, table: str, params: dict) -> list[dict] | None:
+        return table_rows.get(table, [])
+
+    return _query
+
+
+def _snapshot_memory(generated_at: str = "2024-06-09T12:00:00+00:00",
+                     verdicts: list[dict] | None = None) -> dict:
+    """Build a `memories` row whose body carries a fenced yaml contradiction
+    cache, mirroring what the status-record L1 audit writes."""
+    verdicts = verdicts if verdicts is not None else [
+        {
+            "decision_id": "d1",
+            "issue_number": 42,
+            "repo": "Osasuwu/jarvis",
+            "verdict": "contradiction",
+            "rationale": "memory says shipped; issue still open",
+        },
+    ]
+    lines = [
+        "# Status snapshot 2024-06-09",
+        "",
+        "```yaml",
+        "contradiction_cache:",
+        "  schema: contradiction-cache/v1",
+        f"  generated_at: '{generated_at}'",
+        "  verdicts:",
+    ]
+    for v in verdicts:
+        lines.append(f"    - decision_id: {v['decision_id']}")
+        lines.append(f"      issue_number: {v['issue_number']}")
+        lines.append(f"      repo: {v['repo']}")
+        lines.append(f"      verdict: {v['verdict']}")
+        lines.append(f"      rationale: {v['rationale']}")
+    lines.append("```")
+    return {
+        "name": "status_snapshot_2024-06-09",
+        "content": "\n".join(lines),
+        "created_at": "2024-06-09T12:00:05+00:00",
+    }
 
 
 # ============================================================================
@@ -609,3 +662,152 @@ class TestGitStateDegradation:
         assert git_prov["ok"] is False  # local dir not available
         assert repo["branch"] is None
         assert repo["clean"] is None
+
+
+# ============================================================================
+# Test: Contradiction-cache gather (#1016 AC3/AC4)
+#
+# The status-record L1 audit writes the LLM contradiction verdicts into the
+# `status-snapshot`-tagged memory as a fenced yaml block. gather() reads that
+# cache back WITHOUT re-running the LLM (AC4: "readable by the renderer without
+# re-running the LLM"). These tests pin the read-back path.
+# ============================================================================
+
+
+class TestExtractContradictionCache:
+    """Pure helper: pull the contradiction_cache dict out of a memory body."""
+
+    def test_extracts_cache_from_fenced_yaml(self):
+        snap = _snapshot_memory()
+        cache = _extract_contradiction_cache(snap["content"])
+        assert isinstance(cache, dict)
+        assert cache["schema"] == "contradiction-cache/v1"
+        assert len(cache["verdicts"]) == 1
+        assert cache["verdicts"][0]["issue_number"] == 42
+
+    def test_no_yaml_block_returns_none(self):
+        cache = _extract_contradiction_cache("# Just a heading\n\nNo fenced block.")
+        assert cache is None
+
+    def test_yaml_without_cache_key_returns_none(self):
+        body = "```yaml\nsomething_else: 1\n```"
+        assert _extract_contradiction_cache(body) is None
+
+    def test_malformed_yaml_returns_none(self):
+        body = "```yaml\n  : : not valid : :\n```"
+        assert _extract_contradiction_cache(body) is None
+
+    def test_empty_content_returns_none(self):
+        assert _extract_contradiction_cache("") is None
+
+
+class TestGatherContradictionCache:
+    """gather_contradiction_cache reads the latest status-snapshot memory."""
+
+    def test_snapshot_with_cache_returns_ok(self):
+        snap = _snapshot_memory()
+        query = _fixture_query_by_table({"memories": [snap]})
+        cache, prov = gather_contradiction_cache(
+            "https://x", "k", query, now=1_717_000_000.0,
+        )
+        assert cache is not None
+        assert cache["schema"] == "contradiction-cache/v1"
+        assert prov.ran is True
+        assert prov.ok is True
+        assert prov.input_rows == 1  # one verdict
+
+    def test_no_snapshot_row_returns_not_ok(self):
+        query = _fixture_query_by_table({"memories": []})
+        cache, prov = gather_contradiction_cache(
+            "https://x", "k", query, now=1_717_000_000.0,
+        )
+        assert cache is None
+        assert prov.ran is True
+        assert prov.ok is False
+
+    def test_query_failure_returns_not_ok(self):
+        def _failing(url, key, table, params):
+            return None
+        cache, prov = gather_contradiction_cache(
+            "https://x", "k", _failing, now=1_717_000_000.0,
+        )
+        assert cache is None
+        assert prov.ran is True
+        assert prov.ok is False
+
+    def test_snapshot_without_cache_block_returns_not_ok(self):
+        row = {
+            "name": "status_snapshot_x",
+            "content": "# Snapshot\n\nno cache here",
+            "created_at": "2024-06-09T12:00:00+00:00",
+        }
+        query = _fixture_query_by_table({"memories": [row]})
+        cache, prov = gather_contradiction_cache(
+            "https://x", "k", query, now=1_717_000_000.0,
+        )
+        assert cache is None
+        assert prov.ok is False
+
+    def test_age_reflects_generated_at_not_query_time(self):
+        # generated_at is 2024-06-09T12:00:00Z; now is +100s. Age must be the
+        # data age (~100s), so the renderer's freshness gate is meaningful.
+        snap = _snapshot_memory(generated_at="2024-06-09T12:00:00+00:00")
+        query = _fixture_query_by_table({"memories": [snap]})
+        gen_epoch = 1_717_934_400.0  # 2024-06-09T12:00:00 UTC
+        cache, prov = gather_contradiction_cache(
+            "https://x", "k", query, now=gen_epoch + 100.0,
+        )
+        assert prov.age is not None
+        assert abs(prov.age - 100.0) < 2.0
+
+
+class TestGatherIntegratesContradictionCache:
+    """gather() Step 5 populates result.contradiction_cache from the snapshot."""
+
+    def test_gather_populates_contradiction_cache(self):
+        snap = _snapshot_memory()
+        result = gather(
+            jarvis_home="/fake",
+            read_repos_conf_fn=_fixture_repos_conf("Osasuwu/jarvis\n"),
+            read_device_json_fn=_fixture_device_json({"repos_path": "/fake/repos"}),
+            run_git_fn=_fixture_run_git({"stdout": "main", "stderr": "",
+                                         "returncode": 0}),
+            run_gh_fn=_fixture_run_gh(_make_gh_success([])),
+            query_supabase_fn=_fixture_query_by_table({"memories": [snap]}),
+            now_fn=_fixture_now(),
+        )
+        assert result.contradiction_cache is not None
+        assert result.contradiction_cache["schema"] == "contradiction-cache/v1"
+        snap_prov = result.provenance[SourceKind.STATUS_SNAPSHOT]
+        assert snap_prov["ran"] is True
+        assert snap_prov["ok"] is True
+
+    def test_gather_no_snapshot_leaves_cache_none(self):
+        result = gather(
+            jarvis_home="/fake",
+            read_repos_conf_fn=_fixture_repos_conf("Osasuwu/jarvis\n"),
+            read_device_json_fn=_fixture_device_json({"repos_path": "/fake/repos"}),
+            run_git_fn=_fixture_run_git({"stdout": "main", "stderr": "",
+                                         "returncode": 0}),
+            run_gh_fn=_fixture_run_gh(_make_gh_success([])),
+            query_supabase_fn=_fixture_query_supabase([]),
+            now_fn=_fixture_now(),
+        )
+        assert result.contradiction_cache is None
+        snap_prov = result.provenance[SourceKind.STATUS_SNAPSHOT]
+        assert snap_prov["ok"] is False
+
+    def test_contradiction_cache_is_json_serializable(self):
+        snap = _snapshot_memory()
+        result = gather(
+            jarvis_home="/fake",
+            read_repos_conf_fn=_fixture_repos_conf("Osasuwu/jarvis\n"),
+            read_device_json_fn=_fixture_device_json({"repos_path": "/fake/repos"}),
+            run_git_fn=_fixture_run_git({"stdout": "main", "stderr": "",
+                                         "returncode": 0}),
+            run_gh_fn=_fixture_run_gh(_make_gh_success([])),
+            query_supabase_fn=_fixture_query_by_table({"memories": [snap]}),
+            now_fn=_fixture_now(),
+        )
+        parsed = json.loads(json.dumps(result.to_dict(), default=str))
+        assert parsed["contradiction_cache"]["schema"] == "contradiction-cache/v1"

--- a/tests/test_status_gather.py
+++ b/tests/test_status_gather.py
@@ -554,8 +554,12 @@ class TestSnapshotGapTolerance:
         assert decisions_prov["input_rows"] == 2
 
     def test_status_snapshot_not_available(self):
-        """AC: no status baselines → snapshot source not ok, but repos + decisions
-        still gathered."""
+        """AC: no status baselines → snapshot query ran and succeeded-empty
+        (ok=True, cache None), but repos + decisions still gathered.
+
+        Empty is NOT a failure (MAJOR fix, PR #1046): only a transport error
+        is ok=False. The renderer reads "no snapshot" from cache is None /
+        input_rows==0, not from ok."""
         result = gather(
             jarvis_home="/fake",
             read_repos_conf_fn=_fixture_repos_conf("Osasuwu/jarvis\n"),
@@ -567,10 +571,12 @@ class TestSnapshotGapTolerance:
             now_fn=_fixture_now(),
         )
 
-        # Baseline source not ok (not available in this context)
+        # Snapshot query ran and succeeded with no rows — empty, not failed.
         snap_prov = result.provenance.get(SourceKind.STATUS_SNAPSHOT, {})
         assert snap_prov.get("ran") is True
-        assert snap_prov.get("ok") is False
+        assert snap_prov.get("ok") is True
+        assert snap_prov.get("input_rows") == 0
+        assert result.contradiction_cache is None
 
         # But repos and decisions are still gathered
         assert len(result.repos) == 1
@@ -758,14 +764,20 @@ class TestGatherContradictionCache:
         assert prov.ok is True
         assert prov.input_rows == 1  # one verdict
 
-    def test_no_snapshot_row_returns_not_ok(self):
+    def test_no_snapshot_row_is_ok_empty(self):
+        # No snapshot yet (first-run device, or intraday before L1) is a
+        # legitimate empty state, NOT a failure — mirrors gather_decisions
+        # where an empty query result is ok=True. Only a transport failure
+        # is ok=False. Conflating the two (MAJOR, PR #1046 re-review) hid a
+        # Supabase outage behind an indistinguishable "no data" stamp.
         query = _fixture_query_by_table({"memories": []})
         cache, prov = gather_contradiction_cache(
             "https://x", "k", query, now=1_717_000_000.0,
         )
         assert cache is None
         assert prov.ran is True
-        assert prov.ok is False
+        assert prov.ok is True
+        assert prov.input_rows == 0
 
     def test_query_failure_returns_not_ok(self):
         def _failing(url, key, table, params):
@@ -776,6 +788,23 @@ class TestGatherContradictionCache:
         assert cache is None
         assert prov.ran is True
         assert prov.ok is False
+
+    def test_provenance_distinguishes_empty_from_failed(self):
+        # The whole point of the MAJOR fix: a caller must be able to tell a
+        # Supabase outage (None) apart from a first-run empty result ([]).
+        empty_q = _fixture_query_by_table({"memories": []})
+        _, empty_prov = gather_contradiction_cache(
+            "https://x", "k", empty_q, now=1_717_000_000.0,
+        )
+
+        def _failing(url, key, table, params):
+            return None
+        _, failed_prov = gather_contradiction_cache(
+            "https://x", "k", _failing, now=1_717_000_000.0,
+        )
+        assert empty_prov.ok != failed_prov.ok
+        assert empty_prov.ok is True
+        assert failed_prov.ok is False
 
     def test_snapshot_without_cache_block_returns_not_ok(self):
         row = {
@@ -801,6 +830,27 @@ class TestGatherContradictionCache:
         )
         assert prov.age is not None
         assert abs(prov.age - 100.0) < 2.0
+
+    def test_query_filters_exclude_soft_deleted_and_poisoned_rows(self):
+        # Security/integrity (PR #1046 re-review LOWs): a soft-deleted or
+        # expired snapshot must not be folded, and a sandcastle-written row
+        # (anon key, RLS-gated to source_provenance like 'sandcastle:%') must
+        # not be trusted as an L1 baseline. Assert the query carries the
+        # live-row + provenance filters so the DB never returns those rows.
+        captured = {}
+
+        def _capturing(url, key, table, params):
+            captured.update(params)
+            return []
+
+        gather_contradiction_cache(
+            "https://x", "k", _capturing, now=1_717_000_000.0,
+        )
+        assert captured.get("deleted_at") == "is.null"
+        assert captured.get("expired_at") == "is.null"
+        # NULL or non-sandcastle provenance passes; sandcastle:* is rejected.
+        assert "sandcastle" in captured.get("or", "")
+        assert "not.like" in captured.get("or", "")
 
 
 class TestGatherIntegratesContradictionCache:
@@ -837,7 +887,10 @@ class TestGatherIntegratesContradictionCache:
         )
         assert result.contradiction_cache is None
         snap_prov = result.provenance[SourceKind.STATUS_SNAPSHOT]
-        assert snap_prov["ok"] is False
+        # Empty snapshot query succeeds with no rows (ok=True); cache is None.
+        # ok=False is reserved for a transport failure (MAJOR fix, PR #1046).
+        assert snap_prov["ok"] is True
+        assert snap_prov["input_rows"] == 0
 
     def test_contradiction_cache_is_json_serializable(self):
         snap = _snapshot_memory()

--- a/tests/test_status_gather.py
+++ b/tests/test_status_gather.py
@@ -700,6 +700,48 @@ class TestExtractContradictionCache:
     def test_empty_content_returns_none(self):
         assert _extract_contradiction_cache("") is None
 
+    def test_trailing_blank_line_before_fence(self):
+        """A blank line before the closing fence (common Markdown emit) must not
+        defeat extraction — the cache should still parse (M1)."""
+        body = (
+            "```yaml\n"
+            "contradiction_cache:\n"
+            "  schema: contradiction-cache/v1\n"
+            "  verdicts: []\n"
+            "\n"  # trailing blank line before the closing fence
+            "```"
+        )
+        cache = _extract_contradiction_cache(body)
+        assert isinstance(cache, dict)
+        assert cache["schema"] == "contradiction-cache/v1"
+
+    def test_fence_with_info_string_after_yaml(self):
+        """A fence tagged ```yaml title=... still extracts (M1 regex tolerance)."""
+        body = (
+            "```yaml extra-info\n"
+            "contradiction_cache:\n"
+            "  verdicts: []\n"
+            "```"
+        )
+        assert _extract_contradiction_cache(body) is not None
+
+    def test_multi_fence_skips_to_cache_block(self):
+        """First yaml fence lacks contradiction_cache; the loop continues to the
+        second fence that has it (N2 — finditer continuation)."""
+        body = (
+            "```yaml\n"
+            "other_metadata: 1\n"
+            "```\n\n"
+            "```yaml\n"
+            "contradiction_cache:\n"
+            "  schema: contradiction-cache/v1\n"
+            "  verdicts: []\n"
+            "```"
+        )
+        cache = _extract_contradiction_cache(body)
+        assert isinstance(cache, dict)
+        assert cache["schema"] == "contradiction-cache/v1"
+
 
 class TestGatherContradictionCache:
     """gather_contradiction_cache reads the latest status-snapshot memory."""


### PR DESCRIPTION
## Summary
Wires the L1 memory↔git contradiction detector end-to-end so its cached verdicts reach `/status`. The cached verdict is now read back from the `status-snapshot` memory and folded into the status digest **without re-running the LLM** — closing AC4 of #1016, which PR #1043 merged unmet.

## Why
#1016 shipped the detector (#1043) but AC4 ("the cached contradiction result is written into the `status-snapshot`-tagged memory and is **readable by the renderer without re-running the LLM**") was merged unmet — the cache was produced but never read back into the digest. This PR closes that gap, the last slice of milestone #53.

Closes #1016

## Decisions & Alternatives
- **Fold cached verdicts INSIDE `status_engine.analyze()`** (via optional `contradiction_verdicts=()` param), not at the MCP boundary — so contradiction hits participate in `rank_detector_hits` + `compute_health_verdict` like any other detector hit (appear in "Куда смотреть", flip health red). Decision `7d9c0d7e-10f6-4cdc-88b4-ed8585a1cd7d`.
- **Default empty tuple = intraday/L2 path**: no verdicts → no contradiction hit → no LLM cost. This is how the L1-only contract (AC2) is preserved — `analyze()` *folds* pre-judged verdicts but never invokes the LLM itself.
- **Gather reads the raw cache dict; deserialize at the mcp-status boundary** — keeps `status_gather` free of any `status_engine` dependency (mirrors how `gather_decisions` works). Snapshot age is stamped from the cache's `generated_at` (data age) so the freshness gate is meaningful.
- Alternative rejected: folding at the MCP boundary after `analyze()` — would have left contradiction hits out of ranking/health, defeating the point of surfacing them.

## Deliberate divergences
- **`tests/test_status_engine.py`: source-grep guard → behavioral guard.** The old `TestL1OnlyGuard.test_analyze_does_not_call_fold` asserted via source inspection that `analyze()` never calls `fold_contradiction_verdicts`. That is now false by design (AC4 requires the fold), and the assertion was over-specified — it pinned an implementation detail, not a behavior. Replaced with two behavioral tests: default-empty `analyze()` produces no contradiction hit (the real L1-only guarantee), and a passed cached verdict surfaces exactly one hit. Net: stronger coverage of the actual AC2 contract, no LLM-invocation path added to `analyze()`.

## Risk Assessment
- **LOW/MEDIUM**: additive optional param (`contradiction_verdicts=()`) + read-back wiring. The default-empty value preserves the existing L2/intraday behavior exactly — no existing call site changes semantics. No protected files touched (only `scripts/`, `tests/`, `mcp-status/`).

## Testing
- `pytest tests/test_status_engine.py tests/test_status_gather.py tests/test_mcp_status_server.py` → 106 passed
- `ruff check` on all 6 touched files → clean
- End-to-end test (`test_cached_contradiction_surfaces_in_digest_without_llm`) proves a cached verdict folds through `gather → analyze → digest.detector_hits` with NO LLM call in the path — the AC4 proof.

## HITL note
AC5 (prompt + shortlist reviewed with owner before merge) is an owner step — the detector prompt itself shipped in #1043; this PR is the read-back wiring only and adds no new LLM prompt.

## Files Changed
- `scripts/status_engine.py` — `analyze()` gains `contradiction_verdicts=()`; folds via `fold_contradiction_verdicts` before ranking/health.
- `scripts/status_gather.py` — `gather_contradiction_cache()` reads the latest `status-snapshot` memory, extracts the fenced-yaml cache, stamps age from `generated_at`; `GatherResult.contradiction_cache` field added.
- `mcp-status/server.py` — `_contradiction_verdicts_from_gather()` deserializes the cache at the boundary; `analyze()` called with the verdicts.
- `tests/test_status_engine.py` — behavioral L1-only guard + fold round-trip tests.
- `tests/test_status_gather.py` — cache-extraction + gather-integration tests.
- `tests/test_mcp_status_server.py` — deserialize + end-to-end fold-through tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)