### PR TITLE
fix(status): resolve jarvis_home from $JARVIS_HOME before git rev-parse

### DIFF
--- a/scripts/status_gather.py
+++ b/scripts/status_gather.py
@@ -686,7 +686,13 @@ def gather(
     gathered_at = datetime.fromtimestamp(gather_start, tz=timezone.utc).isoformat()
     result = GatherResult(gathered_at=gathered_at)
 
-    # --- Resolve jarvis_home via git rev-parse ---
+    # --- Resolve jarvis_home: explicit arg > $JARVIS_HOME > git rev-parse > cwd ---
+    # git rev-parse keys off the *current* repo, so a call from another repo
+    # (e.g. redrobot) would resolve to the wrong toplevel and degrade the gather.
+    # $JARVIS_HOME pins the jarvis root regardless of CWD.
+    if not jarvis_home:
+        jarvis_home = os.environ.get("JARVIS_HOME", "").strip()
+
     if not jarvis_home:
         try:
             git_result = subprocess.run(

--- a/tests/test_status_gather.py
+++ b/tests/test_status_gather.py
@@ -1135,3 +1135,46 @@ class TestLabelsFlowThrough:
             "Osasuwu/jarvis",
             "SergazyNarynov/redrobot",
         ]
+
+
+class TestJarvisHomeResolution:
+    """Resolution precedence: explicit arg > $JARVIS_HOME > git rev-parse > cwd.
+
+    Regression: gather() previously resolved only via `git rev-parse`, which
+    keys off the *current* repo. A call from another repo (e.g. redrobot) then
+    resolved to the wrong toplevel and degraded the whole gather. $JARVIS_HOME
+    must pin the jarvis root before git rev-parse is ever consulted.
+    """
+
+    def _run(self, monkeypatch, jarvis_home):
+        """Run gather with all I/O stubbed; guard git rev-parse from firing."""
+        called = {"rev_parse": False}
+
+        def _guard_subprocess_run(cmd, *a, **k):
+            if isinstance(cmd, (list, tuple)) and "rev-parse" in cmd:
+                called["rev_parse"] = True
+            raise AssertionError(f"unexpected subprocess.run({cmd})")
+
+        monkeypatch.setattr(status_gather.subprocess, "run", _guard_subprocess_run)
+        gather(
+            jarvis_home=jarvis_home,
+            read_repos_conf_fn=_fixture_repos_conf("Osasuwu/jarvis\n"),
+            read_device_json_fn=_fixture_device_json({"repos_path": "/fake/repos"}),
+            run_git_fn=_fixture_run_git({"stdout": "main", "stderr": "", "returncode": 0}),
+            run_gh_fn=_fixture_run_gh(_make_gh_success([])),
+            query_supabase_fn=_fixture_query_supabase([]),
+            now_fn=_fixture_now(),
+        )
+        return called
+
+    def test_env_var_short_circuits_git_rev_parse(self, monkeypatch):
+        """Empty arg + $JARVIS_HOME set → env wins, git rev-parse not called."""
+        monkeypatch.setenv("JARVIS_HOME", "/env/jarvis")
+        called = self._run(monkeypatch, jarvis_home="")
+        assert called["rev_parse"] is False
+
+    def test_explicit_arg_beats_env_var(self, monkeypatch):
+        """Explicit jarvis_home wins over $JARVIS_HOME; git rev-parse untouched."""
+        monkeypatch.setenv("JARVIS_HOME", "/env/jarvis")
+        called = self._run(monkeypatch, jarvis_home="/explicit/jarvis")
+        assert called["rev_parse"] is False


### PR DESCRIPTION
## Problem

`статус` / status_digest failed from the **redrobot** repo but worked from **jarvis**. Root cause: `gather()` resolved the jarvis root purely via `git rev-parse --show-toplevel`, which keys off the *current* repo. From another repo it resolved to the wrong toplevel → `repos_conf ok=False` → whole gather degraded. `$JARVIS_HOME` was set in the environment (and the status skill docs already promise it), but the code never read it.

## Fix

Resolution precedence in `gather()`: **explicit arg > `$JARVIS_HOME` > git rev-parse > cwd**.

## Tests

`TestJarvisHomeResolution` (2 cases): env var short-circuits git rev-parse; explicit arg beats env var. Full suite green (51 passed).

Verified live: empty-arg gather from redrobot cwd now returns `repos_conf ok=True`.

[no-issue]