### PR TITLE
docs(skills): fix outcome memory_id rule — episode UUIDs violate FK

### DIFF
--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -342,7 +342,7 @@ One `outcome_record` per issue (delegated or inline). Distinguish:
 - Subagent: `pattern_tags: ["delegation", "subagent", "<area>"]`
 - Inline: `pattern_tags: ["delegation", "inline", "<area>"]`
 
-**Also pass `memory_id`** — the primary informing memory id from the per-task `record_decision` episode. Rule: `memory_id = memories_used[0]` (first = dominant basis). For batch-level inline work, use the inline task's own decision_made memories_used; for subagent work, the subagent's record_decision episode is the source. If `memories_used` was empty at decision time, omit `memory_id`.
+**Also pass `memory_id`** — the primary informing memory id from the per-task `record_decision` episode. Rule: the first element of `memories_used` that is a **memory-row UUID** (an id from `memory_recall`/`memory_get` — the recall map). Decision-**episode** UUIDs also appear in `memories_used` (grill decisions cited in issue bodies, `record_decision` returns) and are NOT valid — the FK `task_outcomes.memory_id → memories(id)` rejects them with 23503; provenance, not shape, tells them apart. For batch-level inline work, use the inline task's own decision_made memories_used; for subagent work, the subagent's record_decision episode is the source. If no memory-row UUID is present (or `memories_used` was empty at decision time), omit `memory_id`.
 
 In `lessons`, note anything non-obvious: subagent misread the issue, scope drift, worktree contamination, etc. These make future delegation decisions smarter.
 

--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -307,7 +307,7 @@ outcome_record(
 )
 ```
 
-**Rule — primary informing memory**: pass `memory_id = memories_used[0]` from the §3 `record_decision` call (first element is the dominant basis). If `memories_used` was empty, omit `memory_id`. Never pass multiple — the FK is a single UUID and `memory_calibration` joins on one memory per outcome; richer attribution belongs at the view layer, not the row.
+**Rule — primary informing memory**: pass the first element of the §3 `record_decision` call's `memories_used` that is a **memory-row UUID** — an id that came from `memory_recall`/`memory_get` (the recall map). `memories_used` may legitimately also carry decision-**episode** UUIDs (a grill decision cited in the issue's `## Decisions` section, a `record_decision` return value) — those are NOT valid here: the FK `task_outcomes.memory_id → memories(id)` rejects them with 23503 (bitten 2026-07-02, #971 outcome). Provenance is the discriminator, not shape — both are UUIDs; only where you got it tells them apart. If no element is a memory-row UUID (or `memories_used` was empty), omit `memory_id`. Never pass multiple — the FK is a single UUID and `memory_calibration` joins on one memory per outcome; richer attribution belongs at the view layer, not the row.
 
 **Always record**, even on failure — failed outcomes are the most valuable for learning.
 

