### PR TITLE
feat(#979): --check drift-detection mode + required-check contexts_source provenance

### DIFF
--- a/scripts/repo_baseline/auditor.py
+++ b/scripts/repo_baseline/auditor.py
@@ -103,10 +103,19 @@ class BranchProtection:
     **not** modelled here. The baseline cares whether the right CI checks gate
     merges; the richer protection surface is out of scope for slice 1 and a
     downstream slice can extend this dataclass if the applier needs those axes.
+
+    ``contexts_source`` is a parallel list to ``contexts``: for each required
+    check context, the workflow file path that produces it (or ``None`` when no
+    local workflow defines it — e.g. a marketplace/app check like ``review``).
+    Populated by the auditor during :meth:`Auditor.audit`. ``None`` means
+    provenance was not computed (legacy snapshot); an entry of ``None`` inside
+    the list means that specific context has no matching local workflow.
+    Added in issue #979.
     """
 
     strict: bool = False
     contexts: list[str] = field(default_factory=list)
+    contexts_source: list[str | None] | None = None
 
 
 @dataclass
@@ -196,12 +205,22 @@ class Auditor:
         """
         try:
             settings = self._read_settings(repo)
+            workflows, wf_name_map = self._read_workflows(repo)
+            bp = self._read_branch_protection(repo, settings.default_branch)
+            if bp is not None:
+                # For each required check context, try to find a workflow whose
+                # name matches — that workflow's path is the provenance source.
+                # Contexts not produced by any local workflow (e.g. marketplace
+                # app checks like "review") get a null entry.
+                bp.contexts_source = [
+                    wf_name_map.get(ctx) for ctx in bp.contexts
+                ]
             return RepoSnapshot(
                 repo=repo,
                 settings=settings,
                 labels=self._read_labels(repo),
-                workflows=self._read_workflows(repo),
-                branch_protection=self._read_branch_protection(repo, settings.default_branch),
+                workflows=workflows,
+                branch_protection=bp,
                 dependabot_ecosystems=self._read_dependabot_ecosystems(repo),
             )
         except Exception as e:  # noqa: BLE001 — boundary: attribute to the repo
@@ -262,7 +281,7 @@ class Auditor:
             for lb in data
         ]
 
-    def _read_workflows(self, repo: str) -> list[str]:
+    def _read_workflows(self, repo: str) -> tuple[list[str], dict[str, str]]:
         # The workflows endpoint returns a ``{total_count, workflows: [...]}``
         # envelope, not a bare array, so the runner's array-paginate merge path
         # cannot handle it — ``--paginate`` here would trip the "unexpected page
@@ -272,7 +291,10 @@ class Auditor:
         # any realistic repo in scope; a repo exceeding it would need true
         # envelope-aware pagination, which no current target requires.
         data = self.runner(f"repos/{repo}/actions/workflows?per_page=100")
-        return [wf["path"] for wf in data.get("workflows", [])]
+        wfs = data.get("workflows", [])
+        paths = [wf["path"] for wf in wfs]
+        name_to_path = {wf["name"]: wf["path"] for wf in wfs}
+        return paths, name_to_path
 
     def _read_branch_protection(self, repo: str, default_branch: str) -> BranchProtection | None:
         try:

--- a/scripts/repo_baseline/generate_snapshots.py
+++ b/scripts/repo_baseline/generate_snapshots.py
@@ -17,12 +17,18 @@ under the Osasuwu token; deferred to issue #940.
 
 Usage::
 
+    # Generate (or re-generate) committed fixtures
     python -m scripts.repo_baseline.generate_snapshots
