### PR TITLE
docs(#1055): /to-issues assigns a milestone to every published issue

### DIFF
--- a/.claude-userlevel/skills/to-issues/SKILL.md
+++ b/.claude-userlevel/skills/to-issues/SKILL.md
@@ -81,6 +81,17 @@ For each approved slice, publish a new issue to the issue tracker. Use the issue
 
 Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
 
+**Milestone assignment (every published issue MUST land in a milestone)**:
+
+An issue with no milestone falls off the board — it is invisible to milestone-scoped triage and rots. Never publish milestone-less. Resolve the milestone per slice, in this order:
+
+1. **Inherit from parent** — if the slice has a `## Parent` reference, read that issue's milestone and apply the same one. The `## Parent` body link is text only; the issue tracker does NOT propagate the milestone, so you must set it explicitly (e.g. `gh issue edit <N> --milestone "<title>"`). If the parent itself is milestone-less, fix the parent first (assign it, then inherit) rather than propagating the gap.
+2. **Inherit from source** — if the slices came from an existing issue/PRD passed as the argument, use that source's milestone.
+3. **Match by theme** — no parent and no source: pick the open milestone whose theme the slice fits (enumerate the tracker's open milestones first). Fold this into the §4 quiz — show the proposed milestone per slice and let the user correct it.
+4. **No fit** — if genuinely nothing matches, surface it in the quiz and ask whether to create a new milestone or leave it orphan by explicit choice. Orphan is only ever a deliberate, stated decision — never a default.
+
+This applies to follow-up / tech-debt slices too: a spin-off inherits the milestone of the issue it spun off from (rule 1), which is the single most common case and the one that was silently dropping issues off the board.
+
 <issue-template>
 ## Parent
 


### PR DESCRIPTION
## What

Adds a mandatory milestone-resolution step to the publish section of `/to-issues`. Every published slice now lands in a milestone; orphan is only ever an explicit, stated choice.

Resolution order:
1. inherit from `## Parent` (set explicitly — the body link does not propagate the milestone)
2. else inherit from the source issue/PRD
3. else match by theme, folded into the §4 quiz
4. else orphan by explicit choice

Follow-up / tech-debt spin-offs inherit the parent milestone (rule 1) — the most common case and the one that was silently dropping issues off the board.

## Why

redrobot had 50/103 open issues with no milestone; even the TCP-rework parent was orphan while its sibling slice sat in a milestone. Root cause: the skill had no milestone step at all. Backfill of the redrobot orphans was done separately.

Canonical source edit; propagate to the `~/.claude` mirror via `install.ps1 -Apply`.

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)