### PR TITLE
feat(status): add stale-backlog detector over ProjectV2 status (#1059)

### DIFF
--- a/config/repos.conf
+++ b/config/repos.conf
@@ -8,6 +8,10 @@
 #                                       memory, owner executes manually)
 #
 # Local path is resolved as {device.json.repos_path}/{repo-name}.
+#
+# Optional trailing `project=N` token binds the repo to a GitHub Projects v2
+# board (USER-owned, project number N) so the stale-backlog detector (#1059)
+# can read each issue's Status field. Omit it for repos without a board.
 
-Osasuwu/jarvis
-SergazyNarynov/redrobot
+Osasuwu/jarvis project=3
+SergazyNarynov/redrobot project=1

--- a/mcp-status/server.py
+++ b/mcp-status/server.py
@@ -155,6 +155,7 @@ def _convert_gather_to_engine_format(gather_result):
                 labels=labels,
                 milestone=issue.get("milestone"),
                 updated_at=issue.get("updatedAt", ""),
+                project_status=issue.get("project_status"),
             ))
 
         # Create RepoState for delta (most recent data)

--- a/scripts/status_engine.py
+++ b/scripts/status_engine.py
@@ -28,6 +28,10 @@ from typing import Sequence
 STALE_INPROGRESS_DAYS = 3
 """Days before an in-progress issue is considered stale."""
 
+STALE_BACKLOG_DAYS = 30
+"""Days an issue may sit in a ProjectV2 Backlog/Ready status before the
+stale-backlog detector flags it (#1059)."""
+
 DECISION_FOLLOWTHROUGH_STALE_DAYS = 14
 """Days a decision-referenced issue may sit without movement before the
 decision-without-followthrough detector flags it (#1057)."""
@@ -83,6 +87,7 @@ class IssueInfo:
     updated_at: str = ""  # ISO 8601
     is_blocked: bool = False
     blocks: list[int] = field(default_factory=list)
+    project_status: str | None = None  # ProjectV2 Status field (#1059)
 
 
 @dataclass
@@ -146,7 +151,7 @@ class DetectorHit:
     """A single detector firing."""
 
     detector: str
-    severity: str  # 'critical' | 'major' | 'minor'
+    severity: str  # 'critical' | 'major' | 'minor' | 'info'
     repo: str
     issue_number: int | None = None
     title: str = ""
