### PR TITLE
fix(scripts): loud DB-failure signal in telegram mark_processed + dedup fok-batch guard

### DIFF
--- a/scripts/fok-batch.py
+++ b/scripts/fok-batch.py
@@ -392,8 +392,16 @@ def main():
     # writes). Mirrors telegram-notify-hook.py's not-dry-run + missing-config gate.
     if not args.dry_run:
         api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
-        if not api_key or httpx is None:
-            reason = "ANTHROPIC_API_KEY not set" if not api_key else "httpx not available"
+        # Single source of truth for both the guard and the message: whichever
+        # precondition is unmet names itself; None means the config is sound.
+        reason = (
+            "ANTHROPIC_API_KEY not set"
+            if not api_key
+            else "httpx not available"
+            if httpx is None
+            else None
+        )
+        if reason:
             print(
                 f"Error: {reason} — every FoK verdict would be a degenerate 'unknown'. "
                 "Refusing to persist. (Use --dry-run to preview without writing.)",

--- a/scripts/telegram-notify-hook.py
+++ b/scripts/telegram-notify-hook.py
@@ -136,7 +136,7 @@ def send_telegram(token: str, chat_id: str, text: str) -> tuple[bool, str]:
         return False, f"{type(e).__name__}: {e}"
 
 
-def mark_processed(client, event_id: str, action: str) -> None:
+def mark_processed(client, event_id: str, action: str) -> bool:
     """Mark event processed so it won't notify again.
 
     Sets the FSM ``state='processed'`` column alongside the legacy
@@ -153,6 +153,18 @@ def mark_processed(client, event_id: str, action: str) -> None:
     It deliberately does NOT delegate to the ``claim_next`` / ``mark_processed``
     RPCs: those transition ``pending -> claimed -> processed`` and would force
     this drain to first *claim* the row, stealing it from the orchestrator.
+
+    Returns ``True`` when the write settled without error — either the pending
+    row was flipped to ``processed`` (the normal path) or no pending row matched
+    because the orchestrator/a concurrent drain already advanced it (a benign
+    no-op; the row is no longer ``pending`` so it will not be re-fetched). The
+    benign no-match is signalled by the rowcount INFO, NOT by an exception, so
+    the ``except`` below is reached ONLY on a real DB/network failure. That case
+    is systematic — the event stays ``state='pending'`` and re-notifies on the
+    next run, exactly the #649 re-send loop — so it is surfaced as ERROR and
+    returns ``False`` for the caller to fold into the run's exit status. Do not
+    downgrade it back to a WARN-and-continue: a swallowed failure looks like a
+    clean run while silently reintroducing the loop.
     """
     now = datetime.now(timezone.utc).isoformat()
     try:
@@ -180,8 +192,17 @@ def mark_processed(client, event_id: str, action: str) -> None:
                 "(no pending row — already claimed/processed elsewhere)",
                 file=sys.stderr,
             )
+        return True
     except Exception as e:
-        print(f"WARN: failed to mark {event_id} processed: {e}", file=sys.stderr)
+        # Real DB/network failure — NOT the benign no-match (that returns above
+        # with empty data). The event stays 'pending' and re-notifies next run
+        # (#649 loop). Surface loudly and let the caller flag the run failed.
+        print(
+            f"ERROR: failed to mark {event_id} processed — event stays pending "
+            f"and WILL re-notify next run: {e}",
+            file=sys.stderr,
+        )
+        return False
 
 
 def main() -> int:
@@ -231,6 +252,7 @@ def main() -> int:
     print(f"Draining {len(events)} pending events (min severity: {args.min_severity})")
     sent = 0
     failed = 0
+    mark_failed = 0
 
     for ev in events:
         msg = format_message(ev)
@@ -242,9 +264,15 @@ def main() -> int:
 
         ok, detail = send_telegram(token, chat_id, msg)
         if ok:
-            mark_processed(client, ev["id"], f"telegram sent: {detail}")
             sent += 1
-            print(f"[OK] {ev['id']} — sent")
+            if mark_processed(client, ev["id"], f"telegram sent: {detail}"):
+                print(f"[OK] {ev['id']} — sent")
+            else:
+                # Message went out but the processed-write failed: the event
+                # will re-notify next run. Counted separately so a systematic
+                # DB failure at the mark step doesn't read as a clean drain.
+                mark_failed += 1
+                print(f"[WARN] {ev['id']} — sent but NOT marked (will re-notify)", file=sys.stderr)
         else:
             failed += 1
             print(f"[FAIL] {ev['id']} — {detail}", file=sys.stderr)
@@ -252,9 +280,9 @@ def main() -> int:
     if args.dry_run:
         print(f"DRY RUN complete. Would have sent {len(events)} messages.")
     else:
-        print(f"Done. sent={sent} failed={failed}")
+        print(f"Done. sent={sent} failed={failed} mark_failed={mark_failed}")
 
