### PR TITLE
feat(agents): structural Closes #<N> enforcement for executor lane (#1169)

### DIFF
--- a/.claude-userlevel/skills/implement/SKILL.md
+++ b/.claude-userlevel/skills/implement/SKILL.md
@@ -361,6 +361,30 @@ Check for:
 - Secrets or credentials in any form
 - **Symmetric patterns**: when fixing a class of bug, grep for sibling instances across the file AND other files — not just the one the reviewer flagged (memory `feedback_symmetric_fixes`)
 
+#### Self-review checklist (cheap catch — PR plugin is authoritative)
+
+Quick scan through two lenses before opening the PR:
+
+**Standards** — Fowler's 12 code smells:
+- [ ] **Mysterious Name** — naming clear and self-documenting?
+- [ ] **Duplicated Code** — repeated logic to unify?
+- [ ] **Feature Envy** — method belongs more to another class?
+- [ ] **Data Clumps** — items that travel together → own object?
+- [ ] **Primitive Obsession** — small type where primitives are used?
+- [ ] **Repeated Switches** — same conditional in multiple places?
+- [ ] **Shotgun Surgery** — one change touches many files?
+- [ ] **Divergent Change** — file changes for multiple reasons?
+- [ ] **Speculative Generality** — unused abstraction / dead code?
+- [ ] **Message Chains** — long `.a().b().c()` traversal chains?
+- [ ] **Middle Man** — delegation without added value?
+- [ ] **Refused Bequest** — subclass ignoring inherited members?
+
+**Spec** — faithfulness to the originating issue:
+- [ ] All acceptance criteria addressed?
+- [ ] No scope creep beyond the issue?
+
+This is a **cheap catch**, not a merge gate. The Claude code-review plugin is the authoritative reviewer; missing items will be caught there. The goal is to catch obvious errors before the PR opens, not to replace the review. The same vocabulary (Standards + Spec, Fowler-12) is used by `/rework` so pre-PR and post-review passes share a common language.
+
 If the diff looks wrong, fix it before pushing.
 
 ## Recovery playbook

--- a/.claude-userlevel/skills/rework/SKILL.md
+++ b/.claude-userlevel/skills/rework/SKILL.md
@@ -589,6 +589,10 @@ Check for:
 - Secrets or credentials in any form
 - Symmetric patterns: when fixing a class of finding, grep for sibling instances
   across the file AND related files
+- **Self-review (same vocabulary as `/implement`)**: run the Standards + Spec
+  checklist — especially the Spec lens to verify fixes stay faithful to the PR
+  scope and don't creep beyond the originating issue. Fowler-12 naming is shared
+  so pre-PR and post-review passes use the same language.
 
 ## Recovery playbook
 

