### PR TITLE
fix(#1127): reconcile Supabase RLS/view ERRORs + migration drift

### DIFF
--- a/mcp-memory/schema.sql
+++ b/mcp-memory/schema.sql
@@ -2194,7 +2194,8 @@ create index if not exists idx_task_outcomes_memory_id
 -- Only includes memories with at least one resolved outcome (success or
 -- failure). Partial/unknown/pending outcomes are excluded — they would
 -- bias the Brier score either way.
-create or replace view memory_calibration as
+create or replace view memory_calibration
+  with (security_invoker = on) as
 select
   m.id as memory_id,
   m.type as memory_type,
@@ -3230,3 +3231,65 @@ drop policy if exists "Allow all for authenticated" on global_task_sources;
 drop policy if exists "Anon select only" on global_task_sources;
 create policy "Anon select only" on global_task_sources
   for select to anon using (true);
+
+-- ===========================================================================
+-- credential_registry (Pillar 9): metadata inventory of credentials — service,
+-- env-var NAME, storage location, rotation/expiry. NEVER secret values (see
+-- mcp-memory/handlers/credential.py). Applied to remote as migrations
+-- 20260415082814 (create) + 20260708044124 (RLS); documented here per #326.
+-- ===========================================================================
+create table if not exists credential_registry (
+  id uuid primary key default gen_random_uuid(),
+  service text not null,
+  env_var text not null unique,
+  stored_in text not null default '.env',
+  scope text not null default 'jarvis',
+  created_at timestamptz default now(),
+  expires_at timestamptz,
+  last_rotated_at timestamptz,
+  rotation_notes text,
+  notes text,
+  -- Defence-in-depth: reject rows whose metadata columns look like a raw secret.
+  check (
+    env_var !~ '^(eyJ|sk-|ghp_|ghs_|AKIA|xox[bpras]-)'
+    and (rotation_notes is null or rotation_notes !~ '(eyJ|sk-|ghp_|ghs_|AKIA)')
+    and (notes is null or notes !~ '(eyJ|sk-|ghp_|ghs_|AKIA)')
+  )
+);
+
+-- RLS: allow-all convention (service_role bypasses). Enabled to clear the
+-- Supabase rls_disabled_in_public ERROR; access is unchanged (app-layer trust).
+alter table credential_registry enable row level security;
+drop policy if exists "Allow all for authenticated" on credential_registry;
+drop policy if exists "Allow all for anon" on credential_registry;
+create policy "Allow all for authenticated" on credential_registry
+  for all using (true) with check (true);
+create policy "Allow all for anon" on credential_registry
+  for all to anon using (true) with check (true);
+
+-- ===========================================================================
+-- audit_log: fire-and-forget trail of MCP tool invocations. Applied to remote
+-- as migrations 20260415113317 (create) + 20260708044124 (RLS); documented
+-- here per #326.
+-- ===========================================================================
+create table if not exists audit_log (
+  id uuid primary key default gen_random_uuid(),
+  "timestamp" timestamptz default now(),
+  agent_id text,
+  tool_name text not null,
+  action text not null,
+  target text,
+  details jsonb default '{}'::jsonb,
+  outcome text default 'success'
+);
+
+create index if not exists idx_audit_log_timestamp on audit_log ("timestamp" desc);
+create index if not exists idx_audit_log_tool_name on audit_log (tool_name);
+
+alter table audit_log enable row level security;
+drop policy if exists "Allow all for authenticated" on audit_log;
+drop policy if exists "Allow all for anon" on audit_log;
+create policy "Allow all for authenticated" on audit_log
+  for all using (true) with check (true);
+create policy "Allow all for anon" on audit_log
+  for all to anon using (true) with check (true);

--- a/supabase/migrations/20260415082814_create_credential_registry.sql
+++ b/supabase/migrations/20260415082814_create_credential_registry.sql
@@ -1,0 +1,30 @@
+-- Credential registry (Pillar 9): a metadata inventory of credentials — service
+-- name, env-var name, storage location, rotation/expiry — and NEVER the secret
+-- values themselves (see mcp-memory/handlers/credential.py).
+--
+-- Reconstructed retroactively 2026-07-08: this table was applied to the remote
+-- migration ledger as version 20260415082814, but the migration file was never
+-- committed to the repo (repo<->ledger drift). Body mirrors the live deployed
+-- schema exactly so a fresh `supabase db reset` reproduces production. RLS was
+-- NOT part of the original create — it was added later; see
+-- 20260708044124_enable_rls_credential_registry_audit_log.sql.
+create table if not exists credential_registry (
+  id uuid primary key default gen_random_uuid(),
+  service text not null,
+  env_var text not null unique,
+  stored_in text not null default '.env',
+  scope text not null default 'jarvis',
+  created_at timestamptz default now(),
+  expires_at timestamptz,
+  last_rotated_at timestamptz,
+  rotation_notes text,
+  notes text,
+  -- Defence-in-depth: reject rows whose metadata columns look like they carry a
+  -- raw secret. Prefixes: JWT (eyJ), OpenAI (sk-), GitHub (ghp_/ghs_), AWS
+  -- (AKIA), Slack (xox[bpras]-). env_var must never itself be a value.
+  check (
+    env_var !~ '^(eyJ|sk-|ghp_|ghs_|AKIA|xox[bpras]-)'
+    and (rotation_notes is null or rotation_notes !~ '(eyJ|sk-|ghp_|ghs_|AKIA)')
+    and (notes is null or notes !~ '(eyJ|sk-|ghp_|ghs_|AKIA)')
+  )
+);

--- a/supabase/migrations/20260415113317_create_audit_log_table.sql
+++ b/supabase/migrations/20260415113317_create_audit_log_table.sql
@@ -1,0 +1,21 @@
+-- Audit log: fire-and-forget trail of MCP tool invocations (tool, action,
+-- target, outcome). Written by mcp-memory/client.py::_audit_log; never blocks
+-- the caller.
+--
+-- Reconstructed retroactively 2026-07-08: applied to the remote ledger as
+-- version 20260415113317 but the migration file was never committed (repo<->
+-- ledger drift). Body mirrors the live deployed schema. RLS was added later;
+-- see 20260708044124_enable_rls_credential_registry_audit_log.sql.
+create table if not exists audit_log (
+  id uuid primary key default gen_random_uuid(),
+  "timestamp" timestamptz default now(),
+  agent_id text,
+  tool_name text not null,
+  action text not null,
+  target text,
+  details jsonb default '{}'::jsonb,
+  outcome text default 'success'
+);
+
+create index if not exists idx_audit_log_timestamp on audit_log ("timestamp" desc);
+create index if not exists idx_audit_log_tool_name on audit_log (tool_name);

--- a/supabase/migrations/20260708044124_enable_rls_credential_registry_audit_log.sql
+++ b/supabase/migrations/20260708044124_enable_rls_credential_registry_audit_log.sql
@@ -1,0 +1,27 @@
+-- Enable RLS + allow-all policies on credential_registry and audit_log to match
+-- the schema-wide convention (fok_judgments / known_unknowns / task_queue: RLS
+-- on, allow-all for authenticated + anon; service_role bypasses automatically).
+--
+-- Motivation: Supabase Security Advisor raised rls_disabled_in_public ERRORs on
+-- both tables (2026-07-08 Supabase email). App-layer-trust model — access is not
+-- weakened, effective reachability is identical; enabling RLS silences the ERROR
+-- and aligns the two tables with their ~10 siblings. Per-role hardening is a
+-- separate schema-wide sweep.
+--
+-- credential_registry stores credential METADATA only (names, expiry, rotation
+-- notes) — never secret values; its no-secret-values CHECK constraint enforces
+-- that independently of RLS.
+
+alter table credential_registry enable row level security;
+
+create policy "Allow all for authenticated" on credential_registry
+  for all using (true) with check (true);
+create policy "Allow all for anon" on credential_registry
+  for all to anon using (true) with check (true);
+
+alter table audit_log enable row level security;
+
+create policy "Allow all for authenticated" on audit_log
+  for all using (true) with check (true);
+create policy "Allow all for anon" on audit_log
+  for all to anon using (true) with check (true);

--- a/supabase/migrations/20260708044528_fix_memory_calibration_security_invoker.sql
+++ b/supabase/migrations/20260708044528_fix_memory_calibration_security_invoker.sql
@@ -1,0 +1,7 @@
+-- Fix Supabase Security Advisor security_definer_view ERROR on memory_calibration
+-- (2026-07-08 Supabase email). A view owned by postgres runs with definer rights
+-- by default, bypassing the querying role's RLS. security_invoker = on makes the
+-- view enforce the caller's RLS instead — the correct posture for a view exposed
+-- through PostgREST. Paired with mcp-memory/schema.sql per #326 schema-drift gate.
+
+alter view public.memory_calibration set (security_invoker = on);


### PR DESCRIPTION
## What

Reconciles the repo with three Supabase Security Advisor ERRORs (2026-07-08 email), all **already remediated on the live DB** — this PR commits the migration files + schema.sql pairing that were missing.

| Advisor ERROR | Object | Fix |
|---|---|---|
| `rls_disabled_in_public` | `credential_registry` | enable RLS + allow-all policies |
| `rls_disabled_in_public` | `audit_log` | enable RLS + allow-all policies |
| `security_definer_view` | `memory_calibration` | `security_invoker = on` |

## Why the migration files were missing

`credential_registry` and `audit_log` were applied to the remote ledger (versions `20260415082814` / `20260415113317`) but their `.sql` files were **never committed** — repo↔ledger drift, not ad-hoc DDL. Reconstructing them at their exact ledger versions restores `supabase db reset` fidelity (they're skipped on remote push, recreated on fresh DBs).

## Changes

- `20260415082814_create_credential_registry.sql` — reconstructed create (metadata-only table; no-secret CHECK; no RLS, matching original state)
- `20260415113317_create_audit_log_table.sql` — reconstructed create + 2 indexes
- `20260708044124_enable_rls_credential_registry_audit_log.sql` — RLS enable + allow-all (as applied)
- `20260708044528_fix_memory_calibration_security_invoker.sql` — `alter view … security_invoker=on` (as applied)
- `mcp-memory/schema.sql` — `security_invoker` on the view + both table defs/RLS appended (#326 pairing gate)

## Design notes

- **Allow-all RLS** is the user-authorized choice, matching the ~10 sibling tables' app-layer-trust convention. Effective access is **unchanged** — this only clears the ERROR. `service_role` bypasses RLS as before.
- `credential_registry` holds credential **metadata only** (service/env-var name, expiry, rotation notes) — never secret values; its no-secret CHECK enforces that independently of RLS.
- Remaining WARN advisories (`rls_policy_always_true`, `function_search_path_mutable`, `extension_in_public`, `materialized_view_in_api`) are pre-existing schema-wide patterns — out of scope, tracked separately if hardened.

Decision + rationale in memory: episode `a0227c41`.

Closes #1127