-    return 0 if failed == 0 else 2
+    return 0 if (failed == 0 and mark_failed == 0) else 2
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_notify_hook.py
+++ b/tests/test_telegram_notify_hook.py
@@ -159,6 +159,74 @@ def test_mark_processed_guards_on_pending_state():
 
 
 # ---------------------------------------------------------------------------
+# Test-B3 (PR #1142 follow-up): mark_processed must distinguish a benign no-op
+# (returns True) from a real DB/network failure (returns False + ERROR). A
+# swallowed failure would silently reintroduce the #649 re-send loop.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingClient:
+    """Supabase stand-in whose events update raises — models a DB/network fault."""
+
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def table(self, name):
+        assert name == "events", f"unexpected table {name!r}"
+        return self
+
+    def update(self, *_a, **_k):
+        return self
+
+    def eq(self, *_a, **_k):
+        return self
+
+    def execute(self):
+        raise self._exc
+
+
+def test_mark_processed_returns_true_on_success():
+    client = FakeEventsClient([_pending_event("e1")])
+    assert telegram_hook.mark_processed(client, "e1", "telegram sent: ok") is True
+
+
+def test_mark_processed_returns_true_on_benign_no_match():
+    """Row already claimed elsewhere → empty update, no exception → benign True."""
+    row = _pending_event("e1")
+    row["state"] = "claimed"
+    client = FakeEventsClient([row])
+    assert telegram_hook.mark_processed(client, "e1", "telegram sent: ok") is True
+
+
+def test_mark_processed_returns_false_on_db_failure(capsys):
+    """A real exception is surfaced (ERROR), not swallowed as a soft WARN."""
+    client = _RaisingClient(RuntimeError("connection reset"))
+    assert telegram_hook.mark_processed(client, "e1", "telegram sent: ok") is False
+    err = capsys.readouterr().err
+    assert "ERROR" in err
+    assert "will re-notify" in err.lower()
+
+
+def test_main_flags_run_failed_when_mark_fails(monkeypatch):
+    """Send succeeds but the processed-write fails → exit 2, not a clean 0."""
+    monkeypatch.setattr("sys.argv", ["telegram-notify-hook.py"])
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot:token")
+    monkeypatch.setenv("TELEGRAM_ALLOW_USER_ID", "12345")
+    monkeypatch.setenv("SUPABASE_URL", "http://localhost")
+    monkeypatch.setenv("SUPABASE_KEY", "test-key")
+    with (
+        patch("supabase.create_client", return_value=MagicMock()),
+        patch.object(
+            telegram_hook, "fetch_pending_events", return_value=[_pending_event("e1")]
+        ),
+        patch.object(telegram_hook, "send_telegram", return_value=(True, "sent")),
+        patch.object(telegram_hook, "mark_processed", return_value=False),
+    ):
+        rc = telegram_hook.main()
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
 # AC-B2 (#649): fail loud on missing Telegram secrets. Non-dry-run with either
 # TELEGRAM_BOT_TOKEN or TELEGRAM_ALLOW_USER_ID unset must exit non-zero BEFORE
 # any send. Behavior already lives at telegram-notify-hook.py:168; these lock


### PR DESCRIPTION
Follow-up to #1142 / #649. Actions the two advisory MINOR/NITPICK findings from the PR #1142 Claude review (verdict was *Blocking issues — None*), which were AC-lock deferred on #649. Neither was blocking; this is the visibility cleanup.

`[no-issue]` — drive-by review follow-up, trivial + reversible (per Fix > track, #428).

## 1. `scripts/telegram-notify-hook.py` — `mark_processed` no longer swallows real failures
The bare `except Exception` logged a soft `WARN` and moved on, conflating a genuine DB/network failure with a benign case. A real failure there is **systematic**: the event stays `state='pending'` and re-notifies on the next run — the exact #649 re-send loop the fix set out to close, now invisible behind a clean-looking drain.

- `mark_processed()` returns `bool`: `True` on the normal write **and** on the benign no-match (row already claimed/processed elsewhere — an empty update, *not* an exception, already handled by the rowcount INFO log); `False` only on a real exception, now surfaced as `ERROR`.
- `main()` counts `mark_failed` separately and folds it into the exit code (`exit 2`), so a systematic mark failure no longer reads as `sent=N failed=0` success.

## 2. `scripts/fok-batch.py` — dedup the fail-fast predicate
`not api_key or httpx is None` was evaluated once for the guard and re-derived for the reason string. Factored into a single `reason` expression — guard and message now read from one source of truth. Pure refactor, behavior identical (both existing fail-fast tests stay green).

## Tests
`tests/test_telegram_notify_hook.py` +4:
- `mark_processed` returns `True` on success, `True` on benign no-match, `False` + `ERROR` on DB failure.
- `main()` returns exit `2` when the send succeeds but the mark fails.

`python -m pytest tests/test_telegram_notify_hook.py tests/test_fok_batch.py` → 35 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)