+
+    # Check for drift without writing
+    python -m scripts.repo_baseline.generate_snapshots --check
 """
 
 from __future__ import annotations
 
+import argparse
 import json
+import sys
 from pathlib import Path
 
 import yaml
@@ -31,6 +37,7 @@ from .auditor import (
     OSASUWU_REPOS,
     Auditor,
     GhRunner,
+    RepoSnapshot,
     gh_runner,
     scrub_topology,
     seed_manifest,
@@ -109,7 +116,75 @@ def generate(
     return written
 
 
+def check(
+    repos: list[str],
+    runner: GhRunner = gh_runner,
+    *,
+    snapshots_dir: Path | None = None,
+) -> list[str]:
+    """Re-audit each repo and diff against its committed snapshot.
+
+    Returns a list of drift reports (one per drifted repo). Each report names
+    the repo and the differing top-level axes. An empty list means every repo
+    matches its committed snapshot — clean.
+
+    Does **not** fail fast: every repo is audited, even if one has already
+    drifted. Never writes anything — pure read-only check.
+    """
+    snapshots_dir = snapshots_dir if snapshots_dir is not None else SNAPSHOTS_DIR
+
+    auditor = Auditor(runner)
+    drifts: list[str] = []
+
+    for repo in repos:
+        try:
+            committed = RepoSnapshot.from_dict(
+                json.loads((snapshots_dir / f"{_slug(repo)}.snapshot.json").read_text(encoding="utf-8"))
+            )
+            fresh_scrubbed = scrub_topology(auditor.audit(repo).to_dict())
+            committed_dict = scrub_topology(committed.to_dict())
+
+            diff_axes = _diff_snapshot_dicts(fresh_scrubbed, committed_dict)
+            if diff_axes:
+                drifts.append(f"{repo}: {', '.join(sorted(diff_axes))}")
+        except FileNotFoundError as e:
+            drifts.append(f"{repo}: no committed snapshot found ({e})")
+        except Exception as e:  # noqa: BLE001 — collect, don't fail-fast
+            drifts.append(f"{repo}: check error ({type(e).__name__}: {e})")
+
+    return drifts
+
+
+def _diff_snapshot_dicts(fresh: dict, committed: dict) -> list[str]:
+    """Return top-level axis names that differ between two snapshot dicts.
+    Keys present in only one dict are reported as drifts."""
+    differing: list[str] = []
+    all_keys = set(fresh) | set(committed)
+    for key in sorted(all_keys):
+        if fresh.get(key) != committed.get(key):
+            differing.append(key)
+    return differing
+
+
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate or check repo baseline snapshots.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Re-audit and diff against committed snapshots. Exit non-zero on drift.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        drifts = check(OSASUWU_REPOS)
+        if drifts:
+            print(f"Drift detected in {len(drifts)} of {len(OSASUWU_REPOS)} repo(s):")
+            for d in drifts:
+                print(f"  {d}")
+            sys.exit(1)
+        print(f"All {len(OSASUWU_REPOS)} repo(s) match their committed snapshots.")
+        return
+
     written = generate(OSASUWU_REPOS)
     print(f"Wrote {len(written)} files for {len(OSASUWU_REPOS)} repos:")
     for path in written:

--- a/tests/test_repo_baseline_auditor.py
+++ b/tests/test_repo_baseline_auditor.py
@@ -79,6 +79,13 @@ class TestRepoSnapshotParsing:
         assert snap.branch_protection.strict is True
         assert snap.branch_protection.contexts == ["review", "pytest"]
 
+        # contexts_source: "review" has no matching local workflow (app check),
+        # "pytest" matches the workflow named "pytest" at its known path.
+        assert snap.branch_protection.contexts_source == [
+            None,
+            ".github/workflows/pytest.yml",
+        ]
+
         # dependabot ecosystems
         assert snap.dependabot_ecosystems == ["pip", "github-actions"]
 
@@ -91,12 +98,14 @@ class TestRepoSnapshotParsing:
         runner = FakeRunner(
             {
                 "repos/Osasuwu/x/actions/workflows?per_page=100": {
-                    "workflows": [{"path": ".github/workflows/a.yml"}]
+                    "workflows": [{"name": "Workflow A", "path": ".github/workflows/a.yml"}]
                 }
             }
         )
         auditor = Auditor(runner)
-        assert auditor._read_workflows("Osasuwu/x") == [".github/workflows/a.yml"]
+        paths, name_map = auditor._read_workflows("Osasuwu/x")
+        assert paths == [".github/workflows/a.yml"]
+        assert name_map == {"Workflow A": ".github/workflows/a.yml"}
         # Single, non-paginated request that carries the larger page size.
         assert runner.paginate_for("repos/Osasuwu/x/actions/workflows?per_page=100") is False
 
@@ -304,6 +313,81 @@ class TestSnapshotSerialization:
         assert "INJECTED" not in snap.branch_protection.contexts
         assert "INJECTED" not in snap.dependabot_ecosystems
         assert "INJECTED" not in snap.workflows
+
+
+class TestContextsSource:
+    """AC2 — BranchProtection.contexts_source provenance."""
+
+    def test_locally_produced_check_resolves_to_workflow_path(self):
+        """A context matching a workflow name gets that workflow's path."""
+        responses = dict(_jarvis_responses())
+        snap = Auditor(FakeRunner(responses)).audit("Osasuwu/jarvis")
+        assert snap.branch_protection.contexts_source == [
+            None,  # "review" is an app check, no local workflow
+            ".github/workflows/pytest.yml",  # "pytest" workflow matches
+        ]
+
+    def test_all_checks_mapped_or_null_per_context(self):
+        """contexts_source must be same length as contexts — one entry per
+        required check context, in the same order."""
+        responses = dict(_jarvis_responses())
+        responses["repos/Osasuwu/jarvis/actions/workflows?per_page=100"] = {
+            "workflows": [
+                {"name": "review", "path": ".github/workflows/code-review.yml"},
+                {"name": "pytest", "path": ".github/workflows/pytest.yml"},
+            ]
+        }
+        snap = Auditor(FakeRunner(responses)).audit("Osasuwu/jarvis")
+        assert snap.branch_protection.contexts_source == [
+            ".github/workflows/code-review.yml",
+            ".github/workflows/pytest.yml",
+        ]
+
+    def test_no_branch_protection_yields_none_contexts_source(self):
+        """A repo with no branch protection has bp=None → contexts_source=None."""
+        responses = {
+            "repos/Osasuwu/dnd-calendar": {
+                "allow_auto_merge": False,
+                "allow_squash_merge": True,
+                "allow_merge_commit": True,
+                "allow_rebase_merge": True,
+                "delete_branch_on_merge": False,
+                "visibility": "public",
+                "default_branch": "main",
+            },
+            "repos/Osasuwu/dnd-calendar/labels": [],
+            "repos/Osasuwu/dnd-calendar/actions/workflows?per_page=100": {"workflows": []},
+        }
+        not_found = {
+            "repos/Osasuwu/dnd-calendar/branches/main/protection",
+            "repos/Osasuwu/dnd-calendar/contents/.github/dependabot.yml",
+        }
+        snap = Auditor(FakeRunner(responses, not_found)).audit("Osasuwu/dnd-calendar")
+        assert snap.branch_protection is None
+
+    def test_contexts_source_round_trips_through_to_dict_from_dict(self):
+        """contexts_source survives serialization."""
+        snap = Auditor(FakeRunner(_jarvis_responses())).audit("Osasuwu/jarvis")
+        restored = RepoSnapshot.from_dict(snap.to_dict())
+        assert restored.branch_protection.contexts_source == snap.branch_protection.contexts_source
+
+    def test_from_dict_tolerates_missing_contexts_source(self):
+        """A legacy snapshot without contexts_source loads with it as None."""
+        data = {
+            "repo": "Osasuwu/jarvis",
+            "settings": {"visibility": "public", "default_branch": "main"},
+            "labels": [],
+            "workflows": [],
+            "branch_protection": {
+                "strict": True,
+                "contexts": ["review"],
+            },
+            "dependabot_ecosystems": [],
+        }
+        snap = RepoSnapshot.from_dict(data)
+        assert snap.branch_protection.strict is True
+        assert snap.branch_protection.contexts == ["review"]
+        assert snap.branch_protection.contexts_source is None
 
 
 class TestSeedManifest:

