### PR TITLE
fix(sandcastle): restore Closes #<N> in fresh-run PRs

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -463,6 +463,28 @@ if (result.commits.length === 0 || !pinnedBranchExists) {
       execFileSync("gh", ["pr", "create", "--head", pinnedBranch, "--fill"], {
         stdio: "inherit",
       });
+      // Belt-and-suspenders (this PR's thesis: the supervisor is the
+      // enforcement authority, not the agent). `--fill` derives the body
+      // from the commit message; prompt.md step 6 mandates `Closes #<N>`
+      // there, but that relies on agent compliance. If the closing keyword
+      // is missing, the merged PR silently won't auto-close its issue (the
+      // #948 failure mode). We can't inject it here — the supervisor doesn't
+      // know which issue a free-pick fresh run claimed — but we can make the
+      // omission LOUD instead of silent so the orchestrator catches it at
+      // review time rather than after a stale issue accumulates.
+      const createdBody = execFileSync(
+        "gh",
+        ["pr", "view", pinnedBranch, "--json", "body", "--jq", ".body"],
+        { encoding: "utf8" },
+      );
+      if (!/\b(clos|fix|resolv)(e|es|ed)?\s+#\d+/i.test(createdBody)) {
+        console.error(
+          `[sandcastle] WARNING: PR for ${pinnedBranch} has no ` +
+            "Closes/Fixes/Resolves #<N> keyword in its body — merging it will " +
+            "NOT auto-close the issue (#948 failure mode). The agent's commit " +
+            "message dropped the closing keyword; flag for the orchestrator.",
+        );
+      }
     }
   }
 }

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -472,17 +472,34 @@ if (result.commits.length === 0 || !pinnedBranchExists) {
       // know which issue a free-pick fresh run claimed — but we can make the
       // omission LOUD instead of silent so the orchestrator catches it at
       // review time rather than after a stale issue accumulates.
-      const createdBody = execFileSync(
-        "gh",
-        ["pr", "view", pinnedBranch, "--json", "body", "--jq", ".body"],
-        { encoding: "utf8" },
-      );
-      if (!/\b(clos|fix|resolv)(e|es|ed)?\s+#\d+/i.test(createdBody)) {
+      // This runs AFTER the PR is created — the run has already succeeded.
+      // Wrap in try/catch so a transient `gh pr view` failure (API hiccup,
+      // rate limit, read-after-write replication lag right after `gh pr
+      // create`) degrades to its own warning instead of throwing past the
+      // resultFile-write at the end of this script, which would surface a
+      // successful run to the watchdog as a hard infra fault and risk a
+      // spurious tier-escalation retry. The check is advisory — it must not
+      // be able to crash a run that already committed + pushed + opened a PR.
+      try {
+        const createdBody = execFileSync(
+          "gh",
+          ["pr", "view", pinnedBranch, "--json", "body", "--jq", ".body"],
+          { encoding: "utf8" },
+        );
+        if (!/\b(clos|fix|resolv)(e|es|ed)?\s+#\d+/i.test(createdBody)) {
+          console.error(
+            `[sandcastle] WARNING: PR for ${pinnedBranch} has no ` +
+              "Closes/Fixes/Resolves #<N> keyword in its body — merging it will " +
+              "NOT auto-close the issue (#948 failure mode). The agent's commit " +
+              "message dropped the closing keyword; flag for the orchestrator.",
+          );
+        }
+      } catch (err) {
         console.error(
-          `[sandcastle] WARNING: PR for ${pinnedBranch} has no ` +
-            "Closes/Fixes/Resolves #<N> keyword in its body — merging it will " +
-            "NOT auto-close the issue (#948 failure mode). The agent's commit " +
-            "message dropped the closing keyword; flag for the orchestrator.",
+          `[sandcastle] WARNING: could not verify Closes #<N> keyword for ` +
+            `${pinnedBranch} — \`gh pr view\` failed: ${
+              err instanceof Error ? err.message : String(err)
+            }. PR creation itself succeeded; skipping the advisory check.`,
         );
       }
     }

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -66,7 +66,14 @@ issues**, not to the prompt-level context blocks.
 6. **Commit** — single rich commit. Do NOT open the PR yourself; the
    supervisor pushes the pinned branch and opens (or updates) the PR after
    this run finishes (AC1, #1118). Just leave the commit(s) on the current
-   branch.
+   branch. **The commit message body MUST contain `Closes #<N>` on its own
+   line** (N = the issue you claimed in step 3). The supervisor opens the PR
+   with `gh pr create --fill`, which derives the PR body from this commit
+   message — if `Closes #<N>` is not in the commit, the merged PR will NOT
+   auto-close the issue, silently leaving it open with stale labels (the
+   #948 failure mode documented in CLAUDE.md). This is the only place the
+   closing keyword can enter a fresh-run PR now that the agent no longer
+   opens the PR itself.
 7. **Record outcome** — emit one `outcome_record` describing the iteration
    (success / partial / failure) with the provenance tags from §"Memory
    provenance" below. Always record, even on failure — failed outcomes are


### PR DESCRIPTION
## Summary
Fresh-run sandcastle PRs no longer silently drop `Closes #<N>`. `prompt.md` now mandates the closing keyword in the commit message body (the only channel it can reach a `--fill`-derived PR after #1118 moved PR-creation from the agent to the supervisor), and the supervisor emits a loud WARNING if a created PR body lacks any `Closes/Fixes/Resolves #<N>` keyword.

## Why
#1118 (PR #1131) correctly removed PR-creation from the agent per AC1/AC2, but dropped the `Closes #<N>` instruction along with the old "Commit + PR" step. `gh pr create --fill` derives the PR body from the commit message; with no step putting the closing keyword there, a merged fresh-run PR would not auto-close its issue — the #948 failure mode (stale `sandcastle`/`status:in-progress` labels on a silently-open issue).

Caught as a code-review CRITICAL on #1131, but the finding posted 27s after the `review` verdict gate had already gone green, so #1131 auto-merged unaddressed. This PR lands the fix on main; the gate race that let a CRITICAL merge is tracked separately in #1134.

Closes #1133

## Decisions & Alternatives
- **Fix in `prompt.md` (agent commit message), not the supervisor** — the supervisor can't inject `Closes #<N>` itself because a free-pick fresh run doesn't know which issue the agent claimed. The commit message is the only channel. Rework mode is unaffected (targets an existing PR, must not touch the `Closes` line).
- **Supervisor warning as belt-and-suspenders** — the prompt instruction relies on agent compliance; this PR's parent thesis is "the supervisor is the enforcement authority." The supervisor can't fix a missing keyword but it can make the omission observable at review time (loud `console.error`) instead of after a stale issue accumulates.

## Risk Assessment
- **LOW**: one prompt-doc instruction + one read-only post-create check that only logs. No control-flow change to branch pinning, push, or PR creation. The warning regex was unit-validated (7 positive / 3 negative cases).

## Testing
- Closing-keyword regex validated via node one-liner: `Closes/Fixes/Fixed/Resolves/Resolve/Close/fix #N` → match; `see #5`, `discloses #5`, keyword-less body → no match.
- `main.mts` edit mirrors the existing `execFileSync(..., {encoding:"utf8"})` idiom directly above it (no new dependency, no new failure surface).

## Files Changed
- `.sandcastle/prompt.md` — step 6 mandates `Closes #<N>` in the commit message body, with rationale tying it to `--fill` and the #948 mode.
- `.sandcastle/main.mts` — post-`gh pr create` read of the PR body + WARNING when no closing keyword is present.