### PR TITLE
feat(code-review): grant Write(//tmp/**) for body-file verdict posting

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -114,8 +114,11 @@ jobs:
           # job-level `if:` requires head.repo.full_name == github.repository,
           # so fork/external PRs never reach this step, and workflow_dispatch /
           # branch pushes both require repo write access. No untrusted external
-          # actor can initiate this run. Allowed-tools are also locked
-          # read-only below. Uniform across owned repos for the M48 baseline.
+          # actor can initiate this run. Allowed-tools are locked read-only
+          # below, except Write(//tmp/**) — the plugin composes its verdict
+          # comment there and posts via `gh pr comment --body-file` so review
+          # prose never passes through shell string-interpretation (#971).
+          # Uniform across owned repos for the M48 baseline.
           allowed_bots: "*"
           prompt: |
             Run /code-review for PR #${{ steps.pr.outputs.number }} in repo ${{ github.repository }}.
@@ -138,7 +141,7 @@ jobs:
             # probe comments, fragment comments, or no post at all → verdict gate
             # fails closed → admin-merge). Keep this list and the plugin frontmatter
             # in lockstep (tests/ci/test_code_review_allowed_tools.py pins it).
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*)"
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*),Write(//tmp/**)"
 
       # Auto-merge MERGE gate (Gate 1 of the two-gate model, #988). Without
       # this step the `review` check is SUCCESS as long as the bot ran —

--- a/scripts/repo_baseline/canon/code-review.yml
+++ b/scripts/repo_baseline/canon/code-review.yml
@@ -60,7 +60,7 @@ jobs:
             Do NOT load Jarvis SOUL.md, do NOT call memory_recall/memory_store
             (not available in this runner). This is plugin invocation only.
           claude_args: |
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*)"
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*),Write(//tmp/**)"
 
   attempt-2:
     name: attempt-2
@@ -109,7 +109,7 @@ jobs:
             Do NOT load Jarvis SOUL.md, do NOT call memory_recall/memory_store
             (not available in this runner). This is plugin invocation only.
           claude_args: |
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*)"
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(python -m py_compile:*),Bash(python3 -m py_compile:*),Bash(bash -n:*),Bash(node --check:*),Bash(git show:*),Bash(git blame:*),Bash(git log:*),Bash(wc:*),Write(//tmp/**)"
 
   verify-verdict:
     name: verify-verdict

--- a/tests/ci/test_code_review_allowed_tools.py
+++ b/tests/ci/test_code_review_allowed_tools.py
@@ -40,6 +40,13 @@ REQUIRED_TOOLS = (
     "Bash(git blame:*)",
     "Bash(git log:*)",
     "Bash(wc:*)",
+    # #971: the plugin composes the verdict body with the Write tool at
+    # /tmp/code-review-comment.md and posts via `gh pr comment --body-file`,
+    # so no shell string-interpretation touches review prose (backticks,
+    # $(...), $VAR would otherwise be evaluated under bash -c). Dropping this
+    # grant denies the Write in the headless runner and the post step degrades
+    # back to shell-assembled bodies.
+    "Write(//tmp/**)",
 )
 
 # Sanity floor — the pre-existing tools that must never disappear either.


### PR DESCRIPTION
## Summary
Adds `Write(//tmp/**)` to the code-review runner allowlists (live workflow + both canon retry jobs) and pins it in the drift test. This is the jarvis half of #971: it grants the tool the plugin will use to compose its verdict comment at `/tmp/code-review-comment.md` and post via `gh pr comment --body-file`, removing shell string-interpretation from the comment path.

## Why
The verdict body currently travels as a shell-interpreted string (`gh pr comment <n> --body "<markdown>"` under `bash -c` in the headless runner). Backticks, `$(...)`, `$VAR`, and backslashes in review prose get shell-evaluated — mangled comments at best, command substitution inside the runner at worst. #1042 stopped scratch comments; it did nothing for shell interpretation of the real one.

Closes #971

## Companion PR (merge order)
The plugin-side change (posting-discipline mandate + frontmatter grant) lands in `Osasuwu/claude-plugins-official`. **This PR merges FIRST**: the plugin is consumed live via git-subdir `ref: main` from `marketplace.json`, so granting the tool before the plugin uses it is harmless, while the reverse order would deny the Write on any live review run in the window between merges. Companion PR link posted in a follow-up comment on #971.

## Decisions & Alternatives
- Grill decision `1b38a9ca-4770-4c00-9658-b7cfcc91a48a` locked the mechanism: Write→`--body-file`, path-scoped grant (`Write(//tmp/**)`, permission-layer enforcement not convention), fixed literal paths; heredoc-stdin / `gh api -f body=@file` / single-quoted `--body` rejected; cleanup step dropped (YAGNI, no recurrence since #1042).
- Session decision `ed04f755-f2f4-4d1a-b228-72c39b2a7322`: two ordered PRs, jarvis first (plugin loads at `ref: main` — no breakage window).
- The drift test can only pin jarvis-side allowlists; the workflow ⊇ plugin-frontmatter superset invariant across repos stays convention + live smoke (AC 5).

## Risk Assessment
- **MEDIUM**: widens the headless runner's tool surface from read-only to one path-scoped write (`/tmp/**` only, tmpfs, discarded with the runner). No repo-tree write access; posting still goes through the pre-existing `Bash(gh pr comment:*)` grant.
- **Known risk (AC 5)**: out-of-cwd writes have deadlocked headless runs under acceptEdits (memory `acceptedits_scope_is_project_cwd`); an explicit allow rule should override. If the first live run shows the Write denied, fallback = workspace-relative temp path per the issue's AC.

## Testing
- `python -m pytest tests/ci/ -q` — 520 passed (drift test extended TDD-style: `Write(//tmp/**)` pinned in `REQUIRED_TOOLS`, confirmed RED before the workflow edits, GREEN after).
- `tests/ci/test_code_review_verdict_guard.py` green — verdict guard is transport-agnostic (AC 4).
- Live-run smoke (AC 5) is post-merge by definition: first review run must show exactly one `### Code review` comment with literal backticks/`$(...)`/`$VAR` rendering, and the `/tmp` Write honored.

## Files Changed
- `.github/workflows/code-review.yml` — `Write(//tmp/**)` appended to `--allowed-tools`; stale "locked read-only" comment corrected.
- `scripts/repo_baseline/canon/code-review.yml` — same grant in both retry jobs (canon-two-jobs-identical invariant).
- `tests/ci/test_code_review_allowed_tools.py` — `Write(//tmp/**)` added to `REQUIRED_TOOLS` with rationale.

## Merge note
This PR modifies `code-review.yml` itself → `anthropics/claude-code-action@v1` refuses self-modifying PRs → the `review` gate fails by design → **admin-merge** per the documented structural case (issue is labeled `unsafe-for-AFK` for exactly this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)