### PR TITLE
ci: port redrobot loud-fail "Verify review ran cleanly" step

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -95,6 +95,7 @@ jobs:
           echo "::notice::Push by osasuwu-ci[bot] is an auto-rebase only (no new code); skipping code review."
 
       - name: Run /code-review
+        id: review
         if: steps.autobase.outputs.skip != 'true' && (github.event_name == 'workflow_dispatch' || steps.diff.outputs.has_code == 'true')
         uses: anthropics/claude-code-action@v1
         with:
@@ -194,6 +195,49 @@ jobs:
       # that jam (above) makes retries succeed, so this gate must enforce on
       # the dispatch path too. steps.pr.outputs.number resolves on dispatch
       # via inputs.pr_number, so the lookup works for both events.
+      # Loud-fail diagnostic (mirror of SergazyNarynov/redrobot PR #1304). The
+      # verdict guard below fails CLOSED on a missing/unparseable comment — which
+      # masks two very different causes as one "re-run code-review" message:
+      #   (a) the model genuinely posted no blocking verdict, vs
+      #   (b) the review run itself broke — is_error=true, or its subagents were
+      #       permission-denied tools they need (allowlist drift between this
+      #       workflow's claude_args --allowed-tools and the plugin command's
+      #       frontmatter), so the orchestrator burned turns and never posted.
+      # When (b) happens the verdict guard says "errored, re-run" but a re-run
+      # hits the SAME wall silently. This step reads the action's execution log
+      # and fails LOUDLY with the exact denied tool calls, so allowlist drift is
+      # self-diagnosing instead of presenting as a flaky verdict gate. jarvis is
+      # the allowlist source-of-truth (already a superset), so in steady state
+      # this should always pass with 0 denials — it is a regression tripwire.
+      - name: Verify review ran cleanly
+        if: steps.autobase.outputs.skip != 'true' && (github.event_name == 'workflow_dispatch' || steps.diff.outputs.has_code == 'true')
+        env:
+          EXEC_FILE: ${{ steps.review.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+          if [ -z "${EXEC_FILE:-}" ] || [ ! -f "$EXEC_FILE" ]; then
+            echo "::notice::No execution log (review skipped or produced no output); nothing to verify."
+            exit 0
+          fi
+          result=$(jq -c '[.[] | select(.type == "result")] | last // {}' "$EXEC_FILE")
+          is_error=$(jq -r '.is_error // false' <<<"$result")
+          denials=$(jq -r '.permission_denials_count // 0' <<<"$result")
+          echo "Review result: is_error=$is_error permission_denials_count=$denials"
+          if [ "$is_error" = "true" ]; then
+            echo "::error::Code review run reported is_error=true — the model call failed. Failing loudly (not masking as a verdict-guard fail-closed)."
+            exit 1
+          fi
+          if [ "$denials" -gt 0 ]; then
+            echo "::error::Code review hit $denials permission denial(s) — its subagents were blocked from tools they need, so the review is incomplete and may not have posted. Add the tools below to the claude_args --allowed-tools and re-run."
+            echo "Denied tool calls:"
+            jq -r '[.[] | select(.type == "result")] | last
+                   | (.permission_denials // [])[]
+                   | "  - \(.tool_name): \(.tool_input | tostring | .[0:160])"' \
+              "$EXEC_FILE" 2>/dev/null | sort -u || true
+            exit 1
+          fi
+          echo "::notice::Code review ran cleanly (0 permission denials)."
+
       - name: Verify review verdict
         if: steps.autobase.outputs.skip != 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
         env:


### PR DESCRIPTION
## What

Ports the loud-fail diagnostic step from [SergazyNarynov/redrobot PR #1304](https://github.com/SergazyNarynov/redrobot/pull/1304) into jarvis's `code-review.yml`. Adds `id: review` to the `Run /code-review` step and a new **Verify review ran cleanly** step before the verdict guard.

## Why

The `Verify review verdict` gate fails **closed** on a missing/unparseable review comment. That correctly blocks merge, but it masks two very different causes under one "re-run code-review" message:

- **(a)** the model genuinely posted no blocking verdict, vs
- **(b)** the review run itself broke — `is_error=true`, or its reviewer subagents were **permission-denied** tools they need (allowlist drift between this workflow's `claude_args --allowed-tools` and the plugin command frontmatter).

In case (b) a re-run silently hits the same wall. This step reads the action's `execution_file`, and on `is_error` or `permission_denials_count > 0` fails **loudly**, printing the exact denied tool calls — so allowlist drift becomes self-diagnosing instead of looking like a flaky verdict gate. That drift is exactly what broke redrobot's gate (#1303/#1304).

jarvis is the allowlist source-of-truth (already a superset of the plugin frontmatter), so in steady state this passes with 0 denials — it's a regression tripwire, not an active fix.

## Note

This PR edits `code-review.yml` itself, so `anthropics/claude-code-action@v1` refuses to run the `review` check on it (self-modifying workflow). Expect that gate to be skipped/failed → admin-merge once other gates are green.

[no-issue]

🤖 Generated with [Claude Code](https://claude.com/claude-code)