### PR TITLE
feat(dispatch): dedup in-flight issues at dispatch time (#931)

### DIFF
--- a/.claude-userlevel/skills/delegate/SKILL.md
+++ b/.claude-userlevel/skills/delegate/SKILL.md
@@ -86,6 +86,65 @@ shortcut that hands work directly to a subagent) would silently bypass
 the gate. Re-surface this risk in any architectural change that restructures
 the dispatch chain.
 
+## Contract: dispatch-dedup (in-flight skip, runs before claim/spawn)
+
+Issue #931. An issue that already has an **open PR** or an **in-flight branch**
+is being worked — dispatching a second subagent onto it duplicates effort and
+races two branches to the same `Closes #N`. The check is network-fed but the
+predicate is the same pure `check_in_flight` the autonomous drain uses
+([`scripts/delegate_predispatch_gate.py`](../../../scripts/delegate_predispatch_gate.py)),
+so interactive `/delegate` and the reactive-core drain skip identically.
+
+**Per issue that survived the pre-dispatch gate, before §2 claim:**
+
+1. **Fetch in-flight evidence — explicit pagination** (a truncated first page
+   silently misses later PRs/branches and re-dispatches a duplicate):
+
+   ```bash
+   gh pr list --repo <owner/repo> --state open --limit 200 \
+     --json number,body,headRefName
+   gh api --paginate "repos/<owner/repo>/branches" --jq '.[].name'
+   ```
+
+2. **Check task_queue live rows** — a sibling autonomous drain may already be
+   running this issue with no PR yet. Query the `claimed`/`running` rows
+   (`agents.task_queue.list_active`) and match the issue number out of each
+   `goal`. A live sibling row for `#N` counts as in-flight.
+
+3. **Run the predicate** — feed the issue number + the fetched `open_prs`
+   (`number`/`body`/`headRefName`) + `open_branches` (names) into
+   `check_in_flight`. Verdicts:
+   - `live_pr` (closing keyword `#N` in a PR body, or a PR head branch
+     `^[a-z]+/<N>-`) **or a live sibling row** → **SKIP**.
+   - `stale_branch` (a `feat/<N>-` branch with no PR) → owner-attention route,
+     not an auto-dispatch.
+   - `clear` → proceed to claim.
+
+**On SKIP:**
+
+1. Report a **pointer** in the batch summary: `#N skipped — already in flight:
+   <PR #M / branch / live task row>`. No further routing.
+2. **No label mutation** — do NOT add `status:in-progress` or
+   `status:owner-queue`; the issue is already owned by the in-flight work.
+3. `mcp__memory__outcome_record(task_type="delegation", outcome_status="unknown",
+   outcome_summary="dispatch-dedup skip: <pointer>", project="<repo>",
+   issue_url=..., pattern_tags=["delegation","dispatch-dedup","skip"])` —
+   low-severity, for `/reflect` pattern-spotting. Not a `failure`: the issue
+   isn't broken, it's already being handled.
+
+**Atomic claim before spawn** — closes the residual race where two `/delegate`
+runs both read `clear` in the same window. Push an **empty** branch ref as the
+claim *before* spawning the subagent:
+
+```bash
+git push origin "$(git rev-parse origin/main)":refs/heads/feat/<N>-<slug>
+# non-zero exit (ref already exists) ⇒ another run claimed it ⇒ treat as SKIP
+```
+
+A rejected push means a concurrent claimer won — SKIP as above. This makes the
+branch namespace the lock; the pre-claim window (between the read and the push)
+is the only residual race, and it is documented in the gate module docstring.
+
 ## Contract: dispatch routing (per issue: mechanical / TDD-mode / `grill_required`)
 
 Per ADR-0001, skills do not self-trigger mid-task ("Type 3" is rejected). `/delegate` does **not** run `/grill` inline (and there is no standalone `/tdd` skill — TDD-mode is dispatched as inline operating discipline carrying `_shared/tdd/` reference docs). For **each** issue that **passed** the pre-dispatch gate above, inspect two inputs and route to one of three branches. Routing is per-issue: a single batch can mix mechanical-mode and TDD-mode dispatches (and exclude grill-failing issues).

--- a/agents/github_client.py
+++ b/agents/github_client.py
@@ -469,6 +469,60 @@ class HttpxGitHubClient:
             page += 1
         return commits
 
