### PR TITLE
test(ci): add agents-stack doc-drift regression guard (#1138)

### DIFF
--- a/scripts/dispatcher_smoke_live.py
+++ b/scripts/dispatcher_smoke_live.py
@@ -1,12 +1,13 @@
-"""One-shot live smoke test for the dispatcher — seed one row, spawn real Claude, verify.
+"""One-shot live smoke test for the reactive-core dispatch path — seed one row, spawn real Claude, verify.
 
 Usage:
     python scripts/dispatcher_smoke_live.py seed      # insert a row, print marker
     python scripts/dispatcher_smoke_live.py check     # inspect row/audit/marker file
     python scripts/dispatcher_smoke_live.py cleanup   # delete row + audit + marker file
 
-The workflow is deliberately split so the operator runs `python -m agents.dispatcher`
-in between `seed` and `check`, keeping each subprocess boundary observable.
+The workflow is deliberately split so the operator runs `python -m agents.wake_driver --once`
+in between `seed` and `check`, keeping each subprocess boundary observable. The wake driver
+drains the seeded `task_queue` row and the executor spawns the real Claude subprocess.
 """
 
 from __future__ import annotations
@@ -35,7 +36,7 @@ def seed() -> int:
     marker = uuid.uuid4().hex[:12]
     # Marker lives inside the project dir so the spawned Claude's acceptEdits
     # permission mode approves the Write. Writes outside the project root
-    # still require explicit --add-dir flags, which the dispatcher does not
+    # still require explicit --add-dir flags, which the executor does not
     # grant (and shouldn't for a test utility).
     smoke_file = MARKER_DIR / f"{marker}.ok"
 
@@ -86,7 +87,7 @@ def seed() -> int:
     print(f"[seed] expected smoke file: {smoke_file}")
     print(f"[seed] state saved to: {STATE_FILE}")
     print()
-    print("Next: python -m agents.dispatcher")
+    print("Next: python -m agents.wake_driver --once")
     return 0
 
 

--- a/tests/ci/test_agents_stack_drift_guard.py
+++ b/tests/ci/test_agents_stack_drift_guard.py
@@ -1,0 +1,212 @@
+"""Regression guard: no *live* doc/docstring/comment presents the retired
+agents-stack as runnable or current (#1138).
+
+The LangGraph / APScheduler / Postgres-checkpointer "agents-stack" was retired
+in #743/#744; the doc, config, and env drift it left behind was swept in #734.
+This guard is the *stay-clean* invariant that keeps a future edit from quietly
+re-introducing a runnable reference to the dead stack — the exact failure mode
+where a stale `python -m agents.dispatcher` in a script outlives the module it
+names.
+
+Mechanism — a grep-clean invariant with an inline allowlist:
+
+  * scan every git-tracked file for the retired-token set (word-boundary,
+    case-insensitive);
+  * every surviving match MUST be covered by ``ALLOWLIST`` below — the single
+    source of truth for "this mention is correct by design" (#1138). There is
+    no sidecar file: the token set and its allowlist live together here so a
+    reviewer sees both in one place.
+
+Word boundaries matter: the bare token ``5433`` (the retired Postgres port)
+substring-matches inside SVG coordinate floats and other digit runs. Matching
+on ``\b5433\b`` reduces it — and ``docker-compose.agents`` / ``agents.main`` /
+``agents.scheduler`` — to zero live matches, which is exactly what #734's sweep
+achieved. The dotted module tokens (``agents.dispatcher`` etc.) are the
+*runnable* form; the file-path form ``agents/dispatcher.py`` (slash) is a
+retirement/lineage reference and is deliberately NOT matched.
+
+Runs via ci-meta.yml (``pytest tests/ci/`` — not path-filtered) and the regular
+suite (``testpaths = ["tests"]``), so it fires on every PR.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The retired agents-stack token set. Casing here is for readability only —
+# matching is case-insensitive. Keep this list in lock-step with the retirement
+# work (#743/#744/#734); dropping a token silently narrows the guard.
+RETIRED_TOKENS: tuple[str, ...] = (
+    "langgraph",
+    "langchain-ollama",
+    "PostgresSaver",
+    "event_monitor",
+    "docker-compose.agents",
+    "5433",
+    "SQLAlchemyJobStore",
+    "APScheduler",
+    "agents.main",
+    "agents.scheduler",
+    "agents.dispatcher",
+)
+
+# Sentinel: every retired token is correct-by-design in this path.
+ALL = "*"
+
+# Allowlist of correct-by-design mentions — the single source of truth (#1138).
+#
+# Keys ending in "/" are directory prefixes; others are exact repo-relative
+# paths (posix, matching ``git ls-files`` output). The value is either ``ALL``
+# (the whole file is a legitimate home for any retired token) or a set of
+# lowercased tokens permitted in that specific file (a genuine drift of a
+# *different* token in the same file is still caught).
+#
+# Anything matching a retired token that is NOT covered here is drift: fix it,
+# or — if the mention is genuinely correct-by-design — add it here WITH A REASON.
+ALLOWLIST: dict[str, object] = {
+    # -- whole-file-legitimate: the mention IS the point of the file ----------
+    "docs/decisions/": ALL,  # decision logs — retirement rationale by design
+    "supabase/migrations/": ALL,  # applied migrations — frozen historical DDL
+    ".out-of-scope/": ALL,  # audit snapshots — historical record
+    ".hex-skills/runtime-artifacts/": ALL,  # captured run artifacts — historical record
+    "docs/design/": ALL,  # design-history docs — lineage mentions
+    # -- specific files, restricted to their correct-by-design tokens ---------
+    "pyproject.toml": {  # retirement-rationale comment block (#734)
+        "langgraph",
+        "langchain-ollama",
+        "event_monitor",
+        "apscheduler",
+    },
+    "agents/supabase_client.py": {"langgraph"},  # DB source-identifier string-literals
+    "agents/executor.py": {"langgraph"},  # "Salvaged from agents/dispatcher.py" lineage
+    "tests/test_agents_supabase_bridge.py": {  # asserts the DB-identifier bridge
+        "langgraph",
+        "event_monitor",
+    },
+    "tests/test_wake_driver.py": {"apscheduler"},  # retirement-enforcement assertions
+    ".claude-userlevel/skills/implement/SKILL.md": {
+        "apscheduler"
+    },  # historical bug-class example (#304/#298)
+    # This guard file itself defines the token set — every token appears here.
+    "tests/ci/test_agents_stack_drift_guard.py": ALL,
+}
+
+# Compile once. re.escape keeps "." / "-" literal; \b anchors whole-token match.
+_TOKEN_RES: dict[str, re.Pattern[str]] = {
+    token: re.compile(rf"\b{re.escape(token)}\b", re.IGNORECASE) for token in RETIRED_TOKENS
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tracked_files() -> list[str]:
+    """Every git-tracked (or staged) repo-relative path, posix-style."""
+    result = subprocess.run(
+        ["git", "ls-files"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return [f for f in result.stdout.splitlines() if f]
+
+
+def _allowed(rel_path: str, token: str) -> bool:
+    """True iff ``token`` in ``rel_path`` is a correct-by-design mention."""
+    token_l = token.lower()
+    for key, permitted in ALLOWLIST.items():
+        hit = rel_path.startswith(key) if key.endswith("/") else rel_path == key
+        if hit and (permitted is ALL or token_l in permitted):  # type: ignore[operator]
+            return True
+    return False
+
+
+def _iter_matches():
+    """Yield (rel_path, line_no, token) for every retired-token hit in the tree.
+
+    Binary files (containing a NUL byte) are skipped; text is decoded utf-8
+    with replacement so an odd byte never crashes the scan.
+    """
+    for rel in _tracked_files():
+        path = REPO_ROOT / rel
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        if b"\x00" in data:  # binary — not a doc/docstring/comment
+            continue
+        text = data.decode("utf-8", errors="replace")
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            for token, rx in _TOKEN_RES.items():
+                if rx.search(line):
+                    yield rel, line_no, token
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsStackDriftGuard:
+    def test_no_live_runnable_reference_to_retired_stack(self):
+        """Every retired-token match must be allowlisted; anything else is drift."""
+        offenses = [
+            f"{rel}:{line_no}: {token}"
+            for rel, line_no, token in _iter_matches()
+            if not _allowed(rel, token)
+        ]
+        assert not offenses, (
+            f"Found {len(offenses)} live reference(s) to the retired agents-stack "
+            f"(retired in #743/#744, swept in #734).\n"
+            "Fix the doc/docstring/comment, or — if the mention is correct by design "
+            "— add its path to ALLOWLIST in this file with a reason.\n"
+            + "\n".join(f"  {o}" for o in offenses)
+        )
+
+    def test_allowlist_entries_are_live(self):
+        """No stale exemptions: every ALLOWLIST entry must suppress a real match.
+
+        When a future cleanup removes the last legitimate mention from an
+        allowlisted file, its entry becomes dead weight — this test flags it so
+        the allowlist stays an honest inventory of correct-by-design mentions.
+        """
+        raw = {(rel, token.lower()) for rel, _, token in _iter_matches()}
+        stale: list[str] = []
+        for key, permitted in ALLOWLIST.items():
+            covers = any(
+                (rel.startswith(key) if key.endswith("/") else rel == key)
+                and (permitted is ALL or tok in permitted)  # type: ignore[operator]
+                for rel, tok in raw
+            )
+            if not covers:
+                stale.append(key)
+        assert not stale, (
+            f"{len(stale)} ALLOWLIST entr(ies) no longer match any retired token "
+            "and should be removed:\n" + "\n".join(f"  {s}" for s in stale)
+        )
+
+    def test_token_set_is_canonical(self):
+        """Lock the retired-token set so no token is silently dropped (#1138)."""
+        expected = {
+            "langgraph",
+            "langchain-ollama",
+            "PostgresSaver",
+            "event_monitor",
+            "docker-compose.agents",
+            "5433",
+            "SQLAlchemyJobStore",
+            "APScheduler",
+            "agents.main",
+            "agents.scheduler",
+            "agents.dispatcher",
+        }
+        assert set(RETIRED_TOKENS) == expected
+        assert len(RETIRED_TOKENS) == len(expected), "duplicate token in RETIRED_TOKENS"


### PR DESCRIPTION
## Summary
Adds `tests/ci/test_agents_stack_drift_guard.py` — a grep-clean CI guard that scans every git-tracked file for the retired agents-stack token set and fails if any **live** doc/docstring/comment presents the dead stack as runnable. Also repoints the one genuine residual drift in `scripts/dispatcher_smoke_live.py` from `python -m agents.dispatcher` to the live `python -m agents.wake_driver --once`.

## Why
The LangGraph / APScheduler / Postgres-checkpointer "agents-stack" was retired (#743/#744) and its doc/config/env drift swept (#734). Nothing stops a future edit from quietly re-introducing a runnable reference to a module that no longer exists — the exact failure mode where a stale `python -m agents.dispatcher` outlives its module. This is the stay-clean regression guard.
Closes #1138

## Decisions & Alternatives
- **Content-scan over `git ls-files`, not a workflow-config meta-test.** #1138 is about repo *content* (docstrings/comments), so the schema-drift-guard shape (which reimplements a workflow's decision rule) doesn't fit. Modeled instead on `test_powershell_encoding_guard.py`'s enumerate-and-allowlist pattern.
- **Word-boundary regex (`\bTOKEN\b`, case-insensitive).** Required: bare `5433` substring-matches inside SVG coordinate floats (302 KB of false positives). Word boundaries reduce `5433` / `docker-compose.agents` / `agents.main` / `agents.scheduler` to zero live matches — exactly what #734 achieved. The dotted `agents.dispatcher` (runnable form) is matched; the slash form `agents/dispatcher.py` (lineage/retirement reference) is deliberately not.
- **Inline path-based allowlist, not a sidecar file.** #1138 mandates the allowlist be the single source of truth living IN the test. Keys are directory prefixes (`docs/design/`) or exact paths; values are `ALL` or a per-file token set (so a *different* token drifting into an allowlisted file is still caught). Path-based (not `path:line`) so it's robust to line-number churn.
- **Repoint the smoke script, don't allowlist it.** `agents.wake_driver` drains the seeded `task_queue` row and the executor spawns Claude, so the smoke flow is still valid — the reference was just stale. Allowlisting a genuinely-wrong runnable command would weaken the guard. Fixed inline per #428 (trivial, reversible).
- **Two self-audit tests beyond the scan:** `test_allowlist_entries_are_live` (every exemption must suppress a real match — flags dead weight after a future cleanup) and `test_token_set_is_canonical` (locks the 11 tokens so none is silently dropped).

## Risk Assessment
- **LOW**: new test-only file + a docstring/comment repoint in a manual smoke utility. No runtime/production code path touched.

## Testing
- `pytest tests/ci/test_agents_stack_drift_guard.py -q` → 3 passed.
- `pytest tests/ci/ -q` (full ci-meta surface, exactly what `ci-meta.yml` runs) → 544 passed.
- **Negative control**: injected a file containing `python -m agents.dispatcher` + `5433`, confirmed the guard goes RED with precise `file:line: token` output, then reverted. Proves the scan is not a no-op.
- `ruff check` clean, `ruff format` applied.

## Files Changed
- `tests/ci/test_agents_stack_drift_guard.py` — new guard (scan + inline allowlist + 2 self-audit tests).
- `scripts/dispatcher_smoke_live.py` — repoint retired `agents.dispatcher` → `agents.wake_driver --once` (docstring, comment, and `Next:` hint); reword "the dispatcher" → "the executor" for accuracy.

## Note on protected file
`.claude-userlevel/skills/implement/SKILL.md` [PROTECTED] is **allowlisted, not edited** — it legitimately mentions APScheduler in a historical bug-class example ("APScheduler pickling, env propagation (#304, #298)"). The allowlist entry restricts it to the `apscheduler` token only.