### PR TITLE
feat(agents): mandate Closes #<N> on executor-lane gh pr create (#1136)

### DIFF
--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -52,11 +52,17 @@ jobs:
               return;
             }
 
-            const issueMatches = [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)];
+            // Linkage keywords: closing keywords (closes/fixes/resolves) auto-close on
+            // merge; refs/references LINK WITHOUT closing (#1136 AC-GATE). A partial-work
+            // PR uses `Refs #N` to satisfy this gate while leaving the issue open — the
+            // executor lane's Closes-mandate escape (agents/task_dispatch.py) mirrors this.
+            // pr-merged.yml is deliberately unchanged: auto-close stays closingIssuesReferences-
+            // driven, so `Refs` links-without-closing by construction.
+            const issueMatches = [...body.matchAll(/(?:closes|fixes|resolves|refs?|references?)\s+#(\d+)/gi)];
             const issueNumbers = [...new Set(issueMatches.map(m => parseInt(m[1], 10)))];
 
             if (issueNumbers.length === 0) {
-              core.setFailed('PR body must include a linked issue reference (e.g. "Closes #123"), the [no-issue] marker for trivial fix-inline drive-bys (#428), or the priority:critical label for hotfixes.');
+              core.setFailed('PR body must include a linked issue reference (e.g. "Closes #123" to auto-close, or "Refs #123" to link a partial-work PR without closing), the [no-issue] marker for trivial fix-inline drive-bys (#428), or the priority:critical label for hotfixes.');
               return;
             }
 

--- a/agents/github_client.py
+++ b/agents/github_client.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import re
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any, Protocol
 
@@ -324,6 +325,64 @@ def check_pr_evidence_fresh_shape(
         return True
     except Exception:
         logger.exception("check_pr_evidence_fresh_shape: client error for %s", task_id)
+        return None
+
+
+def check_pr_closing_ref_fresh_shape(
+    task_id: str,
+    goal: str,
+    issue_number: int,
+    *,
+    client: GitHubClient | None = None,
+    closing_ref_matcher: Callable[[int], re.Pattern[str]],
+) -> bool | None:
+    """Report whether a fresh-shape task's PR body *closes* its issue (#1136 AC4).
+
+    A SEPARATE return channel from ``check_pr_evidence_fresh_shape`` — that one
+    answers "did this spawn produce a fresh PR?" (a ``bool | None`` freshness
+    tri-state); this one answers the orthogonal "does that PR's body carry a
+    closing keyword for issue ``#N``?". Overloading the freshness tri-state was
+    explicitly rejected in the grill (decision ``ec66db74``): the two questions
+    have independent None/False/True semantics and one channel can't carry both.
+
+    The closing-ref regex is *not* re-implemented here — it is injected
+    (``closing_ref_matcher``, in practice the /delegate pre-dispatch gate's
+    ``_closing_ref_re``) so this HTTP-client module never path-loads a
+    ``scripts/`` module. By construction the matcher recognizes only closing
+    keywords (``closes/fixes/resolves``), NOT ``Refs``/``References`` — a
+    ``Refs #N``-only body links-without-closing and correctly reports False,
+    which is what feeds the AC5 advisory WARNING upstream.
+
+    Branch resolution mirrors ``check_pr_evidence_fresh_shape`` (explicit
+    ``(branch=...)`` directive, else the ``task/<task_id>`` convention). The PR
+    fetch already returns the raw REST object including ``body``, so no extra
+    field plumbing is needed.
+
+    Returns:
+    - True: a PR exists on the branch AND its body closes ``#issue_number``
+    - False: a PR exists but its body has no closing ref for ``#issue_number``
+      (includes the ``Refs #N``-only case)
+    - None: no client, or no PR found on the branch (existence unknown here —
+      distinct from False, which asserts a PR was seen)
+    """
+    if client is None:
+        logger.warning("check_pr_closing_ref_fresh_shape: no client provided")
+        return None
+
+    branch_match = re.search(r"\(branch=([^)]+)\)", goal)
+    if branch_match:
+        branch = branch_match.group(1).strip()
+    else:
+        branch = f"task/{task_id}"
+
+    try:
+        pr = client.get_pull_by_head_branch(branch)
+        if not pr:
+            return None
+        body = pr.get("body") or ""
+        return bool(closing_ref_matcher(issue_number).search(body))
+    except Exception:
+        logger.exception("check_pr_closing_ref_fresh_shape: client error for %s", task_id)
         return None
 
 

--- a/agents/task_dispatch.py
+++ b/agents/task_dispatch.py
@@ -52,6 +52,7 @@ from typing import Any, Protocol, runtime_checkable
 from agents import task_queue
 from agents.github_client import (
     GitHubClient,
+    check_pr_closing_ref_fresh_shape,
     check_pr_evidence_fresh_shape,
     check_pr_evidence_rework_shape,
     parse_executor_stdout,
@@ -170,6 +171,43 @@ def _augment_branch_directive(goal: str, task_id: str) -> str:
     return f"{goal}\n\n(branch=task/{task_id})"
 
 
+def _augment_closes_mandate(goal: str, task_id: str) -> str:
+    """Append a ``Closes #<N>`` PR-body mandate to a fresh-shape goal (#1136 AC1).
+
+    The executor lane's spawned ``claude -p`` sessions are permitted to run
+    ``Bash(gh pr create:*)`` (``executor._SPAWN_ALLOWED_TOOLS``) with no directive
+    to link the issue their PR closes — so a merged PR can silently fail to
+    auto-close its issue (the #948 failure mode; native linked-issue auto-close is
+    suppressed for bot/App-attributed merges, so the closing keyword in the PR body
+    is what the ``pr-merged.yml`` close path keys on). Fresh-shape goals naming an
+    issue ``#N`` get an explicit mandate appended so the child's PR body carries
+    that keyword.
+
+    Fires **iff** the goal is fresh-shape AND names an issue (``#N``). Rework goals
+    (``/rework #N``) target an existing PR and are left untouched; a fresh goal with
+    no ``#N`` has no close target; an empty goal is a no-op. AC3 escape: the mandate
+    permits the child to emit ``Refs #N`` instead when the PR only partially
+    addresses the issue — both satisfy the ``require-linked-issue`` merge gate, but
+    only ``Closes`` triggers auto-close. Additive like
+    :func:`_augment_branch_directive` — the original goal is preserved verbatim as a
+    prefix. ``task_id`` is unused (sibling-parity with the branch augmenter); kept in
+    the signature for a uniform augmenter shape.
+    """
+    shape, _ = parse_goal_shape(goal)
+    if shape != "fresh":
+        return goal
+    issue_number = _goal_issue_number(goal)
+    if issue_number is None:
+        return goal
+    return (
+        f"{goal}\n\n(PR-body requirement: when you open the PR, put "
+        f"`Closes #{issue_number}` on its own line in the body so the merge "
+        f"auto-closes the issue. If this PR only partially addresses "
+        f"#{issue_number}, use `Refs #{issue_number}` instead — it still satisfies "
+        f"the linked-issue merge gate but leaves the issue open.)"
+    )
+
+
 # A task_id is interpolated into the executor-log path, so it must be confined
 # to a charset that cannot escape the directory — no ``/``, ``\``, ``.`` (hence
 # no ``..``), or other path-significant characters. UUIDs and the alnum ids used
@@ -238,6 +276,10 @@ def _compute_pr_evidence(
         return check_pr_evidence_rework_shape(task_id, goal, pr_number, spawned_at, client=client)
 
     evidence = check_pr_evidence_fresh_shape(task_id, goal, spawned_at, client=client)
+    # #1136 AC5: advisory-only — surface a fresh-shape PR that links but does not
+    # *close* its named issue. Runs at this evidence boundary regardless of the
+    # freshness verdict; never blocks and never edits the PR.
+    _warn_if_pr_lacks_closing_ref(task_id, goal, client=client)
     if evidence is False and stdout_reader is not None:
         # AC3 — the head-branch lookup found nothing; fall back to whatever PR
         # the agent claimed in its stdout, then verify it actually exists.
@@ -254,6 +296,59 @@ def _compute_pr_evidence(
             if pr:
                 return True
     return evidence
+
+
+def _warn_if_pr_lacks_closing_ref(
+    task_id: str,
+    goal: str,
+    *,
+    client: GitHubClient,
+) -> None:
+    """Log an advisory WARNING if a fresh-shape task's PR does not close its issue (#1136 AC5).
+
+    Advisory-only: this neither blocks the pipeline nor edits the PR. It is a
+    SEPARATE, deliberate second fetch of the PR (via
+    :func:`check_pr_closing_ref_fresh_shape`) — the freshness evidence and the
+    closing-ref question are orthogonal (grill decision ``ec66db74``), so they
+    are not folded into one call. The closing-ref matcher is the /delegate gate's
+    ``_closing_ref_re`` (recognizing ``closes/fixes/resolves`` only, NOT
+    ``Refs``), reused by injection so this module keeps its single path-load in
+    :func:`_load_gate_module` rather than importing gate internals directly.
+
+    Fires only when the goal names an issue AND a PR exists on the branch whose
+    body carries no closing ref for that issue (``check_...`` returns ``False``).
+    A missing issue reference, an absent PR (``None``), or a genuine ``Closes #N``
+    (``True``) are all silent. The AC7 follow-up (#1169) turns this signal into a
+    disposition; here it is observation only.
+    """
+    issue_number = _goal_issue_number(goal)
+    if issue_number is None:
+        return
+    try:
+        gate = _load_gate_module()
+    except Exception:  # noqa: BLE001 — advisory must never break the evidence path
+        logger.debug("closing-ref advisory: gate module unavailable; skipping")
+        return
+    closes = check_pr_closing_ref_fresh_shape(
+        task_id,
+        goal,
+        issue_number,
+        client=client,
+        closing_ref_matcher=gate._closing_ref_re,
+    )
+    if closes is False:
+        logger.warning(
+            "pr_closing_ref_missing: task=%s issue=#%s — the PR links but carries "
+            "no `Closes #%s` keyword; this merge will NOT auto-close the issue "
+            "(native auto-close is suppressed for bot/App merges). Use `Closes #%s` "
+            "for a full close; `Refs #%s` is correct only for partial work. "
+            "Advisory only — see #1169 for enforcement.",
+            task_id,
+            issue_number,
+            issue_number,
+            issue_number,
+            issue_number,
+        )
 
 
 def _severity_for(event_type: str, pr_evidence: bool | None) -> str:
@@ -811,10 +906,19 @@ def default_spawn(goal: str, *, task_id: str | None = None) -> Any:
     untouched — augmentation is purely additive and never rewrites an operator's
     branch choice. The un-augmented goal is what ``drain_tasks`` records in
     ``spawned_meta`` for evidence (the default head ``task/<task_id>`` matches).
+
+    AC1 (#1136): a fresh-shape goal naming an issue ``#N`` additionally gets a
+    ``Closes #<N>`` PR-body mandate appended (:func:`_augment_closes_mandate`), so a
+    PR the executor lane opens links its issue and auto-closes on merge (#948).
     """
     from agents.executor import spawn as executor_spawn
 
     spawn_goal = _augment_branch_directive(goal, task_id) if task_id else goal
+    # #1136 AC1: also inject the Closes #<N> PR-body mandate for a fresh-shape goal
+    # naming an issue. Order-independent of the branch directive above — the branch
+    # suffix carries no ``#N`` and is not a ``/rework`` marker, so it neither adds a
+    # spurious close target nor flips the goal's shape.
+    spawn_goal = _augment_closes_mandate(spawn_goal, task_id) if task_id else spawn_goal
     return executor_spawn(spawn_goal, task_id=task_id)
 
 

--- a/tests/ci/test_pr_body_check_guard.py
+++ b/tests/ci/test_pr_body_check_guard.py
@@ -22,12 +22,7 @@ from pathlib import Path
 import pytest
 
 
-WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2]
-    / ".github"
-    / "workflows"
-    / "pr-body-check.yml"
-)
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-body-check.yml"
 
 
 def evaluate(body: str, labels: list[str], title: str = "") -> tuple[bool, str]:
@@ -41,7 +36,14 @@ def evaluate(body: str, labels: list[str], title: str = "") -> tuple[bool, str]:
     if re.match(r"^refactor(\([^)]*\))?:", title, re.IGNORECASE):
         return True, "refactor"
 
-    matches = re.findall(r"(?:closes|fixes|resolves)\s+#(\d+)", body, re.IGNORECASE)
+    # Mirror of the YAML alternation (#1136 AC-GATE): closing keywords
+    # (closes/fixes/resolves) auto-close on merge; refs/references link WITHOUT
+    # closing (the partial-work escape). `refs?|references?` deliberately does
+    # not swallow the verb "refers" — `refers to #N` carries no `\s+#` right
+    # after "ref"/"refs", so it stays blocked.
+    matches = re.findall(
+        r"(?:closes|fixes|resolves|refs?|references?)\s+#(\d+)", body, re.IGNORECASE
+    )
     if matches:
         return True, "linked"
 
@@ -59,6 +61,34 @@ def test_alt_markers_allow():
         body = f"{marker} #42"
         allowed, _ = evaluate(body, [])
         assert allowed, f"{marker} should be accepted"
+
+
+def test_refs_marker_allows():
+    """#1136 AC-GATE: `Refs #N` links a partial-work PR without closing it."""
+    for marker in ("Ref", "Refs", "ref", "REFS"):
+        body = f"{marker} #42"
+        allowed, reason = evaluate(body, [])
+        assert allowed, f"{marker} should be accepted as a linkage keyword"
+        assert reason == "linked"
+
+
+def test_references_marker_allows():
+    """#1136 AC-GATE: `References #N` / `Reference #N` are linkage keywords."""
+    for marker in ("Reference", "References", "references", "REFERENCE"):
+        body = f"{marker} #42"
+        allowed, reason = evaluate(body, [])
+        assert allowed, f"{marker} should be accepted as a linkage keyword"
+        assert reason == "linked"
+
+
+def test_refers_to_still_blocked():
+    """#1136 AC-GATE: prose `refers to #N` is NOT a linkage keyword — must block.
+
+    Guards the alternation boundary: `refs?`/`references?` must not swallow the
+    English verb `refers`, which carries no linkage semantics.
+    """
+    allowed, _ = evaluate("This PR refers to #42 for background.", [])
+    assert not allowed
 
 
 def test_hotfix_label_bypasses():
@@ -97,6 +127,21 @@ def test_workflow_yaml_keeps_closes_regex():
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "closes|fixes|resolves" in text.lower(), (
         "PR Body Check regex changed shape — update this test to match."
+    )
+
+
+def test_workflow_yaml_carries_refs_alternation():
+    """Config dimension (#1136 AC-GATE): the YAML regex must accept refs/references.
+
+    Locks the executor-lane partial-work escape into the merge gate: a PR that
+    uses `Refs #N` (link-without-close) must pass require-linked-issue. If the
+    alternation drops the `refs?|references?` branch, this test (and the
+    `_augment_closes_mandate` escape it backs) is stale.
+    """
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "refs?|references?" in text.lower(), (
+        "PR Body Check regex no longer carries the refs/references alternation; "
+        "the #1136 partial-work `Refs #N` escape is now unsupported."
     )
 
 

--- a/tests/test_agents_953_event_emission.py
+++ b/tests/test_agents_953_event_emission.py
@@ -15,6 +15,7 @@ Tests cover:
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime
 from typing import Any
 from unittest import mock
@@ -24,6 +25,7 @@ import pytest
 from agents.github_client import (
     GitHubClient,
     HttpxGitHubClient,
+    check_pr_closing_ref_fresh_shape,
     check_pr_evidence_fresh_shape,
     check_pr_evidence_rework_shape,
     parse_executor_stdout,
@@ -38,7 +40,9 @@ from agents.orchestrator import (
 from agents.task_dispatch import (
     TrackedProc,
     _augment_branch_directive,
+    _augment_closes_mandate,
     _compute_pr_evidence,
+    default_spawn,
     default_stdout_reader,
     format_lineage_key,
     parse_lineage,
@@ -237,6 +241,148 @@ class TestPREvidenceFreshShape:
             client=mock_client,
         )
         assert evidence is True
+
+
+def _real_closing_ref_matcher() -> Any:
+    """Load the /delegate gate's closing-ref regex factory (source of truth, #1136 AC4).
+
+    ``check_pr_closing_ref_fresh_shape`` takes the matcher by injection so the
+    HTTP client never path-loads a ``scripts/`` module. The test exercises the
+    *real* regex (not a re-implementation) to stay in lockstep with the gate.
+    """
+    import importlib
+    import sys
+    from pathlib import Path
+
+    scripts_dir = str(Path(__file__).resolve().parents[1] / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    return importlib.import_module("delegate_predispatch_gate")._closing_ref_re
+
+
+class TestClosingRefChannel:
+    """AC4 (#1136): a SEPARATE return channel reporting whether the fetched PR
+    body carries a *closing* ref for the task's issue.
+
+    Distinct from the freshness tri-state — this reuses the gate's
+    ``_closing_ref_re`` (via injection) so ``Refs #N``-only bodies (which link
+    without closing) report False, feeding the AC5 advisory WARNING.
+    """
+
+    def test_body_with_closes_keyword_reports_true(self) -> None:
+        mock_client = mock.MagicMock()
+        mock_client.get_pull_by_head_branch.return_value = {
+            "number": 42,
+            "body": "Some summary.\n\nCloses #1136\n",
+        }
+        result = check_pr_closing_ref_fresh_shape(
+            task_id="abc123",
+            goal="implement the guard for #1136",
+            issue_number=1136,
+            client=mock_client,
+            closing_ref_matcher=_real_closing_ref_matcher(),
+        )
+        assert result is True
+
+    def test_body_with_fixes_variant_reports_true(self) -> None:
+        mock_client = mock.MagicMock()
+        mock_client.get_pull_by_head_branch.return_value = {
+            "number": 42,
+            "body": "Fixes #1136",
+        }
+        result = check_pr_closing_ref_fresh_shape(
+            task_id="abc123",
+            goal="implement the guard for #1136",
+            issue_number=1136,
+            client=mock_client,
+            closing_ref_matcher=_real_closing_ref_matcher(),
+        )
+        assert result is True
+
+    def test_body_with_only_refs_reports_false(self) -> None:
+        """``Refs #N`` links without closing → NOT a closing ref (drives the advisory)."""
+        mock_client = mock.MagicMock()
+        mock_client.get_pull_by_head_branch.return_value = {
+            "number": 42,
+            "body": "Refs #1136 — partial work, issue stays open.",
+        }
+        result = check_pr_closing_ref_fresh_shape(
+            task_id="abc123",
+            goal="implement the guard for #1136",
+            issue_number=1136,
+            client=mock_client,
+            closing_ref_matcher=_real_closing_ref_matcher(),
+        )
+        assert result is False
+
+    def test_body_without_any_ref_reports_false(self) -> None:
+        mock_client = mock.MagicMock()
+        mock_client.get_pull_by_head_branch.return_value = {
+            "number": 42,
+            "body": "No linkage keyword at all.",
+        }
+        result = check_pr_closing_ref_fresh_shape(
+            task_id="abc123",
+            goal="implement the guard for #1136",
+            issue_number=1136,
+            client=mock_client,
+            closing_ref_matcher=_real_closing_ref_matcher(),
+        )
+        assert result is False
+
+    def test_closing_ref_for_other_issue_reports_false(self) -> None:
+        """A close of a *different* issue is not a close of this one."""
+        mock_client = mock.MagicMock()
+        mock_client.get_pull_by_head_branch.return_value = {
+            "number": 42,
+            "body": "Closes #999",
+        }
+        result = check_pr_closing_ref_fresh_shape(
+            task_id="abc123",
+            goal="implement the guard for #1136",
+            issue_number=1136,
+            client=mock_client,
+            closing_ref_matcher=_real_closing_ref_matcher(),
+        )
+        assert result is False
+
+    def test_no_pr_on_branch_reports_none(self) -> None:
+        """No PR found → None (unknown), distinct from False (PR exists, no close)."""
+        mock_client = mock.MagicMock()
+        mock_client.get_pull_by_head_branch.return_value = None
+        result = check_pr_closing_ref_fresh_shape(
+            task_id="abc123",
+            goal="implement the guard for #1136",
+            issue_number=1136,
+            client=mock_client,
+            closing_ref_matcher=_real_closing_ref_matcher(),
+        )
+        assert result is None
+
+    def test_explicit_branch_directive_is_honored(self) -> None:
+        mock_client = mock.MagicMock()
+        mock_client.get_pull_by_head_branch.return_value = {
+            "number": 42,
+            "body": "Closes #1136",
+        }
+        check_pr_closing_ref_fresh_shape(
+            task_id="abc123",
+            goal="implement feature X (branch=feat/1136-x)",
+            issue_number=1136,
+            client=mock_client,
+            closing_ref_matcher=_real_closing_ref_matcher(),
+        )
+        mock_client.get_pull_by_head_branch.assert_called_with("feat/1136-x")
+
+    def test_no_client_reports_none(self) -> None:
+        result = check_pr_closing_ref_fresh_shape(
+            task_id="abc123",
+            goal="implement the guard for #1136",
+            issue_number=1136,
+            client=None,
+            closing_ref_matcher=_real_closing_ref_matcher(),
+        )
+        assert result is None
 
 
 # =============================================================================
@@ -710,6 +856,109 @@ class TestComputePrEvidenceStdoutFallback:
         )
         assert evidence is False
         client.get_pull_by_number.assert_not_called()
+
+
+# =============================================================================
+# AC5/AC6 (#1136): Closing-ref advisory at the evidence boundary
+# =============================================================================
+
+
+class TestClosingRefAdvisory:
+    """``_compute_pr_evidence`` emits an advisory WARNING (no blocking, no edit)
+    when a fresh-shape task naming an issue produces a PR whose body links but
+    does not *close* that issue (#1136 AC5/AC6).
+
+    Native auto-close is ``closingIssuesReferences``-driven and suppressed for
+    bot/App merges (memory 21866efc), so a ``Refs #N``-only body silently leaves
+    the issue open. The advisory surfaces that at the boundary; it does not
+    change the returned evidence tri-state.
+    """
+
+    _WARN_TOKEN = "pr_closing_ref_missing"
+
+    def _fresh_pr(self, body: str) -> dict[str, Any]:
+        return {
+            "number": 42,
+            "created_at": "2026-06-21T10:30:00Z",  # after the spawn below
+            "body": body,
+        }
+
+    def test_advisory_fires_for_refs_only_body(self, caplog: pytest.LogCaptureFixture) -> None:
+        spawned_at = datetime(2026, 6, 21, 10, 0, 0, tzinfo=UTC)
+        client = mock.MagicMock()
+        client.get_pull_by_head_branch.return_value = self._fresh_pr("Refs #1136 — partial work.")
+        with caplog.at_level(logging.WARNING, logger="agents.task_dispatch"):
+            _compute_pr_evidence(
+                "abc123",
+                "implement the guard for #1136",
+                spawned_at,
+                client=client,
+            )
+        assert any(self._WARN_TOKEN in r.message for r in caplog.records), (
+            "expected a closing-ref advisory for a Refs-only PR body"
+        )
+
+    def test_advisory_fires_for_no_ref_body(self, caplog: pytest.LogCaptureFixture) -> None:
+        spawned_at = datetime(2026, 6, 21, 10, 0, 0, tzinfo=UTC)
+        client = mock.MagicMock()
+        client.get_pull_by_head_branch.return_value = self._fresh_pr("No linkage keyword.")
+        with caplog.at_level(logging.WARNING, logger="agents.task_dispatch"):
+            _compute_pr_evidence(
+                "abc123",
+                "implement the guard for #1136",
+                spawned_at,
+                client=client,
+            )
+        assert any(self._WARN_TOKEN in r.message for r in caplog.records), (
+            "expected a closing-ref advisory for a PR body with no linkage"
+        )
+
+    def test_no_advisory_when_body_closes_issue(self, caplog: pytest.LogCaptureFixture) -> None:
+        spawned_at = datetime(2026, 6, 21, 10, 0, 0, tzinfo=UTC)
+        client = mock.MagicMock()
+        client.get_pull_by_head_branch.return_value = self._fresh_pr("Closes #1136")
+        with caplog.at_level(logging.WARNING, logger="agents.task_dispatch"):
+            _compute_pr_evidence(
+                "abc123",
+                "implement the guard for #1136",
+                spawned_at,
+                client=client,
+            )
+        assert not any(self._WARN_TOKEN in r.message for r in caplog.records), (
+            "a Closes #N body must not trigger the advisory"
+        )
+
+    def test_no_advisory_when_goal_names_no_issue(self, caplog: pytest.LogCaptureFixture) -> None:
+        spawned_at = datetime(2026, 6, 21, 10, 0, 0, tzinfo=UTC)
+        client = mock.MagicMock()
+        client.get_pull_by_head_branch.return_value = self._fresh_pr("no ref")
+        with caplog.at_level(logging.WARNING, logger="agents.task_dispatch"):
+            _compute_pr_evidence(
+                "abc123",
+                "refactor the usage probe module",  # names no issue
+                spawned_at,
+                client=client,
+            )
+        assert not any(self._WARN_TOKEN in r.message for r in caplog.records), (
+            "a goal naming no issue must not trigger the advisory"
+        )
+
+    def test_no_advisory_for_rework_shape(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Rework-shape tasks return before the fresh-path advisory (AC5 scope)."""
+        spawned_at = datetime(2026, 6, 21, 10, 0, 0, tzinfo=UTC)
+        client = mock.MagicMock()
+        client.get_pull_by_number.return_value = {"number": 7, "state": "open"}
+        client.list_commits_for_pull.return_value = []
+        with caplog.at_level(logging.WARNING, logger="agents.task_dispatch"):
+            _compute_pr_evidence(
+                "abc123",
+                "/rework #7 address review on #1136",
+                spawned_at,
+                client=client,
+            )
+        assert not any(self._WARN_TOKEN in r.message for r in caplog.records), (
+            "rework-shape must not reach the fresh-path advisory"
+        )
 
 
 # =============================================================================
@@ -1352,6 +1601,71 @@ class TestBranchContract:
         goal = "/rework #42"
         # Rework targets an existing PR's branch — augmenting it would be wrong.
         assert _augment_branch_directive(goal, "abc123") == goal
+
+
+# =============================================================================
+# #1136 AC1/AC3: Executor-Lane Closes #N Mandate — Goal Augmentation
+# =============================================================================
+
+
+class TestClosesMandate:
+    """`_augment_closes_mandate` injects a `Closes #N` PR-body mandate (#1136).
+
+    The executor lane's spawned ``claude -p`` sessions may run
+    ``Bash(gh pr create:*)`` with no directive to link the issue their PR
+    closes — so a merged PR can silently fail to auto-close its issue (#948).
+    A fresh-shape goal naming issue #N gets an explicit mandate appended.
+    """
+
+    def test_fresh_shape_with_issue_gets_closes_mandate(self) -> None:
+        """Fresh goal naming #N → mandate appended carrying `Closes #<N>` (AC1)."""
+        goal = "implement the executor guard for #1136"
+        augmented = _augment_closes_mandate(goal, "abc123")
+        assert augmented != goal  # it WAS augmented
+        assert augmented.startswith(goal)  # additive — original goal preserved verbatim
+        assert "Closes #1136" in augmented
+
+    def test_closes_mandate_permits_refs_escape(self) -> None:
+        """The mandate offers the partial-work `Refs #<N>` escape (AC3)."""
+        goal = "implement feature for #1136"
+        augmented = _augment_closes_mandate(goal, "abc123")
+        assert "Refs #1136" in augmented
+
+    def test_rework_shape_no_closes_mandate(self) -> None:
+        """Rework goal (`/rework #N`) targets an existing PR → never augmented (AC1)."""
+        goal = "/rework #42"
+        assert _augment_closes_mandate(goal, "abc123") == goal
+
+    def test_fresh_shape_without_issue_no_mandate(self) -> None:
+        """Fresh goal with no `#N` has no close target → unchanged (AC1)."""
+        goal = "refactor the usage probe module"
+        assert _augment_closes_mandate(goal, "abc123") == goal
+
+    def test_empty_goal_no_mandate(self) -> None:
+        """Empty/whitespace goal → unchanged (AC1)."""
+        assert _augment_closes_mandate("", "abc123") == ""
+        assert _augment_closes_mandate("   ", "abc123") == "   "
+
+    def test_default_spawn_composes_branch_and_closes_mandate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`default_spawn` applies BOTH augmenters before the executor hand-off (AC1)."""
+        import agents.executor as executor_mod
+
+        captured: dict[str, Any] = {}
+
+        def fake_spawn(goal: str, *, task_id: str | None = None) -> Any:
+            captured["goal"] = goal
+            captured["task_id"] = task_id
+            return object()
+
+        monkeypatch.setattr(executor_mod, "spawn", fake_spawn)
+
+        default_spawn("implement the guard for #1136", task_id="t1")
+
+        assert "(branch=task/t1)" in captured["goal"]  # branch directive applied
+        assert "Closes #1136" in captured["goal"]  # closes mandate applied
+        assert captured["task_id"] == "t1"
 
 
 # =============================================================================

--- a/tests/test_agents_executor.py
+++ b/tests/test_agents_executor.py
@@ -303,6 +303,42 @@ def test_spawn_uses_resolved_binary_path(
     assert "--dangerously-skip-permissions" not in argv
 
 
+def test_spawn_passes_issue_bearing_goal_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """AC2 (#1136): the executor stays goal-agnostic.
+
+    ``spawn`` places ``task_text`` at ``argv[2]`` unchanged — it must NOT
+    inject issue semantics (no ``Closes #<N>`` appended here). The
+    ``Closes``/``Refs`` PR-body mandate is composed upstream in
+    ``task_dispatch._augment_closes_mandate`` before ``spawn`` is called,
+    so the executor never learns the issue number. This lock test pins that
+    boundary: a goal that already names ``#42`` passes through byte-for-byte
+    with no linkage keyword grafted on by the executor.
+    """
+    from agents.executor import spawn
+
+    fake = tmp_path / "resolved-claude.exe"
+    fake.write_text("")
+    monkeypatch.setenv("JARVIS_CLAUDE_BIN", str(fake))
+
+    goal = "implement the guard for #42"
+    captured = _CapturedPopen()
+    result = spawn(
+        goal,
+        stderr_log_dir=str(tmp_path / "logs"),
+        popen=captured,
+        probe=_FixedProbe(_healthy_reading()),
+    )
+
+    assert result.proc is not None, "spawn should not be throttled"
+    argv = captured.calls[0]["argv"]
+    assert argv[2] == goal, "executor must pass the goal through verbatim"
+    assert "Closes #42" not in argv[2], "executor must not inject a closing keyword"
+    assert "Refs #42" not in argv[2], "executor must not inject a linkage keyword"
+
+
 def test_spawn_captures_stderr_to_file(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
@@ -352,7 +388,6 @@ class _FixedProbe:
 
 
 def _healthy_reading() -> Any:
-
     from agents.usage_probe import UsageReading
 
     return UsageReading(
@@ -365,7 +400,6 @@ def _healthy_reading() -> Any:
 
 
 def _exhausted_reading() -> Any:
-
     from agents.usage_probe import UsageReading
 
     return UsageReading(


### PR DESCRIPTION
## Summary
The M44 reactive-core **executor lane** — spawned `claude -p` sessions permitted to run `Bash(gh pr create:*)` (`executor._SPAWN_ALLOWED_TOOLS`) — had no `Closes #<N>` mandate, so a PR it opens can merge without auto-closing its issue. This mirrors #1133's fix into the executor lane: a `Closes #<N>` PR-body mandate is injected into fresh-shape spawn goals, the merge gate accepts a `Refs #<N>` partial-work escape, and an advisory WARNING surfaces PRs that link-but-don't-close.

## Why
Closes #1136

Native linked-issue auto-close is **suppressed for all bot/App-attributed merges** (memory `github_token_merge_suppresses_native_issue_autoclose`), so the closing keyword in the PR body is the only thing `pr-merged.yml` keys on. Without a mandate, the executor lane reproduces the #948 failure mode (merged PR silently leaves its issue open with stale `sandcastle`/`in-progress` labels), parallel to what #1133 fixed for the interactive path.

## Decisions & Alternatives
- **Separate return channel for the closing-ref check, not an overload of the freshness tri-state** — `agents/github_client.check_pr_closing_ref_fresh_shape` is a new `bool | None` function distinct from `check_pr_evidence_fresh_shape`. The two questions ("did this spawn produce a fresh PR?" vs "does that PR's body close #N?") have independent None/False/True semantics; folding them into one channel was explicitly rejected. Decision `ec66db74-656a-4c38-91fb-12f7f5f541d1`.
- **`require-linked-issue` accepts `refs`/`references` as a linkage keyword** — a partial-work PR uses `Refs #N` to satisfy the merge gate while leaving the issue open; only `closes/fixes/resolves` trigger auto-close. `pr-merged.yml` is deliberately **unchanged** — auto-close stays `closingIssuesReferences`-driven, so `Refs` links-without-closing by construction. Decision `27062c3c-ae1b-4ef4-b85b-ea7001fe93eb`. The alternation `refs?|references?` does not swallow the English verb `refers` (no `\s+#` after `ref`/`refs`), guarded by `test_refers_to_still_blocked`.
- **Closing-ref regex reused by injection, not path-loaded** — `check_pr_closing_ref_fresh_shape` takes the matcher as a `closing_ref_matcher` kwarg (in practice the /delegate gate's `_closing_ref_re`), so the HTTP-client module never imports `scripts/` internals. `task_dispatch` owns the single `_load_gate_module()` path-load and passes the matcher down.
- **AC2 lock**: `executor.py` stays goal-agnostic — all issue-semantics live in `task_dispatch`; a lock test asserts `spawn` passes `task_text` through verbatim.
- Trade-off: the AC5 advisory is a deliberate **second PR fetch** at the evidence boundary (see Risk). Gained: an observable signal for the #1169 enforcement follow-up without coupling it to the freshness path.

## Risk Assessment
- **LOW**: `pr-body-check.yml` regex widening (adds `refs`/`references` linkage keywords — strictly more-permissive on an advisory paperwork gate; pytest/gitleaks/meta-tests still gate). New goal-text augmentation is additive (original goal preserved verbatim as prefix).
- **MEDIUM**: AC5 advisory performs a **second `get_pull_by_head_branch` fetch** per fresh-shape evidence computation (one extra GitHub API call on the drain+poll path). It is wrapped so it can never raise into the evidence path (`_warn_if_pr_lacks_closing_ref` swallows all exceptions; gate-load failure degrades to a debug log). Advisory-only — no blocking, no PR auto-edit.
- **AC2** guarantees no issue-semantics leak into the executor tool boundary.

## Testing
- `ruff check --fix && ruff format` — clean.
- `python -m pytest tests/test_agents_953_event_emission.py tests/test_agents_executor.py tests/test_agents_task_dispatch.py tests/ci/test_pr_body_check_guard.py -q` → **206 passed**.
- TDD red→green per AC: AC1/AC3 (6 `TestClosesMandate`), AC2 (`test_spawn_passes_issue_bearing_goal_verbatim`), AC4 (8 `TestClosingRefChannel`), AC5/AC6 (5 `TestClosingRefAdvisory`), AC-GATE (23 in `test_pr_body_check_guard.py`, +5 new).
- §4d AC gate: symbol grep + call-site check (all three new symbols wired outside tests) + minimal-call sanity check.

## Files Changed
- `agents/task_dispatch.py` — `_augment_closes_mandate` (AC1/AC3) composed in `default_spawn`; `_warn_if_pr_lacks_closing_ref` advisory (AC5) at the fresh-shape evidence boundary.
- `agents/github_client.py` — `check_pr_closing_ref_fresh_shape` separate return channel (AC4).
- `.github/workflows/pr-body-check.yml` — `require-linked-issue` regex accepts `refs`/`references` (AC-GATE).
- `tests/ci/test_pr_body_check_guard.py` — lockstep mirror + config-dimension test (#326).
- `tests/test_agents_953_event_emission.py` — `TestClosingRefChannel` + `TestClosingRefAdvisory`.
- `tests/test_agents_executor.py` — AC2 verbatim-passthrough lock test.

AC7 (supervisor/tool-boundary enforcement, reconciliation sweep, wiring the AC5 advisory into a disposition) is deferred to #1169.