@@ -439,6 +444,107 @@ def detect_decision_without_followthrough(
 
 
 # ============================================================================
+# Detector: stale-backlog (#1059)
+# ============================================================================
+
+
+# Vocabulary — case-normalized ProjectV2 Status strings the detector reacts to.
+# Backlog is time-only; Ready additionally requires no referencing decision.
+# Every other status (In Progress / In review / Done) and None (not on board)
+# is silent — the false-negative-over-false-positive posture.
+_BACKLOG_STATUS = "backlog"
+_READY_STATUS = "ready"
+
+
+def _decision_refs_by_repo(
+    decisions: list[DecisionInfo], repos: list[str]
+) -> dict[str, set[int]]:
+    """Map repo → set of issue numbers referenced by any project decision.
+
+    Matching is robust to the decision's ``project`` being either the full
+    ``owner/repo`` or the short repo slug (``jarvis`` for ``Osasuwu/jarvis``).
+    A decision with a falsy project is skipped (cannot be scoped to a repo).
+    """
+    refs: dict[str, set[int]] = {r: set() for r in repos}
+    for dec in decisions:
+        if not dec.project:
+            continue
+        ref_nums = {int(m) for m in _ISSUE_REF_RE.findall(dec.decision)}
+        if not ref_nums:
+            continue
+        for repo in repos:
+            if repo == dec.project or repo.endswith(f"/{dec.project}"):
+                refs[repo].update(ref_nums)
+    return refs
+
+
+def detect_stale_backlog(
+    baseline: Baseline,
+    delta: Delta,
+    decisions: list[DecisionInfo],
+) -> list[DetectorHit]:
+    """Flag issues idle ≥STALE_BACKLOG_DAYS in a ProjectV2 Backlog/Ready status.
+
+    Vocab-driven (branches on the case-normalized ``project_status`` string, no
+    repo hardcode):
+
+    - **Backlog** + idle ≥30d → candidate (time-only).
+    - **Ready** + idle ≥30d + no project-scoped decision referencing ``#<n>``
+      → candidate. A decision means the issue is intentionally staged, so it is
+      suppressed.
+    - **In Progress / In review / Done / None** → never flagged. ``None`` means
+      the issue is not on the board, so it is skipped (bias to false-negative).
+
+    Aggregation (AC3): one ``info``-severity hit PER REPO listing all candidate
+    issue numbers oldest-first (largest ``updated_at`` age first). Zero
+    candidates in a repo ⇒ no hit for that repo. ``info`` severity does not flip
+    health and is excluded from ranking (see compute_health_verdict /
+    rank_detector_hits).
+    """
+    now = datetime.now(timezone.utc)
+    merged = _merge_repos(baseline, delta)
+    decision_refs = _decision_refs_by_repo(decisions, list(merged.keys()))
+
+    hits: list[DetectorHit] = []
+    for repo_name, state in merged.items():
+        referenced = decision_refs.get(repo_name, set())
+        # (age, number) candidates so we can order oldest-first deterministically.
+        candidates: list[tuple[float, int]] = []
+        for issue in state.open_issues:
+            status = (issue.project_status or "").strip().lower()
+            if status not in (_BACKLOG_STATUS, _READY_STATUS):
+                continue
+            age = _parse_iso_age(issue.updated_at, now)
+            if age < STALE_BACKLOG_DAYS:
+                continue
+            if status == _READY_STATUS and issue.number in referenced:
+                continue
+            candidates.append((age, issue.number))
+
+        if not candidates:
+            continue
+
+        candidates.sort(key=lambda c: c[0], reverse=True)  # oldest (largest age) first
+        numbers = [num for _, num in candidates]
+        refs = ", ".join(f"#{n}" for n in numbers)
+        hits.append(
+            DetectorHit(
+                detector="stale-backlog",
+                severity="info",
+                repo=repo_name,
+                issue_number=None,
+                title=f"{len(numbers)} issue(s) idle ≥{STALE_BACKLOG_DAYS}d in Backlog/Ready",
+                description=(
+                    f"{len(numbers)} issue(s) sitting in Backlog/Ready for "
+                    f"≥{STALE_BACKLOG_DAYS}d with no movement (oldest first): {refs}"
+                ),
+            )
+        )
+
+    return hits
+
+
+# ============================================================================
 # Detector: blocker-cascade
 # ============================================================================
 
@@ -630,9 +736,12 @@ def rank_detector_hits(hits: list[DetectorHit]) -> list[RankedItem]:
     """Rank detector hits by severity, return at most TOP_N_CAP items.
 
     Critical first, then major, then minor. Stable sort within severity.
+    ``info`` hits (e.g. stale-backlog, #1059) are advisory — excluded from
+    "Куда смотреть" entirely.
     """
+    rankable = [h for h in hits if h.severity != "info"]
     sorted_hits = sorted(
-        hits,
+        rankable,
         key=lambda h: _SEVERITY_SORT.get(h.severity, 99),
     )
 
@@ -684,13 +793,16 @@ def compute_health_verdict(
             reason="Unhealthy: " + "; ".join(stale_or_failed),
         )
 
-    if hits:
-        critical_count = sum(1 for h in hits if h.severity == "critical")
-        major_count = sum(1 for h in hits if h.severity == "major")
+    # ``info`` hits (stale-backlog, #1059) are advisory — they surface only in
+    # --deep and must NOT flip health red. Gate on the blocking subset.
+    blocking = [h for h in hits if h.severity != "info"]
+    if blocking:
+        critical_count = sum(1 for h in blocking if h.severity == "critical")
+        major_count = sum(1 for h in blocking if h.severity == "major")
         return HealthVerdict(
             ok=False,
             reason=(
-                f"Unhealthy: {len(hits)} detector hit(s)"
+                f"Unhealthy: {len(blocking)} detector hit(s)"
                 f" ({critical_count} critical, {major_count} major)"
             ),
         )
@@ -728,6 +840,7 @@ def analyze(
     hits.extend(detect_stale_in_progress(baseline, delta, decisions))
     hits.extend(detect_priority_inversion(baseline, delta, decisions))
     hits.extend(detect_decision_without_followthrough(baseline, delta, decisions))
+    hits.extend(detect_stale_backlog(baseline, delta, decisions))
     hits.extend(detect_blocker_cascade(baseline, delta, decisions))
     hits.extend(fold_contradiction_verdicts(contradiction_verdicts))
 

--- a/scripts/status_gather.py
+++ b/scripts/status_gather.py
@@ -80,6 +80,7 @@ class SourceKind:
     GH_ISSUES = "gh_issues"
     GH_CI = "gh_ci"
     GH_MILESTONES = "gh_milestones"
+    GH_PROJECTS = "gh_projects"
     SUPABASE_DECISIONS = "supabase_decisions"
     STATUS_SNAPSHOT = "status_snapshot"
 
@@ -153,6 +154,9 @@ class GatherResult:
 # read_repos_conf(path) -> list[str] (owner/repo lines)
 ReadReposConfFn = Callable[[str], list[str]]
 
+# read_repos_conf_projects(path) -> dict[str, int] (owner/repo -> project number)
+ReadReposConfProjectsFn = Callable[[str], dict]
+
 # read_device_json(path) -> dict | None (parsed device.json or None)
 ReadDeviceJsonFn = Callable[[str], dict | None]
 
@@ -187,6 +191,19 @@ def _default_read_repos_conf(path: str) -> list[str]:
     if raw is None:
         return []
     return parse_repos_conf(raw)
+
+
+def _default_read_repos_conf_projects(path: str) -> dict:
+    """Read owner/repo → project-number map from repos.conf (#1059).
+
+    Only lines carrying a ``project=<N>`` token contribute an entry; a repo
+    without one simply has no ProjectV2 board configured and is skipped by the
+    project-status fetch. Empty/unreadable file → empty map.
+    """
+    raw = _default_read_file(path)
+    if raw is None:
+        return {}
+    return parse_repos_conf_projects(raw)
 
 
 def _default_read_device_json(path: str) -> dict | None:
@@ -273,13 +290,41 @@ def _default_query_supabase(
 
 
 def parse_repos_conf(raw: str) -> list[str]:
-    """Parse repos.conf content into owner/repo list (pure, tested directly)."""
+    """Parse repos.conf content into owner/repo list (pure, tested directly).
+
+    A line may carry trailing key=value tokens (e.g. ``project=3``, #1059);
+    only the first whitespace-delimited token — the ``owner/repo`` — is the
+    repo identifier. Bare lines (no tokens) are returned unchanged.
+    """
     repos: list[str] = []
     for line in raw.splitlines():
         line = line.strip()
         if line and not line.startswith("#"):
-            repos.append(line)
+            repos.append(line.split()[0])
     return repos
+
+
+def parse_repos_conf_projects(raw: str) -> dict:
+    """Parse repos.conf ``project=<N>`` tokens into owner/repo → int map (#1059).
+
+    Only lines with a parseable ``project=<int>`` token yield an entry; lines
+    without one (or with a non-integer value) are omitted, so a repo with no
+    ProjectV2 board is simply absent from the map. Pure, tested directly.
+    """
+    projects: dict[str, int] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        tokens = line.split()
+        repo = tokens[0]
+        for tok in tokens[1:]:
+            if tok.startswith("project="):
+                try:
+                    projects[repo] = int(tok.split("=", 1)[1])
+                except ValueError:
+                    pass
+    return projects
 
 
 # ============================================================================
@@ -416,6 +461,80 @@ def _gather_gh_milestones(
 
     prov = Provenance(ran=True, ok=ok, input_rows=len(data), age=elapsed)
     return {"milestones": data, "milestones_truncated": truncated}, prov
+
+
+# ============================================================================
+# ProjectV2 status gather (#1059)
+# ============================================================================
+
+# GraphQL for a *user*-owned Project (owner from repo.split("/")[0]); the
+# board tracked repos live under is a user project, not an org project.
+_PROJECT_STATUS_QUERY = (
+    "query($owner: String!, $number: Int!) {"
+    "  user(login: $owner) {"
+    "    projectV2(number: $number) {"
+    "      items(first: 100) {"
+    "        nodes {"
+    "          content { ... on Issue { number } }"
+    "          fieldValueByName(name: \"Status\") {"
+    "            ... on ProjectV2ItemFieldSingleSelectValue { name }"
+    "          }"
+    "        }"
+    "      }"
+    "    }"
+    "  }"
+    "}"
+)
+
+_PROJECT_STATUS_JQ = (
+    ".data.user.projectV2.items.nodes[] "
+    "| select(.content.number != null) "
+    "| {number: .content.number, status: (.fieldValueByName.name // null)}"
+)
+
+
+def _gather_project_status(
+    repo: str, project_number: int, run_gh: RunGhFn, now: float,
+) -> tuple[dict, Provenance]:
+    """Fetch GitHub Projects v2 ``Status`` per issue number for one repo (#1059).
+
+    Returns ({issue_number: status_string}, Provenance). A fetch failure (or
+    malformed payload) yields an empty map with ok=False so the caller leaves
+    ``project_status=None`` on every issue and surfaces a provenance gap rather
+    than a false-green (AC5). Issues without a Status value are simply absent
+    from the map (join leaves them None → detector treats as "not on board").
+    """
+    start = time.time()
+    owner = repo.split("/")[0]
+    result = run_gh(repo, [
+        "api", "graphql",
+        "-f", f"query={_PROJECT_STATUS_QUERY}",
+        "-F", f"owner={owner}",
+        "-F", f"number={project_number}",
+        "--jq", _PROJECT_STATUS_JQ,
+    ])
+
+    elapsed = time.time() - start
+    ok = result["returncode"] == 0
+    status_by_number: dict[int, str] = {}
+
+    if ok and result["stdout"]:
+        try:
+            for line in result["stdout"].splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                num = row.get("number")
+                status = row.get("status")
+                if num is not None and status:
+                    status_by_number[int(num)] = str(status)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            ok = False
+            status_by_number = {}
+
+    prov = Provenance(ran=True, ok=ok, input_rows=len(status_by_number), age=elapsed)
+    return status_by_number, prov
 
 
 # ============================================================================
@@ -599,6 +718,7 @@ def gather(
     *,
     # Injectable I/O callbacks (defaults = real implementations)
     read_repos_conf_fn: ReadReposConfFn | None = None,
+    read_repos_conf_projects_fn: ReadReposConfProjectsFn | None = None,
     read_device_json_fn: ReadDeviceJsonFn | None = None,
     run_git_fn: RunGitFn | None = None,
     run_gh_fn: RunGhFn | None = None,
@@ -622,6 +742,9 @@ def gather(
     """
     # Resolve defaults
     _read_conf = read_repos_conf_fn or _default_read_repos_conf
+    _read_conf_projects = (
+        read_repos_conf_projects_fn or _default_read_repos_conf_projects
+    )
     _read_dev = read_device_json_fn or _default_read_device_json
     _run_git = run_git_fn or _default_run_git
     _run_gh = run_gh_fn or _default_run_gh
@@ -666,6 +789,11 @@ def gather(
         ran=True, ok=True, input_rows=len(repos),
         age=_now() - gather_start,
     ).to_dict()
+
+    # Project-number map (owner/repo -> ProjectV2 number) from the same conf.
+    # A repo absent from the map has no board configured; its issues keep
+    # project_status=None and no gh_projects provenance is stamped (#1059 AC1).
+    repos_projects = _read_conf_projects(conf_path) or {}
 
     # --- Step 2: Read device.json for repos_path ---
     dev_path = str(jarvis_path / DEVICE_CONF_RELPATH)
@@ -717,6 +845,26 @@ def gather(
         issues_state, issues_prov = _gather_gh_issues(repo_name_stripped, _run_gh, _now())
         repo_entry.update(issues_state)
         repo_entry["provenance"][SourceKind.GH_ISSUES] = issues_prov.to_dict()
+
+        # ProjectV2 Status — join onto issues by number (#1059 AC1). Only for
+        # repos with a configured project number. The provenance is stamped at
+        # TOP level (`gh_projects:<repo>`) so a fetch failure gates health via
+        # compute_health_verdict rather than false-greening (AC5).
+        project_number = repos_projects.get(repo_name_stripped)
+        if project_number is not None:
+            status_map, project_prov = _gather_project_status(
+                repo_name_stripped, project_number, _run_gh, _now(),
+            )
+            for issue in repo_entry.get("issues") or []:
+                issue["project_status"] = status_map.get(issue.get("number"))
+            result.provenance[
+                f"{SourceKind.GH_PROJECTS}:{repo_name_stripped}"
+            ] = project_prov.to_dict()
+            if not project_prov.ok:
+                result.errors.append(
+                    f"{SourceKind.GH_PROJECTS}:{repo_name_stripped}: "
+                    f"ProjectV2 status fetch failed"
+                )
 
         # CI
         ci_state, ci_prov = _gather_gh_ci(repo_name_stripped, _run_gh, _now())

--- a/scripts/status_render.py
+++ b/scripts/status_render.py
@@ -94,6 +94,10 @@ def _anomalies(digest: dict, deep: bool) -> list[str]:
     full description text for each hit.
     """
     hits = digest.get("detector_hits") or []
+    # info hits (stale-backlog, #1059) are advisory — the default surface hides
+    # them; they appear only under --deep.
+    if not deep:
+        hits = [h for h in hits if (h.get("severity") or "") != "info"]
     if not hits:
         return []
     lines = ["Аномалии:"]

--- a/tests/test_mcp_status_server.py
+++ b/tests/test_mcp_status_server.py
@@ -121,6 +121,26 @@ def test_convert_gather_to_engine_format():
     assert "status_digest" in decisions[0].decision
 
 
+def test_convert_carries_project_status():
+    """AC1 (#1059): gather's per-issue project_status flows onto IssueInfo."""
+    gather_result = make_fixture_gather_result()
+    gather_result.repos[0]["issues"][0]["project_status"] = "Backlog"
+
+    baseline, delta, decisions = _convert_gather_to_engine_format(gather_result)
+
+    issue = delta.repos["Osasuwu/jarvis"].open_issues[0]
+    assert issue.project_status == "Backlog"
+
+
+def test_convert_project_status_defaults_none():
+    """AC1 (#1059): absent project_status → None (issue not on the board)."""
+    gather_result = make_fixture_gather_result()
+    baseline, delta, decisions = _convert_gather_to_engine_format(gather_result)
+
+    issue = delta.repos["Osasuwu/jarvis"].open_issues[0]
+    assert issue.project_status is None
+
+
 def test_convert_flattens_object_labels():
     """gh returns labels as objects [{"name":..,"color":..}], not strings.
 

--- a/tests/test_status_engine.py
+++ b/tests/test_status_engine.py
@@ -14,6 +14,7 @@ from status_engine import (
     DECISION_PREFILTER_DAYS,
     FRESHNESS_AGE_SECONDS,
     MEMORY_GIT_CONTRADICTION,
+    STALE_BACKLOG_DAYS,
     STALE_INPROGRESS_DAYS,
     TOP_N_CAP,
     Baseline,
@@ -33,6 +34,7 @@ from status_engine import (
     detect_blocker_cascade,
     detect_decision_without_followthrough,
     detect_priority_inversion,
+    detect_stale_backlog,
     detect_stale_in_progress,
     fold_contradiction_verdicts,
     rank_detector_hits,
@@ -57,6 +59,7 @@ def make_issue(
     updated_days_ago: float = 0,
     is_blocked: bool = False,
     blocks: list[int] | None = None,
+    project_status: str | None = None,
 ) -> IssueInfo:
     """Helper to construct an IssueInfo fixture."""
     return IssueInfo(
@@ -67,6 +70,7 @@ def make_issue(
         updated_at=_days_ago(updated_days_ago),
         is_blocked=is_blocked,
         blocks=blocks or [],
+        project_status=project_status,
     )
 
 
@@ -1154,6 +1158,193 @@ class TestHealthVerdict:
 
 
 # ============================================================================
+# AC2/AC3 (#1059): stale-backlog detector
+# ============================================================================
+
+
+def _backlog_state(repo="Osasuwu/jarvis", issues=None):
+    return make_state(repo, issues=issues or [])
+
+
+class TestStaleBacklog:
+    """AC2: vocab-driven candidate selection; AC3: per-repo info aggregation."""
+
+    def test_backlog_idle_flagged(self):
+        """Backlog + idle ≥30d → candidate (time-only, no decision needed)."""
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(
+                            42, updated_days_ago=40, project_status="Backlog"
+                        )
+                    ],
+                )
+            }
+        )
+        hits = detect_stale_backlog(baseline, make_delta(), [])
+        assert len(hits) == 1
+        assert hits[0].severity == "info"
+        assert hits[0].issue_number is None
+        assert "#42" in hits[0].description
+
+    def test_backlog_fresh_not_flagged(self):
+        """Backlog but idle <30d → not a candidate."""
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(
+                            42, updated_days_ago=5, project_status="Backlog"
+                        )
+                    ],
+                )
+            }
+        )
+        assert detect_stale_backlog(baseline, make_delta(), []) == []
+
+    def test_status_case_normalized(self):
+        """Status matched case-insensitively (`.strip().lower()`)."""
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(
+                            42, updated_days_ago=40, project_status="  backlog "
+                        )
+                    ],
+                )
+            }
+        )
+        assert len(detect_stale_backlog(baseline, make_delta(), [])) == 1
+
+    def test_ready_idle_no_decision_flagged(self):
+        """Ready + idle ≥30d + no referencing decision → candidate."""
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(7, updated_days_ago=40, project_status="Ready")
+                    ],
+                )
+            }
+        )
+        hits = detect_stale_backlog(baseline, make_delta(), [])
+        assert len(hits) == 1
+        assert "#7" in hits[0].description
+
+    def test_ready_with_decision_not_flagged(self):
+        """Ready + idle ≥30d but a project decision references it → suppressed."""
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(7, updated_days_ago=40, project_status="Ready")
+                    ],
+                )
+            }
+        )
+        decisions = [
+            make_decision(
+                decision="Ship #7 next sprint", project="Osasuwu/jarvis"
+            )
+        ]
+        assert detect_stale_backlog(baseline, make_delta(), decisions) == []
+
+    def test_ready_decision_short_project_slug_matches(self):
+        """Decision.project may be the short slug (`jarvis`) — still matches."""
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(7, updated_days_ago=40, project_status="Ready")
+                    ],
+                )
+            }
+        )
+        decisions = [make_decision(decision="Do #7", project="jarvis")]
+        assert detect_stale_backlog(baseline, make_delta(), decisions) == []
+
+    def test_in_progress_not_flagged(self):
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(
+                            9, updated_days_ago=99, project_status="In Progress"
+                        )
+                    ],
+                )
+            }
+        )
+        assert detect_stale_backlog(baseline, make_delta(), []) == []
+
+    def test_none_status_not_flagged(self):
+        """project_status None (not on board) → never flagged."""
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(9, updated_days_ago=99, project_status=None)
+                    ],
+                )
+            }
+        )
+        assert detect_stale_backlog(baseline, make_delta(), []) == []
+
+    def test_zero_candidates_no_hit(self):
+        assert detect_stale_backlog(make_baseline(), make_delta(), []) == []
+
+    def test_aggregate_one_hit_per_repo_oldest_first(self):
+        """One info hit per repo; numbers ordered oldest-first by updated_at."""
+        baseline = make_baseline(
+            repos={
+                "Osasuwu/jarvis": _backlog_state(
+                    issues=[
+                        make_issue(3, updated_days_ago=35, project_status="Backlog"),
+                        make_issue(1, updated_days_ago=90, project_status="Backlog"),
+                        make_issue(2, updated_days_ago=60, project_status="Ready"),
+                    ],
+                )
+            }
+        )
+        hits = detect_stale_backlog(baseline, make_delta(), [])
+        assert len(hits) == 1
+        # oldest (largest age) first: #1 (90d), #2 (60d), #3 (35d)
+        assert hits[0].description.index("#1") < hits[0].description.index("#2")
+        assert hits[0].description.index("#2") < hits[0].description.index("#3")
+
+    def test_info_does_not_flip_health(self):
+        """AC3: an info-only hit set leaves health green."""
+        verdict = compute_health_verdict(
+            make_baseline(),
+            [
+                DetectorHit(
+                    detector="stale-backlog",
+                    severity="info",
+                    repo="Osasuwu/jarvis",
+                    description="#42",
+                )
+            ],
+        )
+        assert verdict.ok is True
+
+    def test_info_excluded_from_ranking(self):
+        """AC3: info hits never appear in 'Куда смотреть'."""
+        ranked = rank_detector_hits(
+            [
+                DetectorHit(
+                    detector="stale-backlog",
+                    severity="info",
+                    repo="Osasuwu/jarvis",
+                    description="#42",
+                )
+            ]
+        )
+        assert ranked == []
+
+
+# ============================================================================
 # AC: Constants are module-level
 # ============================================================================
 
@@ -1172,6 +1363,26 @@ class TestModuleConstants:
     def test_decision_prefilter_days_constant(self):
         assert isinstance(DECISION_PREFILTER_DAYS, int)
         assert DECISION_PREFILTER_DAYS > 0
+
+    def test_stale_backlog_days_constant(self):
+        assert isinstance(STALE_BACKLOG_DAYS, int)
+        assert STALE_BACKLOG_DAYS == 30
+
+
+# ============================================================================
+# AC1: IssueInfo carries the Projects v2 Status string
+# ============================================================================
+
+
+class TestIssueProjectStatus:
+    """AC1: IssueInfo.project_status holds the ProjectV2 Status (or None)."""
+
+    def test_defaults_to_none(self):
+        assert IssueInfo(number=1).project_status is None
+
+    def test_carries_status_value(self):
+        issue = IssueInfo(number=1, project_status="Backlog")
+        assert issue.project_status == "Backlog"
 
 
 # ============================================================================

--- a/tests/test_status_gather.py
+++ b/tests/test_status_gather.py
@@ -1029,3 +1029,131 @@ class TestDefaultRunGhRepoFlag:
         captured = self._capture_cmd(monkeypatch)
         _default_run_gh("Owner/repo", ["issue", "list"])
         assert captured["cmd"][-2:] == ["--repo", "Owner/repo"]
+
+
+# ============================================================================
+# Test: ProjectV2 status fetch + join (#1059 AC1)
+# ============================================================================
+
+
+def _fixture_repos_conf_projects(mapping: dict) -> callable:
+    """Return a read_repos_conf_projects_fn returning owner/repo → project number."""
+    return lambda path: dict(mapping)
+
+
+def _project_status_gh(status_by_number: dict[int, str], *, fail: bool = False):
+    """Arg-aware run_gh: returns ProjectV2 status for the graphql call, issues
+    for `issue list`, empty-ok for everything else.
+
+    When ``fail`` is set the graphql call errors (returncode 1) so AC5's
+    degradation path can be exercised.
+    """
+    def _run(repo: str, args: list[str]) -> dict:
+        # ProjectV2 status query goes through `gh api graphql`.
+        if args and args[0] == "api" and "graphql" in args:
+            if fail:
+                return {"stdout": "", "stderr": "graphql: not found", "returncode": 1}
+            nodes = [
+                {"number": n, "status": s} for n, s in status_by_number.items()
+            ]
+            return {
+                "stdout": "\n".join(json.dumps(node) for node in nodes),
+                "stderr": "",
+                "returncode": 0,
+            }
+        # Open issues list.
+        if "issue" in args:
+            return _make_gh_success([
+                {"number": 42, "title": "Backlog issue", "labels": [],
+                 "updatedAt": "2024-05-01T00:00:00Z"},
+                {"number": 7, "title": "Ready issue", "labels": [],
+                 "updatedAt": "2024-05-01T00:00:00Z"},
+            ])
+        # Everything else (PRs, CI, milestones): empty-but-ok.
+        return _make_gh_empty()
+
+    return _run
+
+
+class TestParseReposConfProjects:
+    """parse_repos_conf_projects — pure, maps owner/repo → project number."""
+
+    def test_parses_project_numbers(self):
+        content = "Osasuwu/jarvis project=3\nSergazyNarynov/redrobot project=1\n"
+        assert status_gather.parse_repos_conf_projects(content) == {
+            "Osasuwu/jarvis": 3,
+            "SergazyNarynov/redrobot": 1,
+        }
+
+    def test_line_without_project_is_omitted(self):
+        content = "Osasuwu/jarvis\nSergazyNarynov/redrobot project=1\n"
+        assert status_gather.parse_repos_conf_projects(content) == {
+            "SergazyNarynov/redrobot": 1,
+        }
+
+    def test_skips_comments_and_blanks(self):
+        content = "# comment\n\nOsasuwu/jarvis project=3\n"
+        assert status_gather.parse_repos_conf_projects(content) == {
+            "Osasuwu/jarvis": 3,
+        }
+
+    def test_parse_repos_conf_still_returns_bare_repo(self):
+        # The project= suffix must not leak into the plain repo list.
+        content = "Osasuwu/jarvis project=3\nSergazyNarynov/redrobot project=1\n"
+        assert parse_repos_conf(content) == [
+            "Osasuwu/jarvis", "SergazyNarynov/redrobot",
+        ]
+
+
+class TestProjectStatusJoin:
+    """AC1 — ProjectV2 Status is fetched per repo and joined onto issues."""
+
+    def test_project_status_joined_onto_issues(self):
+        result = gather(
+            jarvis_home="/fake",
+            read_repos_conf_fn=_fixture_repos_conf("Osasuwu/jarvis\n"),
+            read_repos_conf_projects_fn=_fixture_repos_conf_projects(
+                {"Osasuwu/jarvis": 3}
+            ),
+            read_device_json_fn=_fixture_device_json({"repos_path": "/fake/repos"}),
+            run_git_fn=_fixture_run_git({"stdout": "main", "stderr": "",
+                                         "returncode": 0}),
+            run_gh_fn=_project_status_gh({42: "Backlog", 7: "Ready"}),
+            query_supabase_fn=_fixture_query_supabase([]),
+            now_fn=_fixture_now(),
+        )
+
+        jarvis = result.repos[0]
+        by_num = {i["number"]: i for i in jarvis["issues"]}
+        assert by_num[42]["project_status"] == "Backlog"
+        assert by_num[7]["project_status"] == "Ready"
+
+        # Top-level provenance stamp for the projects source (AC5 gating point).
+        prov = result.provenance[f"{SourceKind.GH_PROJECTS}:Osasuwu/jarvis"]
+        assert prov["ran"] is True
+        assert prov["ok"] is True
+        assert prov["input_rows"] == 2
+
+    def test_project_fetch_failure_degrades_and_leaves_status_none(self):
+        """AC5 — graphql failure ⇒ project_status=None + gh_projects ok=False."""
+        result = gather(
+            jarvis_home="/fake",
+            read_repos_conf_fn=_fixture_repos_conf("Osasuwu/jarvis\n"),
+            read_repos_conf_projects_fn=_fixture_repos_conf_projects(
+                {"Osasuwu/jarvis": 3}
+            ),
+            read_device_json_fn=_fixture_device_json({"repos_path": "/fake/repos"}),
+            run_git_fn=_fixture_run_git({"stdout": "main", "stderr": "",
+                                         "returncode": 0}),
+            run_gh_fn=_project_status_gh({}, fail=True),
+            query_supabase_fn=_fixture_query_supabase([]),
+            now_fn=_fixture_now(),
+        )
+
+        jarvis = result.repos[0]
+        for issue in jarvis["issues"]:
+            assert issue["project_status"] is None
+
+        prov = result.provenance[f"{SourceKind.GH_PROJECTS}:Osasuwu/jarvis"]
+        assert prov["ran"] is True
+        assert prov["ok"] is False

--- a/tests/test_status_render.py
+++ b/tests/test_status_render.py
@@ -216,6 +216,46 @@ class TestBothRepos:
 
 
 # ---------------------------------------------------------------------------
+# #1059 AC4 — info hits (stale-backlog) hidden by default, shown under --deep
+# ---------------------------------------------------------------------------
+
+
+DIGEST_WITH_INFO = {
+    "health": {"ok": True, "reason": "All sources fresh, no anomalies detected"},
+    "detector_hits": [
+        _hit(
+            "stale-backlog",
+            "info",
+            "Osasuwu/jarvis",
+            None,
+            "3 issue(s) idle",
+            "3 issue(s) sitting in Backlog/Ready for ≥30d: #1, #2, #3",
+        ),
+    ],
+    "ranking": [],
+    "provenance": {
+        "jarvis": {"ran": True, "ok": True, "input_rows": 10, "age": 60.0},
+    },
+}
+
+
+class TestInfoSeverityGate:
+    def test_info_hidden_in_default_render(self):
+        out = render(DIGEST_WITH_INFO, deep=False)
+        assert "stale-backlog" not in out
+        assert "Аномалии" not in out  # no non-info hits ⇒ block absent entirely
+
+    def test_info_shown_under_deep(self):
+        out = render(DIGEST_WITH_INFO, deep=True)
+        assert "stale-backlog" in out
+        assert "#1, #2, #3" in out
+
+    def test_info_does_not_break_green_default(self):
+        # info-only digest still reads green in the default surface.
+        assert "🟢" in render(DIGEST_WITH_INFO, deep=False)
+
+
+# ---------------------------------------------------------------------------
 # AC5 — snapshot test pins the deterministic render against a fixture digest
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Adds a `detect_stale_backlog` status detector that flags issues sitting in a GitHub Projects v2 **Backlog/Ready** status for ≥30 days with no decision and no in-progress. Extends the status-synthesis pipeline (gather → engine → render → MCP) with a new `project_status` data axis; the detector is **vocab-driven** (branches on the case-normalized status string, no repo hardcode).

## Why
Idle issues in Backlog/Ready are invisible to the label-based detectors — nothing surfaces "this has been staged and forgotten for a month". #1059 closes that gap.
Closes #1059

## Decisions & Alternatives
- **info severity, not minor/major** — a stale backlog item is advisory, not a health problem. `info` hits are excluded from `rank_detector_hits`/"Куда смотреть", do NOT flip `compute_health_verdict`, and are hidden from the default render (surface only under `--deep`). Grill decision `f57869a8-c38a-45c3-a859-ceecae165804`.
- **One aggregate hit per repo** (issue_number=None, oldest-first by `updated_at`) rather than one hit per issue — avoids drowning the digest.
- **Backlog time-only; Ready requires no decision** — a `Ready` item referenced by a project-scoped decision is intentionally staged, so it's suppressed. Robust project matching (`repo == dec.project` OR `repo.endswith("/"+dec.project)`) so the short slug (`jarvis`) and full `owner/repo` both match.
- **`None`/`In Progress`/`In review`/`Done` never flagged** — `None` = not on the board → skip. Bias to false-negative over false-positive.
- **Project number from config, not hardcoded** — `config/repos.conf` gains an optional `project=N` token; gather parses it. jarvis=3, redrobot=1.
- **Degradation (AC5)**: ProjectV2 fetch failure ⇒ all `project_status=None` ⇒ detector silent AND `gh_projects:<repo>` provenance stamped `ok=False` so health shows a gap, not a false-green.

## Risk Assessment
- **LOW**: new detector is additive; `info` severity can't flip health or block. Existing detectors/renders untouched in behavior (verified by the frozen `SNAPSHOT_UNHEALTHY` render test still passing).
- **MEDIUM**: gather-layer ProjectV2 GraphQL fetch is new I/O — smoke-tested against the live jarvis board (below).

## Testing
- `pytest tests/test_status_{gather,engine,render}.py tests/test_mcp_status_server.py` → **169 passed**; full suite 3068 passed (1 unrelated pre-existing failure: `test_memory_server_script_launch` — local venv lacks the `mcp` package, not touched here).
- `ruff check` clean on all touched files.
- **E2E smoke** (real `gh api graphql`): fetched the live jarvis board (project 3) → `ok=True, rows=100` (statuses: Done×96, In Progress×4). Degradation path with bad project number → `ok=False, rows=0, map={}`.
- Engine tests cover: Backlog-idle ✓, Ready-idle-no-decision ✓, Ready+decision ✗ (incl. short-slug), In-Progress/None ✗, zero-candidate ✗, aggregate oldest-first order, info-doesn't-flip-health, info-excluded-from-ranking. Render tests: info hidden default / shown `--deep`. Gather tests: `project=N` parse + join-by-number + fetch-failure degradation.

## Files Changed
- `scripts/status_engine.py` — `STALE_BACKLOG_DAYS`, `IssueInfo.project_status`, `detect_stale_backlog`, `info` exclusion in `rank_detector_hits`/`compute_health_verdict`, wired into `analyze()`
- `scripts/status_gather.py` — `project=N` config parse, ProjectV2 GraphQL fetch + join, `gh_projects` provenance
- `scripts/status_render.py` — hide `info` hits unless `--deep`
- `mcp-status/server.py` — carry `project_status` through the gather→engine conversion
- `config/repos.conf` — `project=3` (jarvis) / `project=1` (redrobot)
- tests — engine / render / gather / server coverage per AC6

## Follow-up (not in this slice)
#1065 — migrate other status detectors from labels to `project_status`; normalize the jarvis board with `Ready` + `In review` columns (the board currently has no Backlog/Ready items, so this detector fires on nothing until #1065 lands).