--- a/.claude-userlevel/skills/verify/SKILL.md
+++ b/.claude-userlevel/skills/verify/SKILL.md
@@ -64,9 +64,12 @@ outcome_update(
 )
 ```
 
-**Enrich `memory_id` if the outcome row has it NULL**: look up the linked `decision_made` episode (same issue/PR) and pass `memory_id = payload.memories_used[0]`. Rule — primary informing memory = first entry (dominant basis). If the outcome already has `memory_id`, leave it alone; `/verify` is not where you rewrite attribution. If no decision episode references this issue, omit — the backfill script (`scripts/backfill-outcome-memories.py`) can handle historical rows in bulk.
+**Enrich `memory_id` if the outcome row has it NULL**: look up the linked `decision_made` episode (same issue/PR) and pass the first entry of `payload.memories_used` that is a **memory-row UUID** (verify with `memory_get` by id, or match it in the session's recall map). If the outcome already has `memory_id`, leave it alone; `/verify` is not where you rewrite attribution. If no decision episode references this issue, omit — the backfill script (`scripts/backfill-outcome-memories.py`) can handle historical rows in bulk.
 
-**Only backfill when `memories_used[0]` is a UUID** (matches `^[0-9a-f]{8}-`). Empirical audit per #325: of 33 historical `decision_made` episodes, 21 had empty `memories_used` and 12 stored memory NAMES, not UUIDs (zero matched the FK shape). Passing a name to `outcome_update.memory_id` writes a broken FK. If the first entry is a name, omit `memory_id` and leave the row for `scripts/backfill-outcome-memories.py`, which handles name→id resolution in bulk. If no decision episode references this issue, also omit.
+**Only backfill a verified memory-row UUID.** Two known bad shapes in historical `memories_used` (both write a broken FK or get rejected):
+- Memory NAMES, not UUIDs — per #325 audit: of 33 historical `decision_made` episodes, 21 had empty `memories_used` and 12 stored names (zero matched the FK shape). A name fails the `^[0-9a-f]{8}-` shape check; omit and leave for the backfill script's name→id resolution.
+- Decision-**episode** UUIDs — shape-valid UUIDs that live in the episodes table, not `memories`; the FK `task_outcomes.memory_id → memories(id)` rejects them with 23503 (bitten 2026-07-02, #971 outcome). Shape checks can't catch these — confirm the id resolves via `memory_get` (or is present in the recall map) before passing it.
+If the first entry fails either check, try the next; if none qualify, omit `memory_id`. If no decision episode references this issue, also omit.
 
 **Empty `memories_used` is valid** (per #334 expanded triggers: policy/schema/tag/config decisions may genuinely have no memory basis). If the matching decision episode exists but its `memories_used` list is empty, skip the enrichment — do NOT error, do NOT guess. Outcome stays `memory_id = NULL`; this is the correct representation for a decision that wasn't informed by prior memory.
 


### PR DESCRIPTION
## Summary
Corrects the `memory_id` attribution rule in three skill files (`implement`, `delegate`, `verify` under `.claude-userlevel/skills/`). The old rule said `memory_id = memories_used[0]` literally; the corrected rule requires the first element that is an actual **memory-row UUID** (provenance: the `memory_recall`/`memory_get` recall map), excluding decision-episode UUIDs and names.

## Why
`[no-issue]` — drive-by fix per #428 (trivial, reversible, scope-obvious; open item from today's /end report).

`record_decision.memories_used[]` legitimately carries decision-**episode** UUIDs (e.g. a grill decision cited in an issue's `## Decisions` section). Passing one into `task_outcomes.memory_id` violates the FK → `memories(id)` with Postgres 23503 — hit live 2026-07-02 while recording the #971 outcome (`Key (memory_id)=(1b38a9ca-…) is not present in table "memories"`). The skill text was the direct cause: it prescribed the failing call verbatim.

## Decisions & Alternatives
- **Provenance as the discriminator, not shape.** Episode and memory UUIDs are shape-identical; verify's existing `^[0-9a-f]{8}-` guard (#325, names-vs-UUIDs) cannot catch them. The fix extends that guard rather than contradicting it: shape check for names, provenance/`memory_get` resolution for episodes.
- **Fixed all three siblings in one PR** (sibling-grep rule) — same broken rule in implement §6, delegate task-outcome step, verify Step 3.
- Rejected: making the memory server coerce episode→memory ids server-side — attribution semantics belong at the call site; silent coercion would hide bad data.

## Risk Assessment
- **LOW**: documentation-only change to skill prose; no code, no schema, no workflow.

## Testing
- N/A (markdown). Rule already exercised live: retrying the #971 `outcome_record` with a real memory-row UUID (`2dcbc5ac-…`) succeeded → outcome a5acf9a9.

## Files Changed
- `.claude-userlevel/skills/implement/SKILL.md` — §6 rule corrected
- `.claude-userlevel/skills/delegate/SKILL.md` — per-task `memory_id` rule corrected
- `.claude-userlevel/skills/verify/SKILL.md` — Step 3 enrichment rule corrected; #325 shape guard extended with the episode-UUID case

Note: `~/.claude/skills/` mirror updates on next `install.ps1 -Apply` (user-run).