### PR TITLE
fix(ci): run verdict gate on autobase push, anchor on last non-bot head (#1134)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -254,11 +254,18 @@ jobs:
           echo "::notice::Code review ran cleanly (0 permission denials)."
 
       - name: Verify review verdict
-        if: steps.autobase.outputs.skip != 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+        # #1134: RUN on the osasuwu-ci[bot] auto-rebase push too (do NOT gate on
+        # steps.autobase.outputs.skip here). On that push HEAD is the bot's
+        # 2-parent merge commit; skipping left the `review` check green with
+        # nothing evaluated and native auto-merge shipped #1131 past a live
+        # CRITICAL. Instead the step runs and, when SKIP=true, anchors comment
+        # freshness on the last non-bot head (see ANCHOR_TIME below).
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
+          SKIP: ${{ steps.autobase.outputs.skip }}
         run: |
           set -euo pipefail
           # Freshness anchor (#993): a /code-review comment is a verdict only for
@@ -274,6 +281,30 @@ jobs:
           HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
           HEAD_TIME=$(gh api "repos/$REPO/commits/$HEAD_SHA" -q .commit.committer.date)
 
+          # Freshness anchor (#1134). Normal path: anchor on HEAD_TIME (above).
+          # Autobase path (SKIP=true — this push is an osasuwu-ci[bot] auto-
+          # rebase): HEAD is the bot's just-made 2-parent merge commit. No review
+          # comment is newer than that, so anchoring on it is an anchor-trap — a
+          # clean PR fail-closes forever AND #1131's live CRITICAL (posted for the
+          # last real head) reads as stale. Instead anchor on the LAST NON-BOT
+          # HEAD: the committer date of the most recent PR commit whose author is
+          # not osasuwu-ci[bot], walking newest→oldest so a run of consecutive
+          # auto-rebases (PR #963 had 28) is skipped — parents[0] alone would not
+          # suffice. A null/unlinked commit author counts as real (safe default:
+          # it keeps a comment eligible rather than dropping it). If (impossibly)
+          # every commit is the bot, fall back to HEAD_TIME → strict freshness →
+          # fail-closed rather than pass unverified.
+          if [ "${SKIP:-}" = "true" ]; then
+            ANCHOR_TIME=$(gh api "repos/$REPO/pulls/$PR/commits" --paginate \
+              | jq -rs 'add
+                  | map(select((.author.login // "") != "osasuwu-ci[bot]"))
+                  | (.[-1].commit.committer.date // "")')
+            if [ -z "$ANCHOR_TIME" ]; then ANCHOR_TIME="$HEAD_TIME"; fi
+            echo "::notice::autobase push — anchoring review freshness on last non-bot head ($ANCHOR_TIME) instead of the bot merge commit ($HEAD_TIME)."
+          else
+            ANCHOR_TIME="$HEAD_TIME"
+          fi
+
           # Selection happens in standalone jq, not gh's --jq:
           #   - gh rejects `--slurp` combined with `--jq` (despite the help
           #     text), and without slurping, --jq runs per page so `.[-1]`
@@ -287,7 +318,7 @@ jobs:
           # `total` = all code-review-titled comments (any age); `freshBody` =
           # body of the latest one created at/after the head commit ($head).
           sel=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            | jq -rs --arg head "$HEAD_TIME" 'add
+            | jq -rs --arg head "$ANCHOR_TIME" 'add
                 | map(select(.body | test("(^|\\n)#{1,6}[ \\t]*(Claude[ \\t]+)?Code[ \\t]+Review"; "i")))
                 | { total: length,
                     freshBody: ( map(select(.created_at >= $head)) | (.[-1].body // "") ) }
@@ -305,11 +336,11 @@ jobs:
           fi
 
           if [ -z "$body" ]; then
-            # The plugin HAS reviewed this PR before, but no comment is newer
-            # than the current head commit — the latest review run errored or
-            # never posted for $HEAD_SHA. A stale prior-SHA comment is not a
-            # verdict for this head (#993). Fail closed; re-run code-review.
-            echo "::error::/code-review has prior comments on this PR but none newer than head commit $HEAD_SHA ($HEAD_TIME) — the latest review likely errored. Failing closed; re-run code-review."
+            # Prior review comment(s) exist but none is newer than the freshness
+            # anchor ($ANCHOR_TIME, computed above). The latest review errored or
+            # never posted for this head; a comment before the anchor is not its
+            # verdict (#993/#1134). Fail closed; re-run code-review.
+            echo "::error::/code-review comments exist but none newer than anchor $ANCHOR_TIME (head $HEAD_SHA @ $HEAD_TIME) — latest review likely errored. Failing closed; re-run."
             exit 1
           fi
 

--- a/tests/ci/test_code_review_autobase_skip.py
+++ b/tests/ci/test_code_review_autobase_skip.py
@@ -13,7 +13,11 @@ collide with the stable-PR-author contract for dependabot[bot].
 Predicates mirrored here:
   autobase_skip  = event == pull_request AND actor == 'osasuwu-ci[bot]'
   review_runs    = NOT autobase_skip AND (workflow_dispatch OR has_code)
-  verdict_runs   = NOT autobase_skip AND (pull_request OR workflow_dispatch)
+  verdict_runs   = pull_request OR workflow_dispatch  (#1134: the verdict step
+                   now RUNS on the autobase push too — it re-enforces the last
+                   real review verdict against the last-non-bot head anchor
+                   instead of skipping, which let #1131 auto-merge past a live
+                   CRITICAL — and branches on autobase_skip INTERNALLY.)
 """
 
 from __future__ import annotations
@@ -22,12 +26,7 @@ from pathlib import Path
 
 import yaml
 
-WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2]
-    / ".github"
-    / "workflows"
-    / "code-review.yml"
-)
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "code-review.yml"
 
 AUTOBASE_BOT = "osasuwu-ci[bot]"
 AUTOBASE_STEP_ID = "autobase"
@@ -49,8 +48,13 @@ def _review_should_run(
 
 
 def _verdict_should_run(*, event_name: str, actor: str) -> bool:
-    if _is_autobase_push(event_name=event_name, actor=actor):
-        return False
+    # #1134: the verdict step now RUNS on the autobase push. It no longer
+    # short-circuits on the osasuwu-ci[bot] actor — instead it runs and, on that
+    # push, anchors freshness on the last non-bot head (see the run body). The
+    # bug it fixes: skipping here left the `review` check green with nothing
+    # evaluated, so native auto-merge shipped #1131 past a live CRITICAL. `actor`
+    # is retained for call-site symmetry with `_review_should_run`.
+    del actor
     return event_name in ("pull_request", "workflow_dispatch")
 
 
@@ -58,25 +62,23 @@ def _verdict_should_run(*, event_name: str, actor: str) -> bool:
 
 
 def test_autobase_bot_synchronize_skips_review():
-    assert not _review_should_run(
-        event_name="pull_request", actor=AUTOBASE_BOT, has_code=True
-    )
+    assert not _review_should_run(event_name="pull_request", actor=AUTOBASE_BOT, has_code=True)
 
 
-def test_autobase_bot_synchronize_skips_verdict():
-    assert not _verdict_should_run(event_name="pull_request", actor=AUTOBASE_BOT)
+def test_autobase_bot_synchronize_runs_verdict():
+    # #1134: the verdict step now RUNS on the autobase push so it can re-enforce
+    # the last real review verdict against the last-non-bot head anchor. It used
+    # to skip — leaving `review` green with nothing evaluated → #1131 auto-merged
+    # past a live CRITICAL.
+    assert _verdict_should_run(event_name="pull_request", actor=AUTOBASE_BOT)
 
 
 def test_human_push_with_code_runs_review():
-    assert _review_should_run(
-        event_name="pull_request", actor="Osasuwu", has_code=True
-    )
+    assert _review_should_run(event_name="pull_request", actor="Osasuwu", has_code=True)
 
 
 def test_human_push_no_code_skips_review():
-    assert not _review_should_run(
-        event_name="pull_request", actor="Osasuwu", has_code=False
-    )
+    assert not _review_should_run(event_name="pull_request", actor="Osasuwu", has_code=False)
 
 
 def test_workflow_dispatch_always_runs_review():
@@ -87,17 +89,13 @@ def test_workflow_dispatch_always_runs_review():
 
 
 def test_workflow_dispatch_always_runs_verdict():
-    assert _verdict_should_run(
-        event_name="workflow_dispatch", actor="github-actions[bot]"
-    )
+    assert _verdict_should_run(event_name="workflow_dispatch", actor="github-actions[bot]")
 
 
 def test_jarvis_agent_push_runs_review():
     # Real rework commits come from "Jarvis Agent" (git author), but the
     # github.actor on the push is "Osasuwu" or a PAT — never osasuwu-ci[bot].
-    assert _review_should_run(
-        event_name="pull_request", actor="Osasuwu", has_code=True
-    )
+    assert _review_should_run(event_name="pull_request", actor="Osasuwu", has_code=True)
 
 
 # --- Config dimension: pin the YAML structure ---
@@ -155,13 +153,25 @@ def test_review_step_gated_on_autobase():
     )
 
 
-def test_verdict_step_gated_on_autobase():
+def test_verdict_step_runs_on_autobase_but_branches_internally():
+    # #1134: the verdict step's if: must NOT gate on steps.autobase.outputs.skip
+    # (so it RUNS on the autobase push), but the flag must still reach the step
+    # (env or run body) so it can branch the freshness anchor internally.
     steps = _load_steps()
     step = _step_by_name(steps, "Verify review verdict")
     assert step is not None, "Verify review verdict step not found"
     condition = str(step.get("if", ""))
-    assert "steps.autobase.outputs.skip" in condition, (
-        "Verify review verdict step must gate on steps.autobase.outputs.skip != 'true'"
+    assert "steps.autobase.outputs.skip" not in condition, (
+        "Verify review verdict must RUN on the autobase push — drop the "
+        "steps.autobase.outputs.skip gate from its if: (#1134). Skipping there "
+        "let #1131 auto-merge past a CRITICAL (`review` green, nothing evaluated)."
+    )
+    env = step.get("env", {}) or {}
+    in_env = any("steps.autobase.outputs.skip" in str(v) for v in env.values())
+    in_run = "steps.autobase.outputs.skip" in str(step.get("run", ""))
+    assert in_env or in_run, (
+        "Verdict step must still reference steps.autobase.outputs.skip (via env "
+        "or run body) to branch the freshness anchor on the autobase path."
     )
 
 

--- a/tests/ci/test_code_review_verdict_guard.py
+++ b/tests/ci/test_code_review_verdict_guard.py
@@ -25,6 +25,7 @@ Two halves, per the #326 guard-test convention:
   - Logic: reimplement the verdict decision rule in Python and assert it
     blocks/allows the scenarios the workflow claims to handle.
 """
+
 from __future__ import annotations
 
 import re
@@ -148,6 +149,66 @@ def verdict_fresh(comments: list[tuple[str, str]], head_time: str) -> str:
     if not fresh:
         return "fail"  # only stale prior-SHA comment(s) — fail closed (#993)
     return verdict([fresh[-1]])  # latest fresh comment → content verdict
+
+
+# -- Autobase carry-forward anchor (mirror of the #1134 autobase branch) -------
+#
+# On the osasuwu-ci[bot] auto-rebase (update-branch) push the verdict step now
+# RUNS — its if: no longer short-circuits on steps.autobase.outputs.skip — but
+# HEAD is the bot's 2-parent merge commit. Anchoring freshness on that commit's
+# committer time is an anchor-trap: no review comment is newer than a just-made
+# merge commit, so a clean PR would fail-closed forever. Instead the autobase
+# branch anchors on the LAST NON-BOT HEAD — the committer date of the most
+# recent PR commit whose author is not osasuwu-ci[bot] — so the last REAL review
+# verdict is re-enforced. The walk is newest→oldest so a run of consecutive
+# auto-rebases (PR #963 had 28) is skipped, not just parents[0]. A null/unlinked
+# commit author counts as real (safe default). Normal path unchanged: anchor ==
+# head_time.
+AUTOBASE_BOT = "osasuwu-ci[bot]"
+
+
+def anchor_time(commits: list[tuple[str, str | None]], head_time: str, *, autobase: bool) -> str:
+    """Freshness anchor for the verdict step (mirror of the #1134 bash).
+
+    Args:
+        commits: ``(committer_date, author_login)`` pairs for the PR commits,
+            oldest→newest (REST ``pulls/<n>/commits`` order). ``author_login`` is
+            the GitHub login or ``None`` when the commit email is unlinked.
+        head_time: committer date of the current head commit.
+        autobase: whether ``steps.autobase.outputs.skip == 'true'`` (the push was
+            an osasuwu-ci[bot] auto-rebase).
+
+    Returns the ISO-8601 UTC string to anchor freshness on. Normal path →
+    ``head_time``. Autobase path → committer date of the most recent non-bot
+    commit, or ``head_time`` if the PR is (impossibly) all-bot.
+    """
+    if not autobase:
+        return head_time
+    non_bot = [c for c in commits if (c[1] or "") != AUTOBASE_BOT]
+    if not non_bot:
+        # No real commit at all (should not happen — every PR has a first human
+        # commit). Fall back to HEAD → strict freshness → fail-closed on this
+        # bizarre all-bot PR rather than pass unverified.
+        return head_time
+    return non_bot[-1][0]
+
+
+def verdict_autobase(
+    comments: list[tuple[str, str]],
+    commits: list[tuple[str, str | None]],
+    head_time: str,
+    *,
+    autobase: bool,
+) -> str:
+    """Mirror of the full verdict step INCLUDING the #1134 autobase branch.
+
+    Computes the freshness anchor (``head_time`` on the normal path, the last
+    non-bot head on the autobase path) then applies the SAME freshness + two-gate
+    content verdict as ``verdict_fresh``. AC3 (total==0→pass) and AC4 (comments
+    exist but none fresh-for-anchor→fail-closed) fall out of ``verdict_fresh``
+    unchanged — only the anchor differs.
+    """
+    return verdict_fresh(comments, anchor_time(commits, head_time, autobase=autobase))
 
 
 # The literal shape that false-passed the gate on PR #957: MAJOR + MINOR
@@ -332,9 +393,7 @@ class TestVerdictLogic:
 
     def test_major_heading_with_stray_no_blockers_line_fails(self):
         # "Blocking issues — None" prose must not shadow a real "### MAJOR".
-        body = (
-            "## Code Review\n\n### Blocking issues — None\n\n### MAJOR\n\n1. real bug\n"
-        )
+        body = "## Code Review\n\n### Blocking issues — None\n\n### MAJOR\n\n1. real bug\n"
         assert verdict([body]) == "fail"
 
     def test_severity_decoration_does_not_span_lines(self):
@@ -524,6 +583,155 @@ class TestFreshnessLogic:
         )
 
 
+class TestAutobaseAnchorLogic:
+    """#1134: on the autobase (osasuwu-ci[bot] update-branch) push the verdict
+    step now RUNS and anchors freshness on the last non-bot head — not the bot's
+    2-parent merge commit. Anchoring on the merge commit is an anchor-trap (no
+    review comment is newer than a just-made merge commit → a clean PR would
+    fail-closed forever; and #1131's live CRITICAL, posted for the last real
+    head, would be dropped as stale). AC2-AC6.
+    """
+
+    # --- #1131 timeline (AC6), all 2026-07-08 UTC ---
+    CRITICAL_COMMENT = "## Code Review — PR #1131\n\n### CRITICAL\n\n1. Data-loss on empty batch\n"
+    # commits oldest→newest: last real head, then the bot 2-parent merge (HEAD).
+    PR_1131_COMMITS = [
+        ("2026-07-08T06:00:52Z", "Osasuwu"),  # 45e17d61b — last real head
+        ("2026-07-08T06:14:50Z", AUTOBASE_BOT),  # ef39b0a86 — bot merge (HEAD)
+    ]
+    PR_1131_HEAD = "2026-07-08T06:14:50Z"  # bot merge committer time
+    PR_1131_COMMENTS = [
+        (CRITICAL_COMMENT, "2026-07-08T05:51:50Z"),  # stale (< 06:00:52 anchor)
+        (CRITICAL_COMMENT, "2026-07-08T06:14:38Z"),  # fresh (>= anchor) — selected
+    ]
+
+    def test_pr_1131_autobase_anchors_on_last_real_head_and_blocks(self):
+        # AC6: the 06:14:57 autobase run must BLOCK. Carry-forward anchor =
+        # 06:00:52 → the 06:14:38 CRITICAL is fresh → block-first grep → fail.
+        assert (
+            verdict_autobase(
+                self.PR_1131_COMMENTS,
+                self.PR_1131_COMMITS,
+                self.PR_1131_HEAD,
+                autobase=True,
+            )
+            == "fail"
+        )
+
+    def test_pr_1131_head_anchor_would_have_masked_the_critical(self):
+        # Why not anchor on HEAD: the bot merge commit (06:14:50) is newer than
+        # BOTH CRITICAL comments, so a naive head anchor finds nothing fresh.
+        # (Combined with the OLD if-gate the step was skipped entirely — either
+        # way the live CRITICAL went un-enforced and #1131 auto-merged.)
+        assert verdict_fresh(self.PR_1131_COMMENTS, self.PR_1131_HEAD) == "fail"
+
+    # --- AC3: autobase, zero review comments → pass (do not fail-close) ---
+    def test_autobase_no_review_comment_passes(self):
+        commits = [
+            ("2026-07-01T10:00:00Z", "Osasuwu"),
+            ("2026-07-01T11:00:00Z", AUTOBASE_BOT),
+        ]
+        head = "2026-07-01T11:00:00Z"
+        assert verdict_autobase([], commits, head, autobase=True) == "pass"
+        # non-review comments only (no code-review title) also pass
+        assert (
+            verdict_autobase(
+                [("merge-train queued", "2026-07-01T11:30:00Z")],
+                commits,
+                head,
+                autobase=True,
+            )
+            == "pass"
+        )
+
+    # --- AC4 / CRITIC Risk #1: stale clean before the last real head → fail ---
+    def test_autobase_stale_clean_before_last_real_head_fails_closed(self):
+        commits = [
+            ("2026-07-01T10:00:00Z", "Osasuwu"),  # older real commit
+            ("2026-07-01T12:00:00Z", "Osasuwu"),  # LAST real head → anchor
+            ("2026-07-01T13:00:00Z", AUTOBASE_BOT),  # autobase (HEAD)
+        ]
+        # Clean verdict from 11:00 — after the OLDER real commit but BEFORE the
+        # last real head (12:00). Must not be resurrected → fail closed. Pins
+        # "anchor on the LAST real head", not the first.
+        stale = [(CANONICAL_CLEAN_SPEC, "2026-07-01T11:00:00Z")]
+        assert verdict_autobase(stale, commits, "2026-07-01T13:00:00Z", autobase=True) == "fail"
+
+    # --- AC5 + autobase-clean-fresh: walk past consecutive autobases ---
+    def test_autobase_consecutive_rebases_anchor_on_last_real_head(self):
+        # PR #963 shape: a run of consecutive bot rebases. The anchor must walk
+        # back past ALL of them (not parents[0]) to the last real head, so a
+        # clean review of that head still passes.
+        commits = [
+            ("2026-07-01T10:00:00Z", "Osasuwu"),  # real head, reviewed clean
+            ("2026-07-01T11:00:00Z", AUTOBASE_BOT),  # autobase 1
+            ("2026-07-01T12:00:00Z", AUTOBASE_BOT),  # autobase 2
+            ("2026-07-01T13:00:00Z", AUTOBASE_BOT),  # autobase 3 (HEAD)
+        ]
+        clean_for_real_head = [(CANONICAL_CLEAN_SPEC, "2026-07-01T10:30:00Z")]
+        assert (
+            verdict_autobase(clean_for_real_head, commits, "2026-07-01T13:00:00Z", autobase=True)
+            == "pass"
+        )
+        # Anchor-trap proof: naive head anchoring (13:00) drops the 10:30 clean
+        # comment → fail-closed on a legitimately clean PR.
+        assert verdict_fresh(clean_for_real_head, "2026-07-01T13:00:00Z") == "fail"
+
+    # --- anchor_time unit behaviour ---
+    def test_anchor_time_normal_path_is_head(self):
+        assert (
+            anchor_time(
+                [("2026-07-01T10:00:00Z", "Osasuwu")],
+                "2026-07-01T12:00:00Z",
+                autobase=False,
+            )
+            == "2026-07-01T12:00:00Z"
+        )
+
+    def test_anchor_time_autobase_walks_back_past_bots(self):
+        commits = [
+            ("2026-07-01T10:00:00Z", "Osasuwu"),
+            ("2026-07-01T11:00:00Z", AUTOBASE_BOT),
+            ("2026-07-01T12:00:00Z", AUTOBASE_BOT),
+        ]
+        assert anchor_time(commits, "2026-07-01T12:00:00Z", autobase=True) == "2026-07-01T10:00:00Z"
+
+    def test_anchor_time_null_author_counts_as_real(self):
+        # An unlinked/null GitHub author is treated as non-bot (safe default).
+        commits = [
+            ("2026-07-01T10:00:00Z", None),
+            ("2026-07-01T11:00:00Z", AUTOBASE_BOT),
+        ]
+        assert anchor_time(commits, "2026-07-01T11:00:00Z", autobase=True) == "2026-07-01T10:00:00Z"
+
+    def test_anchor_time_all_bot_falls_back_to_head(self):
+        assert (
+            anchor_time(
+                [("2026-07-01T11:00:00Z", AUTOBASE_BOT)],
+                "2026-07-01T11:00:00Z",
+                autobase=True,
+            )
+            == "2026-07-01T11:00:00Z"
+        )
+
+    # --- AC1 sanity: normal path via the mirror == verdict_fresh (unchanged) ---
+    def test_normal_path_matches_verdict_fresh(self):
+        commits = [
+            ("2026-07-01T10:00:00Z", "Osasuwu"),
+            ("2026-07-01T12:00:00Z", "Osasuwu"),
+        ]
+        head = "2026-07-01T12:00:00Z"
+        for comments in (
+            [(CANONICAL_CLEAN_SPEC, head)],
+            [(BLOCKING_COMMENT, head)],
+            [(CANONICAL_CLEAN_SPEC, "2026-07-01T09:00:00Z")],  # stale → fail
+            [],
+        ):
+            assert verdict_autobase(comments, commits, head, autobase=False) == verdict_fresh(
+                comments, head
+            )
+
+
 # -- Workflow wiring ----------------------------------------------------------
 
 
@@ -629,9 +837,9 @@ class TestVerdictStepWiring:
             "check under the runner's C.UTF-8 default and a coexisting MINOR "
             "section flips the merge gate to a false PASS."
         )
-        assert run.index("export LC_ALL=C") < run.index(
-            "(CRITICAL|MAJOR|BLOCKING)"
-        ), "LC_ALL=C must be exported before the first severity grep."
+        assert run.index("export LC_ALL=C") < run.index("(CRITICAL|MAJOR|BLOCKING)"), (
+            "LC_ALL=C must be exported before the first severity grep."
+        )
 
     def test_block_check_is_case_sensitive_allcaps(self, verdict_step):
         # #976: the block grep must be `-qE` (case-sensitive), NOT `-qiE` —
@@ -643,8 +851,7 @@ class TestVerdictStepWiring:
             "case prose (#976)."
         )
         assert "grep -qiE '^#{1,6}[^[:alnum:]]*(CRITICAL" not in run, (
-            "Block check must not use -i (case-insensitive) — that is the "
-            "#962 false-block bug."
+            "Block check must not use -i (case-insensitive) — that is the #962 false-block bug."
         )
 
     def test_found_n_issues_is_a_nonblocking_pass(self, verdict_step):
@@ -655,13 +862,11 @@ class TestVerdictStepWiring:
         )
         block_at = run.index("(CRITICAL|MAJOR|BLOCKING)")
         found_at = run.index("Found [0-9]+ issues?:")
-        assert block_at < found_at, (
-            "Block check must precede the Found-N pass branch."
-        )
+        assert block_at < found_at, "Block check must precede the Found-N pass branch."
         # The Found-N branch must lead to a pass (exit 0), not a block. The
         # branch spans the if-guard, a count-extraction line, the notice, and
         # exit 0 — widen the slice to cover it without reaching the next branch.
-        found_branch = run[found_at:found_at + 380]
+        found_branch = run[found_at : found_at + 380]
         assert "exit 0" in found_branch and "exit 1" not in found_branch, (
             "A 'Found N issues:' comment with no blocking heading must PASS "
             "(exit 0), not block (#956 advisory-only false-block)."
@@ -672,15 +877,13 @@ class TestVerdictStepWiring:
         # case-insensitively (it is title-case prose).
         run = verdict_step["run"]
         assert "blocking issues" in run.lower(), (
-            "A 'Blocking issues — None' APPROVE summary (#962) must be "
-            "recognized as a pass."
+            "A 'Blocking issues — None' APPROVE summary (#962) must be recognized as a pass."
         )
 
     def test_nonblocking_severity_headings_pass(self, verdict_step):
         run = verdict_step["run"]
         assert r"^#{1,6}[^[:alnum:]]*(MINOR|NITPICK|LOW|INFO|MEDIUM)\b" in run, (
-            "Minor-only / advisory-only severity sections must be a positive "
-            "pass signal (#963)."
+            "Minor-only / advisory-only severity sections must be a positive pass signal (#963)."
         )
 
     def test_nonblocking_severity_grep_is_case_insensitive(self, verdict_step):
@@ -688,9 +891,7 @@ class TestVerdictStepWiring:
         # heading ("#### Low" on PR #1049) passes instead of fail-closing. Safe
         # because it runs after the case-sensitive block check.
         run = verdict_step["run"]
-        assert (
-            "grep -qiE '^#{1,6}[^[:alnum:]]*(MINOR|NITPICK|LOW|INFO|MEDIUM)" in run
-        ), (
+        assert "grep -qiE '^#{1,6}[^[:alnum:]]*(MINOR|NITPICK|LOW|INFO|MEDIUM)" in run, (
             "Non-blocking severity grep must be case-insensitive (-qiE) so a "
             "title-case advisory heading (#### Low, PR #1049) is a pass, not a "
             "fail-closed (#1050)."
@@ -727,9 +928,7 @@ class TestVerdictStepWiring:
         nonblock_at = run.index("(MINOR|NITPICK|LOW|INFO|MEDIUM)")
         assert block_at < clean_at, "Clean line must not shadow a block heading."
         assert block_at < found_at, "Found-N must not shadow a block heading."
-        assert block_at < nonblock_at, (
-            "Non-blocking severity check must run after the block check."
-        )
+        assert block_at < nonblock_at, "Non-blocking severity check must run after the block check."
 
     def test_step_ends_fail_closed(self, verdict_step):
         assert verdict_step["run"].strip().endswith("exit 1"), (
@@ -787,4 +986,60 @@ class TestFreshnessGateWiring:
             "Stale-only (no comment fresh for the head SHA) must FAIL CLOSED "
             "(exit 1) — the latest review errored; do not consume a prior-SHA "
             "verdict (#993)."
+        )
+
+
+class TestAutobaseAnchorWiring:
+    """#1134: the verdict step must RUN on the osasuwu-ci[bot] auto-rebase push
+    (drop the skip gate from its `if:`) and, on that branch, anchor freshness on
+    the last non-bot head instead of the bot's 2-parent merge commit. #1131
+    auto-merged past a live CRITICAL because the step was skipped there and the
+    `review` check went green with nothing evaluated."""
+
+    def test_step_no_longer_if_gated_on_autobase_skip(self, verdict_step):
+        assert "steps.autobase.outputs.skip" not in str(verdict_step.get("if", "")), (
+            "Verify review verdict must RUN on the autobase push — the "
+            "steps.autobase.outputs.skip gate must not be in its if: (#1134). "
+            "Skipping there is what let #1131 auto-merge past a CRITICAL."
+        )
+
+    def test_step_imports_autobase_skip_for_internal_branch(self, verdict_step):
+        # The flag no longer gates the step; it must still reach the body (via
+        # env or the run script) so the step can branch the anchor internally.
+        env = verdict_step.get("env", {}) or {}
+        in_env = any("steps.autobase.outputs.skip" in str(v) for v in env.values())
+        in_run = "steps.autobase.outputs.skip" in verdict_step.get("run", "")
+        assert in_env or in_run, (
+            "Verdict step must still reference steps.autobase.outputs.skip (via "
+            "env or run body) to branch the freshness anchor internally (#1134)."
+        )
+
+    def test_autobase_branch_walks_pr_commits_filtering_the_bot(self, verdict_step):
+        run = verdict_step["run"]
+        assert "pulls/" in run and "/commits" in run, (
+            "Autobase branch must list the PR commits (pulls/<n>/commits) to "
+            "find the last non-bot head."
+        )
+        assert ".author.login" in run, (
+            "Autobase anchor must key off commit author.login (null/unlinked "
+            "author counts as real — safe default, #1134)."
+        )
+        assert "osasuwu-ci[bot]" in run, (
+            "Autobase anchor must filter out osasuwu-ci[bot] commits so it walks "
+            "back to the last real head (#963: 28 consecutive rebases; "
+            "parents[0] alone breaks)."
+        )
+
+    def test_autobase_anchor_feeds_the_shared_fresh_selection(self, verdict_step):
+        # The computed anchor must feed the SAME selection/grep chain — the
+        # autobase path is not a parallel copy of the two-gate verdict.
+        run = verdict_step["run"]
+        assert '--arg head "$ANCHOR_TIME"' in run, (
+            "The freshness selection must consume the computed ANCHOR_TIME "
+            "(head_time on the normal path, last-non-bot-head on the autobase "
+            "path), not a raw HEAD_TIME — so both paths share one verdict chain."
+        )
+        assert ".created_at >= $head" in run, (
+            "Autobase path must reuse the shared freshness filter, not a "
+            "separate selection (#1134)."
         )


### PR DESCRIPTION
## Summary
The `Verify review verdict` step in `code-review.yml` was `if:`-gated on `steps.autobase.outputs.skip != 'true'`, so on the osasuwu-ci[bot] auto-rebase / update-branch push it **never ran** — the `review` check concluded green with nothing evaluated. Native auto-merge then fired on that unverified green and shipped **#1131 past a live CRITICAL**. This drops the skip-gate from the step's `if:` (so it runs on the autobase push) and branches internally on the `SKIP` env: on the autobase path it anchors comment freshness on the **last non-bot head** instead of the bot's 2-parent merge commit.

## Why
On an autobase push HEAD is the bot's just-made merge commit — no review comment is newer than it, so the existing head-time freshness anchor (#993) would either fail-close a clean PR forever *or*, combined with the old skip-gate, silently pass with nothing checked (the actual #1131 failure). Anchoring on the committer date of the most recent PR commit whose author is not `osasuwu-ci[bot]` restores the last real review verdict as the gate — a live CRITICAL posted for the last real head is correctly seen as fresh and blocks.

Closes #1134

## Decisions & Alternatives
Grill-locked; decision `5b541518-96d3-4907-9349-ca21bb99e055` (actor `session:grill-1134`).
- **Run-and-branch-internally, not a second gated step.** Keeps one verdict step; the normal (non-autobase) path is byte-for-byte unchanged (anchor = HEAD committer date, #993). Alternative — a parallel autobase-only verdict step — was rejected as duplicated block/pass logic that would drift.
- **Anchor on last non-bot head, walking newest→oldest.** `parents[0]` alone breaks on a run of consecutive autobases (PR #963 had 28). Walking the PR commit list and filtering `author.login == 'osasuwu-ci[bot]'` handles any-length rebase runs.
- **Null/unlinked commit author counts as real** (safe default — keeps a comment eligible rather than dropping it). **All-bot → fall back to HEAD_TIME** → strict freshness → fail-closed rather than pass unverified.
- **Elegant consequence:** feeding a conditional `ANCHOR_TIME` into the *unchanged* selection/verdict chain means AC3 (total==0 → pass) and AC4 (comments-but-none-fresh → fail-closed) fall out of the existing `verdict_fresh` branches — only the anchor computation is genuinely new.

## Risk Assessment
- **MEDIUM**: merge-gate hardening on a PROTECTED CI file. The normal path is unchanged (pinned by `test_normal_path_matches_verdict_fresh` / `test_anchor_time_normal_path_is_head`); only the previously-skipped autobase path gains behavior. No security/data-loss surface.

## Testing
- `pytest tests/ci/` → **558 passed**. TDD RED→GREEN confirmed: the 4 `TestAutobaseAnchorWiring` config tests + the inverted `test_verdict_step_runs_on_autobase_but_branches_internally` were RED against the unedited YAML, GREEN after the edit.
- `bash -n` on the extracted verdict-step run body → no syntax errors.
- Secret-pattern scan on the staged diff → clean.
- New logic tests (`TestAutobaseAnchorLogic`) are an executable spec for the anchor walk incl. null-author and all-bot fallback edge cases, and pin the #1131 replay (CRITICAL at the last real head blocks; head-anchor would have masked it).

## Files Changed
- `.github/workflows/code-review.yml` **[PROTECTED]** — verdict step: dropped `steps.autobase.outputs.skip` from `if:`, added `SKIP` env, conditional `ANCHOR_TIME` block, `--arg head "$ANCHOR_TIME"`, reworded stale-fail branch for #993/#1134. Edited inline per `/implement` with principal approval (grill-locked).
- `tests/ci/test_code_review_verdict_guard.py` — `TestAutobaseAnchorLogic` (logic dimension) + `TestAutobaseAnchorWiring` (config dimension).
- `tests/ci/test_code_review_autobase_skip.py` — inverted the verdict predicate/tests so the autobase push RUNS the verdict.

## ⚠️ AC8 — self-modifying `code-review.yml` (held as draft)
`anthropics/claude-code-action@v1` skip-passes PRs that modify `code-review.yml` (exit 0, no comment), so the `review` gate is a **structural false-green** here — it cannot actually review this PR. Held as **draft** so native auto-merge cannot fire on that fake green. Merge is deliberate after self-review + local `pytest tests/ci/` (done, 558 green) + secret scan (clean); **#1134 will be linked in the merge comment**. This is the documented path (verified PR #1084, 2026-07-02) — admin-merge is not needed; the action exits 0.