--- a/tests/test_repo_baseline_generate_snapshots.py
+++ b/tests/test_repo_baseline_generate_snapshots.py
@@ -160,3 +160,58 @@ class TestPerRepoIsolation:
         assert (mans / "Osasuwu__jarvis.manifest.yml").exists()
         # The failed repo wrote nothing.
         assert not (snaps / "Osasuwu__ghost.snapshot.json").exists()
+
+
+class TestCheckMode:
+    """AC1 — generate_snapshots --check re-audits and diffs without writing."""
+
+    def test_clean_match_returns_empty_drifts(self, tmp_path):
+        """When committed snapshot matches a fresh audit, check returns []. """
+        # First, write a snapshot via generate.
+        gen.generate(
+            ["Osasuwu/jarvis"],
+            runner=FakeRunner(_jarvis_responses()),
+            snapshots_dir=tmp_path / "snaps",
+            manifests_dir=tmp_path / "mans",
+        )
+        drifts = gen.check(
+            ["Osasuwu/jarvis"],
+            runner=FakeRunner(_jarvis_responses()),
+            snapshots_dir=tmp_path / "snaps",
+        )
+        assert drifts == []
+
+    def test_single_axis_drift_detected(self, tmp_path):
+        """When a setting changes, check detects the drift and names the axis."""
+        gen.generate(
+            ["Osasuwu/jarvis"],
+            runner=FakeRunner(_jarvis_responses()),
+            snapshots_dir=tmp_path / "snaps",
+            manifests_dir=tmp_path / "mans",
+        )
+        # Modify the committed snapshot on disk — change visibility.
+        snap_path = tmp_path / "snaps" / "Osasuwu__jarvis.snapshot.json"
+        data = json.loads(snap_path.read_text(encoding="utf-8"))
+        data["settings"]["visibility"] = "private"
+        snap_path.write_text(json.dumps(data, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+        drifts = gen.check(
+            ["Osasuwu/jarvis"],
+            runner=FakeRunner(_jarvis_responses()),
+            snapshots_dir=tmp_path / "snaps",
+        )
+        assert len(drifts) == 1
+        assert "Osasuwu/jarvis" in drifts[0]
+        assert "settings" in drifts[0]
+
+    def test_missing_snapshot_file_reported(self, tmp_path):
+        """If no committed snapshot exists, check lists it as a missing-snapshot
+        drift rather than crashing."""
+        drifts = gen.check(
+            ["Osasuwu/jarvis"],
+            runner=FakeRunner(_jarvis_responses()),
+            snapshots_dir=tmp_path / "snaps",
+        )
+        assert len(drifts) == 1
+        assert "Osasuwu/jarvis" in drifts[0]
+        assert "no committed snapshot" in drifts[0]


### PR DESCRIPTION
## Summary

Two enhancements carved out of #934 (PR #978) round-3 review, per decision `77dac15f`:

1. **`--check` (drift-detection) mode** — `generate_snapshots --check` re-audits every repo live and diffs against the committed JSON snapshot, exiting non-zero with drifted repo + axis names instead of writing. Zero exit on clean match. Natural CI guard for the baseline.

2. **`contexts_source` provenance** — `BranchProtection` now carries a parallel `contexts_source` list mapping each required check context to the workflow file path that produces it (or `None` for marketplace/app checks like `review`). Populated during audit by cross-referencing check context names against workflow names from the workflows API.

## Changes

- `auditor.py`: Add `contexts_source` field to `BranchProtection` dataclass; change `_read_workflows` to return `(paths, name_map)` tuple; compute `contexts_source` in `audit()`
- `generate_snapshots.py`: Add `check()` function + `--check` CLI arg with `argparse`; add `_diff_snapshot_dicts` helper for top-level axis comparison
- Tests: `TestContextsSource` (5 tests: local vs app check, round-trip, legacy forward compat), `TestCheckMode` (3 tests: clean match, drift, missing snapshot)

## Acceptance criteria

- [x] `generate_snapshots --check` re-audits and exits non-zero on drift, zero on clean match, never writes
- [x] `BranchProtection` carries per-context provenance, populated by auditor and round-tripped through `to_dict`/`from_dict`
- [x] Pure-core tests cover: clean match, single-axis drift, contexts_source for local vs app check, legacy forward compat

Closes #979