### PR TITLE
fix(#1063): detach stdin in status_gather to stop ~70s MCP stall

### DIFF
--- a/scripts/status_gather.py
+++ b/scripts/status_gather.py
@@ -203,7 +203,7 @@ def _default_run_git(repo_path: str, args: list[str]) -> dict:
     try:
         result = subprocess.run(
             ["git", "-C", repo_path, *args],
-            capture_output=True, text=True,
+            capture_output=True, text=True, stdin=subprocess.DEVNULL,
             encoding="utf-8", errors="replace", timeout=15,
         )
         return {"stdout": result.stdout.strip(), "stderr": result.stderr.strip(),
@@ -221,7 +221,7 @@ def _default_run_gh(repo: str, args: list[str]) -> dict:
     try:
         result = subprocess.run(
             cmd,
-            capture_output=True, text=True,
+            capture_output=True, text=True, stdin=subprocess.DEVNULL,
             encoding="utf-8", errors="replace", timeout=30,
         )
         return {"stdout": result.stdout.strip(), "stderr": result.stderr.strip(),
@@ -637,7 +637,7 @@ def gather(
         try:
             git_result = subprocess.run(
                 ["git", "rev-parse", "--show-toplevel"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True, text=True, stdin=subprocess.DEVNULL, timeout=5,
             )
             if git_result.returncode == 0:
                 jarvis_home = git_result.stdout.strip()

--- a/tests/test_status_gather.py
+++ b/tests/test_status_gather.py
@@ -956,6 +956,45 @@ class TestDefaultRunnersUtf8:
         assert out["stdout"] == "тест"
 
 
+class TestDefaultRunnersDetachStdin:
+    """_default_run_git / _default_run_gh must pass stdin=DEVNULL.
+
+    Regression: when gather() runs inside the mcp-status stdio server, the
+    process's stdin (fd 0) is the MCP transport pipe from the client. A child
+    gh/git spawned without stdin=DEVNULL inherits that pipe; its own background
+    grandchildren keep the pipe's write end open, so subprocess.run's
+    communicate() can't reach EOF and every call stalls toward its timeout —
+    turning a ~10s gather into ~70s (observed via the status_digest MCP tool).
+    Detaching stdin severs the inheritance. Same class of bug as the memory
+    lesson `subprocess_capture_output_grandchild_pipe_hang`.
+    """
+
+    def _capture_run(self, monkeypatch):
+        captured: dict = {}
+
+        class _FakeCompleted:
+            stdout = ""
+            stderr = ""
+            returncode = 0
+
+        def _fake_run(*args, **kwargs):
+            captured.update(kwargs)
+            return _FakeCompleted()
+
+        monkeypatch.setattr(status_gather.subprocess, "run", _fake_run)
+        return captured
+
+    def test_run_git_detaches_stdin(self, monkeypatch):
+        captured = self._capture_run(monkeypatch)
+        _default_run_git("/repo", ["status"])
+        assert captured.get("stdin") is status_gather.subprocess.DEVNULL
+
+    def test_run_gh_detaches_stdin(self, monkeypatch):
+        captured = self._capture_run(monkeypatch)
+        _default_run_gh("Owner/repo", ["issue", "list"])
+        assert captured.get("stdin") is status_gather.subprocess.DEVNULL
+
+
 class TestDefaultRunGhRepoFlag:
     """_default_run_gh targets the repo correctly per subcommand.
 


### PR DESCRIPTION
## What
Pass `stdin=subprocess.DEVNULL` to all three `subprocess.run` calls in `scripts/status_gather.py` (gh, git, `git rev-parse` auto-detect).

## Why
When `gather()` runs inside the mcp-status stdio server, the process's stdin is the MCP transport pipe. Children (`gh`/`git`) inherited it; their background grandchildren kept the pipe open, so `subprocess.run`'s `communicate()` never reached EOF and each call stalled toward its timeout. A ~10s gather became ~70s through the `status_digest` tool — `/status` felt like it hung for minutes. Standalone shell runs don't reproduce because stdin there is a terminal. Same class as the `subprocess_capture_output_grandchild_pipe_hang` lesson.

## Evidence
| path | before | after |
|---|---|---|
| raw `gather()` from bash | ~10-12s | ~10s |
| `status_digest` via live MCP stdio server | **71s** | **10s** |

Per-stage timing showed all latency in `gather()`; `analyze`/convert ≈ 0.

## Tests
`TestDefaultRunnersDetachStdin` asserts `_default_run_git` / `_default_run_gh` pass `stdin=DEVNULL`. Full `test_status_gather.py`: 46 passed.

Closes #1063