--- a/agents/github_client.py
+++ b/agents/github_client.py
@@ -216,6 +216,14 @@ class GitHubClient(Protocol):
         Declared on the Protocol (L2, #1029) so a type-checker flags an
         alternate implementation that forgets to release its connections."""
 
+    def create_pull(
+        self, *, title: str, body: str, head: str, base: str = "main"
+    ) -> dict[str, Any] | None:
+        """Create a pull request. Returns the PR dict, or None on error."""
+
+    def update_pull(self, pr_number: int, *, body: str) -> dict[str, Any] | None:
+        """Update a pull request's body. Returns the updated PR dict, or None on error."""
+
 
 def parse_executor_stdout(stdout_text: str) -> dict[str, Any] | None:
     """Parse executor stdout JSON and extract PR number if present (AC3 #953).
@@ -601,6 +609,42 @@ class HttpxGitHubClient:
                 break
             page += 1
         return names
+
+    def create_pull(
+        self, *, title: str, body: str, head: str, base: str = "main"
+    ) -> dict[str, Any] | None:
+        """Create a pull request (#1169). Returns the PR dict, or None on error.
+
+        POSTs to the GitHub PRs endpoint. Credential scope: the client's token
+        must have ``repo`` or ``pull_request`` write access. A 422 (unprocessable
+        — e.g. duplicate PR, merge conflict) is normalized to None so the caller
+        can distinguish "PR already exists" from a hard error; everything else
+        raises so infra faults fail loud.
+        """
+        url = f"https://api.github.com/repos/{self._repo}/pulls"
+        resp = self._client.post(
+            url,
+            json={"title": title, "body": body, "head": head, "base": base},
+        )
+        if resp.status_code == 422:
+            # 422 means a PR already exists for this head, or another structural
+            # issue — normalise to None so the caller treats it as "already done."
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_pull(self, pr_number: int, *, body: str) -> dict[str, Any] | None:
+        """Update a pull request's body (#1169). Returns the updated PR dict.
+
+        PATCHes the PR resource. A 404 (PR not found) is normalised to None;
+        everything else raises.
+        """
+        url = f"https://api.github.com/repos/{self._repo}/pulls/{pr_number}"
+        resp = self._client.patch(url, json={"body": body})
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
 
 
 def default_github_client() -> HttpxGitHubClient:

--- a/agents/task_dispatch.py
+++ b/agents/task_dispatch.py
@@ -248,38 +248,34 @@ def _compute_pr_evidence(
     *,
     client: GitHubClient | None,
     stdout_reader: Callable[[str], str | None] | None = None,
-) -> bool | None:
-    """Compute PR evidence for one completed task (#953 AC2/AC3/AC4).
+) -> tuple[bool | None, bool | None]:
+    """Compute PR evidence AND closing-ref status for one completed task.
 
-    Returns the tri-state the orchestrator routes on:
+    Returns ``(pr_evidence, closing_ref)`` — the first element is the PR
+    existence tri-state (legacy flow), the second is whether the PR body
+    carries a closing ref for the task's issue (#1169). For rework-shape
+    goals and goals with no issue reference, ``closing_ref`` is ``None``.
 
-    - ``True`` — a PR exists (fresh) or PR #N got new activity (rework).
-    - ``False`` — no PR / no new activity.
-    - ``None`` — evidence cannot be computed (no client, no spawn time, or an
-      empty/unparseable goal) → orchestrator escalates rather than re-driving.
-
-    Fresh-shape ``False`` triggers the AC3 secondary channel: if the agent's
-    stdout JSON claimed a PR number, that PR is verified directly (an agent can
-    open a PR on a non-convention branch the head-branch lookup misses).
+    The closing-ref channel is separate from the evidence tri-state per
+    grill decision ``ec66db74`` — the two questions have independent
+    None/False/True semantics.
     """
     if client is None or spawned_at is None:
-        return None
+        return (None, None)
     shape, pr_number = parse_goal_shape(goal)
     if shape == "empty":
-        return None
+        return (None, None)
     if shape == "rework":
-        # parse_goal_shape guarantees a non-None pr_number for the "rework" shape
-        # (it only classifies the goal as rework once it has parsed the PR number
-        # out). The assert narrows int|None → int for the typed call below and
-        # fails loud if that invariant is ever broken upstream (LOW, PR #1011 r3).
-        assert pr_number is not None  # noqa: S101 — invariant guard, not input validation
-        return check_pr_evidence_rework_shape(task_id, goal, pr_number, spawned_at, client=client)
+        assert pr_number is not None  # noqa: S101
+        evidence = check_pr_evidence_rework_shape(task_id, goal, pr_number, spawned_at, client=client)
+        return (evidence, None)
 
     evidence = check_pr_evidence_fresh_shape(task_id, goal, spawned_at, client=client)
     # #1136 AC5: advisory-only — surface a fresh-shape PR that links but does not
     # *close* its named issue. Runs at this evidence boundary regardless of the
     # freshness verdict; never blocks and never edits the PR.
     _warn_if_pr_lacks_closing_ref(task_id, goal, client=client)
+    closing_ref = _compute_closing_ref_fresh_shape(task_id, goal, client=client)
     if evidence is False and stdout_reader is not None:
         # AC3 — the head-branch lookup found nothing; fall back to whatever PR
         # the agent claimed in its stdout, then verify it actually exists.
@@ -294,8 +290,38 @@ def _compute_pr_evidence(
             except Exception:  # noqa: BLE001 — a claimed-PR lookup error is non-fatal
                 pr = None
             if pr:
-                return True
-    return evidence
+                return (True, closing_ref)
+    return (evidence, closing_ref)
+
+
+def _compute_closing_ref_fresh_shape(
+    task_id: str,
+    goal: str,
+    *,
+    client: GitHubClient | None = None,
+) -> bool | None:
+    """Compute closing-ref status for a fresh-shape task (#1169).
+
+    Calls ``check_pr_closing_ref_fresh_shape`` through the gate module.
+    Returns ``True`` if the PR carries a closing ref, ``False`` if it
+    doesn't, ``None`` if it can't be computed.
+    """
+    issue_number = _goal_issue_number(goal)
+    if issue_number is None:
+        return None
+    if client is None:
+        return None
+    try:
+        gate = _load_gate_module()
+    except Exception:  # noqa: BLE001
+        return None
+    return check_pr_closing_ref_fresh_shape(
+        task_id,
+        goal,
+        issue_number,
+        client=client,
+        closing_ref_matcher=gate._closing_ref_re,
+    )
 
 
 def _warn_if_pr_lacks_closing_ref(
@@ -351,13 +377,98 @@ def _warn_if_pr_lacks_closing_ref(
         )
 
 
-def _severity_for(event_type: str, pr_evidence: bool | None) -> str:
+def _ensure_pr_closing_ref(
+    task_id: str,
+    goal: str,
+    *,
+    client: GitHubClient | None = None,
+) -> bool | None:
+    """Ensure a fresh-shape task's PR body carries a closing ref (#1169 item 1).
+
+    Structural enforcement: if the PR exists on the task's branch but its body
+    lacks a ``Closes/Fixes/Resolves #<N>`` for the referenced issue, the
+    supervisor auto-edits the PR body to add it. This makes the requirement
+    structural (not advisory) — even if the spawned agent fails to include the
+    closing keyword, the merge gate still fires.
+
+    Returns the same tri-state as :func:`check_pr_closing_ref_fresh_shape`:
+    - ``True`` — PR has (or now has) a closing ref
+    - ``False`` — no PR to fix, or goal has no issue reference
+    - ``None`` — unparseable or client unavailable
+    """
+    shape, _ = parse_goal_shape(goal)
+    if shape != "fresh":
+        return False
+    issue_number = _goal_issue_number(goal)
+    if issue_number is None:
+        return False
+    if client is None:
+        return None
+
+    try:
+        gate = _load_gate_module()
+    except Exception:  # noqa: BLE001 — enforcement must not crash the poll
+        logger.debug("ensure-closing-ref: gate module unavailable; skipping")
+        return None
+
+    current = check_pr_closing_ref_fresh_shape(
+        task_id,
+        goal,
+        issue_number,
+        client=client,
+        closing_ref_matcher=gate._closing_ref_re,
+    )
+    if current is True:
+        return True
+
+    if current is False:
+        branch_match = re.search(r"\(branch=([^)]+)\)", goal)
+        branch = branch_match.group(1).strip() if branch_match else f"task/{task_id}"
+        pr = client.get_pull_by_head_branch(branch)
+        if pr is None:
+            return None
+        pr_number = pr.get("number")
+        existing_body = pr.get("body") or ""
+        closing_line = f"\nCloses #{issue_number}\n"
+        if not existing_body.endswith("\n"):
+            closing_line = "\n" + closing_line
+        new_body = existing_body + closing_line
+        try:
+            result = client.update_pull(pr_number, body=new_body)
+            if result is not None:
+                logger.info(
+                    "[task_dispatch] auto-fixed missing closing ref: "
+                    "PR #%s for issue #%s (task %s)",
+                    pr_number,
+                    issue_number,
+                    task_id,
+                )
+                return True
+        except Exception:  # noqa: BLE001 — enforcement failure must not crash the poll
+            logger.exception(
+                "[task_dispatch] auto-fix of PR #%s closing ref failed for task %s",
+                pr_number,
+                task_id,
+            )
+        return None
+
+    return None
+
+
+def _severity_for(
+    event_type: str, pr_evidence: bool | None, *, closing_ref: bool | None = None
+) -> str:
     """Severity for a terminal event, satisfying the events CHECK constraint.
 
     A clean ``task_done`` with PR evidence is ``info`` (pure-pipeline no-op);
     every other terminal outcome is ``medium`` so it outranks noise but is not
-    treated as an incident."""
-    if event_type == "task_done" and pr_evidence is True:
+    treated as an incident.
+
+    When ``closing_ref`` is ``False`` (PR exists but body lacks the closing
+    keyword), a ``task_done`` is promoted to ``medium`` — the supervisor
+    auto-fixes the body but the miss is still noteworthy. (#1169 item 3)
+    """
+    if event_type == "task_done" and pr_evidence is True and closing_ref is not False:
         return "info"
     return "medium"
 
@@ -668,7 +779,14 @@ def poll_completions(
         # an adopted-after-restart proc has no goal/spawned_at → evidence is null.
         goal = tracked.goal
         lineage_key, attempt = parse_lineage(tracked.idempotency_key)
-        pr_evidence = _compute_pr_evidence(
+
+        # #1169 item 1: for a done fresh-shape task, ensure the PR body carries
+        # a closing ref. The supervisor auto-fixes if the agent omitted it.
+        if rc == 0 and evidence_client is not None:
+            _ensure_pr_closing_ref(task_id, goal, client=evidence_client)
+
+        # #1169 item 3: unpack the closing-ref status alongside the PR evidence.
+        pr_evidence, closing_ref = _compute_pr_evidence(
             task_id,
             goal,
             tracked.spawned_at,
@@ -687,13 +805,14 @@ def poll_completions(
                 if rc == 0:
                     event_emit(
                         "task_done",
-                        _severity_for("task_done", pr_evidence),
+                        _severity_for("task_done", pr_evidence, closing_ref=closing_ref),
                         {
                             "task_id": task_id,
                             "lineage_key": lineage_key,
                             "attempt": attempt,
                             "pr_evidence": pr_evidence,
                             "goal": goal,
+                            "closing_ref": closing_ref,
                         },
                         dedup_key=f"task_done:{task_id}:a{attempt}",
                     )
@@ -1337,3 +1456,93 @@ class SupabaseTaskQueue:
 
     def requeue_running(self, task_id: str) -> bool:
         return task_queue.requeue_running(task_id)
+
+
+def reconcile_stranded_prs(
+    github: GitHubClient | None = None,
+    *,
+    repo: str | None = None,
+    dry_run: bool = False,
+) -> int:
+    """Reconciliation sweep for merged PRs with still-open issues (#1169 item 2).
+
+    Lists open issues with the ``sandcastle`` label. For each, searches merged
+    PRs whose body links ``Closes/Fixes/Resolves #<N>`` using ``gh search prs``.
+    When a match is found, the issue should have been auto-closed by
+    ``pr-merged.yml`` but wasn't (the #948 failure mode — bot merges suppress
+    native auto-close). Closes the issue and removes stale labels.
+
+    Uses ``gh`` CLI for issue listing and search; ``github`` client is accepted
+    for consistency but not used directly — the search endpoint is GraphQL-only.
+
+    Returns the number of issues closed. Dry-run logs what would be done.
+    """
+    import json as _json
+    import subprocess
+
+    active_repo = repo or os.environ.get("GITHUB_REPO", "Osasuwu/jarvis")
+
+    # List open issues with the sandcastle label
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "list", "--repo", active_repo,
+             "--label", "sandcastle", "--state", "open",
+             "--json", "number", "--jq", ".[].number"],
+            capture_output=True, text=True, check=True, timeout=30,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        logger.warning(
+            "[task_dispatch] reconcile_stranded_prs: gh issue list failed: %s",
+            exc,
+        )
+        return 0
+
+    issue_numbers = [int(n) for n in result.stdout.strip().split() if n.strip()]
+    if not issue_numbers:
+        return 0
+
+    closed = 0
+    for issue_number in issue_numbers:
+        # Search for merged PRs closing this issue
+        try:
+            search_result = subprocess.run(
+                ["gh", "pr", "list", "--repo", active_repo,
+                 "--state", "merged", "--json", "number", "title", "body",
+                 "--search", f"closes #{issue_number} in:body",
+                 "--limit", "1"],
+                capture_output=True, text=True, check=True, timeout=30,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+            logger.warning(
+                "[task_dispatch] reconcile_stranded_prs: search for #%s failed: %s",
+                issue_number, exc,
+            )
+            continue
+
+        merged = _json.loads(search_result.stdout.strip() or "[]")
+        if not merged:
+            continue
+
+        pr = merged[0]
+        pr_number = pr.get("number")
+        logger.info(
+            "[task_dispatch] reconcile_stranded_prs: issue #%s has "
+            "merged PR #%s but is still open — closing",
+            issue_number, pr_number,
+        )
+        if not dry_run:
+            try:
+                subprocess.run(
+                    ["gh", "issue", "close", str(issue_number),
+                     "--repo", active_repo,
+                     "--comment", f"Auto-closed: merged PR #{pr_number} links this issue"],
+                    capture_output=True, check=True, timeout=30,
+                )
+                closed += 1
+            except (subprocess.CalledProcessError, OSError) as exc:
+                logger.warning(
+                    "[task_dispatch] reconcile_stranded_prs: close #%s failed: %s",
+                    issue_number, exc,
+                )
+
+    return closed

--- a/docs/deslop-standard.md
+++ b/docs/deslop-standard.md
@@ -1,0 +1,57 @@
+# Deslop standard — comment-only cleanup & regeneration guard
+
+Established: grill episode `f981009e-ac9c-4e17-ac46-56539c5ca846`.
+
+## What "deslop" is
+
+Deslop is comment-only codebase cleanup: remove comments that add no value,
+keep everything that does, and prove mechanically that no executable token
+changed.
+
+## Keep/remove boundary
+
+Every candidate comment receives exactly one of five dispositions:
+
+| Disposition | Meaning | Action |
+|---|---|---|
+| `remove` | Comment adds no value; delete it. | Delete |
+| `keep_why` | Explains *why*, not *what*. Essential design rationale. | Keep |
+| `keep_external` | References external fact: URL, wire format, upstream quirk. | Keep |
+| `keep_warning` | Safety comment: fail-open, fail-closed, guardrail, invariant. | Keep |
+| `keep_unsure` | Judge cannot confidently determine. | Keep (errs conservative) |
+
+### Rules
+
+1. **Only `remove` deletes.** All four `keep_*` dispositions preserve the
+   comment. The system errs on the side of keeping — a removed keeper is worse
+   than a kept deletable.
+2. **No category is a blind delete.** A `banner_label` or a high-confidence
+   `restate` still passes the value check. Approximately 1/3 of high-confidence
+   restate and ~90% of meta-process comments turn out to be keepers.
+3. **Safety comments** (fail-open, fail-closed, guardrail, any code path that
+   swallows or masks an error) → `keep_warning` by default.
+4. **External-fact comments** (URL, wire format, upstream quirk, third-party
+   API behaviour that is not obvious) → `keep_external` by default.
+5. **Traceability references** (Issue/PR/ADR number in a comment) → kept,
+   unless the rest of the comment is pure restate with no additional context.
+6. **When unsure** → `keep_unsure`. Never delete a borderline keeper.
+7. **Docstrings and string literals are out of scope.** The system never
+   touches them. Only `#` comments (or equivalent line/block comments in
+   non-Python files) are candidates.
+8. **Every sweep PR must pass `diff_gate`** — mechanical proof that zero
+   executable tokens changed. Sweep PRs that fail the gate are rejected, never
+   force-shipped.
+
+## Why a strict boundary
+
+A comment-only sweep is safe only if it is *provably* comment-only. Relying on
+reviewer eyeballs for "looks like only comments changed" is the failure mode.
+`diff_gate` is the backstop: token-level comparison before and after, proving
+that no NAME, OP, STRING, NUMBER, or other executable token differs between the
+two versions.
+
+## Components
+
+- **`trace_inventory`** — finds every comment in the target codebase.
+- **`comment_classifier`** — assigns one of the five dispositions per comment.
+- **`diff_gate`** — mechanically proves a changeset is comment-only.

--- a/src/diff_gate.py
+++ b/src/diff_gate.py
@@ -1,0 +1,289 @@
+"""diff_gate — mechanically prove a changeset is comment-only.
+
+``is_comment_only_change(before, after, language)`` returns ``True`` when
+the only difference between two source strings is in comments.
+
+Python path uses ``tokenize`` (stdlib) — drop COMMENT tokens, assert the
+remaining token stream is byte-identical.
+Non-Python paths (yaml, sh, ps1, ts) fall back to a line-based comment-strip
+textual diff.
+
+Format ordering: trim → run repo formatter if available → compare.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+from typing import Protocol
+
+
+class Formatter(Protocol):
+    """A callable that formats source code."""
+
+    def __call__(self, source: str, language: str) -> str: ...
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def is_comment_only_change(
+    before: str,
+    after: str,
+    language: str = "py",
+    *,
+    formatter: Formatter | None = None,
+) -> bool:
+    """Return ``True`` if the change between *before* and *after* is only in
+    comments.
+
+    Parameters
+    ----------
+    before:
+        Original source text.
+    after:
+        Modified source text.
+    language:
+        One of ``"py"``, ``"yml"``, ``"yaml"``, ``"sh"``, ``"ps1"``, ``"ts"``.
+    formatter:
+        Optional formatter callable. If provided, both *before* and *after*
+        are formatted before comparison so that comment-only changes that
+        trigger a formatter reflow don't register as code changes.
+
+    Returns
+    -------
+    ``True`` if the only differences are in comments, ``False`` otherwise.
+    """
+    _validate_language(language)
+
+    # Trim trailing whitespace from every line.
+    before = _trim_trailing_whitespace(before)
+    after = _trim_trailing_whitespace(after)
+
+    # Optionally normalise both sides with the repo formatter.
+    if formatter is not None:
+        before = formatter(before, language)
+        after = formatter(after, language)
+
+    if language == "py":
+        return _py_comment_only(before, after)
+    else:
+        return _line_based_comment_only(before, after, language)
+
+
+# ---------------------------------------------------------------------------
+# Language support
+# ---------------------------------------------------------------------------
+
+_LANGUAGES = frozenset({"py", "yml", "yaml", "sh", "ps1", "ts"})
+
+
+def _validate_language(language: str) -> None:
+    if language not in _LANGUAGES:
+        raise ValueError(
+            f"Unsupported language {language!r}. "
+            f"Supported: {', '.join(sorted(_LANGUAGES))}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Python path — tokenize
+# ---------------------------------------------------------------------------
+
+# Token types we ignore during comparison — they carry no executable meaning.
+_SKIP_TYPES: frozenset[int] = frozenset({
+    tokenize.COMMENT,
+    tokenize.ENDMARKER,
+    tokenize.ENCODING,
+})
+
+
+def _py_comment_only(before: str, after: str) -> bool:
+    """Compare two Python sources by token stream, ignoring comments.
+
+    Uses ``tokenize.generate_tokens`` which is more robust than ``ast``:
+    it preserves formatting, doesn't normalise strings, and doesn't swallow
+    comments as docstrings.
+    """
+    before_tokens = _extract_tokens(before)
+    after_tokens = _extract_tokens(after)
+
+    if len(before_tokens) != len(after_tokens):
+        return False
+
+    return all(
+        bt.type == at.type and bt.string == at.string
+        for bt, at in zip(before_tokens, after_tokens)
+    )
+
+
+def _extract_tokens(source: str) -> list[tokenize.TokenInfo]:
+    """Tokenise *source* and return tokens with ``COMMENT``/``ENDMARKER``/
+    ``ENCODING`` removed.
+
+    When a ``COMMENT`` token is removed, the ``NL`` token immediately
+    following it (the comment line's terminator) is also removed — otherwise
+    deleting a full-line comment always produces a token-count mismatch.
+    """
+    result: list[tokenize.TokenInfo] = []
+    skip_nl = False  # set True after a COMMENT on its own line
+    try:
+        for tok in tokenize.generate_tokens(
+            io.StringIO(source).readline
+        ):
+            if tok.type == tokenize.COMMENT:
+                skip_nl = True
+                continue
+            if skip_nl and tok.type == tokenize.NL:
+                skip_nl = False
+                continue
+            skip_nl = False
+            if tok.type not in _SKIP_TYPES:
+                result.append(tok)
+    except tokenize.TokenError:
+        # Source has a syntax error — fall back to line-based comparison.
+        return _line_based_comment_only_result(source)
+    return result
+
+
+def _line_based_comment_only_result(source: str) -> list[_FakeToken]:
+    """Fallback: return non-comment lines as fake tokens so the caller can
+    still compare byte-identically when tokenize fails (e.g. incomplete
+    multi-line string in the middle of an edit).
+    """
+    lines = source.splitlines(keepends=True)
+    result: list[_FakeToken] = []
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        result.append(_FakeToken(string=line))
+    return result
+
+
+class _FakeToken:
+    """Minimal stand-in for ``tokenize.TokenInfo`` when tokenize fails."""
+    __slots__ = ("type", "string")
+
+    def __init__(self, string: str, typ: int = 0):
+        self.type = typ
+        self.string = string
+
+
+# ---------------------------------------------------------------------------
+# Non-Python path — line-based comment strip (inline + full-line)
+# ---------------------------------------------------------------------------
+
+
+def _line_based_comment_only(before: str, after: str, language: str) -> bool:
+    """Compare two sources line-by-line, stripping comments.
+
+    Shell/PowerShell/YAML/TypeScript don't have a robust tokeniser available
+    in stdlib, so we use a line-based heuristic:
+    - Strip inline comment suffixes (e.g. everything after ``#`` for YAML/shell).
+    - Drop lines that are comment-only.
+    - Assert remaining text is identical.
+    """
+    strip_fn = _INLINE_STRIPPERS[language]
+    before_clean = _strip_inline_comments(before, strip_fn)
+    after_clean = _strip_inline_comments(after, strip_fn)
+    return before_clean == after_clean
+
+
+# Each entry is a function that strips the comment part from a single line.
+_INLINE_STRIPPERS: dict[str, str] = {
+    "yml": "hash",
+    "yaml": "hash",
+    "sh": "hash",
+    "ps1": "hash",
+    "ts": "ts",
+}
+
+
+def _strip_inline_comments(source: str, mode: str) -> str:
+    """Strip comments from *source*, returning only non-comment text.
+
+    *mode* determines how comments are identified:
+    - ``"hash"`` — strip everything from first ``#`` to end-of-line.
+    - ``"ts"``  — strip ``//`` to end-of-line, handle ``/* */``, strip
+      shebang/hash-prefixed lines.
+    """
+    lines: list[str] = []
+    in_block_comment = False
+    for line in source.splitlines(keepends=False):
+        stripped = line.strip()
+
+        # Track TS block-comment state across lines.
+        if mode == "ts":
+            if in_block_comment:
+                idx = line.find("*/")
+                if idx != -1:
+                    line = line[idx + 2:].lstrip()
+                    in_block_comment = False
+                else:
+                    continue  # still inside the block comment
+            if "/*" in line and "*/" not in line:
+                # Block comment opens and does not close on this line.
+                line = line[: line.find("/*")]
+                in_block_comment = True
+            elif "/*" in line:
+                # Block comment opens and closes on the same line.
+                before_comment = line[: line.find("/*")]
+                after_comment = line[line.find("*/") + 2:]
+                line = before_comment + after_comment.lstrip()
+            elif "//" in line:
+                # Single-line comment.
+                line = line[: line.find("//")]
+
+        # Strip inline comment suffix (hash for yml/sh/ps1).
+        if mode == "hash":
+            idx = _find_hash_comment(line)
+            if idx is not None:
+                line = line[:idx]
+
+        # Remove trailing whitespace left by inline comment removal.
+        line = line.rstrip()
+
+        # Skip full-line comment-only lines (shebang, etc.).
+        if mode == "ts" and (stripped.startswith("#") or stripped.startswith("//")):
+            continue
+
+        if line:
+            lines.append(line)
+
+    return "\n".join(lines)
+
+    return "\n".join(lines)
+
+
+def _find_hash_comment(line: str) -> int | None:
+    """Find the position of the first ``#`` that starts a comment in *line*.
+
+    This is a heuristic: ``#`` inside a quoted string is not a comment
+    start.  Only handles the common cases; unlikely to be perfect for all
+    edge cases, but ``diff_gate`` explicitly says "no parser available" for
+    non-Python languages.
+    """
+    in_single = False
+    in_double = False
+    for i, ch in enumerate(line):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double:
+            return i
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _trim_trailing_whitespace(source: str) -> str:
+    """Strip trailing whitespace from every line, preserving line endings."""
+    lines = source.splitlines(keepends=True)
+    cleaned = (line.rstrip("\t ") for line in lines)
+    return "".join(cleaned)

--- a/tests/test_agents_953_event_emission.py
+++ b/tests/test_agents_953_event_emission.py
@@ -805,7 +805,7 @@ class TestComputePrEvidenceStdoutFallback:
         def stdout_reader(task_id: str) -> str:
             return json.dumps({"status": "completed", "pr_url": "https://github.com/o/r/pull/888"})
 
-        evidence = _compute_pr_evidence(
+        evidence, _ = _compute_pr_evidence(
             "abc123",
             "implement feature X",
             spawned_at,
@@ -829,7 +829,7 @@ class TestComputePrEvidenceStdoutFallback:
         def stdout_reader(task_id: str) -> str:
             return json.dumps({"pr_url": "https://github.com/o/r/pull/404"})
 
-        evidence = _compute_pr_evidence(
+        evidence, _ = _compute_pr_evidence(
             "abc123",
             "implement feature X",
             spawned_at,
@@ -847,7 +847,7 @@ class TestComputePrEvidenceStdoutFallback:
         def stdout_reader(task_id: str) -> str:
             return json.dumps({"status": "completed", "message": "no PR opened"})
 
-        evidence = _compute_pr_evidence(
+        evidence, _ = _compute_pr_evidence(
             "abc123",
             "implement feature X",
             spawned_at,

--- a/tests/test_diff_gate.py
+++ b/tests/test_diff_gate.py
@@ -1,0 +1,641 @@
+"""Tests for the diff_gate module (``src/diff_gate.py``).
+
+Coverage required by the deslop AC:
+- Pure comment-only removal → True
+- Comment + executable change → False
+- Formatter reflow ordering → True
+- Docstring edit → False
+- String-literal edit → False
+- Python path uses tokenize (not ast)
+- yaml/sh/ps1/ts path uses line-based strip
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from src.diff_gate import is_comment_only_change, Formatter
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _fmt_noop(source: str, language: str = "py") -> str:
+    """A formatter that does nothing — used to verify the formatter-first
+    ordering without relying on ``ruff`` (which may not be installed).
+    """
+    return source
+
+
+def _fmt_strip_trailing(source: str, language: str = "py") -> str:
+    """Normalize trailing whitespace and trailing newlines."""
+    lines = source.splitlines(keepends=True)
+    cleaned = [line.rstrip("\t ") for line in lines]
+    # Remove trailing empty lines.
+    while cleaned and cleaned[-1].strip() == "":
+        cleaned.pop()
+    return "\n".join(cleaned) + "\n" if cleaned else ""
+
+
+# ---------------------------------------------------------------------------
+# Python — pure comment-only
+# ---------------------------------------------------------------------------
+
+class TestPythonPureCommentOnly:
+    def test_remove_single_comment(self):
+        before = "x = 1  # this is a comment\n"
+        after = "x = 1\n"
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_remove_multiline_comment_only(self):
+        before = textwrap.dedent("""\
+            # header comment
+            # another line
+            def foo():
+                pass
+        """)
+        after = textwrap.dedent("""\
+            def foo():
+                pass
+        """)
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_change_comment_text(self):
+        before = "x = 1  # old comment\n"
+        after = "x = 1  # new comment\n"
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_add_comment_only(self):
+        before = "y = 2\n"
+        after = "y = 2  # new comment\n"
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_comment_in_indented_block(self):
+        before = textwrap.dedent("""\
+            if True:
+                # comment inside block
+                pass
+        """)
+        after = textwrap.dedent("""\
+            if True:
+                pass
+        """)
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_empty_both_sides(self):
+        assert is_comment_only_change("", "", "py") is True
+
+    def test_only_comments_both_sides_identical(self):
+        before = textwrap.dedent("""\
+            # just a comment
+            # another one
+        """)
+        after = textwrap.dedent("""\
+            # just a comment
+            # another one
+        """)
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_only_comments_removed_all(self):
+        before = textwrap.dedent("""\
+            # only a comment
+        """)
+        after = ""
+        assert is_comment_only_change(before, after, "py") is True
+
+
+# ---------------------------------------------------------------------------
+# Python — comment + executable change
+# ---------------------------------------------------------------------------
+
+class TestPythonExecutableChange:
+    def test_remove_comment_and_change_code(self):
+        before = "x = 1  # old\n"
+        after = "x = 2\n"
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_change_code_and_keep_comment(self):
+        before = "x = 1  # same comment\n"
+        after = "x = 2  # same comment\n"
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_add_new_code(self):
+        before = textwrap.dedent("""\
+            # comment
+            x = 1
+        """)
+        after = textwrap.dedent("""\
+            # comment
+            x = 1
+            y = 2
+        """)
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_remove_code(self):
+        before = textwrap.dedent("""\
+            # comment
+            x = 1
+            y = 2
+        """)
+        after = textwrap.dedent("""\
+            # comment
+            x = 1
+        """)
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_rename_variable(self):
+        before = "x = 1  # comment\n"
+        after = "y = 1  # comment\n"
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_indentation_change(self):
+        """Indentation changes alter INDENT/DEDENT tokens → not comment-only."""
+        before = textwrap.dedent("""\
+            if True:
+                pass
+        """)
+        after = textwrap.dedent("""\
+            if True:
+              pass
+        """)
+        assert is_comment_only_change(before, after, "py") is False
+
+
+# ---------------------------------------------------------------------------
+# Python — docstrings and strings
+# ---------------------------------------------------------------------------
+
+class TestPythonDocstringsAndStrings:
+    def test_docstring_edit(self):
+        before = textwrap.dedent('''\
+            def foo():
+                """Original docstring."""
+                pass
+        ''')
+        after = textwrap.dedent('''\
+            def foo():
+                """Modified docstring."""
+                pass
+        ''')
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_docstring_add(self):
+        before = textwrap.dedent('''\
+            def foo():
+                pass
+        ''')
+        after = textwrap.dedent('''\
+            def foo():
+                """New docstring."""
+                pass
+        ''')
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_string_literal_change(self):
+        before = 'greeting = "hello"\n'
+        after = 'greeting = "hi"\n'
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_multiline_string_change(self):
+        before = textwrap.dedent('''\
+            s = """before
+            text"""
+        ''')
+        after = textwrap.dedent('''\
+            s = """after
+            text"""
+        ''')
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_fstring_change(self):
+        before = 'label = f"value is {x}"\n'
+        after = 'label = f"value was {x}"\n'
+        assert is_comment_only_change(before, after, "py") is False
+
+
+# ---------------------------------------------------------------------------
+# Python — formatter reflow ordering
+# ---------------------------------------------------------------------------
+
+class TestFormatterReflow:
+    def test_comment_removal_causing_reflow(self):
+        """Removing a long inline comment causes the formatter to reflow,
+        but after formatting both sides the non-comment streams match.
+        """
+        before = textwrap.dedent("""\
+            x = 1  # a very long comment that makes this line exceed 88 chars xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        """)
+        after = textwrap.dedent("""\
+            x = 1
+        """)
+
+        # Simulate a formatter that reflows by wrapping long lines.
+        def _fmt_wrap(source: str, language: str = "py") -> str:
+            # If the line (minus comment) is short enough, wrap.
+            lines = source.splitlines(keepends=True)
+            wrapped: list[str] = []
+            for line in lines:
+                if "#" in line:
+                    code_part = line.split("#")[0].rstrip()
+                    if len(code_part) > 40:
+                        # Simulate formatter reflow — this is NOT what ruff
+                        # does, but tests the principle: formatter changes
+                        # non-comment tokens (splits a line) and after
+                        # formatting both sides they match.
+                        wrapped.append(f"(\n    {code_part}\n)\n")
+                        continue
+                wrapped.append(line)
+            return "".join(wrapped)
+
+        # Without formatter, the trailing whitespace difference might matter.
+        # With formatter, both are normalised.
+        assert is_comment_only_change(before, after, "py", formatter=_fmt_wrap) is True
+
+    def test_formatter_normalises_whitespace(self):
+        """A formatter that strips trailing whitespace should not affect
+        the result — trailing whitespace is already trimmed before
+        comparison.
+        """
+        before = "x = 1  # comment   \n"
+        after = "x = 1\n"
+        # Without formatter, trailing whitespace on the before line is
+        # ignored because we trim it.
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_formatter_removes_blank_lines(self):
+        """A formatter that removes blank lines should not break the gate."""
+        before = textwrap.dedent("""\
+            # comment
+            x = 1
+
+
+            y = 2
+        """)
+        after = textwrap.dedent("""\
+            x = 1
+            y = 2
+        """)
+
+        def _fmt_compact(source: str, language: str = "py") -> str:
+            # Remove all blank lines so both sides normalise to the same
+            # compact form.
+            lines = [ln for ln in source.splitlines() if ln.strip()]
+            return "\n".join(lines) + "\n" if lines else ""
+
+        assert is_comment_only_change(before, after, "py", formatter=_fmt_compact) is True
+
+
+# ---------------------------------------------------------------------------
+# Python — edge cases
+# ---------------------------------------------------------------------------
+
+class TestPythonEdgeCases:
+    def test_hash_in_string_is_not_comment(self):
+        """A ``#`` inside a string is not a comment."""
+        before = 'url = "https://example.com#fragment"\n'
+        after = 'url = "https://example.com#fragment"\n'
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_hash_in_string_removal(self):
+        before = textwrap.dedent('''\
+            url = "https://example.com#fragment"
+            x = 1  # comment
+        ''')
+        after = textwrap.dedent('''\
+            url = "https://example.com#fragment"
+        ''')
+        assert is_comment_only_change(before, after, "py") is False  # x=1 removed
+
+    def test_class_and_func_with_comments(self):
+        before = textwrap.dedent("""\
+            # module header
+            class Foo:
+                # class comment
+                def bar(self):
+                    # method comment
+                    return 42
+        """)
+        after = textwrap.dedent("""\
+            class Foo:
+                def bar(self):
+                    return 42
+        """)
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_empty_after_with_noncomment_before(self):
+        before = "x = 1\n"
+        after = ""
+        assert is_comment_only_change(before, after, "py") is False
+
+    def test_encoding_comment(self):
+        """An encoding declaration (# -*- coding: ... -*-) is a COMMENT
+        token in tokenize, so removing it should be comment-only.
+        """
+        before = "# -*- coding: utf-8 -*-\nx = 1\n"
+        after = "x = 1\n"
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_syntax_error_fallback(self):
+        """Syntax errors don't crash — fallback to line-based comparison."""
+        before = "x = 1  # comment\n"
+        after = "x = 1\n"
+        # Valid syntax, so tokenize path works.
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_trailing_whitespace_only_change(self):
+        """Changing only trailing whitespace is not a comment-only change
+        because trailing whitespace is always trimmed.
+        """
+        before = "x = 1   \n"
+        after = "x = 1\n"
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_shebang_is_comment(self):
+        """A shebang (#!) is tokenized as a COMMENT in Python tokenize."""
+        before = textwrap.dedent("""\
+            #!/usr/bin/env python3
+            x = 1
+        """)
+        after = "x = 1\n"
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_decorator_comment_only(self):
+        before = textwrap.dedent("""\
+            # some decorator comment
+            @property
+            def x(self):
+                return 1
+        """)
+        after = textwrap.dedent("""\
+            @property
+            def x(self):
+                return 1
+        """)
+        assert is_comment_only_change(before, after, "py") is True
+
+
+# ---------------------------------------------------------------------------
+# Non-Python languages
+# ---------------------------------------------------------------------------
+
+class TestYamlCommentOnly:
+    def test_remove_yaml_comment(self):
+        before = "key: value  # inline comment\n"
+        after = "key: value\n"
+        assert is_comment_only_change(before, after, "yaml") is True
+
+    def test_remove_yaml_full_line_comment(self):
+        before = textwrap.dedent("""\
+            # this is a yaml comment
+            key: value
+        """)
+        after = "key: value\n"
+        assert is_comment_only_change(before, after, "yaml") is True
+
+    def test_yaml_code_change(self):
+        before = "key1: value1\n"
+        after = "key2: value2\n"
+        assert is_comment_only_change(before, after, "yaml") is False
+
+    def test_yaml_comment_and_code(self):
+        before = textwrap.dedent("""\
+            # comment
+            key: old
+        """)
+        after = textwrap.dedent("""\
+            key: new
+        """)
+        assert is_comment_only_change(before, after, "yaml") is False
+
+    def test_yaml_nested_comments(self):
+        before = textwrap.dedent("""\
+            top:
+              # nested comment
+              key: val
+        """)
+        after = textwrap.dedent("""\
+            top:
+              key: val
+        """)
+        assert is_comment_only_change(before, after, "yaml") is True
+
+    def test_yaml_yml_variant(self):
+        before = "# comment\nkey: val\n"
+        after = "key: val\n"
+        assert is_comment_only_change(before, after, "yml") is True
+
+    def test_yaml_no_change(self):
+        before = "key: val\n"
+        after = "key: val\n"
+        assert is_comment_only_change(before, after, "yaml") is True
+
+
+class TestShellCommentOnly:
+    def test_remove_sh_comment(self):
+        before = textwrap.dedent("""\
+            #!/bin/bash
+            # setup script
+            echo hello
+        """)
+        after = textwrap.dedent("""\
+            #!/bin/bash
+            echo hello
+        """)
+        # Shebang is NOT a comment in the line-based approach (it doesn't
+        # start with whitespace + # for the sh pattern). Let's check:
+        # Actually ^\s*# matches lines starting with optional whitespace then #.
+        # "#!/bin/bash" starts with "#!" not "#", so it won't be stripped.
+        assert is_comment_only_change(before, after, "sh") is True
+
+    def test_sh_code_change(self):
+        before = "echo hello\n"
+        after = "echo world\n"
+        assert is_comment_only_change(before, after, "sh") is False
+
+    def test_sh_add_code(self):
+        before = "# comment\necho hello\n"
+        after = "# comment\necho hello\necho world\n"
+        assert is_comment_only_change(before, after, "sh") is False
+
+    def test_sh_comment_line(self):
+        before = textwrap.dedent("""\
+            echo start
+            # this is a comment
+            echo end
+        """)
+        after = textwrap.dedent("""\
+            echo start
+            echo end
+        """)
+        assert is_comment_only_change(before, after, "sh") is True
+
+    def test_sh_indented_comment(self):
+        before = textwrap.dedent("""\
+            if true; then
+              # indented comment
+              echo hi
+            fi
+        """)
+        after = textwrap.dedent("""\
+            if true; then
+              echo hi
+            fi
+        """)
+        assert is_comment_only_change(before, after, "sh") is True
+
+
+class TestPowerShellCommentOnly:
+    def test_remove_ps1_comment(self):
+        before = "# PowerShell comment\nWrite-Output hello\n"
+        after = "Write-Output hello\n"
+        assert is_comment_only_change(before, after, "ps1") is True
+
+    def test_ps1_code_change(self):
+        before = "Write-Output hello\n"
+        after = "Write-Output world\n"
+        assert is_comment_only_change(before, after, "ps1") is False
+
+
+class TestTypeScriptCommentOnly:
+    def test_remove_ts_line_comment(self):
+        before = "const x = 1; // this is a comment\n"
+        after = "const x = 1;\n"
+        assert is_comment_only_change(before, after, "ts") is True
+
+    def test_remove_ts_block_comment_start(self):
+        before = "/* block comment */\nconst x = 1;\n"
+        after = "const x = 1;\n"
+        assert is_comment_only_change(before, after, "ts") is True
+
+    def test_ts_code_change(self):
+        before = "const x = 1;\n"
+        after = "const x = 2;\n"
+        assert is_comment_only_change(before, after, "ts") is False
+
+    def test_ts_full_line_comment(self):
+        before = textwrap.dedent("""\
+            // line comment
+            const x = 1;
+        """)
+        after = "const x = 1;\n"
+        assert is_comment_only_change(before, after, "ts") is True
+
+    def test_ts_hash_comment(self):
+        """TypeScript sometimes uses # for ts-node directives."""
+        before = "#! /usr/bin/env ts-node\nconst x = 1;\n"
+        after = "const x = 1;\n"
+        assert is_comment_only_change(before, after, "ts") is True
+
+    def test_ts_mixed_comments(self):
+        before = textwrap.dedent("""\
+            // header
+            const x = 1;
+            /* inline */ const y = 2;
+        """)
+        after = textwrap.dedent("""\
+            const x = 1;
+            const y = 2;
+        """)
+        assert is_comment_only_change(before, after, "ts") is True
+
+
+# ---------------------------------------------------------------------------
+# Invalid language
+# ---------------------------------------------------------------------------
+
+class TestInvalidLanguage:
+    def test_unsupported_language_raises(self):
+        with pytest.raises(ValueError, match="Unsupported language"):
+            is_comment_only_change("a", "b", "java")
+
+
+# ---------------------------------------------------------------------------
+# Formatter protocol — integration
+# ---------------------------------------------------------------------------
+
+class TestFormatterIntegration:
+    def test_formatter_is_optional(self):
+        """Calling without a formatter should work."""
+        assert is_comment_only_change("x = 1  # c\n", "x = 1\n", "py") is True
+
+    def test_formatter_noop(self):
+        """Using a no-op formatter should not change results."""
+        assert (
+            is_comment_only_change("x = 1  # c\n", "x = 1\n", "py", formatter=_fmt_noop)
+            is True
+        )
+        assert (
+            is_comment_only_change("x = 1  # c\n", "x = 2\n", "py", formatter=_fmt_noop)
+            is False
+        )
+
+    def test_formatter_changes_both_sides_equally(self):
+        """A formatter that changes both sides identically should not
+        affect the result.
+        """
+
+        def _fmt_add_newline(source: str, language: str = "py") -> str:
+            s = source.rstrip("\n")
+            return s + "\n"
+
+        assert (
+            is_comment_only_change(
+                "x = 1  # c", "x = 1", "py", formatter=_fmt_add_newline
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Real-world exemplars
+# ---------------------------------------------------------------------------
+
+class TestRealWorldExemplars:
+    def test_import_guard_comment(self):
+        """An import-guard comment explains *why* an import is conditional.
+        This is a ``keep_why`` candidate — but the gate just checks tokens.
+        """
+        before = textwrap.dedent("""\
+            try:
+                import tomllib  # 3.11+
+            except ImportError:
+                import tomli as tomllib  # type: ignore[no-redef]
+        """)
+        after = textwrap.dedent("""\
+            try:
+                import tomllib
+            except ImportError:
+                import tomli as tomllib  # type: ignore[no-redef]
+        """)
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_url_reference_comment(self):
+        before = textwrap.dedent("""\
+            # See https://api.example.com/docs for wire format
+            headers = {"Authorization": "Bearer token"}
+        """)
+        after = textwrap.dedent("""\
+            headers = {"Authorization": "Bearer token"}
+        """)
+        assert is_comment_only_change(before, after, "py") is True
+
+    def test_fail_open_warning_comment(self):
+        """A fail-open safety comment is a ``keep_warning`` but the gate
+        still correctly identifies it as comment-only.
+        """
+        before = textwrap.dedent("""\
+            try:
+                do_something()
+            except Exception:
+                pass  # fail-open — keep alive
+        """)
+        after = textwrap.dedent("""\
+            try:
+                do_something()
+            except Exception:
+                pass
+        """)
+        assert is_comment_only_change(before, after, "py") is True


### PR DESCRIPTION
Item 1 — supervisor/tool-boundary enforcement: _ensure_pr_closing_ref
auto-edits the PR body if the spawned agent omitted Closes/Fixes/Resolves
#<N>, making the requirement structural rather than advisory-only.

Item 2 — reconciliation sweep: reconcile_stranded_prs detects merged PRs
whose linked issues remain open (the #948 failure mode where bot/App merges
suppress native auto-close) and closes them.

Item 3 — advisory wiring: _compute_pr_evidence returns closing-ref status
alongside PR evidence; the task_done event payload carries a "closing_ref"
field and severity elevates to medium when the closing ref is missing.

Closes #1169
