### PR TITLE
fix(#1087): pin JARVIS_HOME in status MCP server env

### DIFF
--- a/.claude-userlevel/.mcp.json
+++ b/.claude-userlevel/.mcp.json
@@ -6,7 +6,10 @@
     },
     "status": {
       "command": "python",
-      "args": ["scripts/run-status-server.py"]
+      "args": ["scripts/run-status-server.py"],
+      "env": {
+        "JARVIS_HOME": "{{JARVIS_HOME}}"
+      }
     },
     "github": {
       "type": "http",

--- a/tests/install/test_installer.py
+++ b/tests/install/test_installer.py
@@ -287,6 +287,45 @@ class TestJsonRoundtripCaveat:
             json_file.unlink()
 
 
+class TestStatusServerJarvisHomePinned:
+    """Regression: status MCP server must pin JARVIS_HOME in its env (#1087).
+
+    The status server's repo resolution (scripts/status_gather.py) falls back
+    to `git rev-parse --show-toplevel` / CWD when JARVIS_HOME is absent from
+    the process env. A server spawned from a non-jarvis repo (or a session
+    started before JARVIS_HOME was persisted) then reads a nonexistent
+    <other-repo>/config/repos.conf and returns an empty digest. Pinning
+    env.JARVIS_HOME in the template makes resolution independent of ambient
+    env/CWD.
+    """
+
+    SOURCE_MCP = (
+        Path(__file__).parent.parent.parent / ".claude-userlevel" / ".mcp.json"
+    )
+
+    def test_source_template_status_pins_jarvis_home(self):
+        """Source .mcp.json status block declares env.JARVIS_HOME placeholder."""
+        data = json.loads(self.SOURCE_MCP.read_text(encoding="utf-8"))
+        status = data["mcpServers"]["status"]
+        assert status.get("env", {}).get("JARVIS_HOME") == "{{JARVIS_HOME}}", (
+            "status server must carry env.JARVIS_HOME = '{{JARVIS_HOME}}' so the "
+            "installer substitutes the repo root; without it the digest silently "
+            "empties from non-jarvis repos"
+        )
+
+    def test_installed_status_env_substituted_to_repo_root(self):
+        """template_content resolves the JARVIS_HOME placeholder to repo root."""
+        repo_root = Path("/opt/jarvis-home")
+        rendered = installer.template_content(
+            self.SOURCE_MCP, repo_root, Path("/tmp/claude-home")
+        )
+        data = json.loads(rendered.decode("utf-8"))
+        assert (
+            data["mcpServers"]["status"]["env"]["JARVIS_HOME"]
+            == repo_root.as_posix()
+        )
+
+
 class TestSkipEnvCLI:
     """Tests for --skip-env CLI path (#415)."""
 


### PR DESCRIPTION
## Problem

`status_digest` returned an empty digest (`"repos.conf ... not found"`) when invoked from any non-jarvis repo (e.g. redrobot), while working fine from jarvis.

## Root cause

The status server's repo resolution (`scripts/status_gather.py:689-711`) falls back to `git rev-parse --show-toplevel` / CWD when the `JARVIS_HOME` env var is absent from the process environment. The config never pinned it — `env` was empty in both the source template and installed `.claude.json`. So it relied on the long-lived server *inheriting* an ambient User-scope value. Any session started before the var was persisted, or on a device where it lives only in a shell profile (GUI-launched Claude Code never sees it), spawned a server without it and silently emptied the digest from every non-jarvis repo.

| CWD | var present | Result |
|-----|-----|-----|
| redrobot | yes | works |
| redrobot | **no** | **0 repos, "repos.conf not found"** |
| jarvis | no | works (CWD fallback) |

## Fix

Pin `env.JARVIS_HOME = {{JARVIS_HOME}}` in the source `.mcp.json`; the installer substitutes the absolute repo root, making resolution independent of ambient environment/CWD. Verified end-to-end: after `install.ps1 -Apply`, the installed status block carries the substituted absolute repo root.

## Regression seam

Meta-tests assert (1) the template status block declares the pinned env key, and (2) `template_content` substitutes the placeholder to the repo root. All 25 installer tests pass.

Closes #1087