+    def list_open_pulls(self) -> list[dict[str, Any]]:
+        """All open PRs as ``{number, body, headRefName}`` dicts (#931 dedup).
+
+        The dispatch-dedup predicate (:func:`delegate_predispatch_gate.check_in_flight`)
+        matches on a PR's closing-keyword body and its head branch under the
+        ``headRefName`` key — the same shape ``gh pr list --json`` emits. The REST
+        list endpoint instead nests the branch under ``head.ref``, so each row is
+        remapped. Paginated at ``per_page=100`` (full walk, short page terminates)
+        so a busy repo's later PRs are never silently dropped.
+        """
+        url = f"https://api.github.com/repos/{self._repo}/pulls"
+        pulls: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            resp = self._client.get(url, params={"state": "open", "per_page": 100, "page": page})
+            resp.raise_for_status()
+            batch = resp.json()
+            if not batch:
+                break
+            for pr in batch:
+                pulls.append(
+                    {
+                        "number": pr.get("number"),
+                        "body": pr.get("body") or "",
+                        "headRefName": (pr.get("head") or {}).get("ref"),
+                    }
+                )
+            if len(batch) < 100:
+                break
+            page += 1
+        return pulls
+
+    def list_branch_names(self) -> list[str]:
+        """All branch names (#931 dedup).
+
+        Backs the head-branch arm of the dedup predicate — an in-flight branch
+        (``feat/<N>-``) with no PR yet still means the issue is being worked.
+        Paginated like :meth:`list_open_pulls`.
+        """
+        url = f"https://api.github.com/repos/{self._repo}/branches"
+        names: list[str] = []
+        page = 1
+        while True:
+            resp = self._client.get(url, params={"per_page": 100, "page": page})
+            resp.raise_for_status()
+            batch = resp.json()
+            if not batch:
+                break
+            names.extend(b["name"] for b in batch)
+            if len(batch) < 100:
+                break
+            page += 1
+        return names
+
 
 def default_github_client() -> HttpxGitHubClient:
     """Production :class:`GitHubClient` — repo from ``GITHUB_REPO`` env (AC4).

--- a/agents/poller.py
+++ b/agents/poller.py
@@ -82,6 +82,10 @@ _REQUEUE_REASONS: dict[str, str] = {
     "done": "completed",
     "failed": "failed",
     "parked": "parked (terminal) — orchestrator re-routes",
+    # #931: a task skipped as a duplicate is terminal — an event blocked on it
+    # will never see it advance, so re-route rather than strand it. The live PR /
+    # sibling row that triggered the skip is the work the event should follow.
+    "skipped_duplicate": "skipped as duplicate (terminal) — orchestrator re-routes",
 }
 
 # Import-time guard: if task_queue adds a new terminal state the poller must

--- a/agents/task_dispatch.py
+++ b/agents/task_dispatch.py
@@ -235,9 +235,7 @@ def _compute_pr_evidence(
         # out). The assert narrows int|None → int for the typed call below and
         # fails loud if that invariant is ever broken upstream (LOW, PR #1011 r3).
         assert pr_number is not None  # noqa: S101 — invariant guard, not input validation
-        return check_pr_evidence_rework_shape(
-            task_id, goal, pr_number, spawned_at, client=client
-        )
+        return check_pr_evidence_rework_shape(task_id, goal, pr_number, spawned_at, client=client)
 
     evidence = check_pr_evidence_fresh_shape(task_id, goal, spawned_at, client=client)
     if evidence is False and stdout_reader is not None:
@@ -305,12 +303,138 @@ class TaskQueuePort(Protocol):
         """Return one process-less ``running`` row to ``pending`` (direct UPDATE, #921 AC4)."""
 
 
+# First "#N" reference in a goal string — the issue a fresh-shape task targets.
+# Right-anchored like the gate's closing-keyword regex so "#93" never reads as
+# "#931" (the (?!\d) lookahead).
+_GOAL_ISSUE_RE = re.compile(r"#(\d+)(?!\d)")
+
+
+def _goal_issue_number(goal: str) -> int | None:
+    """Issue number a goal references, or ``None`` when it references none."""
+    m = _GOAL_ISSUE_RE.search(goal)
+    return int(m.group(1)) if m else None
+
+
+def _load_gate_module() -> Any:
+    """Load ``scripts/delegate_predispatch_gate.py`` for its shared predicate (#931).
+
+    The gate module lives outside the ``agents`` package (it is the /delegate
+    CLI reference implementation), so import it by path, anchored to the repo
+    root the same way :data:`_EXECUTOR_LOG_DIR` is. Cached in ``sys.modules``
+    under its plain name — the tests import it the same way, so the two share
+    one module object.
+    """
+    mod = sys.modules.get("delegate_predispatch_gate")
+    if mod is not None:
+        return mod
+    import importlib.util
+
+    path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "scripts",
+        "delegate_predispatch_gate.py",
+    )
+    spec = importlib.util.spec_from_file_location("delegate_predispatch_gate", path)
+    if spec is None or spec.loader is None:  # pragma: no cover — repo layout broken
+        raise ImportError(f"cannot load dispatch gate module from {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["delegate_predispatch_gate"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@dataclass(frozen=True)
+class DedupConfig:
+    """Pre-spawn dispatch-dedup wiring for :func:`drain_tasks` (#931).
+
+    ``fetch_in_flight`` returns ``(open_prs, open_branches)`` in the shapes the
+    gate's ``check_in_flight`` predicate takes — PR dicts with ``number`` /
+    ``body`` / ``headRefName``, branch names as plain strings. It is called
+    lazily, at most once per drain (the first fresh-shape task with an issue
+    reference triggers it), and a raise means *unverifiable*: the in-flight row
+    is requeued to ``pending`` and the drain stops — never a terminal state on
+    evidence we could not read.
+
+    ``list_active_rows`` returns live (``claimed``/``running``) task_queue rows
+    (``id``/``goal``/``status``) for the sibling check; queried fresh per task
+    so a row spawned earlier in this same drain is seen by later tasks.
+
+    ``record_outcome`` (optional) is called best-effort with a small payload
+    dict on each ``skipped_duplicate`` — a raise is logged and swallowed.
+    """
+
+    fetch_in_flight: Callable[[], tuple[list[dict[str, Any]], list[str]]]
+    list_active_rows: Callable[[], list[dict[str, Any]]]
+    record_outcome: Callable[[dict[str, Any]], None] | None = None
+
+
+def _record_skip_outcome(payload: dict[str, Any]) -> None:
+    """Best-effort ``task_outcomes`` write for a skipped-duplicate (#931).
+
+    Sandcastle-anon insert, so ``source_provenance`` carries the required
+    ``sandcastle:`` prefix (mcp-memory/schema.sql RLS, #542). Any failure is the
+    caller's to swallow — this never raises on the happy path but the caller
+    still guards it. ``GITHUB_REPO`` builds the issue URL for the ``issue_url``
+    link column.
+    """
+    from agents.supabase_client import get_client
+
+    repo = os.environ.get("GITHUB_REPO", "Osasuwu/jarvis")
+    issue_number = payload.get("issue_number")
+    get_client().table("task_outcomes").insert(
+        {
+            "task_type": "autonomous",
+            "task_description": f"dispatch-dedup skip: {payload.get('goal')}",
+            "outcome_status": "unknown",
+            "outcome_summary": (
+                f"Skipped duplicate dispatch for #{issue_number}: {payload.get('pointer')}"
+            ),
+            "project": "jarvis",
+            "issue_url": (
+                f"https://github.com/{repo}/issues/{issue_number}"
+                if issue_number is not None
+                else None
+            ),
+            "pattern_tags": ["dispatch-dedup", "skip", "autonomous"],
+            "source_provenance": "sandcastle:task_dispatch-dedup",
+        }
+    ).execute()
+
+
+def default_task_dedup(
+    github: GitHubClient,
+    *,
+    list_active: Callable[[], list[dict[str, Any]]] | None = None,
+) -> DedupConfig:
+    """Build the production :class:`DedupConfig` from a live GitHub client (#931).
+
+    ``fetch_in_flight`` maps the client's ``list_open_pulls`` / ``list_branch_names``
+    into the ``(open_prs, open_branches)`` shape the gate predicate takes;
+    ``list_active_rows`` defaults to :func:`task_queue.list_active`; ``record_outcome``
+    is the best-effort ``task_outcomes`` writer above. Wired from
+    :func:`wake_driver.main`; unit tests inject fakes into :class:`DedupConfig` directly.
+    """
+    active = list_active if list_active is not None else task_queue.list_active
+
+    def fetch_in_flight() -> tuple[list[dict[str, Any]], list[str]]:
+        return github.list_open_pulls(), github.list_branch_names()
+
+    return DedupConfig(
+        fetch_in_flight=fetch_in_flight,
+        list_active_rows=active,
+        record_outcome=_record_skip_outcome,
+    )
+
+
 @dataclass(frozen=True)
 class DrainResult:
     """What one :func:`drain_tasks` did."""
 
     spawned: int = 0
     failed: int = 0
+    # Tasks terminated as ``skipped_duplicate`` by the #931 pre-spawn dedup:
+    # a live PR (or a live sibling queue row) already covers their issue.
+    skipped_duplicate: int = 0
     # True iff the whole drain was skipped because the claude binary did not
     # resolve (AC7a) — distinct from "ran, claimed nothing".
     skipped_no_binary: bool = False
@@ -722,6 +846,7 @@ def drain_tasks(
     resolve_binary: ResolveBinary = default_resolve_binary,
     read_usage: ReadUsage = default_read_usage,
     sidecar: Sidecar | None = None,
+    dedup: DedupConfig | None = None,
 ) -> DrainResult:
     """Claim pending ``assignee`` tasks up to the cap and spawn each (AC2–AC4, AC7–AC9).
 
@@ -750,6 +875,15 @@ def drain_tasks(
     launched) stops the drain — the one in-flight row is requeued to
     ``pending`` (#921 AC4; reaper backstop if the requeue fails), the rest stay
     ``pending``; quota will not recover mid-drain.
+
+    With ``dedup`` wired (#931), each *fresh-shape* task that references an
+    issue is checked after the running transition and before the spawn: a live
+    PR for the issue or a live sibling queue row → ``running →
+    skipped_duplicate`` (terminal, best-effort outcome record) and the drain
+    continues; a stale claim branch with no PR → ``running → parked`` for
+    owner attention; evidence fetch failure → the row is requeued to
+    ``pending`` and the drain stops (unverifiable is never terminal).
+    Rework-shape goals bypass the check — they target a live PR by design.
     """
     # AC7a — pre-flight once; an unusable binary skips the whole drain. Widened
     # past FileNotFoundError to the other no-usable-binary failures (not
@@ -785,6 +919,9 @@ def drain_tasks(
 
     spawned = 0
     failed = 0
+    skipped_duplicate = 0
+    # #931 — GitHub in-flight evidence, fetched lazily at most once per drain.
+    in_flight_evidence: tuple[list[dict[str, Any]], list[str]] | None = None
     procs: list[tuple[str, Any]] = []
     # AC1/AC2 (#953) — carry each spawned task's goal + idempotency key + tz-aware
     # spawn time out to the wake_driver, which folds them onto the TrackedProc so
@@ -810,6 +947,99 @@ def drain_tasks(
                 task_id,
             )
             continue
+
+        # #931 — pre-spawn dispatch-dedup. Placed AFTER the running transition
+        # (the row is ours under the optimistic lock — a skip verdict can only
+        # terminate a row this drain owns) and BEFORE the spawn (the whole
+        # point: no duplicate process). Fresh-shape goals only; a rework goal
+        # targets a live PR by design and must not be eaten by the live-PR rule.
+        if dedup is not None:
+            shape, _ = parse_goal_shape(row["goal"])
+            issue_number = _goal_issue_number(str(row["goal"])) if shape == "fresh" else None
+            if issue_number is not None:
+                try:
+                    if in_flight_evidence is None:
+                        in_flight_evidence = dedup.fetch_in_flight()
+                    active_rows = dedup.list_active_rows()
+                except Exception:  # noqa: BLE001 — unverifiable is never terminal
+                    try:
+                        requeued = port.requeue_running(task_id)
+                    except Exception:  # noqa: BLE001 — requeue is best-effort
+                        requeued = False
+                    logger.exception(
+                        "[task_dispatch] dedup evidence fetch failed; stopping drain — task %s %s",
+                        task_id,
+                        "requeued to pending" if requeued else "left running for the reaper",
+                    )
+                    return DrainResult(
+                        spawned=spawned,
+                        failed=failed,
+                        skipped_duplicate=skipped_duplicate,
+                        procs=tuple(procs),
+                        spawned_meta=spawned_meta,
+                    )
+
+                open_prs, open_branches = in_flight_evidence
+                in_flight = _load_gate_module().check_in_flight(
+                    issue_number, open_prs, open_branches
+                )
+                sibling = next(
+                    (
+                        r
+                        for r in active_rows
+                        if str(r.get("id")) != task_id
+                        and _goal_issue_number(str(r.get("goal") or "")) == issue_number
+                    ),
+                    None,
+                )
+                if in_flight.verdict == "live_pr" or sibling is not None:
+                    pointer = (
+                        in_flight.pointer
+                        if in_flight.verdict == "live_pr"
+                        else f"live task_queue row {sibling['id']} already targets #{issue_number}"
+                    )
+                    try:
+                        port.transition(task_id, "skipped_duplicate", reason=pointer)
+                    except Exception:  # noqa: BLE001 — row stays running; reaper backstops
+                        logger.exception(
+                            "[task_dispatch] could not mark task %s skipped_duplicate; "
+                            "row left running for the reaper",
+                            task_id,
+                        )
+                        continue
+                    skipped_duplicate += 1
+                    logger.info(
+                        "[task_dispatch] task %s skipped as duplicate: %s", task_id, pointer
+                    )
+                    if dedup.record_outcome is not None:
+                        try:
+                            dedup.record_outcome(
+                                {
+                                    "task_id": task_id,
+                                    "issue_number": issue_number,
+                                    "goal": row["goal"],
+                                    "pointer": pointer,
+                                }
+                            )
+                        except Exception:  # noqa: BLE001 — outcome record is best-effort
+                            logger.exception(
+                                "[task_dispatch] outcome record for skipped task %s raised",
+                                task_id,
+                            )
+                    continue
+                if in_flight.verdict == "stale_branch":
+                    # A claim branch with no open PR is owner-attention territory:
+                    # someone (or some run) claimed the issue and went dark. Park —
+                    # don't spawn over it, don't silently drop it.
+                    try:
+                        port.transition(task_id, "parked", reason=in_flight.pointer)
+                    except Exception:  # noqa: BLE001 — row stays running; reaper backstops
+                        logger.exception(
+                            "[task_dispatch] could not park task %s on stale branch; "
+                            "row left running for the reaper",
+                            task_id,
+                        )
+                    continue
 
         # Capture spawn time BEFORE launching (MAJOR, PR #1011). The terminal
         # evidence check counts PR/commit activity with timestamp > spawned_at;
@@ -855,6 +1085,7 @@ def drain_tasks(
             return DrainResult(
                 spawned=spawned,
                 failed=failed,
+                skipped_duplicate=skipped_duplicate,
                 throttled=True,
                 procs=tuple(procs),
                 spawned_meta=spawned_meta,
@@ -893,7 +1124,13 @@ def drain_tasks(
                         task_id,
                     )
 
-    return DrainResult(spawned=spawned, failed=failed, procs=tuple(procs), spawned_meta=spawned_meta)
+    return DrainResult(
+        spawned=spawned,
+        failed=failed,
+        skipped_duplicate=skipped_duplicate,
+        procs=tuple(procs),
+        spawned_meta=spawned_meta,
+    )
 
 
 def reclaim_stale_tasks(

--- a/agents/task_queue.py
+++ b/agents/task_queue.py
@@ -1,7 +1,7 @@
 """Task queue interface — enqueue, claim_next, transition.
 
 Built on the reshaped ``task_queue`` table (issue #740):
-- FSM: ``pending → claimed → running → done | failed | parked``
+- FSM: ``pending → claimed → running → done | failed | parked | skipped_duplicate``
 - Priority-ordered claiming (highest first, FIFO for ties)
 - Idempotency-key dedup (colliding key on enqueue is a silent no-op)
 
@@ -38,10 +38,12 @@ from agents.supabase_client import get_client
 _VALID_TRANSITIONS: dict[str, frozenset[str]] = {
     "pending": frozenset({"claimed"}),
     "claimed": frozenset({"running"}),
-    "running": frozenset({"done", "failed", "parked"}),
+    "running": frozenset({"done", "failed", "parked", "skipped_duplicate"}),
 }
 
-_TERMINAL_STATES: frozenset[str] = frozenset({"done", "failed", "parked"})
+# `skipped_duplicate` (#931): dispatch-dedup found a live PR (or a live sibling
+# row) for the task's issue after the running transition — terminal, no retry.
+_TERMINAL_STATES: frozenset[str] = frozenset({"done", "failed", "parked", "skipped_duplicate"})
 
 
 # -- Public API ------------------------------------------------------------
@@ -199,7 +201,7 @@ def transition(
 
     if to_status == "claimed":
         update["claimed_at"] = now
-    elif to_status in ("done", "failed"):
+    elif to_status in ("done", "failed", "skipped_duplicate"):
         update["completed_at"] = now
 
     if reason is not None:
@@ -316,6 +318,30 @@ def requeue_running(
         .execute()
     )
     return bool(result.data)
+
+
+def list_active(
+    *,
+    client: Client | None = None,
+) -> list[dict[str, Any]]:
+    """List live (``claimed`` or ``running``) rows for sibling dedup (#931).
+
+    The dispatch-dedup check reads these to detect a *sibling* task_queue row
+    already working the same issue. Only ``id``, ``goal`` and ``status`` are
+    selected — the dedup predicate extracts the issue number from ``goal``.
+    Two ``eq`` queries instead of ``in_`` keeps the call compatible with the
+    minimal client stubs used across the test suite.
+    """
+    cli = client or get_client()
+    rows: list[dict[str, Any]] = []
+    for status in ("claimed", "running"):
+        rows.extend(
+            (
+                cli.table("task_queue").select("id, goal, status").eq("status", status).execute()
+            ).data
+            or []
+        )
+    return rows
 
 
 def list_stale_running(

--- a/agents/wake_driver.py
+++ b/agents/wake_driver.py
@@ -72,9 +72,11 @@ from agents.task_dispatch import (
     TaskQueuePort,
     TrackedProc,
     default_read_usage,
+    DedupConfig,
     default_resolve_binary,
     default_spawn,
     default_stdout_reader,
+    default_task_dedup,
     drain_tasks,
     kill_process_tree,
     kill_runaways,
@@ -226,6 +228,7 @@ def tick(
     task_event_emit: EventEmit | None = None,
     task_evidence_client: GitHubClient | None = None,
     task_stdout_reader: Callable[[str], str | None] | None = None,
+    task_dedup: DedupConfig | None = None,
 ) -> TickResult:
     """One unit of work — ordered steps (#909 AC1, #921 AC3, #745 Path B)::
 
@@ -351,6 +354,7 @@ def tick(
                 resolve_binary=task_resolve_binary,
                 read_usage=task_read_usage,
                 sidecar=task_sidecar,
+                dedup=task_dedup,
             )
             if task_procs is not None:
                 for task_id, proc in task_drain.procs:
@@ -404,6 +408,7 @@ def run(
     task_event_emit: EventEmit | None = None,
     task_evidence_client: GitHubClient | None = None,
     task_stdout_reader: Callable[[str], str | None] | None = None,
+    task_dedup: DedupConfig | None = None,
 ) -> None:
     """The event-driven loop: block on a wake signal, then run one tick.
 
@@ -468,6 +473,7 @@ def run(
                 task_event_emit=task_event_emit,
                 task_evidence_client=task_evidence_client,
                 task_stdout_reader=task_stdout_reader,
+                task_dedup=task_dedup,
             )
         except Exception:  # noqa: BLE001 — daemon must survive a bad tick
             logger.exception("[wake_driver] tick failed; event left claimed for watchdog re-claim")
@@ -661,6 +667,9 @@ def main() -> int:
             task_event_emit=event_emit,
             task_evidence_client=evidence_client,
             task_stdout_reader=default_stdout_reader,
+            # #931 dispatch-dedup: reuse the one evidence client for the
+            # drain-time in-flight PR/branch fetch; sibling rows via task_queue.
+            task_dedup=default_task_dedup(evidence_client),
         )
     except KeyboardInterrupt:
         logger.info("[wake_driver] KeyboardInterrupt — stopping")

--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2593,9 +2593,11 @@ create table if not exists task_queue (
   priority int not null default 0,
   assignee text,
 
-  -- Lifecycle
+  -- Lifecycle. `skipped_duplicate` (#931): dispatch-dedup terminal — issue
+  -- already had a live PR or sibling row. Keep in lockstep with
+  -- supabase/migrations/20260702120000_add_skipped_duplicate_status.sql.
   status text not null default 'pending'
-    check (status in ('pending', 'claimed', 'running', 'done', 'failed', 'parked')),
+    check (status in ('pending', 'claimed', 'running', 'done', 'failed', 'parked', 'skipped_duplicate')),
   claimed_at timestamptz,
   completed_at timestamptz,
   escalated_reason text,

--- a/scripts/delegate_predispatch_gate.py
+++ b/scripts/delegate_predispatch_gate.py
@@ -1,4 +1,4 @@
-"""Pre-dispatch gate for /delegate (issue #642).
+"""Pre-dispatch gate for /delegate (issues #642, #931).
 
 Refuses to dispatch a sandcastle subagent unless the target GitHub issue
 satisfies four readiness conditions:
@@ -8,12 +8,32 @@ satisfies four readiness conditions:
   3. body contains a `## Acceptance criteria` heading (case-insensitive)
   4. body cites at least one decision UUID
 
-The gate is invoked from the /delegate skill prose. Usage:
+and additionally SKIPs an issue that already has in-flight work
+(dispatch-dedup, #931): an open PR referencing it via a closing keyword or a
+`<prefix>/<N>-` head branch, or a `feat/<N>-` branch with no open PR (stale —
+owner attention).
 
-  gh issue view <N> --repo <R> --json number,body,labels \\
+The gate is invoked from the /delegate skill prose with a strict envelope on
+stdin (no bare-issue fallback — a missing or malformed `open_prs` /
+`open_branches` fails closed as SKIP):
+
+  {"issue": {...}, "open_prs": [{number, body, headRefName}, ...],
+   "open_branches": ["feat/123-x", ...]}
     | python scripts/delegate_predispatch_gate.py
 
-Exit code 0 ⇒ allow; exit code 1 ⇒ refuse. Decision text is on stdout.
+Exit codes: 0 ⇒ OK (dispatch), 1 ⇒ REFUSE (readiness failure),
+2 ⇒ SKIP (in-flight or unverifiable evidence). Decision text is on stdout.
+
+Notes:
+  - This module does no network I/O — callers fetch PR/branch lists (with
+    explicit pagination) and pass them in.
+  - Residual race: another dispatcher can start work between this check and
+    the claim. Negligible in practice — the atomic `feat/<N>-<slug>` branch
+    push is the *first* dispatch action, so the unguarded window is one
+    process-local step, and the push itself is a server-side CAS.
+  - The closing-keyword body regex is convention-backed, not speculative: the
+    `require-linked-issue` merge gate forces closing keywords into PR bodies,
+    so a live PR for an issue is reliably detectable this way.
 """
 
 from __future__ import annotations
@@ -30,6 +50,66 @@ _UUID_RE = re.compile(
 _AC_HEADING_RE = re.compile(r"(?m)^##\s+acceptance\s+criteria\b", re.IGNORECASE)
 _NEEDS_PREFIX = "needs-"
 _REQUIRED_LABEL = "sandcastle"
+
+_CLOSING_KEYWORD = r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)"
+
+
+def _closing_ref_re(issue_number: int) -> re.Pattern[str]:
+    return re.compile(rf"(?i)\b{_CLOSING_KEYWORD}\s+#{issue_number}(?!\d)")
+
+
+def _pr_head_re(issue_number: int) -> re.Pattern[str]:
+    return re.compile(rf"^[a-z]+/{issue_number}-")
+
+
+def _claim_branch_re(issue_number: int) -> re.Pattern[str]:
+    return re.compile(rf"^feat/{issue_number}-")
+
+
+@dataclass(frozen=True)
+class InFlightResult:
+    verdict: str  # "clear" | "live_pr" | "stale_branch"
+    pointer: str = ""
+
+    @property
+    def clear(self) -> bool:
+        return self.verdict == "clear"
+
+
+def check_in_flight(
+    issue_number: int,
+    open_prs: list[dict],
+    open_branches: list[str],
+) -> InFlightResult:
+    """Detect in-flight work for an issue from pre-fetched GitHub data.
+
+    Pure function — callers fetch `open_prs` (dicts with `number`, `body`,
+    `headRefName`) and `open_branches` (names) themselves; no network I/O here.
+    A live PR beats a stale branch.
+    """
+    closing_ref = _closing_ref_re(issue_number)
+    pr_head = _pr_head_re(issue_number)
+    for pr in open_prs:
+        if closing_ref.search(pr.get("body") or ""):
+            return InFlightResult(
+                "live_pr",
+                f"open PR #{pr.get('number')} closes #{issue_number}",
+            )
+        if pr_head.match(pr.get("headRefName") or ""):
+            return InFlightResult(
+                "live_pr",
+                f"open PR #{pr.get('number')} from branch {pr.get('headRefName')}",
+            )
+
+    claim_branch = _claim_branch_re(issue_number)
+    for branch in open_branches:
+        if claim_branch.match(branch):
+            return InFlightResult(
+                "stale_branch",
+                f"branch {branch} exists with no open PR — owner attention",
+            )
+
+    return InFlightResult("clear")
 
 
 @dataclass(frozen=True)
@@ -69,12 +149,52 @@ def check_issue(issue: dict) -> GateResult:
     return GateResult(failures=tuple(failures))
 
 
+def _validate_envelope(payload: object) -> tuple[dict, list[dict], list[str]] | str:
+    """Return (issue, open_prs, open_branches) or a SKIP reason string."""
+    if not isinstance(payload, dict):
+        return "payload is not a JSON object"
+    issue = payload.get("issue")
+    if not isinstance(issue, dict):
+        return "missing or malformed `issue` key"
+    if not isinstance(issue.get("number"), int):
+        return "missing or malformed `issue.number`"
+    open_prs = payload.get("open_prs")
+    if not isinstance(open_prs, list) or any(not isinstance(pr, dict) for pr in open_prs):
+        return "missing or malformed `open_prs` (must be a list of objects)"
+    open_branches = payload.get("open_branches")
+    if not isinstance(open_branches, list) or any(
+        not isinstance(b, str) for b in open_branches
+    ):
+        return "missing or malformed `open_branches` (must be a list of strings)"
+    return issue, open_prs, open_branches
+
+
 def main(argv: list[str] | None = None) -> int:
-    payload = sys.stdin.read()
-    issue = json.loads(payload)
-    result = check_issue(issue)
-    print(result.message)
-    return 0 if result.allow else 1
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"SKIP: unverifiable — stdin is not valid JSON ({exc.msg})")
+        return 2
+
+    validated = _validate_envelope(payload)
+    if isinstance(validated, str):
+        print(f"SKIP: unverifiable — {validated}")
+        return 2
+    issue, open_prs, open_branches = validated
+
+    readiness = check_issue(issue)
+    if not readiness.allow:
+        print(readiness.message)
+        return 1
+
+    in_flight = check_in_flight(issue["number"], open_prs, open_branches)
+    if not in_flight.clear:
+        print(f"SKIP: {in_flight.pointer}")
+        return 2
+
+    print(readiness.message)
+    return 0
 
 
 if __name__ == "__main__":

--- a/supabase/migrations/20260702120000_add_skipped_duplicate_status.sql
+++ b/supabase/migrations/20260702120000_add_skipped_duplicate_status.sql
@@ -1,0 +1,9 @@
+-- #931 dispatch-dedup: add `skipped_duplicate` terminal status to task_queue.
+-- A running row whose issue turns out to already have a live PR (or a live
+-- sibling queue row) terminates as skipped_duplicate — no requeue, no retry.
+-- Keep the status list in lockstep with mcp-memory/schema.sql and
+-- agents/task_queue.py (_VALID_TRANSITIONS / _TERMINAL_STATES).
+
+alter table task_queue drop constraint task_queue_status_check;
+alter table task_queue add constraint task_queue_status_check
+  check (status in ('pending', 'claimed', 'running', 'done', 'failed', 'parked', 'skipped_duplicate'));

--- a/tests/test_agents_task_queue.py
+++ b/tests/test_agents_task_queue.py
@@ -16,6 +16,7 @@ from agents.task_queue import (
     claim_next,
     count_running,
     enqueue,
+    list_active,
     list_stale_running,
     reclaim_stale_claimed,
     requeue_running,
@@ -462,8 +463,18 @@ class TestTransition:
 class TestFSMDefinition:
     """Validate the FSM transition table covers every non-terminal state."""
 
+    _ALL_STATES = {
+        "pending",
+        "claimed",
+        "running",
+        "done",
+        "failed",
+        "parked",
+        "skipped_duplicate",
+    }
+
     def test_all_non_terminal_states_defined(self) -> None:
-        all_states = {"pending", "claimed", "running", "done", "failed", "parked"}
+        all_states = self._ALL_STATES
         non_terminal = all_states - _TERMINAL_STATES
         defined = set(_VALID_TRANSITIONS.keys())
         assert defined == non_terminal, f"Missing transition rules for: {non_terminal - defined}"
@@ -477,7 +488,7 @@ class TestFSMDefinition:
             assert state not in targets, f"Self-loop in {state}"
 
     def test_all_targets_are_valid_states(self) -> None:
-        all_states = {"pending", "claimed", "running", "done", "failed", "parked"}
+        all_states = self._ALL_STATES
         for state, targets in _VALID_TRANSITIONS.items():
             for target in targets:
                 assert target in all_states, (
@@ -679,3 +690,70 @@ class TestRequeueRunning:
 
     def test_returns_false_when_missing(self, client: _StubClient) -> None:
         assert requeue_running("ghost", client=client) is False
+
+
+# ===========================================================================
+# skipped_duplicate (#931) — dispatch-dedup terminal state
+# ===========================================================================
+
+
+class TestSkippedDuplicate:
+    """#931: a running row whose issue already has a live PR terminates
+    as `skipped_duplicate` — no requeue, no retry."""
+
+    def test_running_to_skipped_duplicate(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_running()])
+        row = transition(
+            "tq-running",
+            "skipped_duplicate",
+            reason="open PR #555 closes #931",
+            client=client,
+        )
+        assert row["status"] == "skipped_duplicate"
+        assert row["completed_at"] is not None
+        assert row["escalated_reason"] == "open PR #555 closes #931"
+
+    def test_skipped_duplicate_is_terminal(self, client: _StubClient) -> None:
+        assert "skipped_duplicate" in _TERMINAL_STATES
+        client.seed("task_queue", [_running(id="tq-skip", status="skipped_duplicate")])
+        with pytest.raises(ValueError, match="terminal state"):
+            transition("tq-skip", "claimed", client=client)
+
+    def test_pending_cannot_skip_directly(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_pending()])
+        with pytest.raises(ValueError, match="Illegal transition"):
+            transition("tq-pending", "skipped_duplicate", client=client)
+
+    def test_claimed_cannot_skip_directly(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_claimed()])
+        with pytest.raises(ValueError, match="Illegal transition"):
+            transition("tq-claimed", "skipped_duplicate", client=client)
+
+
+# ===========================================================================
+# list_active (#931) — live claimed/running rows for sibling dedup
+# ===========================================================================
+
+
+class TestListActive:
+    def test_lists_claimed_and_running_only(self, client: _StubClient) -> None:
+        client.seed(
+            "task_queue",
+            [
+                _pending(id="p", idempotency_key="k1"),
+                _claimed(id="c", idempotency_key="k2"),
+                _running(id="r", idempotency_key="k3"),
+                _running(id="d", status="done", idempotency_key="k4"),
+                _running(id="s", status="skipped_duplicate", idempotency_key="k5"),
+            ],
+        )
+        rows = list_active(client=client)
+        assert {r["id"] for r in rows} == {"c", "r"}
+
+    def test_rows_carry_goal(self, client: _StubClient) -> None:
+        client.seed("task_queue", [_running(id="r", goal="Implement #931", idempotency_key="k")])
+        rows = list_active(client=client)
+        assert rows[0]["goal"] == "Implement #931"
+
+    def test_empty_queue(self, client: _StubClient) -> None:
+        assert list_active(client=client) == []

--- a/tests/test_delegate_predispatch_gate.py
+++ b/tests/test_delegate_predispatch_gate.py
@@ -181,8 +181,13 @@ def test_handles_missing_labels_key():
 # ── CLI smoke (stdin JSON → exit code) ──────────────────────────────────────
 
 
+# Since #931 the CLI takes a strict envelope: {issue, open_prs, open_branches}.
+# Bare-issue stdin now fails closed (exit 2) — see tests/test_dispatch_dedup.py.
+
+
 def test_main_returns_zero_on_allow(monkeypatch, capsys):
-    monkeypatch.setattr("sys.stdin", _StringStream(json.dumps(_issue())))
+    envelope = {"issue": _issue(), "open_prs": [], "open_branches": []}
+    monkeypatch.setattr("sys.stdin", _StringStream(json.dumps(envelope)))
     rc = gate.main([])
     assert rc == 0
     out = capsys.readouterr().out
@@ -190,10 +195,12 @@ def test_main_returns_zero_on_allow(monkeypatch, capsys):
 
 
 def test_main_returns_nonzero_on_refuse(monkeypatch, capsys):
-    monkeypatch.setattr(
-        "sys.stdin",
-        _StringStream(json.dumps(_issue(body="", labels=()))),
-    )
+    envelope = {
+        "issue": _issue(body="", labels=()),
+        "open_prs": [],
+        "open_branches": [],
+    }
+    monkeypatch.setattr("sys.stdin", _StringStream(json.dumps(envelope)))
     rc = gate.main([])
     assert rc == 1
     out = capsys.readouterr().out

--- a/tests/test_dispatch_dedup.py
+++ b/tests/test_dispatch_dedup.py
@@ -1,0 +1,574 @@
+"""Tests for dispatch-dedup (issue #931).
+
+Covers the shared in-flight predicate ``check_in_flight`` in
+``scripts/delegate_predispatch_gate.py``, the strict-envelope CLI verdicts
+(OK / REFUSE / SKIP, fail-closed), and the pre-spawn dedup in
+``agents/task_dispatch.drain_tasks``. All fixtures are network-free.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+gate = importlib.import_module("delegate_predispatch_gate")
+check_in_flight = gate.check_in_flight
+
+
+# ── Fixture builders ─────────────────────────────────────────────────────────
+
+
+def _pr(number: int = 100, body: str = "", head: str = "task/abc123") -> dict:
+    return {"number": number, "body": body, "headRefName": head}
+
+
+# ── check_in_flight: live-PR via closing keyword ─────────────────────────────
+
+
+def test_closing_keyword_in_pr_body_hits():
+    result = check_in_flight(931, [_pr(body="Closes #931 for good")], [])
+    assert result.verdict == "live_pr"
+    assert "#100" in result.pointer
+
+
+def test_all_closing_keyword_variants_hit():
+    for kw in ("Closes", "closed", "close", "Fixes", "fix", "fixed", "Resolves", "resolve", "resolved"):
+        result = check_in_flight(42, [_pr(body=f"{kw} #42")], [])
+        assert result.verdict == "live_pr", kw
+
+
+def test_issue_ref_without_closing_keyword_does_not_hit():
+    result = check_in_flight(931, [_pr(body="relates to #931, see discussion")], [])
+    assert result.verdict == "clear"
+
+
+def test_number_is_right_anchored_93_does_not_match_931():
+    # PR closing #931 must NOT read as in-flight evidence for issue #93 ...
+    result = check_in_flight(93, [_pr(body="Closes #931")], [])
+    assert result.verdict == "clear"
+
+
+def test_number_is_right_anchored_931_not_matched_by_9310():
+    result = check_in_flight(931, [_pr(body="Closes #9310")], [])
+    assert result.verdict == "clear"
+
+
+# ── check_in_flight: live-PR via head branch ─────────────────────────────────
+
+
+def test_pr_head_branch_prefix_hits():
+    result = check_in_flight(931, [_pr(head="feat/931-dispatch-dedup")], [])
+    assert result.verdict == "live_pr"
+
+
+def test_pr_head_branch_any_lowercase_prefix_hits():
+    result = check_in_flight(931, [_pr(head="fix/931-hotfix")], [])
+    assert result.verdict == "live_pr"
+
+
+def test_pr_head_branch_wrong_number_does_not_hit():
+    result = check_in_flight(931, [_pr(head="feat/9310-other")], [])
+    assert result.verdict == "clear"
+
+
+def test_pr_head_branch_needs_trailing_dash():
+    result = check_in_flight(931, [_pr(head="feat/931")], [])
+    assert result.verdict == "clear"
+
+
+# ── check_in_flight: stale branch (no open PR) ───────────────────────────────
+
+
+def test_branch_without_pr_is_stale_branch():
+    result = check_in_flight(931, [], ["feat/931-dispatch-dedup"])
+    assert result.verdict == "stale_branch"
+    assert "feat/931-dispatch-dedup" in result.pointer
+
+
+def test_branch_for_other_issue_is_clear():
+    result = check_in_flight(931, [], ["feat/930-other", "feat/9310-other", "main"])
+    assert result.verdict == "clear"
+
+
+def test_non_feat_branch_does_not_count_as_claim():
+    result = check_in_flight(931, [], ["task/931-something"])
+    assert result.verdict == "clear"
+
+
+# ── check_in_flight: precedence & message distinction ────────────────────────
+
+
+def test_live_pr_beats_stale_branch():
+    result = check_in_flight(
+        931,
+        [_pr(number=200, body="Closes #931")],
+        ["feat/931-dispatch-dedup"],
+    )
+    assert result.verdict == "live_pr"
+    assert "#200" in result.pointer
+
+
+def test_stale_branch_and_live_pr_pointers_are_distinct():
+    live = check_in_flight(931, [_pr(body="Closes #931")], [])
+    stale = check_in_flight(931, [], ["feat/931-x"])
+    assert live.pointer != stale.pointer
+
+
+def test_clear_when_nothing_matches():
+    result = check_in_flight(931, [_pr(body="Closes #42", head="feat/42-x")], ["feat/42-x"])
+    assert result.verdict == "clear"
+    assert result.clear
+
+
+# ── module purity: no network I/O imports ────────────────────────────────────
+
+
+def test_module_has_no_network_imports():
+    source = Path(gate.__file__).read_text(encoding="utf-8")
+    for lib in ("httpx", "requests", "urllib", "socket", "http.client", "subprocess"):
+        assert f"import {lib}" not in source, f"network/exec import {lib!r} found in gate module"
+
+
+# ── CLI: strict envelope, exit 0/1/2 ─────────────────────────────────────────
+
+VALID_UUID = "6b0a5bf7-8ca9-47cc-81cf-ebae39c81d08"
+READY_BODY = f"## Acceptance criteria\n- [ ] do thing\n\nDecisions: {VALID_UUID}\n"
+
+
+class _StringStream:
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    def read(self) -> str:
+        return self._payload
+
+
+def _envelope(
+    body: str = READY_BODY,
+    labels: tuple[str, ...] = ("sandcastle",),
+    number: int = 931,
+    open_prs: list | None = None,
+    open_branches: list | None = None,
+) -> dict:
+    return {
+        "issue": {
+            "number": number,
+            "body": body,
+            "labels": [{"name": n} for n in labels],
+        },
+        "open_prs": open_prs if open_prs is not None else [],
+        "open_branches": open_branches if open_branches is not None else [],
+    }
+
+
+def _run_main(monkeypatch, payload: str) -> int:
+    import json as _json  # noqa: F401 — payload already serialized by callers
+
+    monkeypatch.setattr("sys.stdin", _StringStream(payload))
+    return gate.main([])
+
+
+def test_cli_exit_zero_on_ready_and_clear(monkeypatch, capsys):
+    import json
+
+    rc = _run_main(monkeypatch, json.dumps(_envelope()))
+    assert rc == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_cli_exit_one_on_readiness_refuse(monkeypatch, capsys):
+    import json
+
+    rc = _run_main(monkeypatch, json.dumps(_envelope(body="", labels=())))
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "REFUSE" in out
+    assert "sandcastle" in out
+
+
+def test_cli_exit_two_on_live_pr(monkeypatch, capsys):
+    import json
+
+    rc = _run_main(
+        monkeypatch,
+        json.dumps(_envelope(open_prs=[_pr(number=555, body="Closes #931")])),
+    )
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert out.startswith("SKIP")
+    assert "#555" in out
+
+
+def test_cli_exit_two_on_stale_branch_with_distinct_message(monkeypatch, capsys):
+    import json
+
+    rc = _run_main(
+        monkeypatch,
+        json.dumps(_envelope(open_branches=["feat/931-dispatch-dedup"])),
+    )
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert out.startswith("SKIP")
+    assert "feat/931-dispatch-dedup" in out
+    assert "owner attention" in out
+
+
+def test_cli_refuse_wins_over_in_flight(monkeypatch, capsys):
+    import json
+
+    payload = _envelope(body="", labels=(), open_prs=[_pr(body="Closes #931")])
+    rc = _run_main(monkeypatch, json.dumps(payload))
+    assert rc == 1
+    assert "REFUSE" in capsys.readouterr().out
+
+
+# ── CLI: fail-closed on malformed payload ────────────────────────────────────
+
+
+def _assert_skip(monkeypatch, capsys, payload: str):
+    rc = _run_main(monkeypatch, payload)
+    assert rc == 2
+    assert capsys.readouterr().out.startswith("SKIP")
+
+
+def test_cli_fails_closed_on_missing_open_prs(monkeypatch, capsys):
+    import json
+
+    env = _envelope()
+    del env["open_prs"]
+    _assert_skip(monkeypatch, capsys, json.dumps(env))
+
+
+def test_cli_fails_closed_on_missing_open_branches(monkeypatch, capsys):
+    import json
+
+    env = _envelope()
+    del env["open_branches"]
+    _assert_skip(monkeypatch, capsys, json.dumps(env))
+
+
+def test_cli_fails_closed_on_non_list_open_prs(monkeypatch, capsys):
+    import json
+
+    env = _envelope()
+    env["open_prs"] = "not-a-list"
+    _assert_skip(monkeypatch, capsys, json.dumps(env))
+
+
+def test_cli_fails_closed_on_non_dict_pr_entry(monkeypatch, capsys):
+    import json
+
+    _assert_skip(monkeypatch, capsys, json.dumps(_envelope(open_prs=["oops"])))
+
+
+def test_cli_fails_closed_on_non_string_branch_entry(monkeypatch, capsys):
+    import json
+
+    _assert_skip(monkeypatch, capsys, json.dumps(_envelope(open_branches=[42])))
+
+
+def test_cli_fails_closed_on_bare_issue_legacy_shape(monkeypatch, capsys):
+    import json
+
+    bare = {"number": 931, "body": READY_BODY, "labels": [{"name": "sandcastle"}]}
+    _assert_skip(monkeypatch, capsys, json.dumps(bare))
+
+
+def test_cli_fails_closed_on_invalid_json(monkeypatch, capsys):
+    _assert_skip(monkeypatch, capsys, "{not json")
+
+
+def test_cli_fails_closed_on_missing_issue_number(monkeypatch, capsys):
+    import json
+
+    env = _envelope()
+    del env["issue"]["number"]
+    _assert_skip(monkeypatch, capsys, json.dumps(env))
+
+
+# ── drain_tasks pre-spawn dedup (agents/task_dispatch.py, #931) ──────────────
+
+from agents.task_dispatch import DedupConfig, drain_tasks  # noqa: E402
+
+
+class _Queue:
+    """Minimal TaskQueuePort fake — mirrors tests/test_agents_task_dispatch.py."""
+
+    def __init__(self, pending: list[dict]) -> None:
+        self.pending = list(pending)
+        self.transitions: list[tuple[str, str, str | None]] = []
+        self.requeued: list[str] = []
+
+    def claim_next(self, *, assignee: str) -> dict | None:
+        return self.pending.pop(0) if self.pending else None
+
+    def count_running(self, *, assignee: str) -> int:
+        return 0
+
+    def transition(self, task_id: str, to_status: str, *, reason: str | None = None) -> dict:
+        self.transitions.append((task_id, to_status, reason))
+        return {"id": task_id, "status": to_status}
+
+    def reclaim_stale_claimed(self, *, assignee: str, older_than_seconds: float) -> int:
+        return 0
+
+    def list_stale_running(self, *, assignee: str, older_than_seconds: float) -> list[dict]:
+        return []
+
+    def requeue_running(self, task_id: str) -> bool:
+        self.requeued.append(task_id)
+        return True
+
+
+def _task(task_id: str, goal: str) -> dict:
+    return {"id": task_id, "goal": goal, "assignee": "sandcastle", "status": "pending"}
+
+
+class _Spawned:
+    """Healthy executor.SpawnResult stand-in: a proc was launched."""
+
+    def __init__(self) -> None:
+        self.proc = object()
+        self.throttled = False
+
+
+def _healthy_usage():
+    class _Reading:
+        near_exhaustion = False
+
+    return _Reading()
+
+
+def _drain(q: _Queue, dedup: DedupConfig | None):
+    return drain_tasks(
+        q,
+        lambda goal, task_id=None: _Spawned(),
+        cap=5,
+        resolve_binary=lambda: "claude",
+        read_usage=_healthy_usage,
+        dedup=dedup,
+    )
+
+
+def test_drain_live_pr_skips_as_duplicate_and_records_outcome():
+    q = _Queue([_task("t1", "Implement #931 dispatch dedup")])
+    outcomes: list[dict] = []
+    cfg = DedupConfig(
+        fetch_in_flight=lambda: ([_pr(number=777, body="Closes #931")], []),
+        list_active_rows=lambda: [],
+        record_outcome=outcomes.append,
+    )
+    res = _drain(q, cfg)
+    assert res.spawned == 0
+    assert res.skipped_duplicate == 1
+    skip = [(t, r) for t, s, r in q.transitions if s == "skipped_duplicate"]
+    assert skip == [("t1", skip[0][1])]
+    assert "#777" in skip[0][1]
+    assert len(outcomes) == 1
+
+
+def test_drain_live_sibling_row_skips_as_duplicate():
+    q = _Queue([_task("t1", "Implement #931 dispatch dedup")])
+    cfg = DedupConfig(
+        fetch_in_flight=lambda: ([], []),
+        list_active_rows=lambda: [
+            {"id": "other", "goal": "Fix #931 from another angle", "status": "running"}
+        ],
+    )
+    res = _drain(q, cfg)
+    assert res.spawned == 0
+    assert res.skipped_duplicate == 1
+    reasons = [r for _, s, r in q.transitions if s == "skipped_duplicate"]
+    assert reasons and "#931" in reasons[0]
+
+
+def test_drain_own_row_is_not_a_sibling():
+    q = _Queue([_task("t1", "Implement #931 dispatch dedup")])
+    cfg = DedupConfig(
+        fetch_in_flight=lambda: ([], []),
+        list_active_rows=lambda: [
+            {"id": "t1", "goal": "Implement #931 dispatch dedup", "status": "running"}
+        ],
+    )
+    res = _drain(q, cfg)
+    assert res.spawned == 1
+    assert res.skipped_duplicate == 0
+
+
+def test_drain_stale_branch_parks_for_owner_attention():
+    q = _Queue([_task("t1", "Implement #931 dispatch dedup")])
+    cfg = DedupConfig(
+        fetch_in_flight=lambda: ([], ["feat/931-dispatch-dedup"]),
+        list_active_rows=lambda: [],
+    )
+    res = _drain(q, cfg)
+    assert res.spawned == 0
+    parked = [(t, r) for t, s, r in q.transitions if s == "parked"]
+    assert parked and parked[0][0] == "t1"
+    assert "owner attention" in parked[0][1]
+
+
+def test_drain_fetch_failure_requeues_and_stops():
+    def boom() -> tuple[list, list]:
+        raise RuntimeError("gh api down")
+
+    q = _Queue([_task("t1", "Implement #931 x"), _task("t2", "Implement #932 y")])
+    cfg = DedupConfig(fetch_in_flight=boom, list_active_rows=lambda: [])
+    res = _drain(q, cfg)
+    # Unverifiable is never terminal: the row goes back to pending ...
+    assert q.requeued == ["t1"]
+    assert res.spawned == 0
+    assert res.skipped_duplicate == 0
+    # ... and the drain stops instead of hammering a down API per task.
+    assert q.pending and q.pending[0]["id"] == "t2"
+
+
+def test_drain_fetches_github_evidence_once_per_drain():
+    calls = {"n": 0}
+
+    def fetch() -> tuple[list, list]:
+        calls["n"] += 1
+        return ([], [])
+
+    q = _Queue([_task("t1", "Implement #931 x"), _task("t2", "Implement #932 y")])
+    cfg = DedupConfig(fetch_in_flight=fetch, list_active_rows=lambda: [])
+    res = _drain(q, cfg)
+    assert res.spawned == 2
+    assert calls["n"] == 1
+
+
+def test_drain_rework_goal_bypasses_dedup():
+    # A rework goal points at a live PR by design — dedup must not eat it.
+    fetched = {"n": 0}
+
+    def fetch() -> tuple[list, list]:
+        fetched["n"] += 1
+        return ([_pr(body="Closes #931")], [])
+
+    q = _Queue([_task("t1", "/rework #931")])
+    cfg = DedupConfig(fetch_in_flight=fetch, list_active_rows=lambda: [])
+    res = _drain(q, cfg)
+    assert res.spawned == 1
+    assert fetched["n"] == 0
+
+
+def test_drain_goal_without_issue_ref_proceeds():
+    q = _Queue([_task("t1", "chore: tidy the docs")])
+    cfg = DedupConfig(
+        fetch_in_flight=lambda: ([_pr(body="Closes #1")], []),
+        list_active_rows=lambda: [],
+    )
+    res = _drain(q, cfg)
+    assert res.spawned == 1
+    assert res.skipped_duplicate == 0
+
+
+def test_drain_without_dedup_config_is_unchanged():
+    q = _Queue([_task("t1", "Implement #931 x")])
+    res = _drain(q, None)
+    assert res.spawned == 1
+    assert res.skipped_duplicate == 0
+    assert [s for _, s, _ in q.transitions] == ["running"]
+
+
+def test_drain_record_outcome_failure_does_not_break_the_skip():
+    def bad_outcome(payload: dict) -> None:
+        raise RuntimeError("supabase down")
+
+    q = _Queue([_task("t1", "Implement #931 x"), _task("t2", "Implement #932 y")])
+    cfg = DedupConfig(
+        fetch_in_flight=lambda: ([_pr(body="Closes #931")], []),
+        list_active_rows=lambda: [],
+        record_outcome=bad_outcome,
+    )
+    res = _drain(q, cfg)
+    assert res.skipped_duplicate == 1
+    assert res.spawned == 1  # t2 still spawned — the drain continued
+
+
+# ── HttpxGitHubClient.list_open_pulls / list_branch_names (production fetch) ──
+#
+# These back the drain-time evidence fetch (cycle 5). They mirror the pooled-
+# client / paginated-GET conventions of the sibling evidence methods and the
+# MagicMock side_effect test pattern in tests/test_agents_953_event_emission.py.
+
+from unittest import mock  # noqa: E402
+
+from agents.github_client import HttpxGitHubClient  # noqa: E402
+from agents.task_dispatch import default_task_dedup  # noqa: E402
+
+
+def _resp(body, status: int = 200):
+    r = mock.MagicMock()
+    r.status_code = status
+    r.json.return_value = body
+    r.raise_for_status.return_value = None
+    return r
+
+
+def _client_with(responses):
+    c = HttpxGitHubClient("Osasuwu/jarvis", token="x")
+    c._client = mock.MagicMock()
+    c._client.get.side_effect = responses
+    return c
+
+
+def test_list_open_pulls_maps_rest_shape_to_gate_keys():
+    # REST returns head.ref; check_in_flight expects headRefName.
+    c = _client_with(
+        [
+            _resp(
+                [
+                    {"number": 12, "body": "Closes #931", "head": {"ref": "feat/931-x"}},
+                    {"number": 13, "body": "unrelated", "head": {"ref": "chore/y"}},
+                ]
+            ),
+            _resp([]),
+        ]
+    )
+    pulls = c.list_open_pulls()
+    assert pulls == [
+        {"number": 12, "body": "Closes #931", "headRefName": "feat/931-x"},
+        {"number": 13, "body": "unrelated", "headRefName": "chore/y"},
+    ]
+    # state=open must be requested.
+    assert c._client.get.call_args_list[0].kwargs["params"]["state"] == "open"
+
+
+def test_list_open_pulls_paginates_until_short_page():
+    page1 = [{"number": n, "body": "", "head": {"ref": f"b/{n}"}} for n in range(100)]
+    page2 = [{"number": 100, "body": "", "head": {"ref": "b/100"}}]
+    c = _client_with([_resp(page1), _resp(page2)])
+    pulls = c.list_open_pulls()
+    assert len(pulls) == 101
+    pages = [call.kwargs["params"]["page"] for call in c._client.get.call_args_list]
+    assert pages == [1, 2]
+
+
+def test_list_branch_names_paginates_and_extracts_names():
+    page1 = [{"name": f"feat/{n}"} for n in range(100)]
+    page2 = [{"name": "main"}]
+    c = _client_with([_resp(page1), _resp(page2)])
+    names = c.list_branch_names()
+    assert names[0] == "feat/0"
+    assert names[-1] == "main"
+    assert len(names) == 101
+    pages = [call.kwargs["params"]["page"] for call in c._client.get.call_args_list]
+    assert pages == [1, 2]
+
+
+# ── default_task_dedup factory ───────────────────────────────────────────────
+
+
+def test_default_task_dedup_wires_github_and_active_rows():
+    gh = mock.MagicMock()
+    gh.list_open_pulls.return_value = [_pr(body="Closes #931")]
+    gh.list_branch_names.return_value = ["feat/931-x"]
+    cfg = default_task_dedup(gh, list_active=lambda: [{"id": "r1", "goal": "Implement #931"}])
+    prs, branches = cfg.fetch_in_flight()
+    assert prs == [_pr(body="Closes #931")]
+    assert branches == ["feat/931-x"]
+    assert cfg.list_active_rows() == [{"id": "r1", "goal": "Implement #931"}]
+    assert callable(cfg.record_outcome)


### PR DESCRIPTION
## Summary
Adds dispatch-dedup: an issue that already has an open PR, an in-flight branch, or a live sibling `task_queue` row is skipped instead of dispatched a second time. A single pure predicate `check_in_flight` (in `scripts/delegate_predispatch_gate.py`) gates both the interactive `/delegate` path and the reactive-core autonomous drain, so both skip identically and network-free tests can cover the logic.

## Why
Dispatching a second subagent onto an issue already being worked duplicates effort and races two branches to the same `Closes #N`.
Closes #931

## Decisions & Alternatives
- **Ordering B for the drain dedup check** (decision `2489782f`): the check runs *after* `transition(running)` (row owned under optimistic lock) and *before* spawn (no duplicate process). Alternative — check before claim — rejected: it reopens the claim/spawn race the FSM closes.
- **`DedupConfig` injection, not a `TaskQueuePort` extension**: adding methods to the `@runtime_checkable` Protocol would break `isinstance` in the test fakes. Dedup is wired as an optional injected param (default `None` → behavior unchanged).
- **Rework-shape goals bypass dedup entirely**: `/rework #N` targets a live PR by design; deduping it would eat legitimate work.
- **Unverifiable is never terminal**: an evidence-fetch raise requeues the row to `pending` and stops the drain, rather than skipping on evidence we could not read.
- **`skipped_duplicate` is a new terminal state** (not reuse of `parked`/`failed`): it is semantically distinct and drives the poller requeue-reason and outcome attribution.
- Decision UUID: `9ebaa7a8-abf0-4d02-a1d1-18dbed53480e` (grill basis `1949e3f3-...`).

## Risk Assessment
- **LOW**: `poller.py` requeue-reason addition, docstrings, CLI envelope.
- **MEDIUM**: new `github_client` paginated fetchers; `drain_tasks` dedup block; `wake_driver` wiring.
- **HIGH**: none — dedup is opt-in (`dedup=None` preserves prior behavior); new terminal state is additive.

## ⚠️ Deploy step (required, not applied by this PR)
The `task_queue_status_check` CHECK constraint migration (`supabase/migrations/20260702120000_add_skipped_duplicate_status.sql`) **must be applied to the live shared Supabase DB** before the production drain can `transition(..., "skipped_duplicate")` — otherwise that write fails the constraint. Applying it against the shared prod DB was intentionally left out of this session (not authorized under `/implement 931`). Apply before/at merge.

## Testing
- `pytest tests/test_dispatch_dedup.py tests/test_agents_task_dispatch.py tests/test_agents_task_queue.py tests/test_wake_driver.py tests/test_poller.py tests/test_delegate_predispatch_gate.py tests/ci/` → **762 passed**.
- `ruff check` clean, `ruff format` applied.
- TDD: one AC bullet at a time, RED→GREEN per cycle (predicate → CLI → FSM+schema → drain dedup → production fetchers+factory→wiring).

## Deviation
2 CLI smoke tests in `test_delegate_predispatch_gate.py` were updated to the strict-envelope stdin shape (`{issue, open_prs, open_branches}`); the 22 `check_in_flight` predicate tests are unchanged.

## Files Changed
- `scripts/delegate_predispatch_gate.py` — `check_in_flight` predicate + strict-envelope CLI.
- `agents/task_queue.py` — `skipped_duplicate` terminal state + `list_active`.
- `agents/task_dispatch.py` — pre-spawn dedup, `DedupConfig`, `default_task_dedup`, outcome writer.
- `agents/github_client.py` — `list_open_pulls` / `list_branch_names` (paginated).
- `agents/wake_driver.py` — thread + wire `task_dedup`.
- `agents/poller.py` — `skipped_duplicate` requeue reason.
- `mcp-memory/schema.sql` + `supabase/migrations/…` — CHECK constraint lockstep.
- `.claude-userlevel/skills/delegate/SKILL.md` — dispatch-dedup contract (fetch/pagination, sibling check, SKIP handling, atomic claim-push).
- `tests/test_dispatch_dedup.py` — network-free fixtures for all verdicts + drain + fetchers + factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)