### PR TITLE
refactor(agents): rename retired langgraph source-identifiers to reactive-core

### DIFF
--- a/agents/supabase_client.py
+++ b/agents/supabase_client.py
@@ -152,7 +152,7 @@ def store_event(
     title: str,
     severity: str = "info",
     payload: dict[str, Any] | None = None,
-    source: str = "langgraph-agent",
+    source: str = "reactive-core",
     dedup_key: str | None = None,
     client: Client | None = None,
     config: AgentConfig | None = None,
@@ -313,7 +313,7 @@ def audit(
     """Best-effort audit entry — never raises.
 
     The ``agent_id`` column on ``audit_log`` is how agents identify
-    themselves (e.g. ``"langgraph-monitor"``). Matches the server.py
+    themselves (e.g. ``"reactive-core"``). Matches the server.py
     ``_audit_log()`` convention, with ``agent_id`` filled in — MCP writes
     leave it NULL, so the column doubles as the actor differentiator.
     """

--- a/tests/ci/test_agents_stack_drift_guard.py
+++ b/tests/ci/test_agents_stack_drift_guard.py
@@ -82,12 +82,8 @@ ALLOWLIST: dict[str, object] = {
         "event_monitor",
         "apscheduler",
     },
-    "agents/supabase_client.py": {"langgraph"},  # DB source-identifier string-literals
     "agents/executor.py": {"langgraph"},  # "Salvaged from agents/dispatcher.py" lineage
-    "tests/test_agents_supabase_bridge.py": {  # asserts the DB-identifier bridge
-        "langgraph",
-        "event_monitor",
-    },
+    "tests/test_agents_supabase_bridge.py": {"event_monitor"},  # tool_name fixture (retired module name is legit test data)
     "tests/test_wake_driver.py": {"apscheduler"},  # retirement-enforcement assertions
     ".claude-userlevel/skills/implement/SKILL.md": {
         "apscheduler"

--- a/tests/test_agents_supabase_bridge.py
+++ b/tests/test_agents_supabase_bridge.py
@@ -200,7 +200,7 @@ def test_store_event_inserts_full_payload() -> None:
         title="t",
         severity="medium",
         payload={"foo": 1},
-        source="langgraph-monitor",
+        source="reactive-core",
         client=cli,
     )
 
@@ -209,7 +209,7 @@ def test_store_event_inserts_full_payload() -> None:
     (payload,) = insert_call[1]
     assert payload["event_type"] == "github.IssuesEvent"
     assert payload["severity"] == "medium"
-    assert payload["source"] == "langgraph-monitor"
+    assert payload["source"] == "reactive-core"
     assert payload["payload"] == {"foo": 1}
     # No dedup_key ⇒ plain insert path; upsert must NOT be used.
     assert "upsert" not in _names(cli.chains["events"][0])
@@ -381,7 +381,7 @@ def test_audit_swallows_backend_errors() -> None:
 
     # Absence of exception is the assertion.
     supabase_client.audit(
-        agent_id="langgraph-monitor",
+        agent_id="reactive-core",
         tool_name="event_monitor",
         action="poll",
         client=_BoomClient(),  # type: ignore[arg-type]
@@ -396,7 +396,7 @@ def test_audit_writes_agent_id_and_defaults() -> None:
     cli.preset("audit_log", _FakeResult(data=[{"id": 1}]))
 
     supabase_client.audit(
-        agent_id="langgraph-monitor",
+        agent_id="reactive-core",
         tool_name="event_monitor",
         action="poll",
         target="o/r",
@@ -405,7 +405,7 @@ def test_audit_writes_agent_id_and_defaults() -> None:
 
     insert_call = _find(cli.chains["audit_log"][0], "insert")
     (payload,) = insert_call[1]
-    assert payload["agent_id"] == "langgraph-monitor"
+    assert payload["agent_id"] == "reactive-core"
     assert payload["tool_name"] == "event_monitor"
     assert payload["action"] == "poll"
     assert payload["target"] == "o/r"


### PR DESCRIPTION
## What

Renames the two LangGraph-era **source-identifier literals** in `agents/supabase_client.py` to `"reactive-core"`:

- `store_event(..., source: str = "langgraph-agent")` → `"reactive-core"` — the default written to `events.source`.
- `audit()` docstring example `"langgraph-monitor"` → `"reactive-core"`.

Plus the bridge-test fixtures and the #1138 drift-guard allowlist, updated in lockstep.

## Why now

These two sites were **deliberately allowlisted out** of #734's grep-clean sweep because renaming changes a *live* DB value (`events.source`) going forward — the deferral was gated on a **consumer grep**, not on a calendar or on #734/#1137/#1138 closing. That grep is now clean:

- **No live consumer** filters on either string. `usage_probe.py:195` / `escalation.py:347` use `DISPATCHER_AGENT_ID = "task-dispatcher"`; `safety.py:462` passes a caller-supplied `agent_id`. Nothing branches on `"langgraph-agent"`/`"langgraph-monitor"`.
- **One live producer**: `wake_driver.py`'s terminal-transition emitter rides the `store_event` `source` default. New event rows now carry `source="reactive-core"`; historical rows keep the old value (harmless — nothing reads it).

Unified to a single name because `event_monitor` is retired (#744), so the old agent-vs-monitor split no longer exists. `reactive-core` is the M44 subsystem name already used throughout `CONTEXT.md`.

## Lockstep with the #1138 drift guard

`tests/ci/test_agents_stack_drift_guard.py::test_allowlist_entries_are_live` asserts every ALLOWLIST entry suppresses a *real* retired-token match. So the rename required trimming the allowlist in the same commit:

- **Removed** the `agents/supabase_client.py: {"langgraph"}` entry — after the rename that file has zero retired tokens.
- **Narrowed** the bridge-test entry from `{"langgraph", "event_monitor"}` to `{"event_monitor"}` — the surviving `tool_name="event_monitor"` fixture is legit test data.

## Verification

`pytest tests/ci/test_agents_stack_drift_guard.py tests/test_agents_supabase_bridge.py` → 20 passed. `git grep 'langgraph-agent|langgraph-monitor'` over `agents/`+`tests/` → no matches.

[no-issue] — deferred follow-up to #734 (closed); trivial reversible per #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)