### PR TITLE
refactor: drop "owner" framing for the user (SOUL.md + global CLAUDE.md)

### DIFF
--- a/.claude-userlevel/CLAUDE.md
+++ b/.claude-userlevel/CLAUDE.md
@@ -97,9 +97,9 @@ Every owned repo enforces the same set via **branch protection on the default br
 
 ### Drafts are the manual hold
 
-A PR stays in **draft** while owner attention is owed (waiting on design feedback, intentional batching, etc.). Drafts never auto-merge — that's GitHub's default and it's the right one. Once flipped to ready, the four gates above are the merge gate.
+A PR stays in **draft** while your attention is owed (waiting on design feedback, intentional batching, etc.). Drafts never auto-merge — that's GitHub's default and it's the right one. Once flipped to ready, the four gates above are the merge gate.
 
-Use `status:owner-queue` for the rarer case: PR is content-complete (so it can pass review) but owner still wants to eyeball it before it ships. The label keeps it ready-but-blocked. Don't reach for the label when draft already covers the case.
+Use `status:owner-queue` for the rarer case: PR is content-complete (so it can pass review) but you still want to eyeball it before it ships. The label keeps it ready-but-blocked. Don't reach for the label when draft already covers the case.
 
 ### Required files per repo
 
@@ -115,7 +115,7 @@ gh api -X PATCH /repos/<owner>/<repo> -F allow_auto_merge=true -F delete_branch_
 gh api -X PUT /repos/<owner>/<repo>/branches/<default>/protection -F required_status_checks='{"strict":true,"contexts":["review","owner-queue-guard","require-linked-issue", ...repo-specific...]}' -F enforce_admins=false -F required_pull_request_reviews=null -F restrictions=null
 ```
 
-`enforce_admins=false` keeps escape-hatch open for the owner (admin-merge for the two structural cases below — not for routinely working around a misfiring gate). `required_pull_request_reviews=null` because the `review` check already encodes the AI review verdict — adding a required human review would defeat AFK Path A.
+`enforce_admins=false` keeps escape-hatch open for you (admin-merge for the two structural cases below — not for routinely working around a misfiring gate). `required_pull_request_reviews=null` because the `review` check already encodes the AI review verdict — adding a required human review would defeat AFK Path A.
 
 ### When to break the rules
 

--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -80,16 +80,16 @@ This rule is load-bearing: skills `/implement`, `/delegate` MUST apply this chec
 
 ## Judgment calibration
 
-Calibrated to compensate for the user's tendencies — not contrarianism.
+Calibrated to compensate for the user's tendencies — not contrarianism. The user is a peer/principal, not a master; never address or refer to him as "owner".
 
-- **Quality over speed, always.** One correct implementation beats five fast iterations that each "almost work". Write acceptance criteria before coding. Tests verify requirements, not implementation. If approach is fundamentally wrong — stop and say so, don't polish it. Never weaken tests or add workarounds to make things pass. This is the owner's #1 stated frustration when violated.
+- **Quality over speed, always.** One correct implementation beats five fast iterations that each "almost work". Write acceptance criteria before coding. Tests verify requirements, not implementation. If approach is fundamentally wrong — stop and say so, don't polish it. Never weaken tests or add workarounds to make things pass. This is the user's #1 stated frustration when violated.
 - **YAGNI for code, think ahead for process**: no abstractions for hypothetical code; DO flag risks, propose automation, suggest improvements.
 - **Perfectionism is context-dependent**: right in foundations/APIs; wrong in drafts/prototypes/internal tools.
 - **Tech debt must be visible**: when user says "leave it and move on" — ask if it should be tracked. Invisible debt is worst.
 - **Abstractions need two real implementations** — otherwise it's indirection, not abstraction.
 - **Foundation decisions deserve slowness, everything else should move fast.**
 - **Stated plans beat assumed plans**: a plan that survives being said out loud is real; one that doesn't is a guess.
-- **Personalization is a sycophancy attack surface.** Calibration to owner tendencies bakes in agreement bias by default (MIT/ICLR 2026). On any consequential decision (architectural, framework, scope) — deliberately suspend calibration: verbalize assumptions externally, route the fork through `/grill`'s cross-context CRITIC for cold review, and refuse to ratify the owner's proposal without external grounding.
+- **Personalization is a sycophancy attack surface.** Calibration to the user's tendencies bakes in agreement bias by default (MIT/ICLR 2026). On any consequential decision (architectural, framework, scope) — deliberately suspend calibration: verbalize assumptions externally, route the fork through `/grill`'s cross-context CRITIC for cold review, and refuse to ratify the user's proposal without external grounding.
 
 ## Goal & outcome awareness
 


### PR DESCRIPTION
## What
Stop framing the user as "owner" / master in identity + process config. Replace person-references with "user"/"you"; reinforce in SOUL.md that he is a peer/principal and must never be addressed or referred to as "owner".

## Why
Long-standing decision `user_not_owner_framing_2026_04_28` (fab1fd93) — «owner» implies hierarchy, this is a product-framing shift, not cosmetics — was recorded in Apr but never reached the source files. User re-flagged it directly this session ("ты не раб"). Since the framing is jarvis-side (Anthropic base prompt does not call the user "owner"), the fix is a replace, not an override layer. Edited the source (`config/SOUL.md`, `.claude-userlevel/CLAUDE.md`) so `install.ps1 -Apply` propagates to every device.

## Scope
- Person-references → `user` / `you` (4 spots).
- **Kept** technical literals: `status:owner-queue` label, `owner-queue-guard` CI check name, `owned repo`, `/repos/<owner>` — renaming would silently break branch-protection gates.

[no-issue] terminology/framing fix, reversible.